### PR TITLE
feat: Publish pre-built Docker images to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -78,3 +78,44 @@ jobs:
             VERSION=${{ github.ref_name }}
           cache-from: type=gha,scope=${{ matrix.variant }}
           cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
+
+  build-and-push-web:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-web
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ui/web
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that builds and publishes Docker images to GHCR on version tags (`v*.*.*`)
- Builds all 4 variants: `latest`, `otel`, `tsnet`, `full`
- Multi-platform support: `linux/amd64` and `linux/arm64`
- Uses GitHub Actions cache for faster builds

## Details

The workflow uses a build matrix to produce the 4 image variants described in #19:

| Variant | OTEL | Tsnet | Tag examples |
|---------|------|-------|--------------|
| latest  | no   | no    | `1.2.3`, `1.2`, `latest` |
| otel    | yes  | no    | `1.2.3-otel`, `1.2-otel`, `otel` |
| tsnet   | no   | yes   | `1.2.3-tsnet`, `1.2-tsnet`, `tsnet` |
| full    | yes  | yes   | `1.2.3-full`, `1.2-full`, `full` |

Quick start after publishing:
```bash
docker pull ghcr.io/nextlevelbuilder/goclaw:latest
docker pull ghcr.io/nextlevelbuilder/goclaw:otel
```

Closes #19

## Test plan

- [ ] Push a test tag (`v0.0.1-rc1`) to verify the workflow triggers
- [ ] Confirm all 4 variants are built and pushed to GHCR
- [ ] Verify multi-platform manifests (`docker manifest inspect`)
- [ ] Pull and run each variant to confirm functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)