### PR TITLE
fix: route delegate session keys to correct agent loop

### DIFF
--- a/cmd/gateway_consumer_process.go
+++ b/cmd/gateway_consumer_process.go
@@ -14,10 +14,20 @@ import (
 // It extracts the agentID from the session key and routes to the correct agent loop.
 func makeSchedulerRunFunc(agents *agent.Router, cfg *config.Config) scheduler.RunFunc {
 	return func(ctx context.Context, req agent.RunRequest) (*agent.RunResult, error) {
-		// Extract agentID from session key (format: agent:{agentId}:{rest})
+		// Extract agentID from session key.
+		// Supported formats:
+		//   agent:{agentId}:{rest}
+		//   delegate:{sourceUUID8}:{targetAgentKey}:{delegationId}
 		agentID := cfg.ResolveDefaultAgentID()
-		if parts := strings.SplitN(req.SessionKey, ":", 3); len(parts) >= 2 && parts[0] == "agent" {
-			agentID = parts[1]
+		if parts := strings.SplitN(req.SessionKey, ":", 4); len(parts) >= 2 {
+			switch parts[0] {
+			case "agent":
+				agentID = parts[1]
+			case "delegate":
+				if len(parts) >= 3 {
+					agentID = parts[2]
+				}
+			}
 		}
 
 		loop, err := agents.Get(agentID)


### PR DESCRIPTION
## Summary
- Delegate session keys (`delegate:{uuid8}:{agentKey}:{delegationId}`) were not handled by `makeSchedulerRunFunc`, causing fallback to default agent ID
- This caused `agent default not found` errors when delegated agents spawn subagents
- Add `switch/case` to handle both `agent:` and `delegate:` prefixes

Extracted from #124 (which bundles multiple unrelated changes and has merge conflicts).

## Test plan
- [ ] Build succeeds
- [ ] Trigger a delegation that spawns subagents → no more `agent default not found` errors
- [ ] Normal `agent:` session key routing still works