### PR TITLE
fix(heartbeat): resolve default agent from DB in managed mode

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -815,7 +815,7 @@ func runGateway() {
 	}
 
 	// Start heartbeat service (matching TS heartbeat-runner.ts).
-	heartbeatSvc := setupHeartbeat(cfg, agentRouter, sessStore, msgBus, workspace)
+	heartbeatSvc := setupHeartbeat(cfg, agentRouter, sessStore, msgBus, workspace, managedStores)
 	if heartbeatSvc != nil {
 		heartbeatSvc.Start()
 	}

--- a/cmd/gateway_agents.go
+++ b/cmd/gateway_agents.go
@@ -369,7 +369,7 @@ func setupTTS(cfg *config.Config) *tts.Manager {
 // setupHeartbeat creates and configures the heartbeat service from config.
 // Returns nil if heartbeats are disabled (every="0m" or no config).
 // Matching TS startHeartbeatRunner().
-func setupHeartbeat(cfg *config.Config, router *agent.Router, sess store.SessionStore, msgBus *bus.MessageBus, workspace string) *heartbeat.Service {
+func setupHeartbeat(cfg *config.Config, router *agent.Router, sess store.SessionStore, msgBus *bus.MessageBus, workspace string, managedStores *store.Stores) *heartbeat.Service {
 	hbCfg := cfg.Agents.Defaults.Heartbeat
 
 	// Determine interval
@@ -389,7 +389,7 @@ func setupHeartbeat(cfg *config.Config, router *agent.Router, sess store.Session
 		return nil
 	}
 
-	agentID := cfg.ResolveDefaultAgentID()
+	agentID := resolveDefaultAgentManaged(cfg, managedStores)
 
 	svcCfg := heartbeat.Config{
 		AgentID:   agentID,
@@ -439,4 +439,31 @@ func setupHeartbeat(cfg *config.Config, router *agent.Router, sess store.Session
 // parseDuration parses a duration string like "30m", "1h", "0m".
 func parseDuration(s string) (time.Duration, error) {
 	return time.ParseDuration(s)
+}
+
+// resolveDefaultAgentManaged resolves the default agent ID, falling back to the
+// managed-mode DB when config returns the generic "default" (which doesn't exist
+// as a real agent in managed mode — agents live in the DB, not config).
+func resolveDefaultAgentManaged(cfg *config.Config, managedStores *store.Stores) string {
+	agentID := cfg.ResolveDefaultAgentID()
+
+	if managedStores == nil || managedStores.Agents == nil || agentID != config.DefaultAgentID {
+		return agentID
+	}
+
+	agents, err := managedStores.Agents.List(context.Background(), "")
+	if err != nil {
+		slog.Warn("resolveDefaultAgentManaged: failed to list agents", "error", err)
+		return agentID
+	}
+	for _, a := range agents {
+		if a.IsDefault {
+			return a.AgentKey
+		}
+	}
+	// No agent marked as default — use first available
+	if len(agents) > 0 {
+		return agents[0].AgentKey
+	}
+	return agentID
 }


### PR DESCRIPTION
## Summary
- In managed mode, agents live in the database (not config files). `ResolveDefaultAgentID()` always returns `"default"` which doesn't exist as a real agent, causing `setupHeartbeat()` to silently fail — the heartbeat service starts but can never run an agent turn.
- Added `resolveDefaultAgentManaged()` helper that queries the managed DB for the agent marked `is_default=true`, falling back to the first available agent.
- Applied the helper in `setupHeartbeat()`.

## Changes
- `cmd/gateway_agents.go`: New `resolveDefaultAgentManaged()` function + updated `setupHeartbeat()` signature to accept `*store.Stores`
- `cmd/gateway.go`: Pass `managedStores` to `setupHeartbeat()` call

## Test plan
- [x] Verified in managed mode deployment with 2 agents (PostgreSQL backend)
- [x] Heartbeat correctly resolves default agent from DB instead of returning "default"
- [x] Standalone mode unaffected (falls through to `cfg.ResolveDefaultAgentID()`)
- [x] Build passes (`go build`)