### PR TITLE
fix(agents): agents.list returns all DB agents in managed mode

### DIFF
--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -90,6 +90,18 @@ func (r *Router) Get(agentID string) (Agent, error) {
 	return nil, fmt.Errorf("agent not found: %s", agentID)
 }
 
+// GetCached returns an agent only if it's already in the cache (no lazy-load).
+// Used by handleList to check isRunning without triggering DB resolution.
+func (r *Router) GetCached(agentID string) (Agent, error) {
+	r.mu.RLock()
+	entry, ok := r.agents[agentID]
+	r.mu.RUnlock()
+	if ok && (r.ttl == 0 || time.Since(entry.cachedAt) < r.ttl) {
+		return entry.agent, nil
+	}
+	return nil, fmt.Errorf("agent not cached: %s", agentID)
+}
+
 // Remove removes an agent from the router.
 func (r *Router) Remove(agentID string) {
 	r.mu.Lock()

--- a/internal/gateway/methods/agents.go
+++ b/internal/gateway/methods/agents.go
@@ -92,6 +92,33 @@ func (m *AgentsMethods) handleAgentWait(_ context.Context, client *gateway.Clien
 }
 
 func (m *AgentsMethods) handleList(_ context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	// In managed mode, query DB for all accessible agents (router cache only
+	// contains lazy-loaded agents; newly created agents won't appear otherwise).
+	if m.isManaged && m.agentStore != nil {
+		ctx := context.Background()
+		agentDataList, err := m.agentStore.ListAccessible(ctx, client.UserID())
+		if err != nil {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, fmt.Sprintf("failed to list agents: %v", err)))
+			return
+		}
+		// Enrich with isRunning from router cache
+		infos := make([]agent.AgentInfo, 0, len(agentDataList))
+		for _, ag := range agentDataList {
+			info := agent.AgentInfo{
+				ID:    ag.AgentKey,
+				Model: ag.Model,
+			}
+			if loop, err := m.agents.GetCached(ag.AgentKey); err == nil {
+				info.IsRunning = loop.IsRunning()
+			}
+			infos = append(infos, info)
+		}
+		client.SendResponse(protocol.NewOKResponse(req.ID, map[string]interface{}{
+			"agents": infos,
+		}))
+		return
+	}
+	// Standalone mode: use router cache (all agents are pre-registered at startup)
 	infos := m.agents.ListInfo()
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]interface{}{
 		"agents": infos,


### PR DESCRIPTION
## Problem

In managed mode, the WebSocket `agents.list` method only returns agents currently in the router's in-memory cache. The router uses lazy loading — agents are only cached when `Get(agentKey)` is first called (e.g. on first chat). Newly created agents are never visible in `agents.list` until they are actually used.

**Repro:** Create a new agent via HTTP API or WebSocket `agents.create`, then call `agents.list` — the new agent does not appear.

The HTTP `GET /v1/agents` endpoint works correctly because it queries the DB directly via `agentStore.ListAccessible()`.

## Root Cause

`handleList` called `m.agents.ListInfo()` which iterates the in-memory map only.

## Fix

- In managed mode, `handleList` now queries `agentStore.ListAccessible(ctx, client.UserID())` from DB.
- `isRunning` is enriched from the router cache via a new `GetCached()` helper (no lazy-load side effect).
- Standalone mode is unchanged (all agents pre-registered at startup).

## Files Changed

- `internal/agent/router.go` — add `GetCached()` method
- `internal/gateway/methods/agents.go` — fix `handleList` for managed mode