### PR TITLE
fix: replace crypto.randomUUID() with fallback for older browsers

### DIFF
--- a/ui/web/src/lib/utils.ts
+++ b/ui/web/src/lib/utils.ts
@@ -9,3 +9,14 @@ let counter = 0;
 export function generateId(): string {
   return `req-${++counter}-${Date.now()}`;
 }
+
+/** Generate a unique ID, with fallback for browsers lacking crypto.randomUUID. */
+export function uniqueId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    return (c === "x" ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}

--- a/ui/web/src/pages/builtin-tools/media-provider-chain-form.tsx
+++ b/ui/web/src/pages/builtin-tools/media-provider-chain-form.tsx
@@ -17,6 +17,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, Trash2, ChevronDown, ChevronUp, Plus } from "lucide-react";
+import { uniqueId } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -76,7 +77,7 @@ function parseInitialEntries(
   // New format: { providers: [...] }
   if (Array.isArray(settings.providers)) {
     return (settings.providers as Record<string, unknown>[]).map((p) => ({
-      id: crypto.randomUUID(),
+      id: uniqueId(),
       provider_id: String(p.provider_id ?? ""),
       provider: String(p.provider ?? ""),
       model: String(p.model ?? ""),
@@ -93,7 +94,7 @@ function parseInitialEntries(
     const providerData = providers.find((p) => p.name === providerName);
     return [
       {
-        id: crypto.randomUUID(),
+        id: uniqueId(),
         provider_id: providerData?.id ?? "",
         provider: providerName,
         model: String(settings.model ?? ""),
@@ -394,7 +395,7 @@ export function MediaProviderChainForm({
     setEntries((prev) => [
       ...prev,
       {
-        id: crypto.randomUUID(),
+        id: uniqueId(),
         provider_id: "",
         provider: "",
         model: "",

--- a/ui/web/src/pages/mcp/mcp-grants-dialog.tsx
+++ b/ui/web/src/pages/mcp/mcp-grants-dialog.tsx
@@ -17,7 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { cn } from "@/lib/utils";
+import { cn, uniqueId } from "@/lib/utils";
 import { useAgents } from "@/pages/agents/hooks/use-agents";
 import type { MCPServerData, MCPAgentGrant, MCPToolInfo } from "./hooks/use-mcp";
 
@@ -123,7 +123,7 @@ export function MCPGrantsDialog({
         setGrants((prev) => [
           ...prev,
           {
-            id: crypto.randomUUID(),
+            id: uniqueId(),
             server_id: server.id,
             agent_id: agentId,
             enabled: true,


### PR DESCRIPTION
## Summary
- Fixes #87
- `crypto.randomUUID()` is unavailable in browsers older than Chrome 92 / Firefox 95 / Safari 15.4
- The uncaught `TypeError` crashes the React component tree, causing a blank white page when opening builtin-tool settings or MCP grant dialogs
- Added a `uniqueId()` helper in `utils.ts` that uses `crypto.randomUUID()` when available and falls back to a `Math.random`-based UUID v4 generator
- Replaced all 4 usages of `crypto.randomUUID()` across `media-provider-chain-form.tsx` and `mcp-grants-dialog.tsx`

## Test plan
- [ ] Open `/builtin-tools`, click Settings on any media tool (e.g. create_image) — dialog should open without blank page
- [ ] Add/remove providers in the chain form — IDs should be generated correctly
- [ ] Open MCP grants dialog, add a grant — should work without errors
- [ ] Test on an older browser (e.g. Chrome < 92) to verify fallback works