### PR TITLE
fix: resolve embedding provider from DB registry + per-agent config

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -321,9 +321,18 @@ func runGateway() {
 	}
 
 	// Wire embedding provider to PGMemoryStore so IndexDocument generates vectors.
+	// Per-agent DB config takes priority over config file defaults.
 	if pgStores.Memory != nil {
 		memCfg := cfg.Agents.Defaults.Memory
-		if embProvider := resolveEmbeddingProvider(cfg, memCfg); embProvider != nil {
+		if pgStores.Agents != nil {
+			if defaultAgent, agErr := pgStores.Agents.GetByKey(context.Background(), "default"); agErr == nil {
+				if agentMemCfg := defaultAgent.ParseMemoryConfig(); agentMemCfg != nil {
+					memCfg = agentMemCfg
+					slog.Debug("using per-agent memory config from DB", "agent", defaultAgent.AgentKey)
+				}
+			}
+		}
+		if embProvider := resolveEmbeddingProvider(cfg, memCfg, providerRegistry); embProvider != nil {
 			pgStores.Memory.SetEmbeddingProvider(embProvider)
 			slog.Info("memory embeddings enabled", "provider", embProvider.Name(), "model", embProvider.Model())
 
@@ -478,7 +487,7 @@ func runGateway() {
 		}
 		if pgSkills, ok := pgStores.Skills.(*pg.PGSkillStore); ok {
 			memCfg := cfg.Agents.Defaults.Memory
-			if embProvider := resolveEmbeddingProvider(cfg, memCfg); embProvider != nil {
+			if embProvider := resolveEmbeddingProvider(cfg, memCfg, providerRegistry); embProvider != nil {
 				pgSkills.SetEmbeddingProvider(embProvider)
 				skillSearchTool.SetEmbeddingSearcher(pgSkills, embProvider)
 				slog.Info("skill embeddings enabled", "provider", embProvider.Name())

--- a/cmd/gateway_agents.go
+++ b/cmd/gateway_agents.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"log/slog"
 	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
@@ -13,23 +14,33 @@ import (
 )
 
 // resolveEmbeddingProvider auto-selects an embedding provider based on config and available API keys.
-// Matching TS embedding provider auto-selection order.
-func resolveEmbeddingProvider(cfg *config.Config, memCfg *config.MemoryConfig) memory.EmbeddingProvider {
+// Resolution order:
+//  1. Explicit provider name from memCfg → hardcoded match → registry lookup (DB providers)
+//  2. Auto-detect: openai → openrouter → gemini (config-file keys)
+//
+// The optional providerReg allows resolving DB-stored provider names (e.g. "openai-embedding")
+// that don't match the hardcoded provider names.
+func resolveEmbeddingProvider(cfg *config.Config, memCfg *config.MemoryConfig, providerReg *providers.Registry) memory.EmbeddingProvider {
 	// Explicit provider in config
 	if memCfg != nil && memCfg.EmbeddingProvider != "" {
-		return createEmbeddingProvider(memCfg.EmbeddingProvider, cfg, memCfg)
+		if p := createEmbeddingProvider(memCfg.EmbeddingProvider, cfg, memCfg, providerReg); p != nil {
+			return p
+		}
+		// Explicit name set but no match — don't auto-detect, log and return nil
+		slog.Warn("embedding provider not found", "name", memCfg.EmbeddingProvider)
+		return nil
 	}
 
 	// Auto-select: openai → openrouter → gemini
 	for _, name := range []string{"openai", "openrouter", "gemini"} {
-		if p := createEmbeddingProvider(name, cfg, memCfg); p != nil {
+		if p := createEmbeddingProvider(name, cfg, memCfg, nil); p != nil {
 			return p
 		}
 	}
 	return nil
 }
 
-func createEmbeddingProvider(name string, cfg *config.Config, memCfg *config.MemoryConfig) memory.EmbeddingProvider {
+func createEmbeddingProvider(name string, cfg *config.Config, memCfg *config.MemoryConfig, providerReg *providers.Registry) memory.EmbeddingProvider {
 	model := "text-embedding-3-small"
 	apiBase := ""
 	if memCfg != nil {
@@ -70,6 +81,22 @@ func createEmbeddingProvider(name string, cfg *config.Config, memCfg *config.Mem
 		}
 		return memory.NewOpenAIEmbeddingProvider("gemini", cfg.Providers.Gemini.APIKey, "https://generativelanguage.googleapis.com/v1beta/openai", geminiModel).
 			WithDimensions(1536)
+	}
+
+	// Fallback: resolve from provider registry (DB-stored providers like "openai-embedding").
+	// Any OpenAI-compatible provider in the registry can serve embeddings.
+	if providerReg != nil {
+		if regProv, err := providerReg.Get(name); err == nil {
+			if op, ok := regProv.(*providers.OpenAIProvider); ok {
+				embBase := op.APIBase()
+				if apiBase != "" {
+					embBase = apiBase // memCfg override takes precedence
+				}
+				slog.Info("embedding provider resolved from registry", "name", name, "base", embBase, "model", model)
+				return memory.NewOpenAIEmbeddingProvider(name, op.APIKey(), embBase, model)
+			}
+			slog.Warn("embedding provider in registry is not OpenAI-compatible", "name", name)
+		}
 	}
 	return nil
 }

--- a/cmd/gateway_managed.go
+++ b/cmd/gateway_managed.go
@@ -456,7 +456,7 @@ func wireExtras(
 		var delegateEmbProvider store.EmbeddingProvider
 		if agentStore, ok := stores.Agents.(*pg.PGAgentStore); ok {
 			memCfg := appCfg.Agents.Defaults.Memory
-			if embProvider := resolveEmbeddingProvider(appCfg, memCfg); embProvider != nil {
+			if embProvider := resolveEmbeddingProvider(appCfg, memCfg, providerReg); embProvider != nil {
 				agentStore.SetEmbeddingProvider(embProvider)
 				delegateEmbProvider = embProvider
 				slog.Info("agent embeddings enabled")

--- a/internal/store/pg/memory_admin.go
+++ b/internal/store/pg/memory_admin.go
@@ -127,7 +127,7 @@ func (s *PGMemoryStore) ListChunks(ctx context.Context, agentID, userID, path st
 	var args []any
 	if userID == "" {
 		q = `SELECT c.id, c.start_line, c.end_line,
-				LEFT(c.text, 200) AS text_preview,
+				c.text AS text_preview,
 				(c.embedding IS NOT NULL) AS has_embedding
 			 FROM memory_chunks c
 			 JOIN memory_documents d ON c.document_id = d.id
@@ -136,7 +136,7 @@ func (s *PGMemoryStore) ListChunks(ctx context.Context, agentID, userID, path st
 		args = []any{aid, path}
 	} else {
 		q = `SELECT c.id, c.start_line, c.end_line,
-				LEFT(c.text, 200) AS text_preview,
+				c.text AS text_preview,
 				(c.embedding IS NOT NULL) AS has_embedding
 			 FROM memory_chunks c
 			 JOIN memory_documents d ON c.document_id = d.id

--- a/internal/store/pg/memory_docs.go
+++ b/internal/store/pg/memory_docs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -175,7 +176,12 @@ func (s *PGMemoryStore) IndexDocument(ctx context.Context, agentID, userID, path
 		for i, c := range chunks {
 			texts[i] = c.Text
 		}
-		embeddings, _ = s.provider.Embed(ctx, texts)
+		var embErr error
+		embeddings, embErr = s.provider.Embed(ctx, texts)
+		if embErr != nil {
+			slog.Warn("memory embedding failed, storing chunks without vectors",
+				"path", path, "chunks", len(chunks), "error", embErr)
+		}
 	}
 
 	// Insert chunks


### PR DESCRIPTION
## Summary

- **Embedding provider resolution fails for DB-stored providers**: `resolveEmbeddingProvider()` only matched 3 hardcoded names (`openai`, `openrouter`, `gemini`). DB-stored provider names like `openai-embedding` silently returned nil, causing all memory chunks to be stored without vectors.
- **Per-agent memory config ignored**: Embedding provider was always resolved from config file defaults (`cfg.Agents.Defaults.Memory`), ignoring per-agent memory settings configured via the web UI.
- **Embedding errors silently swallowed**: `IndexDocument()` discarded embedding API errors with `_ =`, making failures invisible in logs.
- **Chunk text truncated in admin UI**: `ListChunks` returned only first 200 chars (`LEFT(c.text, 200)`), causing confusing partial content display.

## Changes

| File | Change |
|------|--------|
| `cmd/gateway_agents.go` | `createEmbeddingProvider()` falls back to provider registry lookup when name doesn't match hardcoded providers. Logs warning when explicit provider name is set but not found. |
| `cmd/gateway.go` | Reads default agent's `memory_config` from DB before resolving embedding provider. DB config takes priority over config file defaults. Passes provider registry to resolver. |
| `cmd/gateway_managed.go` | Passes provider registry to `resolveEmbeddingProvider()` for delegate/agent embeddings. |
| `internal/store/pg/memory_docs.go` | Logs embedding errors via `slog.Warn` instead of discarding with `_ =`. |
| `internal/store/pg/memory_admin.go` | Returns full chunk text instead of `LEFT(c.text, 200)`. Chunks are max 1000 chars so payload size is minimal. |

## Test plan

- [x] Configured `openai-embedding` (DB provider) as embedding provider in agent UI
- [x] Rebuilt and restarted — logs confirm: `embedding provider resolved from registry name=openai-embedding`
- [x] Backfill ran successfully: `memory embeddings backfill complete chunks_updated=2`
- [x] Verified in DB: both chunks have 1536-dim vectors (`embedding IS NOT NULL`)
- [x] Verify chunk text displays fully in admin UI (no truncation)
- [ ] Verify new memory writes get embeddings in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)