### PR TITLE
fix: OpenAI-compat streaming returns actual token usage

### DIFF
--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -105,10 +105,13 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, req ChatRequest, onChun
 	scanner := bufio.NewScanner(respBody)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "data: ") {
+		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
-		data := strings.TrimPrefix(line, "data: ")
+		// SSE spec allows both "data: value" and "data:value" (space is optional).
+		// Some providers (e.g. Kimi) omit the space after the colon.
+		data := strings.TrimPrefix(line, "data:")
+		data = strings.TrimPrefix(data, " ")
 		if data == "[DONE]" {
 			break
 		}
@@ -116,6 +119,23 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, req ChatRequest, onChun
 		var chunk openAIStreamChunk
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
 			continue
+		}
+
+		// Usage chunk often has empty choices — extract usage before skipping.
+		// When stream_options.include_usage is true, the final chunk contains
+		// usage data but choices is typically an empty array.
+		if chunk.Usage != nil {
+			result.Usage = &Usage{
+				PromptTokens:     chunk.Usage.PromptTokens,
+				CompletionTokens: chunk.Usage.CompletionTokens,
+				TotalTokens:      chunk.Usage.TotalTokens,
+			}
+			if chunk.Usage.PromptTokensDetails != nil {
+				result.Usage.CacheReadTokens = chunk.Usage.PromptTokensDetails.CachedTokens
+			}
+			if chunk.Usage.CompletionTokensDetails != nil && chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
+				result.Usage.ThinkingTokens = chunk.Usage.CompletionTokensDetails.ReasoningTokens
+			}
 		}
 
 		if len(chunk.Choices) == 0 {
@@ -158,20 +178,11 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, req ChatRequest, onChun
 			result.FinishReason = chunk.Choices[0].FinishReason
 		}
 
-		if chunk.Usage != nil {
-			result.Usage = &Usage{
-				PromptTokens:     chunk.Usage.PromptTokens,
-				CompletionTokens: chunk.Usage.CompletionTokens,
-				TotalTokens:      chunk.Usage.TotalTokens,
-			}
-			if chunk.Usage.PromptTokensDetails != nil {
-				result.Usage.CacheReadTokens = chunk.Usage.PromptTokensDetails.CachedTokens
-			}
-			if chunk.Usage.CompletionTokensDetails != nil && chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
-				result.Usage.ThinkingTokens = chunk.Usage.CompletionTokensDetails.ReasoningTokens
-			}
-		}
+	}
 
+	// Check for scanner errors (timeout, connection reset, etc.)
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%s: stream read error: %w", p.name, err)
 	}
 
 	// Parse accumulated tool call arguments


### PR DESCRIPTION
## Summary

- **Fixes #50**: OpenAI-compatible streaming responses always returned `usage: {prompt_tokens: 0, completion_tokens: 0}` because the final `[DONE]` chunk's usage data was never captured
- Parse the last SSE data chunk before `[DONE]` to extract actual `usage` field with real token counts
- Accumulate input/output tokens from the usage summary in the final streaming chunk

## Test plan
- [ ] Stream a chat completion via OpenAI-compat endpoint (`/v1/chat/completions` with `stream: true`)
- [ ] Verify `RunResult.InputTokens` and `OutputTokens` are non-zero after streaming completes
- [ ] Verify traces table records correct token counts for streaming requests
- [ ] Non-streaming requests still work correctly