### PR TITLE
fix(channels): Zalo personal group pairing bypass + wrong reply thread type

### DIFF
--- a/internal/channels/zalo/personal/policy.go
+++ b/internal/channels/zalo/personal/policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal/protocol"
@@ -73,9 +74,14 @@ func (c *Channel) sendPairingReply(senderID, chatID string) {
 		senderID, code, code,
 	)
 
+	threadType := protocol.ThreadTypeUser
+	if strings.HasPrefix(senderID, "group:") {
+		threadType = protocol.ThreadTypeGroup
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if _, err := protocol.SendMessage(ctx, sess, chatID, protocol.ThreadTypeUser, replyText); err != nil {
+	if _, err := protocol.SendMessage(ctx, sess, chatID, threadType, replyText); err != nil {
 		slog.Warn("zalo_personal: failed to send pairing reply", "error", err)
 	} else {
 		c.pairingDebounce.Store(senderID, time.Now())
@@ -102,7 +108,7 @@ func (c *Channel) checkGroupPolicy(senderID, groupID string, mentions []*protoco
 		}
 
 	case "pairing":
-		if c.IsAllowed(groupID) {
+		if c.HasAllowList() && c.IsAllowed(groupID) {
 			// pass — allowlist bypass
 		} else if _, cached := c.approvedGroups.Load(groupID); cached {
 			// pass — already approved


### PR DESCRIPTION
## Summary

Fixes #75

- **Group pairing bypass:** `checkGroupPolicy()` used `IsAllowed(groupID)` which returns `true` on empty allowlist, skipping pairing for all groups. Changed to `HasAllowList() && IsAllowed(groupID)` matching the DM pairing pattern.
- **Wrong thread type:** `sendPairingReply()` always used `ThreadTypeUser`. Now detects group sender IDs (`"group:"` prefix) and uses `ThreadTypeGroup` so the pairing reply reaches the group chat.

## Test plan

- [x] `go build ./...` passes
- [x] Set group_policy to "pairing" → @mention bot in group → pairing reply appears in group chat
- [x] Approve pairing → @mention again → agent responds
- [x] DM from unknown user → pairing reply works (regression check)
- [x] Cron job targeting unpaired group → blocked; after pairing → delivered