### PR TITLE
fix(docker): update gateway config check for managed-only 

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -62,37 +62,6 @@ func runGateway() {
 		os.Exit(1)
 	}
 
-	// Auto-detect: if no provider API key is configured, help the user.
-	// Also trigger auto-onboard when config file doesn't exist (first run),
-	// even if env vars provide API keys — DB seeding is required.
-	_, cfgStatErr := os.Stat(cfgPath)
-	configMissing := os.IsNotExist(cfgStatErr)
-	if !cfg.HasAnyProvider() || configMissing {
-		// Docker / CI: env vars provide API keys → non-interactive auto-onboard.
-		if canAutoOnboard() {
-			if runAutoOnboard(cfgPath) {
-				cfg, _ = config.Load(cfgPath)
-			} else {
-				os.Exit(1)
-			}
-		} else if _, statErr := os.Stat(cfgPath); statErr == nil {
-			// Config file exists — user already onboarded but forgot to source .env.local.
-			envPath := filepath.Join(filepath.Dir(cfgPath), ".env.local")
-			fmt.Println("No AI provider API key found. Did you forget to load your secrets?")
-			fmt.Println()
-			fmt.Printf("  source %s && ./goclaw\n", envPath)
-			fmt.Println()
-			fmt.Println("Or re-run the setup wizard:  ./goclaw onboard")
-			os.Exit(1)
-		} else {
-			// No config file at all → first time, redirect to onboard wizard.
-			fmt.Println("No configuration found. Starting setup wizard...")
-			fmt.Println()
-			runOnboard()
-			return
-		}
-	}
-
 	// Create core components
 	msgBus := bus.New()
 


### PR DESCRIPTION
# Summary
Removes the configuration file check logic from gateway startup that is no longer needed after #70 

# Background
The gateway previously included auto-detection logic at startup to:
- Check if any AI provider API key was configured
- Trigger auto-onboard flow when config file didn't exist (first run)
- Guide users to load `.env.local` or run the setup wizard

# Problem
The gateway startup failed in Docker deployments because:
1. The Makefile and docker-compose setup no longer generate a `config.json` file
2. The old code checked for config file existence and attempted to run interactive onboard wizard when missing
3. Docker containers have no interactive terminal, causing startup to hang or fail
4. Configuration is now fully managed via environment variables and database, making the config file check obsolete

This fix removes the blocking config check, allowing the gateway to start properly in containerized environments where config is injected via environment variables.

# Changes
- Removed 31 lines of config check code from `cmd/gateway.go`
- Removed calls to `canAutoOnboard()` and `runAutoOnboard()`
- Removed interactive guidance logic when config file is missing

# Impact
- **Docker deployments**: Simplified startup flow, no longer blocks waiting for configuration
- **Local development**: Users must ensure config file or environment variables are properly set
- **First-time runs**: Users need to manually run `./goclaw onboard` for initialization (if needed)

# Testing Checklist
- [ ] Verify Docker container starts successfully
- [ ] Verify local development environment starts without issues
