### PR TITLE
fix: remove legacy per-agent imageGen/vision that silently overrides provider chain

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -56,16 +56,7 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 	if req.SenderID != "" {
 		ctx = store.WithSenderID(ctx, req.SenderID)
 	}
-	// Inject per-agent vision/imagegen config for read_image/create_image tools
-	if l.agentToolPolicy != nil {
-		if l.agentToolPolicy.Vision != nil {
-			ctx = tools.WithVisionConfig(ctx, l.agentToolPolicy.Vision)
-		}
-		if l.agentToolPolicy.ImageGen != nil {
-			ctx = tools.WithImageGenConfig(ctx, l.agentToolPolicy.ImageGen)
-		}
-	}
-	// Inject global builtin tool settings (DB-level defaults, lower priority than per-agent)
+	// Inject global builtin tool settings for media tools (provider chain)
 	if l.builtinToolSettings != nil {
 		ctx = tools.WithBuiltinToolSettings(ctx, l.builtinToolSettings)
 	}

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -341,22 +341,6 @@ type ToolPolicySpec struct {
 	Deny       []string                   `json:"deny,omitempty"`
 	AlsoAllow  []string                   `json:"alsoAllow,omitempty"`
 	ByProvider map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
-	Vision     *VisionConfig              `json:"vision,omitempty"`   // per-agent vision provider/model override
-	ImageGen   *ImageGenConfig            `json:"imageGen,omitempty"` // per-agent image generation config
-}
-
-// VisionConfig configures the provider and model for vision tools (read_image).
-type VisionConfig struct {
-	Provider string `json:"provider,omitempty"` // e.g. "gemini", "anthropic"
-	Model    string `json:"model,omitempty"`    // e.g. "gemini-2.0-flash"
-}
-
-// ImageGenConfig configures the provider and model for image generation (create_image).
-type ImageGenConfig struct {
-	Provider string `json:"provider,omitempty"` // provider with image gen API (e.g. "openrouter")
-	Model    string `json:"model,omitempty"`    // e.g. "google/gemini-2.5-flash-image-preview"
-	Size     string `json:"size,omitempty"`     // default aspect ratio / size
-	Quality  string `json:"quality,omitempty"`  // "standard" or "hd"
 }
 
 type WebToolsConfig struct {

--- a/internal/tools/context_keys.go
+++ b/internal/tools/context_keys.go
@@ -125,31 +125,6 @@ func ToolSessionKeyFromCtx(ctx context.Context) string {
 	return v
 }
 
-// --- Vision / ImageGen config (per-agent overrides) ---
-
-const (
-	ctxVisionConfig   toolContextKey = "tool_vision_config"
-	ctxImageGenConfig toolContextKey = "tool_imagegen_config"
-)
-
-func WithVisionConfig(ctx context.Context, cfg *config.VisionConfig) context.Context {
-	return context.WithValue(ctx, ctxVisionConfig, cfg)
-}
-
-func VisionConfigFromCtx(ctx context.Context) *config.VisionConfig {
-	v, _ := ctx.Value(ctxVisionConfig).(*config.VisionConfig)
-	return v
-}
-
-func WithImageGenConfig(ctx context.Context, cfg *config.ImageGenConfig) context.Context {
-	return context.WithValue(ctx, ctxImageGenConfig, cfg)
-}
-
-func ImageGenConfigFromCtx(ctx context.Context) *config.ImageGenConfig {
-	v, _ := ctx.Value(ctxImageGenConfig).(*config.ImageGenConfig)
-	return v
-}
-
 // --- Builtin tool settings (global DB overrides) ---
 
 const ctxBuiltinToolSettings toolContextKey = "tool_builtin_settings"

--- a/internal/tools/create_image.go
+++ b/internal/tools/create_image.go
@@ -78,14 +78,7 @@ func (t *CreateImageTool) Execute(ctx context.Context, args map[string]any) *Res
 		aspectRatio = "1:1"
 	}
 
-	// Extract per-agent config for backward compat
-	var perAgentProvider, perAgentModel string
-	if cfg := ImageGenConfigFromCtx(ctx); cfg != nil {
-		perAgentProvider = cfg.Provider
-		perAgentModel = cfg.Model
-	}
-
-	chain := ResolveMediaProviderChain(ctx, "create_image", perAgentProvider, perAgentModel,
+	chain := ResolveMediaProviderChain(ctx, "create_image", "", "",
 		imageGenProviderPriority, imageGenModelDefaults, t.registry)
 
 	// Inject prompt and aspect_ratio into each chain entry's params

--- a/internal/tools/read_image.go
+++ b/internal/tools/read_image.go
@@ -75,14 +75,7 @@ func (t *ReadImageTool) Execute(ctx context.Context, args map[string]any) *Resul
 		return ErrorResult("No images available in this conversation. The user may not have sent an image.")
 	}
 
-	// Extract per-agent config for backward compat
-	var perAgentProvider, perAgentModel string
-	if cfg := VisionConfigFromCtx(ctx); cfg != nil {
-		perAgentProvider = cfg.Provider
-		perAgentModel = cfg.Model
-	}
-
-	chain := ResolveMediaProviderChain(ctx, "read_image", perAgentProvider, perAgentModel,
+	chain := ResolveMediaProviderChain(ctx, "read_image", "", "",
 		visionProviderPriority, visionModelDefaults, t.registry)
 
 	// Inject prompt and images into each chain entry's params

--- a/ui/web/src/pages/agents/agent-detail/agent-config-tab.tsx
+++ b/ui/web/src/pages/agents/agent-detail/agent-config-tab.tsx
@@ -77,7 +77,9 @@ export function AgentConfigTab({ agent, onUpdate }: AgentConfigTabProps) {
     try {
       const updates: Record<string, unknown> = {
         subagents_config: subEnabled ? sub : null,
-        tools_config: toolsEnabled ? tools : {},
+        tools_config: toolsEnabled
+          ? { profile: tools.profile, allow: tools.allow, deny: tools.deny, alsoAllow: tools.alsoAllow }
+          : {},
         compaction_config: comp,
         context_pruning: pruneEnabled ? prune : null,
         sandbox_config: sbEnabled ? sb : null,


### PR DESCRIPTION
## Summary

- **Remove dead code**: `VisionConfig` and `ImageGenConfig` structs + per-agent override logic added in `d5cc5a7` (Feb 26) were superseded by the media provider chain system (`5815437`, Mar 8) but kept "for backward compat"
- **Fix silent override bug**: If an agent's `tools_config` JSONB contains stale `imageGen`/`vision` data, it silently overrides the global provider chain configured in the builtin tools UI — the user sees the correct chain but the tool calls a completely different provider/model with no indication of why
- **No UI ever existed** for these per-agent fields — they could only be set via direct DB/API access, making them invisible and unmanageable
- **UI cleanup**: Agent config save now whitelists known `tools_config` fields (`profile`, `allow`, `deny`, `alsoAllow`) to prevent stale data from persisting

### Files changed

| File | Change |
|------|--------|
| `config_channels.go` | Remove `Vision`, `ImageGen` fields + `VisionConfig`, `ImageGenConfig` struct definitions |
| `context_keys.go` | Remove 4 context functions + 2 context key constants |
| `loop.go` | Remove per-agent vision/imagegen context injection |
| `create_image.go` | Remove per-agent extraction — chain is sole source of truth |
| `read_image.go` | Remove per-agent extraction — chain is sole source of truth |
| `agent-config-tab.tsx` | Whitelist known fields on save to clean stale DB data |

## Test plan

- [ ] Configure a provider chain for `create_image` in builtin tools UI → verify it's used (no silent override)
- [ ] Configure a provider chain for `read_image` in builtin tools UI → verify it's used
- [ ] Save agent config → verify `tools_config` no longer contains `imageGen`/`vision` keys
- [ ] Agents with existing `imageGen`/`vision` in DB → verify they're ignored (Go struct skips unknown JSON keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)