### PR TITLE
fix(claude-cli): check scanner.Err() and increase stream buffer to 10MB

### DIFF
--- a/internal/providers/claude_cli_chat.go
+++ b/internal/providers/claude_cli_chat.go
@@ -134,7 +134,7 @@ func (p *ClaudeCLIProvider) ChatStream(ctx context.Context, req ChatRequest, onC
 
 	// Parse stream-json line-by-line
 	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024) // 256KB initial, 1MB max
+	scanner.Buffer(make([]byte, 0, 256*1024), 10*1024*1024) // 256KB initial, 10MB max
 
 	var finalResp ChatResponse
 	var contentBuf strings.Builder
@@ -188,6 +188,10 @@ func (p *ClaudeCLIProvider) ChatStream(ctx context.Context, req ChatRequest, onC
 				}
 			}
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("claude-cli: stream read error: %w", err)
 	}
 
 	if err := cmd.Wait(); err != nil {


### PR DESCRIPTION
## Summary
- Fixes #94
- `ChatStream` uses `bufio.Scanner` but never checks `scanner.Err()` after the scan loop — if a stream-json line exceeds the buffer limit, the scanner stops with `bufio.ErrTooLong` and the response is silently truncated
- Added `scanner.Err()` check after the loop to surface the error explicitly
- Increased max buffer from 1MB to 10MB to handle large tool outputs (e.g. base64 payloads, large JSON blobs)

## Test plan
- [ ] Stream a claude-cli response with normal-sized output — should work as before
- [ ] Trigger a large tool output (>1MB) — should now either succeed (up to 10MB) or return an explicit error instead of silent truncation