### PR TITLE
feat(discord): support GOCLAW_DISCORD_TOKEN env var for channel config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ GOCLAW_ENCRYPTION_KEY=
 
 # --- Channels (optional) ---
 GOCLAW_TELEGRAM_TOKEN=
+GOCLAW_DISCORD_TOKEN=
 
 # --- Database (only for non-Docker deployments) ---
 # Docker Compose auto-builds this from POSTGRES_USER/PASSWORD/DB.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - GOCLAW_XAI_API_KEY=${GOCLAW_XAI_API_KEY:-}
       # Channels
       - GOCLAW_TELEGRAM_TOKEN=${GOCLAW_TELEGRAM_TOKEN:-}
+      - GOCLAW_DISCORD_TOKEN=${GOCLAW_DISCORD_TOKEN:-}
       # Debug
       - GOCLAW_TRACE_VERBOSE=${GOCLAW_TRACE_VERBOSE:-0}
     volumes:

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -106,6 +106,7 @@ func (c *Config) applyEnvOverrides() {
 	envStr("GOCLAW_PERPLEXITY_API_KEY", &c.Providers.Perplexity.APIKey)
 	envStr("GOCLAW_GATEWAY_TOKEN", &c.Gateway.Token)
 	envStr("GOCLAW_TELEGRAM_TOKEN", &c.Channels.Telegram.Token)
+	envStr("GOCLAW_DISCORD_TOKEN", &c.Channels.Discord.Token)
 	envStr("GOCLAW_ZALO_TOKEN", &c.Channels.Zalo.Token)
 	envStr("GOCLAW_FEISHU_APP_ID", &c.Channels.Feishu.AppID)
 	envStr("GOCLAW_FEISHU_APP_SECRET", &c.Channels.Feishu.AppSecret)
@@ -121,6 +122,9 @@ func (c *Config) applyEnvOverrides() {
 	// Auto-enable channels if credentials are provided via env
 	if c.Channels.Telegram.Token != "" {
 		c.Channels.Telegram.Enabled = true
+	}
+	if c.Channels.Discord.Token != "" {
+		c.Channels.Discord.Enabled = true
 	}
 	if c.Channels.Zalo.Token != "" {
 		c.Channels.Zalo.Enabled = true


### PR DESCRIPTION
Add env var overlay and auto-enable for Discord channel, matching the existing Telegram pattern. Update .env.example and docker-compose.yml.