### PR TITLE
fix(bootstrap): SeedUserFiles should use agent-level USER.md as seed for predefined agents

### DIFF
--- a/internal/bootstrap/seed_store.go
+++ b/internal/bootstrap/seed_store.go
@@ -92,10 +92,10 @@ var userSeedFilesPredefined = []string{
 // For "predefined" agents: USER.md + BOOTSTRAP.md (user-focused onboarding template).
 // Only writes files that don't already exist — safe to call multiple times.
 //
-// For predefined agents seeding USER.md: if the agent already has a non-empty
-// USER.md in agent_context_files (e.g. written by the wizard), that content is
-// used as the per-user seed instead of the blank embedded template. This ensures
-// wizard-configured owner profiles are preserved on first chat.
+// For predefined agents seeding USER.md: if the agent already has a populated
+// USER.md in agent_context_files (e.g. written by the wizard or management dashboard),
+// that content is used as the per-user seed instead of the blank embedded template.
+// This ensures wizard-configured owner profiles are preserved on first chat.
 //
 // Returns the list of file names that were seeded.
 func SeedUserFiles(ctx context.Context, agentStore store.AgentStore, agentID uuid.UUID, userID, agentType string) ([]string, error) {
@@ -104,7 +104,7 @@ func SeedUserFiles(ctx context.Context, agentStore store.AgentStore, agentID uui
 		files = userSeedFilesPredefined
 	}
 
-	// Check existing files to avoid overwriting personalized content
+	// Check existing per-user files to avoid overwriting personalized content
 	existing, err := agentStore.GetUserContextFiles(ctx, agentID, userID)
 	if err != nil {
 		return nil, err
@@ -116,16 +116,18 @@ func SeedUserFiles(ctx context.Context, agentStore store.AgentStore, agentID uui
 		}
 	}
 
-	// For predefined agents: pre-load agent-level context files once so we can
-	// use the wizard-written USER.md content as the seed instead of the blank template.
-	// Loaded lazily — only when a predefined agent needs to seed USER.md.
-	var agentLevelUserMD string
-	if agentType == store.AgentTypePredefined && !hasFile[UserFile] {
-		if agentFiles, err := agentStore.GetAgentContextFiles(ctx, agentID); err == nil {
+	// For predefined agents: load agent-level files once to use as seed fallback.
+	// USER.md at agent-level may contain a pre-configured owner profile (e.g. set by
+	// the wizard or management dashboard). Use it as the per-user seed instead of the
+	// blank embedded template so the agent starts with the correct owner context.
+	var agentLevelFiles map[string]string
+	if agentType == store.AgentTypePredefined {
+		agentFiles, err := agentStore.GetAgentContextFiles(ctx, agentID)
+		if err == nil && len(agentFiles) > 0 {
+			agentLevelFiles = make(map[string]string, len(agentFiles))
 			for _, f := range agentFiles {
-				if f.FileName == UserFile && f.Content != "" {
-					agentLevelUserMD = f.Content
-					break
+				if f.Content != "" {
+					agentLevelFiles[f.FileName] = f.Content
 				}
 			}
 		}
@@ -134,31 +136,35 @@ func SeedUserFiles(ctx context.Context, agentStore store.AgentStore, agentID uui
 	var seeded []string
 	for _, name := range files {
 		if hasFile[name] {
-			continue // already has content, don't overwrite
+			continue // already has personalized content, don't overwrite
 		}
 
-		var content string
-
-		// Predefined agent USER.md: prefer agent-level content (wizard-written)
-		// over the blank embedded template so the owner profile is preserved.
-		if agentType == store.AgentTypePredefined && name == UserFile && agentLevelUserMD != "" {
-			content = agentLevelUserMD
-		} else {
-			// Predefined agents use a user-focused bootstrap template
-			templateName := name
-			if agentType == store.AgentTypePredefined && name == BootstrapFile {
-				templateName = "BOOTSTRAP_PREDEFINED.md"
-			}
-
-			raw, err := templateFS.ReadFile(filepath.Join("templates", templateName))
-			if err != nil {
-				slog.Warn("bootstrap: failed to read embedded template for user seed", "file", name, "error", err)
+		// For predefined agents seeding USER.md: prefer agent-level content as seed.
+		// This propagates wizard/dashboard-configured owner profile to the first user.
+		if agentType == store.AgentTypePredefined && name == UserFile {
+			if agentContent, ok := agentLevelFiles[name]; ok {
+				if err := agentStore.SetUserContextFile(ctx, agentID, userID, name, agentContent); err != nil {
+					return seeded, err
+				}
+				seeded = append(seeded, name)
 				continue
 			}
-			content = string(raw)
+			// No agent-level USER.md → fall through to blank embedded template
 		}
 
-		if err := agentStore.SetUserContextFile(ctx, agentID, userID, name, content); err != nil {
+		// Predefined agents use a user-focused bootstrap template
+		templateName := name
+		if agentType == store.AgentTypePredefined && name == BootstrapFile {
+			templateName = "BOOTSTRAP_PREDEFINED.md"
+		}
+
+		content, err := templateFS.ReadFile(filepath.Join("templates", templateName))
+		if err != nil {
+			slog.Warn("bootstrap: failed to read embedded template for user seed", "file", name, "error", err)
+			continue
+		}
+
+		if err := agentStore.SetUserContextFile(ctx, agentID, userID, name, string(content)); err != nil {
 			return seeded, err
 		}
 		seeded = append(seeded, name)

--- a/internal/bootstrap/seed_store.go
+++ b/internal/bootstrap/seed_store.go
@@ -91,6 +91,12 @@ var userSeedFilesPredefined = []string{
 // For "open" agents: all 7 files (including BOOTSTRAP.md).
 // For "predefined" agents: USER.md + BOOTSTRAP.md (user-focused onboarding template).
 // Only writes files that don't already exist — safe to call multiple times.
+//
+// For predefined agents seeding USER.md: if the agent already has a non-empty
+// USER.md in agent_context_files (e.g. written by the wizard), that content is
+// used as the per-user seed instead of the blank embedded template. This ensures
+// wizard-configured owner profiles are preserved on first chat.
+//
 // Returns the list of file names that were seeded.
 func SeedUserFiles(ctx context.Context, agentStore store.AgentStore, agentID uuid.UUID, userID, agentType string) ([]string, error) {
 	files := userSeedFilesOpen
@@ -110,25 +116,49 @@ func SeedUserFiles(ctx context.Context, agentStore store.AgentStore, agentID uui
 		}
 	}
 
+	// For predefined agents: pre-load agent-level context files once so we can
+	// use the wizard-written USER.md content as the seed instead of the blank template.
+	// Loaded lazily — only when a predefined agent needs to seed USER.md.
+	var agentLevelUserMD string
+	if agentType == store.AgentTypePredefined && !hasFile[UserFile] {
+		if agentFiles, err := agentStore.GetAgentContextFiles(ctx, agentID); err == nil {
+			for _, f := range agentFiles {
+				if f.FileName == UserFile && f.Content != "" {
+					agentLevelUserMD = f.Content
+					break
+				}
+			}
+		}
+	}
+
 	var seeded []string
 	for _, name := range files {
 		if hasFile[name] {
 			continue // already has content, don't overwrite
 		}
 
-		// Predefined agents use a user-focused bootstrap template
-		templateName := name
-		if agentType == store.AgentTypePredefined && name == BootstrapFile {
-			templateName = "BOOTSTRAP_PREDEFINED.md"
+		var content string
+
+		// Predefined agent USER.md: prefer agent-level content (wizard-written)
+		// over the blank embedded template so the owner profile is preserved.
+		if agentType == store.AgentTypePredefined && name == UserFile && agentLevelUserMD != "" {
+			content = agentLevelUserMD
+		} else {
+			// Predefined agents use a user-focused bootstrap template
+			templateName := name
+			if agentType == store.AgentTypePredefined && name == BootstrapFile {
+				templateName = "BOOTSTRAP_PREDEFINED.md"
+			}
+
+			raw, err := templateFS.ReadFile(filepath.Join("templates", templateName))
+			if err != nil {
+				slog.Warn("bootstrap: failed to read embedded template for user seed", "file", name, "error", err)
+				continue
+			}
+			content = string(raw)
 		}
 
-		content, err := templateFS.ReadFile(filepath.Join("templates", templateName))
-		if err != nil {
-			slog.Warn("bootstrap: failed to read embedded template for user seed", "file", name, "error", err)
-			continue
-		}
-
-		if err := agentStore.SetUserContextFile(ctx, agentID, userID, name, string(content)); err != nil {
+		if err := agentStore.SetUserContextFile(ctx, agentID, userID, name, content); err != nil {
 			return seeded, err
 		}
 		seeded = append(seeded, name)

--- a/internal/bootstrap/seed_store_test.go
+++ b/internal/bootstrap/seed_store_test.go
@@ -1,0 +1,279 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// ---- minimal AgentStore stub for seed tests ----
+
+type seedStubStore struct {
+	// agent-level files (simulates agent_context_files)
+	agentFiles map[string]string // fileName → content
+	// per-user files (simulates user_context_files)
+	userFiles map[string]string // fileName → content (shared across all users for simplicity)
+	// captures what was written per-user: fileName → content
+	seededUserFiles map[string]string
+}
+
+func newSeedStub() *seedStubStore {
+	return &seedStubStore{
+		agentFiles:      make(map[string]string),
+		userFiles:       make(map[string]string),
+		seededUserFiles: make(map[string]string),
+	}
+}
+
+func (s *seedStubStore) GetAgentContextFiles(_ context.Context, _ uuid.UUID) ([]store.AgentContextFileData, error) {
+	var out []store.AgentContextFileData
+	for name, content := range s.agentFiles {
+		out = append(out, store.AgentContextFileData{FileName: name, Content: content})
+	}
+	return out, nil
+}
+func (s *seedStubStore) SetAgentContextFile(_ context.Context, _ uuid.UUID, name, content string) error {
+	s.agentFiles[name] = content
+	return nil
+}
+func (s *seedStubStore) GetUserContextFiles(_ context.Context, _ uuid.UUID, _ string) ([]store.UserContextFileData, error) {
+	var out []store.UserContextFileData
+	for name, content := range s.userFiles {
+		out = append(out, store.UserContextFileData{FileName: name, Content: content})
+	}
+	return out, nil
+}
+func (s *seedStubStore) SetUserContextFile(_ context.Context, _ uuid.UUID, _, name, content string) error {
+	s.seededUserFiles[name] = content
+	return nil
+}
+func (s *seedStubStore) DeleteUserContextFile(_ context.Context, _ uuid.UUID, _, _ string) error {
+	return nil
+}
+
+// Remaining interface methods — not exercised.
+func (s *seedStubStore) Create(_ context.Context, _ *store.AgentData) error              { return nil }
+func (s *seedStubStore) GetByKey(_ context.Context, _ string) (*store.AgentData, error)  { return nil, nil }
+func (s *seedStubStore) GetByID(_ context.Context, _ uuid.UUID) (*store.AgentData, error) { return nil, nil }
+func (s *seedStubStore) Update(_ context.Context, _ uuid.UUID, _ map[string]any) error   { return nil }
+func (s *seedStubStore) Delete(_ context.Context, _ uuid.UUID) error                     { return nil }
+func (s *seedStubStore) List(_ context.Context, _ string) ([]store.AgentData, error)     { return nil, nil }
+func (s *seedStubStore) ShareAgent(_ context.Context, _ uuid.UUID, _, _, _ string) error { return nil }
+func (s *seedStubStore) RevokeShare(_ context.Context, _ uuid.UUID, _ string) error      { return nil }
+func (s *seedStubStore) ListShares(_ context.Context, _ uuid.UUID) ([]store.AgentShareData, error) {
+	return nil, nil
+}
+func (s *seedStubStore) CanAccess(_ context.Context, _ uuid.UUID, _ string) (bool, string, error) {
+	return true, "admin", nil
+}
+func (s *seedStubStore) ListAccessible(_ context.Context, _ string) ([]store.AgentData, error) {
+	return nil, nil
+}
+func (s *seedStubStore) GetUserOverride(_ context.Context, _ uuid.UUID, _ string) (*store.UserAgentOverrideData, error) {
+	return nil, nil
+}
+func (s *seedStubStore) SetUserOverride(_ context.Context, _ *store.UserAgentOverrideData) error {
+	return nil
+}
+func (s *seedStubStore) GetOrCreateUserProfile(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+	return false, nil
+}
+func (s *seedStubStore) IsGroupFileWriter(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+	return false, nil
+}
+func (s *seedStubStore) AddGroupFileWriter(_ context.Context, _ uuid.UUID, _, _, _, _ string) error {
+	return nil
+}
+func (s *seedStubStore) RemoveGroupFileWriter(_ context.Context, _ uuid.UUID, _, _ string) error {
+	return nil
+}
+func (s *seedStubStore) ListGroupFileWriters(_ context.Context, _ uuid.UUID, _ string) ([]store.GroupFileWriterData, error) {
+	return nil, nil
+}
+
+// ---- Tests ----
+
+// TestSeedUserFiles_PredefinedAgent_UsesAgentLevelUserMD is the primary regression test.
+// When a predefined agent has wizard-written USER.md in agent_context_files, SeedUserFiles
+// must seed that content into user_context_files — NOT the blank embedded template.
+func TestSeedUserFiles_PredefinedAgent_UsesAgentLevelUserMD(t *testing.T) {
+	as := newSeedStub()
+	agentID := uuid.New()
+	wizardContent := "# User Profile\nOwner: Alice\nLanguage: English\nNotes: Prefers concise answers"
+
+	// Simulate wizard writing USER.md at agent level via agents.files.set
+	as.agentFiles[UserFile] = wizardContent
+
+	seeded, err := SeedUserFiles(context.Background(), as, agentID, "user-alice", store.AgentTypePredefined)
+	if err != nil {
+		t.Fatalf("SeedUserFiles returned error: %v", err)
+	}
+
+	// USER.md must be in the seeded list
+	foundUserMD := false
+	for _, f := range seeded {
+		if f == UserFile {
+			foundUserMD = true
+		}
+	}
+	if !foundUserMD {
+		t.Errorf("USER.md not in seeded files list: %v", seeded)
+	}
+
+	// The seeded USER.md must contain wizard content, not the blank template
+	got, ok := as.seededUserFiles[UserFile]
+	if !ok {
+		t.Fatal("USER.md was not written to user_context_files")
+	}
+	if got != wizardContent {
+		t.Errorf("seeded USER.md content mismatch:\n  want: %q\n  got:  %q", wizardContent, got)
+	}
+}
+
+// TestSeedUserFiles_PredefinedAgent_FallsBackToTemplateWhenNoAgentLevelUserMD verifies
+// that when there is no wizard-written USER.md at agent level, the blank template is used.
+func TestSeedUserFiles_PredefinedAgent_FallsBackToTemplateWhenNoAgentLevelUserMD(t *testing.T) {
+	as := newSeedStub()
+	agentID := uuid.New()
+	// No agent-level USER.md — wizard did not write one
+
+	seeded, err := SeedUserFiles(context.Background(), as, agentID, "user-bob", store.AgentTypePredefined)
+	if err != nil {
+		t.Fatalf("SeedUserFiles returned error: %v", err)
+	}
+
+	// USER.md should still be seeded (from embedded template)
+	foundUserMD := false
+	for _, f := range seeded {
+		if f == UserFile {
+			foundUserMD = true
+		}
+	}
+	if !foundUserMD {
+		t.Errorf("USER.md should be seeded from template when no agent-level file exists: %v", seeded)
+	}
+
+	// Content should be the embedded template (non-empty — the template file exists)
+	got, ok := as.seededUserFiles[UserFile]
+	if !ok {
+		t.Fatal("USER.md was not written to user_context_files")
+	}
+	if got == "" {
+		t.Error("seeded USER.md should not be empty (expected embedded template content)")
+	}
+}
+
+// TestSeedUserFiles_PredefinedAgent_DoesNotOverwriteExistingPerUserContent verifies
+// that personalized per-user USER.md written via conversation is never overwritten.
+func TestSeedUserFiles_PredefinedAgent_DoesNotOverwriteExistingPerUserContent(t *testing.T) {
+	as := newSeedStub()
+	agentID := uuid.New()
+	personalContent := "# User Profile\nMy customized personal content"
+
+	// Pre-populate per-user USER.md (simulates user who already chatted and personalized)
+	as.userFiles[UserFile] = personalContent
+	// Also set wizard content at agent level
+	as.agentFiles[UserFile] = "wizard content that should NOT override personal content"
+
+	seeded, err := SeedUserFiles(context.Background(), as, agentID, "user-charlie", store.AgentTypePredefined)
+	if err != nil {
+		t.Fatalf("SeedUserFiles returned error: %v", err)
+	}
+
+	// USER.md must NOT be in the seeded list (existing content, should skip)
+	for _, f := range seeded {
+		if f == UserFile {
+			t.Error("USER.md should NOT be re-seeded when per-user content already exists")
+		}
+	}
+
+	// SetUserContextFile must not have been called for USER.md
+	if _, wrote := as.seededUserFiles[UserFile]; wrote {
+		t.Error("SetUserContextFile should not be called when per-user USER.md already has content")
+	}
+}
+
+// TestSeedUserFiles_OpenAgent_UsesEmbeddedTemplate verifies that open agents
+// are completely unaffected — they still receive embedded templates per-user.
+func TestSeedUserFiles_OpenAgent_UsesEmbeddedTemplate(t *testing.T) {
+	as := newSeedStub()
+	agentID := uuid.New()
+	// Open agents should never check agent_context_files for USER.md
+
+	seeded, err := SeedUserFiles(context.Background(), as, agentID, "user-dave", store.AgentTypeOpen)
+	if err != nil {
+		t.Fatalf("SeedUserFiles returned error: %v", err)
+	}
+
+	// Open agents seed the full set: AGENTS.md, SOUL.md, IDENTITY.md, USER.md, BOOTSTRAP.md
+	expectedFiles := map[string]bool{
+		AgentsFile: true, SoulFile: true, IdentityFile: true, UserFile: true, BootstrapFile: true,
+	}
+	for _, f := range seeded {
+		delete(expectedFiles, f)
+	}
+	if len(expectedFiles) > 0 {
+		t.Errorf("open agent: missing seeded files: %v", expectedFiles)
+	}
+
+	// USER.md must have been written using embedded template (non-empty)
+	got, ok := as.seededUserFiles[UserFile]
+	if !ok {
+		t.Fatal("open agent: USER.md was not written to user_context_files")
+	}
+	if got == "" {
+		t.Error("open agent: seeded USER.md should not be empty")
+	}
+}
+
+// TestSeedUserFiles_PredefinedAgent_BootstrapUsesCorrectTemplate verifies that
+// BOOTSTRAP.md is still seeded from BOOTSTRAP_PREDEFINED.md for predefined agents.
+func TestSeedUserFiles_PredefinedAgent_BootstrapUsesCorrectTemplate(t *testing.T) {
+	as := newSeedStub()
+	agentID := uuid.New()
+
+	_, err := SeedUserFiles(context.Background(), as, agentID, "user-eve", store.AgentTypePredefined)
+	if err != nil {
+		t.Fatalf("SeedUserFiles returned error: %v", err)
+	}
+
+	// BOOTSTRAP.md must have been seeded
+	got, ok := as.seededUserFiles[BootstrapFile]
+	if !ok {
+		t.Fatal("predefined agent: BOOTSTRAP.md was not seeded")
+	}
+	if got == "" {
+		t.Error("predefined agent: BOOTSTRAP.md should have content from BOOTSTRAP_PREDEFINED.md template")
+	}
+}
+
+// TestSeedUserFiles_IdempotentOnSecondCall verifies that calling SeedUserFiles
+// a second time for the same user does not re-seed already-present files.
+func TestSeedUserFiles_IdempotentOnSecondCall(t *testing.T) {
+	as := newSeedStub()
+	agentID := uuid.New()
+
+	// First call — seeds files
+	SeedUserFiles(context.Background(), as, agentID, "user-frank", store.AgentTypePredefined)
+
+	// Simulate what the first call wrote (move seededUserFiles → userFiles)
+	for k, v := range as.seededUserFiles {
+		as.userFiles[k] = v
+	}
+	as.seededUserFiles = make(map[string]string)
+
+	// Second call — must seed nothing (all files already exist)
+	seeded, err := SeedUserFiles(context.Background(), as, agentID, "user-frank", store.AgentTypePredefined)
+	if err != nil {
+		t.Fatalf("second SeedUserFiles returned error: %v", err)
+	}
+	if len(seeded) != 0 {
+		t.Errorf("second call should seed nothing, but seeded: %v", seeded)
+	}
+	if len(as.seededUserFiles) != 0 {
+		t.Errorf("second call should not write any files, but wrote: %v", as.seededUserFiles)
+	}
+}


### PR DESCRIPTION
## Summary

`SeedUserFiles` always seeded a blank embedded `USER.md` template into `user_context_files` when a new user chatted with a predefined agent for the first time. It never checked whether a populated `USER.md` already existed in `agent_context_files` (written by the wizard or the management dashboard). As a result, any owner profile configured at install time was silently discarded — overridden by the blank per-user template on the first message.

## Background

GoClaw has two storage levels for context files in managed mode:

| Table | Scope | Used by |
|-------|-------|---------|
| `agent_context_files` | Agent-level (shared) | SOUL.md, IDENTITY.md, AGENTS.md for predefined agents |
| `user_context_files` | Per-user (isolated) | USER.md, BOOTSTRAP.md per individual user |

For predefined agents, `LoadContextFiles` always gives per-user content priority over agent-level:

```go
// context_file_interceptor.go — predefined agent read path
for _, f := range agentFiles {
    content := f.Content
    if uc, ok := userMap[f.FileName]; ok {
        content = uc  // per-user always wins over agent-level
    }
}
```

The intent is:
- **Agent-level USER.md** → default/initial owner profile set at provisioning time
- **Per-user USER.md** → personalized profile built up over conversation

## The Bug

`SeedUserFiles` only checked `user_context_files` for existing content — never `agent_context_files`. So for a new user:

1. `hasFile["USER.md"]` → false (no per-user rows yet)
2. Seeds blank embedded `USER.md` template → `user_context_files`
3. Blank per-user USER.md now overrides agent-level USER.md in `LoadContextFiles`
4. Agent treats owner as an unknown user and starts BOOTSTRAP.md onboarding

**The agent-level USER.md (written by the wizard with real owner info) is stored in DB but never served.**

## Reproduction

1. Install a predefined agent using goclaw-wizards with owner name configured
2. Wizard writes USER.md to `agent_context_files` with owner profile
3. Send the first message from the configured owner account
4. Agent responds as if meeting the user for the first time — ignores the configured USER.md

```sql
-- agent_context_files has the populated USER.md
SELECT content FROM agent_context_files WHERE agent_id = '...' AND file_name = 'USER.md';
-- > "# USER.md -- Owner Profile\n- **Name:** Richard\n..."

-- user_context_files has the blank template (seeded on first chat)
SELECT content FROM user_context_files WHERE agent_id = '...' AND user_id = '12345' AND file_name = 'USER.md';
-- > "# USER.md - About Your Human\n\n- **Name:**\n- **What to call them:**\n..."
```

## The Fix

In `SeedUserFiles`, before seeding the blank embedded template for `USER.md`, check if `agent_context_files` already has a populated USER.md. If it does, use that as the per-user seed instead.

**File changed:** `internal/bootstrap/seed_store.go` — `SeedUserFiles` only.

```go
// Load agent-level files once as seed fallback for predefined agents
var agentLevelFiles map[string]string
if agentType == store.AgentTypePredefined {
    agentFiles, err := agentStore.GetAgentContextFiles(ctx, agentID)
    if err == nil && len(agentFiles) > 0 {
        agentLevelFiles = make(map[string]string, len(agentFiles))
        for _, f := range agentFiles {
            if f.Content != "" {
                agentLevelFiles[f.FileName] = f.Content
            }
        }
    }
}

// In the seeding loop:
if agentType == store.AgentTypePredefined && name == UserFile {
    if agentContent, ok := agentLevelFiles[name]; ok {
        agentStore.SetUserContextFile(ctx, agentID, userID, name, agentContent)
        seeded = append(seeded, name)
        continue
    }
    // No agent-level USER.md → fall through to blank embedded template
}
```

## Behavior After Fix

| Scenario | Before | After |
|----------|--------|-------|
| Predefined agent, new user, agent-level USER.md exists | Seeds blank template → owner profile lost | Seeds agent-level USER.md → owner profile served correctly |
| Predefined agent, new user, no agent-level USER.md | Seeds blank template | Seeds blank template (unchanged) |
| Predefined agent, returning user, already has USER.md | Does not overwrite (correct) | Does not overwrite (unchanged) |
| Open agent | Seeds full per-user file set (unchanged) | Unchanged |

## Scope

- **File changed:** `internal/bootstrap/seed_store.go`
- **No schema changes** — reads from existing `agent_context_files`, writes to existing `user_context_files`
- **No API changes** — internal logic only
- **Backward compatible** — if no agent-level USER.md exists, behaviour is identical to before

## Related

- Discovered during integration testing with goclaw-wizards
- The wizard correctly writes USER.md to `agent_context_files` via `agents.files.set` WS RPC
- There is no external API to write directly to `user_context_files`, so this fix must live server-side