### PR TITLE
fix(tools): add AllowPaths support to list_files tool

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -528,6 +528,20 @@ func runGateway() {
 		}
 	}
 
+	// Allow list_files to access skills directories (outside workspace).
+	if listTool, ok := toolsReg.Get("list_files"); ok {
+		if pa, ok := listTool.(tools.PathAllowable); ok {
+			pa.AllowPaths(globalSkillsDir)
+			if homeDir != "" {
+				pa.AllowPaths(filepath.Join(homeDir, ".agents", "skills"))
+				pa.AllowPaths(filepath.Join(homeDir, ".goclaw", "cli-workspaces"))
+			}
+			if pgStores.Skills != nil {
+				pa.AllowPaths(pgStores.Skills.Dirs()...)
+			}
+		}
+	}
+
 	// Memory tools are PG-backed; always available.
 	hasMemory := true
 

--- a/internal/tools/filesystem_list.go
+++ b/internal/tools/filesystem_list.go
@@ -14,6 +14,7 @@ import (
 type ListFilesTool struct {
 	workspace       string
 	restrict        bool
+	allowedPrefixes []string // path prefixes to allow access to (e.g. skills dirs)
 	deniedPrefixes  []string // path prefixes to deny access to (e.g. .goclaw)
 	sandboxMgr      sandbox.Manager
 	contextFileIntc *ContextFileInterceptor // unused, satisfies InterceptorAware
@@ -31,6 +32,12 @@ func (t *ListFilesTool) SetMemoryInterceptor(intc *MemoryInterceptor) {
 // DenyPaths adds path prefixes that list_files must reject/filter.
 func (t *ListFilesTool) DenyPaths(prefixes ...string) {
 	t.deniedPrefixes = append(t.deniedPrefixes, prefixes...)
+}
+
+// AllowPaths adds extra path prefixes that list_files is allowed to access
+// even when restrict_to_workspace is true (e.g. skills directories).
+func (t *ListFilesTool) AllowPaths(prefixes ...string) {
+	t.allowedPrefixes = append(t.allowedPrefixes, prefixes...)
 }
 
 func NewListFilesTool(workspace string, restrict bool) *ListFilesTool {
@@ -88,7 +95,7 @@ func (t *ListFilesTool) Execute(ctx context.Context, args map[string]any) *Resul
 	if workspace == "" {
 		workspace = t.workspace
 	}
-	resolved, err := resolvePath(path, workspace, t.restrict)
+	resolved, err := resolvePathWithAllowed(path, workspace, t.restrict, t.allowedPrefixes)
 	if err != nil {
 		return ErrorResult(err.Error())
 	}


### PR DESCRIPTION
## Summary

Fixes #143

The `list_files` tool was missing the `PathAllowable` interface implementation that `read_file` already had. This caused `access denied: path outside workspace` errors when agents tried to list files in skill directories.

## Problem

- `read_file` can access skill directories via `AllowPaths()` whitelist
- `list_files` lacks this capability and fails with permission errors
- Agents cannot browse skill directory structures

## Solution

- Add `allowedPrefixes` field to `ListFilesTool` struct
- Add `AllowPaths()` method to implement `PathAllowable` interface  
- Use `resolvePathWithAllowed()` instead of `resolvePath()` in `Execute()`
- Add wiring in `gateway.go` to allow `list_files` access to skills directories

## Changes

- `internal/tools/filesystem_list.go`: +9 lines
- `cmd/gateway.go`: +14 lines

## Verification

```bash
go build ./...  # ✓ Compiles successfully
go vet ./internal/tools/...  # ✓ No issues
```

## Checklist

- [x] Code compiles successfully
- [x] Static analysis passes (`go vet`)
- [x] Follows existing code patterns (matches `read_file` implementation)
- [x] Minimal changes focused on the fix