### PR TITLE
fix(http): use provider API base for anthropic model listing

### DIFF
--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -57,7 +57,7 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 
 	switch p.ProviderType {
 	case "anthropic_native":
-		models, err = fetchAnthropicModels(ctx, p.APIKey)
+		models, err = fetchAnthropicModels(ctx, p.APIKey, p.APIBase)
 	case "gemini_native":
 		models, err = fetchGeminiModels(ctx, p.APIKey)
 	case "bailian":
@@ -88,8 +88,12 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 }
 
 // fetchAnthropicModels calls the Anthropic models API.
-func fetchAnthropicModels(ctx context.Context, apiKey string) ([]ModelInfo, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.anthropic.com/v1/models", nil)
+func fetchAnthropicModels(ctx context.Context, apiKey, apiBase string) ([]ModelInfo, error) {
+	base := strings.TrimRight(apiBase, "/")
+	if base == "" {
+		base = "https://api.anthropic.com/v1"
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", base+"/models", nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- cherry-pick the fix that respects the provider API base when listing Anthropic models

## Test Plan
- not run (not requested)