### PR TITLE
fix(tools): allow read_file to access CLI workspaces directory

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -510,14 +510,16 @@ func runGateway() {
 	toolsReg.Register(tools.NewMessageTool())
 	slog.Info("session + message tools registered")
 
-	// Allow read_file to access skills directories (outside workspace).
+	// Allow read_file to access skills directories and CLI workspaces (outside workspace).
 	// Skills can live in ~/.goclaw/skills/, ~/.agents/skills/, ~/.goclaw/skills-store/, etc.
+	// CLI workspaces live in ~/.goclaw/cli-workspaces/ (agent working files).
 	homeDir, _ := os.UserHomeDir()
 	if readTool, ok := toolsReg.Get("read_file"); ok {
 		if pa, ok := readTool.(tools.PathAllowable); ok {
 			pa.AllowPaths(globalSkillsDir)
 			if homeDir != "" {
 				pa.AllowPaths(filepath.Join(homeDir, ".agents", "skills"))
+				pa.AllowPaths(filepath.Join(homeDir, ".goclaw", "cli-workspaces"))
 			}
 			// Also allow the skills store directory (uploaded skill content).
 			if pgStores.Skills != nil {


### PR DESCRIPTION
## Summary
- Agents using the Claude CLI provider store working files in `~/.goclaw/cli-workspaces/<session>/`
- When these agents call `read_file` on their own files, access was denied because `cli-workspaces` was not in the `allowedPrefixes` list
- Add `~/.goclaw/cli-workspaces` to `read_file` allowed paths alongside the existing skills directories

## Reproducing
Logs show repeated `security.path_escape` + `read_file: access denied` warnings:

```sh
security.path_escape path=/.goclaw/cli-workspaces/agent-xxx/file.md workspace=/.goclaw/workspace
read_file: access denied allowedPrefixes=[~/.goclaw/skills ~/.agents/skills ~/.goclaw/skills-store]
```

## Test plan
- [ ] Verify agents can read files from their cli-workspaces after the fix
- [ ] Verify `go build ./...` and `go vet ./...` pass
- [ ] Confirm agents still cannot read sensitive dirs (`~/.goclaw/data/`, `~/.goclaw/sessions/`)
