### PR TITLE
fix: memory flush UI default should match backend (ON not OFF)

### DIFF
--- a/ui/web/src/pages/agents/agent-detail/config-sections/compaction-section.tsx
+++ b/ui/web/src/pages/agents/agent-detail/config-sections/compaction-section.tsx
@@ -65,14 +65,14 @@ export function CompactionSection({ enabled, value, onToggle, onChange }: Compac
       <div className="space-y-3">
         <div className="flex items-center gap-2">
           <Switch
-            checked={value.memoryFlush?.enabled ?? false}
+            checked={value.memoryFlush?.enabled ?? true}
             onCheckedChange={(v) =>
               onChange({ ...value, memoryFlush: { ...value.memoryFlush, enabled: v } })
             }
           />
           <InfoLabel tip="When enabled, compacted history is also saved to long-term memory for future retrieval.">{t(`${s}.memoryFlush`)}</InfoLabel>
         </div>
-        {value.memoryFlush?.enabled && (
+        {(value.memoryFlush?.enabled ?? true) && (
           <div className="space-y-2 pl-6">
             <InfoLabel tip="Token count threshold that triggers memory flush. When summary exceeds this, older memories are flushed to storage.">{t(`${s}.softThreshold`)}</InfoLabel>
             <Input


### PR DESCRIPTION
## Summary
- Backend defaults `memoryFlush.enabled` to `true` when compaction config is nil (`memoryflush.go:39-46`), but the UI switch used `?? false`, displaying OFF
- Sub-fields (softThresholdTokens input) were also hidden because `undefined && (...)` evaluates to false

## Changes
- `compaction-section.tsx`: `?? false` → `?? true` to match backend default
- `compaction-section.tsx`: `value.memoryFlush?.enabled &&` → `(value.memoryFlush?.enabled ?? true) &&` so sub-fields are visible when using defaults

## Test plan
- [x] Open agent config → Compaction section → Memory Flush toggle should show ON by default (no config set)
- [x] Soft threshold input should be visible when using defaults
- [x] Toggling OFF should hide the input and persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)