### PR TITLE
fix(sandbox): rename from openclaw to goclaw for project name consistency

### DIFF
--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -1,7 +1,7 @@
 # Sandbox overlay — enables Docker-based sandbox for agent code execution.
 #
 # Prerequisites:
-#   1. Build the sandbox image:  docker build -t openclaw-sandbox:bookworm-slim -f Dockerfile.sandbox .
+#   1. Build the sandbox image:  docker build -t goclaw-sandbox:bookworm-slim -f Dockerfile.sandbox .
 #   2. Ensure Docker socket is accessible
 #
 # Usage (with managed mode):
@@ -19,7 +19,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - GOCLAW_SANDBOX_MODE=all
-      - GOCLAW_SANDBOX_IMAGE=openclaw-sandbox:bookworm-slim
+      - GOCLAW_SANDBOX_IMAGE=goclaw-sandbox:bookworm-slim
       - GOCLAW_SANDBOX_WORKSPACE_ACCESS=rw
       - GOCLAW_SANDBOX_SCOPE=session
       - GOCLAW_SANDBOX_MEMORY_MB=512

--- a/internal/mcp/manager_connect.go
+++ b/internal/mcp/manager_connect.go
@@ -32,7 +32,7 @@ func (m *Manager) connectServer(ctx context.Context, name, transportType, comman
 	initReq := mcpgo.InitializeRequest{}
 	initReq.Params.ProtocolVersion = mcpgo.LATEST_PROTOCOL_VERSION
 	initReq.Params.ClientInfo = mcpgo.Implementation{
-		Name:    "openclaw-go",
+		Name:    "goclaw",
 		Version: "1.0.0",
 	}
 

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -40,7 +40,7 @@ func newDockerSandbox(ctx context.Context, name string, cfg Config, workspace st
 	args := []string{
 		"run", "-d",
 		"--name", name,
-		"--label", "openclaw.sandbox=true",
+		"--label", "goclaw.sandbox=true",
 	}
 
 	// Security hardening (matching TS buildSandboxCreateArgs)
@@ -251,7 +251,7 @@ func (m *DockerManager) Get(ctx context.Context, key string, workspace string) (
 
 	prefix := m.config.ContainerPrefix
 	if prefix == "" {
-		prefix = "openclaw-sbx-"
+		prefix = "goclaw-sbx-"
 	}
 	name := prefix + sanitizeKey(key)
 	sb, err := newDockerSandbox(ctx, name, m.config, workspace)

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -86,7 +86,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		Mode:            ModeOff,
-		Image:           "openclaw-sandbox:bookworm-slim",
+		Image:           "goclaw-sandbox:bookworm-slim",
 		WorkspaceAccess: AccessRW,
 		Scope:           ScopeSession,
 		MemoryMB:        512,
@@ -97,7 +97,7 @@ func DefaultConfig() Config {
 		CapDrop:         []string{"ALL"},
 		Tmpfs:           []string{"/tmp", "/var/tmp", "/run"},
 		MaxOutputBytes:  1 << 20, // 1MB
-		ContainerPrefix:  "openclaw-sbx-",
+		ContainerPrefix:  "goclaw-sbx-",
 		Workdir:          "/workspace",
 		IdleHours:        24,
 		MaxAgeDays:       7,


### PR DESCRIPTION
## Summary
Rename sandbox naming pattern from `openclaw` to `goclaw` for consistency with the repository project name.

## Changes
- **internal/sandbox/sandbox.go**: Updated default image name and container prefix
- **internal/sandbox/docker.go**: Updated Docker label and fallback prefix
- **docker-compose.sandbox.yml**: Updated sandbox image reference in comments and env vars
- **internal/mcp/manager_connect.go**: Updated MCP client info name

## Testing
- Verified no references to 'openclaw' remain in sandbox-related code
