### PR TITLE
fix: skip sender allowlist check for group messages

### DIFF
--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -271,7 +271,12 @@ func (c *BaseChannel) ValidatePolicy(dmPolicy, groupPolicy string) {
 // This is the standard way for channels to forward received messages.
 // peerKind should be "direct" or "group" (see sessions.PeerDirect, sessions.PeerGroup).
 func (c *BaseChannel) HandleMessage(senderID, chatID, content string, media []string, metadata map[string]string, peerKind string) {
-	if !c.IsAllowed(senderID) {
+	// For DMs, enforce the allowlist as a safety net.
+	// For group messages, skip this check — group access is already enforced
+	// by the channel-specific group policy (checkGroupPolicy / CheckPolicy).
+	// Re-checking the sender here would incorrectly block users who are not
+	// individually listed but are in an allowed (or open-policy) group.
+	if peerKind != "group" && !c.IsAllowed(senderID) {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- **Bug:** `HandleMessage()` always checked `IsAllowed(senderID)`, which re-gated individual senders against the allowlist even after the channel's group policy (`checkGroupPolicy`) already approved access
- **Impact:** Group members not individually listed in `AllowFrom` were silently blocked — even with `GroupPolicy: "open"` or the group ID in the allowlist
- **Affected channels:** Zalo Personal, Slack (any channel using `HandleMessage` with `peerKind "group"`). Telegram was unaffected (publishes directly to bus)
- **Fix:** `HandleMessage` now only enforces the allowlist for DMs. Group access control is fully delegated to each channel's `checkGroupPolicy`

## Root Cause

```
Group message flow:
1. checkGroupPolicy("open") → PASS ✓
2. @mention gating            → PASS ✓
3. HandleMessage() → IsAllowed(senderID) → FAIL ✗  ← bug here
```

The sender's user ID didn't match any entry in `AllowFrom` (which typically contains group IDs or specific admin user IDs), so the message was silently dropped at step 3.

## Test plan
- [ ] Zalo group with `GroupPolicy: "open"` + non-empty `AllowFrom` — verify non-listed users get responses when mentioning the bot
- [ ] Zalo group with `GroupPolicy: "allowlist"` — verify only allowed groups pass
- [ ] Slack group with `GroupPolicy: "open"` — verify all users can interact
- [ ] DMs still respect `AllowFrom` filtering as before