### PR TITLE
fix: correct cron job delivery to Discord channels

### DIFF
--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -51,12 +51,13 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 
 		result := outcome.Result
 
-		// If job wants delivery to a channel, publish outbound
+		// If job wants delivery to a channel, send the cron reminder message
+		// directly (not the agent response) so it appears as a bot notification.
 		if job.Payload.Deliver && job.Payload.Channel != "" && job.Payload.To != "" {
 			msgBus.PublishOutbound(bus.OutboundMessage{
 				Channel: job.Payload.Channel,
 				ChatID:  job.Payload.To,
-				Content: result.Content,
+				Content: job.Payload.Message,
 			})
 		}
 

--- a/internal/tools/cron.go
+++ b/internal/tools/cron.go
@@ -217,13 +217,15 @@ func (t *CronTool) handleAdd(ctx context.Context, args map[string]interface{}, a
 	channel, _ := jobObj["channel"].(string)
 	to, _ := jobObj["to"].(string)
 
-	// Auto-fill channel and to from context if deliver is requested but not specified
+	// Auto-fill channel and to from context when deliver is requested.
+	// Always prefer context values over LLM-provided values to prevent
+	// misrouted deliveries (e.g. LLM confusing guild ID with channel ID).
 	if deliver {
-		if channel == "" {
-			channel = ToolChannelFromCtx(ctx)
+		if ctxChannel := ToolChannelFromCtx(ctx); ctxChannel != "" {
+			channel = ctxChannel
 		}
-		if to == "" {
-			to = ToolChatIDFromCtx(ctx)
+		if ctxChatID := ToolChatIDFromCtx(ctx); ctxChatID != "" {
+			to = ctxChatID
 		}
 	}
 


### PR DESCRIPTION
- Override LLM-provided channel ID with context value to prevent misrouted deliveries (LLM was confusing guild ID with channel ID)
- Send cron reminder message directly instead of agent response so reminders appear as bot notifications in Discord