### PR TITLE
fix(spawn): resolve parent agent from context in managed mode

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -423,6 +423,9 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 		}
 	}
 
+	// Inject agent key into context for tool-level resolution (managed mode: multiple agents share tool registry)
+	ctx = tools.WithToolAgentKey(ctx, l.id)
+
 	// Security: truncate oversized user messages gracefully (feed truncation notice into LLM)
 	maxChars := l.maxMessageChars
 	if maxChars <= 0 {

--- a/internal/tools/context_keys.go
+++ b/internal/tools/context_keys.go
@@ -20,6 +20,7 @@ const (
 	ctxSandboxKey toolContextKey = "tool_sandbox_key"
 	ctxAsyncCB    toolContextKey = "tool_async_cb"
 	ctxWorkspace  toolContextKey = "tool_workspace"
+	ctxAgentKey   toolContextKey = "tool_agent_key"
 )
 
 func WithToolChannel(ctx context.Context, channel string) context.Context {
@@ -73,6 +74,18 @@ func WithToolWorkspace(ctx context.Context, ws string) context.Context {
 
 func ToolWorkspaceFromCtx(ctx context.Context) string {
 	v, _ := ctx.Value(ctxWorkspace).(string)
+	return v
+}
+
+// WithToolAgentKey injects the calling agent's key into context.
+// In managed mode multiple agents share a single tool registry; the agent key
+// lets tools like spawn/subagent identify which agent is the parent.
+func WithToolAgentKey(ctx context.Context, key string) context.Context {
+	return context.WithValue(ctx, ctxAgentKey, key)
+}
+
+func ToolAgentKeyFromCtx(ctx context.Context) string {
+	v, _ := ctx.Value(ctxAgentKey).(string)
 	return v
 }
 

--- a/internal/tools/subagent_spawn_tool.go
+++ b/internal/tools/subagent_spawn_tool.go
@@ -61,7 +61,13 @@ func (t *SpawnTool) Execute(ctx context.Context, args map[string]interface{}) *R
 	peerKind := ToolPeerKindFromCtx(ctx)
 	callback := ToolAsyncCBFromCtx(ctx)
 
-	msg, err := t.manager.Spawn(ctx, t.parentID, t.depth, task, label, modelOverride,
+	// Resolve parent agent from ctx (managed mode) with fallback to construction-time default
+	parentID := ToolAgentKeyFromCtx(ctx)
+	if parentID == "" {
+		parentID = t.parentID
+	}
+
+	msg, err := t.manager.Spawn(ctx, parentID, t.depth, task, label, modelOverride,
 		channel, chatID, peerKind, callback)
 	if err != nil {
 		return ErrorResult(err.Error())

--- a/internal/tools/subagent_tool.go
+++ b/internal/tools/subagent_tool.go
@@ -148,7 +148,13 @@ func (t *SubagentTool) executeRun(ctx context.Context, args map[string]interface
 	channel := ToolChannelFromCtx(ctx)
 	chatID := ToolChatIDFromCtx(ctx)
 
-	result, iterations, err := t.manager.RunSync(ctx, t.parentID, t.depth, task, label,
+	// Resolve parent agent from ctx (managed mode) with fallback to construction-time default
+	parentID := ToolAgentKeyFromCtx(ctx)
+	if parentID == "" {
+		parentID = t.parentID
+	}
+
+	result, iterations, err := t.manager.RunSync(ctx, parentID, t.depth, task, label,
 		channel, chatID)
 	if err != nil {
 		return ErrorResult(fmt.Sprintf("Subagent '%s' failed: %v", label, err))


### PR DESCRIPTION
## Problem

In managed mode, `NewSpawnTool` and `NewSubagentTool` are constructed with a hardcoded `parentID` of `"default"` (`gateway.go:246-247`). When a non-default agent spawns a subagent, the announce routes back through `gateway_consumer.go` using `parent_agent` metadata — which is `"default"`. The session key resolves to `agent:default:...`, and since agent `"default"` does not exist in managed mode, the announce fails:

```
level=INFO  msg="subagent spawned" parent=default ...
level=INFO  msg="subagent announce → scheduler" session=agent:default:rua-telegram:group:...
level=ERROR msg="subagent announce: agent run failed" error="agent default not found: agent not found: default"
```

This affects **all** non-default agents in managed mode deployments.

## Fix

Add `ctxAgentKey` to tool context keys (same pattern as `ctxChannel`, `ctxChatID`, etc.):

1. **`context_keys.go`** — new `ctxAgentKey` constant + `WithToolAgentKey` / `ToolAgentKeyFromCtx`
2. **`loop.go`** — inject `l.id` (agent key) into ctx before tool execution
3. **`subagent_spawn_tool.go`** — read agent key from ctx, fall back to construction-time `parentID`
4. **`subagent_tool.go`** — same ctx-based resolution for `RunSync`

Standalone mode is unaffected: when `ctxAgentKey` is empty, the fallback `"default"` is used.

## Test plan

- [x] `go build ./...` passes
- [ ] Managed mode: secondary agent spawns subagent → announce routes to correct parent session
- [ ] Standalone mode: spawn still works (fallback to "default")