### PR TITLE
fix(openai): increase SSE scanner buffer to 1MB

### DIFF
--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -103,6 +103,7 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, req ChatRequest, onChun
 	accumulators := make(map[int]*toolCallAccumulator)
 
 	scanner := bufio.NewScanner(respBody)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line for large tool call / thinking chunks
 	for scanner.Scan() {
 		line := scanner.Text()
 		if !strings.HasPrefix(line, "data:") {
@@ -178,11 +179,6 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, req ChatRequest, onChun
 			result.FinishReason = chunk.Choices[0].FinishReason
 		}
 
-	}
-
-	// Check for scanner errors (timeout, connection reset, etc.)
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("%s: stream read error: %w", p.name, err)
 	}
 
 	// Check for scanner errors (timeout, connection reset, etc.)


### PR DESCRIPTION
## Summary
- Increase `bufio.Scanner` buffer from default 64KB to 1MB for SSE streaming in OpenAI provider
- Fix duplicate `scanner.Err()` check that was accidentally left in

## Context
Default scanner limit can truncate large SSE lines from tool call arguments or extended thinking content, causing silent JSON parse failures. This matches buffer sizes used in other providers.

Split from #64 for focused review.

## Test plan
- [ ] Verify streaming works with large tool call responses (>64KB SSE lines)
- [ ] `go build ./...` passes