### PR TITLE
fix: add missing `/v1` to anthropic default API base URL

### DIFF
--- a/cmd/onboard_managed.go
+++ b/cmd/onboard_managed.go
@@ -399,7 +399,7 @@ func resolveProviderAPIBase(providerName string) string {
 	case "openrouter":
 		return "https://openrouter.ai/api/v1"
 	case "anthropic":
-		return "https://api.anthropic.com"
+		return "https://api.anthropic.com/v1"
 	case "openai":
 		return "https://api.openai.com/v1"
 	case "groq":


### PR DESCRIPTION
Small fix for the anthropic default base URL - had me stumped for a couple of hours as to why I was getting 404s after a simple default managed installed with an Anthropic API key