### PR TITLE
fix: honor per-agent restrict_to_workspace from DB

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -73,6 +73,10 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 	if req.ChannelType != "" {
 		ctx = tools.WithToolChannelType(ctx, req.ChannelType)
 	}
+	// Inject per-agent restrict_to_workspace override (from DB) so tools honor per-agent settings.
+	if l.restrictToWs != nil {
+		ctx = tools.WithRestrictToWorkspace(ctx, *l.restrictToWs)
+	}
 
 	// Per-user workspace isolation.
 	// Workspace path comes from user_agent_profiles (includes channel segment

--- a/internal/agent/loop_types.go
+++ b/internal/agent/loop_types.go
@@ -46,6 +46,7 @@ type Loop struct {
 	maxIterations int
 	maxToolCalls  int
 	workspace     string
+	restrictToWs  *bool // per-agent override from DB (nil = use tool default)
 
 	eventPub        bus.EventPublisher // currently unused by Loop; kept for future use
 	sessions        store.SessionStore
@@ -147,6 +148,7 @@ type LoopConfig struct {
 	MaxIterations   int
 	MaxToolCalls    int
 	Workspace       string
+	RestrictToWs    *bool // per-agent DB override (nil = use config default)
 	Bus             bus.EventPublisher
 	Sessions        store.SessionStore
 	Tools           *tools.Registry
@@ -248,6 +250,7 @@ func NewLoop(cfg LoopConfig) *Loop {
 		maxIterations:          cfg.MaxIterations,
 		maxToolCalls:           cfg.MaxToolCalls,
 		workspace:              cfg.Workspace,
+		restrictToWs:           cfg.RestrictToWs,
 		eventPub:               cfg.Bus,
 		sessions:               cfg.Sessions,
 		tools:                  cfg.Tools,

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -345,6 +345,7 @@ func NewManagedResolver(deps ResolverDeps) ResolverFunc {
 			}
 		}
 
+		restrictVal := ag.RestrictToWorkspace
 		loop := NewLoop(LoopConfig{
 			ID:                     ag.AgentKey,
 			AgentUUID:              ag.ID,
@@ -354,6 +355,7 @@ func NewManagedResolver(deps ResolverDeps) ResolverFunc {
 			ContextWindow:          contextWindow,
 			MaxIterations:          maxIter,
 			Workspace:              workspace,
+			RestrictToWs:           &restrictVal,
 			Bus:                    deps.Bus,
 			Sessions:               deps.Sessions,
 			Tools:                  toolsReg,

--- a/internal/tools/context_keys.go
+++ b/internal/tools/context_keys.go
@@ -24,6 +24,7 @@ const (
 	ctxWorkspace   toolContextKey = "tool_workspace"
 	ctxAgentKey    toolContextKey = "tool_agent_key"
 	ctxSessionKey  toolContextKey = "tool_session_key" // origin session key for announce routing
+	ctxRestrictWs  toolContextKey = "tool_restrict_to_workspace"
 )
 
 func WithToolChannel(ctx context.Context, channel string) context.Context {
@@ -98,6 +99,28 @@ func WithToolWorkspace(ctx context.Context, ws string) context.Context {
 func ToolWorkspaceFromCtx(ctx context.Context) string {
 	v, _ := ctx.Value(ctxWorkspace).(string)
 	return v
+}
+
+// WithRestrictToWorkspace injects a per-agent restrict_to_workspace override into context.
+// Tools read this via RestrictFromCtx() to honor per-agent DB settings.
+func WithRestrictToWorkspace(ctx context.Context, restrict bool) context.Context {
+	return context.WithValue(ctx, ctxRestrictWs, restrict)
+}
+
+// RestrictFromCtx returns the per-agent restrict_to_workspace override.
+// Returns (value, true) if set in context, or (false, false) if not set.
+func RestrictFromCtx(ctx context.Context) (bool, bool) {
+	v, ok := ctx.Value(ctxRestrictWs).(bool)
+	return v, ok
+}
+
+// effectiveRestrict returns the per-agent context override if set,
+// otherwise falls back to the tool's constructor default.
+func effectiveRestrict(ctx context.Context, toolDefault bool) bool {
+	if v, ok := RestrictFromCtx(ctx); ok {
+		return v
+	}
+	return toolDefault
 }
 
 // WithToolAgentKey injects the calling agent's key into context.

--- a/internal/tools/edit.go
+++ b/internal/tools/edit.go
@@ -160,7 +160,7 @@ func (t *EditTool) Execute(ctx context.Context, args map[string]any) *Result {
 	if workspace == "" {
 		workspace = t.workspace
 	}
-	resolved, err := resolvePath(path, workspace, t.restrict)
+	resolved, err := resolvePath(path, workspace, effectiveRestrict(ctx, t.restrict))
 	if err != nil {
 		return ErrorResult(err.Error())
 	}

--- a/internal/tools/filesystem.go
+++ b/internal/tools/filesystem.go
@@ -146,7 +146,7 @@ func (t *ReadFileTool) Execute(ctx context.Context, args map[string]any) *Result
 	if workspace == "" {
 		workspace = t.workspace
 	}
-	resolved, err := resolvePathWithAllowed(path, workspace, t.restrict, t.allowedPrefixes)
+	resolved, err := resolvePathWithAllowed(path, workspace, effectiveRestrict(ctx, t.restrict), t.allowedPrefixes)
 	if err != nil {
 		return ErrorResult(err.Error())
 	}

--- a/internal/tools/filesystem_list.go
+++ b/internal/tools/filesystem_list.go
@@ -88,7 +88,7 @@ func (t *ListFilesTool) Execute(ctx context.Context, args map[string]any) *Resul
 	if workspace == "" {
 		workspace = t.workspace
 	}
-	resolved, err := resolvePath(path, workspace, t.restrict)
+	resolved, err := resolvePath(path, workspace, effectiveRestrict(ctx, t.restrict))
 	if err != nil {
 		return ErrorResult(err.Error())
 	}

--- a/internal/tools/filesystem_write.go
+++ b/internal/tools/filesystem_write.go
@@ -128,7 +128,7 @@ func (t *WriteFileTool) Execute(ctx context.Context, args map[string]any) *Resul
 	if workspace == "" {
 		workspace = t.workspace
 	}
-	resolved, err := resolvePath(path, workspace, t.restrict)
+	resolved, err := resolvePath(path, workspace, effectiveRestrict(ctx, t.restrict))
 	if err != nil {
 		return ErrorResult(err.Error())
 	}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -250,7 +250,7 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *Result {
 		cwd = t.workingDir
 	}
 	if wd, _ := args["working_dir"].(string); wd != "" {
-		if t.restrict {
+		if effectiveRestrict(ctx, t.restrict) {
 			resolved, err := resolvePath(wd, t.workingDir, true)
 			if err != nil {
 				return ErrorResult(err.Error())


### PR DESCRIPTION
## Summary

- The per-agent `restrict_to_workspace` toggle (set via UI/API) was stored in the database but never propagated to the tool layer
- All file and exec tools used the global config default (`agents.defaults.restrict_to_workspace`) instead, so toggling the setting per-agent had no effect
- Fix: pass the DB value through context (same pattern as `WithToolWorkspace`) and have each tool check the context override before falling back to the constructor default

## Changes

- **`tools/context_keys.go`**: Add `ctxRestrictWs` context key with `WithRestrictToWorkspace()` / `RestrictFromCtx()` + `effectiveRestrict()` helper
- **`agent/loop_types.go`**: Add `RestrictToWs *bool` to `Loop` and `LoopConfig` (nil = use tool default)
- **`agent/loop.go`**: Inject per-agent value into context via `WithRestrictToWorkspace()` in `runLoop()`
- **`agent/resolver.go`**: Pass `ag.RestrictToWorkspace` from `AgentData` (DB) into `LoopConfig`
- **5 tools** (`read_file`, `write_file`, `list_files`, `edit`, `exec`): Use `effectiveRestrict(ctx, t.restrict)` instead of `t.restrict`

## How it works

```
DB (agents.restrict_to_workspace)
  → resolver.go: LoopConfig.RestrictToWs = &ag.RestrictToWorkspace
    → loop.go: ctx = WithRestrictToWorkspace(ctx, *l.restrictToWs)
      → tools: effectiveRestrict(ctx, t.restrict) → context override wins
```

Subagents inherit the parent's value via context. Delegated agents get their own DB value (resolved independently).

## Test plan

- [ ] Set `restrict_to_workspace = true` (default) on an agent → verify file tools reject paths outside workspace
- [ ] Toggle `restrict_to_workspace = false` on the same agent via UI → verify file tools allow paths like `/tmp`
- [ ] Verify other agents with `restrict_to_workspace = true` are still restricted
- [ ] Verify subagent inherits parent's restrict setting