### PR TITLE
fix(feishu): response websocket event as success

### DIFF
--- a/internal/channels/feishu/larkws.go
+++ b/internal/channels/feishu/larkws.go
@@ -316,11 +316,13 @@ func (c *WSClient) sendResponse(original *wsFrame, headers map[string]string) {
 	respHeaders = append(respHeaders, wsHeader{Key: "biz_rt", Value: "0"})
 
 	respPayload, _ := json.Marshal(map[string]any{
-		"code": 0,
+		"code": http.StatusOK,
 		"msg":  "success",
 	})
 
 	resp := &wsFrame{
+		SeqID:   original.SeqID,
+		LogID:   original.LogID,
 		Method:  frameTypeData,
 		Service: original.Service,
 		Headers: respHeaders,


### PR DESCRIPTION
## Summary

Fix Feishu WebSocket event response to properly acknowledge events with success status and include required frame identifiers (SeqID and LogID) for proper message correlation

**Background:** Feishu server marks pushed messages as failed because our response did not follow the documentation requirements, causing retry attempts. This resulted in a single user message triggering the channel multiple times.

**Impact:** This fix ensures proper event acknowledgment, eliminating duplicate message processing caused by Feishu server retries.

## Changes

**internal/channels/feishu/larkws.go:**
- Replace hardcoded `code: 0` with `http.StatusOK` for better code semantics and readability
- Add `SeqID` and `LogID` fields to response frame, copied from the original request frame to ensure proper message correlation in WebSocket communication

## Test plan

- [x] Verify Feishu WebSocket connection can properly respond to events with success status