### PR TITLE
Update shared network configuration to specify name and driver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,4 +54,5 @@ volumes:
 
 networks:
   shared:
-    external: true
+    name: shared
+    driver: bridge


### PR DESCRIPTION
## Summary                                                                                                                                                                                                  
                                                                                                                                                                                                            
-   Docker Compose shared network auto-create — change external: true to name: shared + driver: bridge so the network is created automatically on docker compose up                                          
                                                                                                                                                                                                           
## Commits                                                                                                                                                                                                  
1.   660e197 feat(docker): update shared network configuration to specify name and driver

