### PR TITLE
fix: resolve media provider type from DB instead of guessing from name

### DIFF
--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -318,6 +318,7 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			registry.Register(providers.NewOpenAIProvider(p.Name, p.APIKey, base, ""))
 		default:
 			prov := providers.NewOpenAIProvider(p.Name, p.APIKey, p.APIBase, "")
+			prov.WithProviderType(p.ProviderType)
 			if p.ProviderType == store.ProviderMiniMax {
 				prov.WithChatPath("/text/chatcompletion_v2")
 			}

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -20,6 +20,7 @@ type OpenAIProvider struct {
 	apiBase      string
 	chatPath     string // defaults to "/chat/completions"
 	defaultModel string
+	providerType string // DB provider_type (e.g. "gemini_native", "openai", "minimax_native")
 	client       *http.Client
 	retryConfig  RetryConfig
 }
@@ -52,6 +53,13 @@ func (p *OpenAIProvider) DefaultModel() string   { return p.defaultModel }
 func (p *OpenAIProvider) SupportsThinking() bool { return true }
 func (p *OpenAIProvider) APIKey() string         { return p.apiKey }
 func (p *OpenAIProvider) APIBase() string        { return p.apiBase }
+func (p *OpenAIProvider) ProviderType() string   { return p.providerType }
+
+// WithProviderType sets the DB provider_type for correct API endpoint routing in media tools.
+func (p *OpenAIProvider) WithProviderType(pt string) *OpenAIProvider {
+	p.providerType = pt
+	return p
+}
 
 // resolveModel returns the model ID to use for a request.
 // For OpenRouter, model IDs require a provider prefix (e.g. "anthropic/claude-sonnet-4-5-20250929").

--- a/internal/tools/create_audio.go
+++ b/internal/tools/create_audio.go
@@ -181,7 +181,7 @@ func (t *CreateAudioTool) callProvider(ctx context.Context, cp credentialProvide
 	slog.Info("create_audio: calling music generation API",
 		"provider", providerName, "model", model)
 
-	switch ProviderTypeFromName(providerName) {
+	switch GetParamString(params, "_provider_type", providerTypeFromName(providerName)) {
 	case "minimax":
 		return callMinimaxMusicGen(ctx, cp.APIKey(), cp.APIBase(), model, prompt, params)
 	case "suno":

--- a/internal/tools/create_image.go
+++ b/internal/tools/create_image.go
@@ -131,7 +131,7 @@ func (t *CreateImageTool) callProvider(ctx context.Context, cp credentialProvide
 	slog.Info("create_image: calling image generation API",
 		"provider", providerName, "model", model, "aspect_ratio", aspectRatio)
 
-	switch ProviderTypeFromName(providerName) {
+	switch GetParamString(params, "_provider_type", providerTypeFromName(providerName)) {
 	case "gemini":
 		return t.callGeminiNativeImageGen(ctx, cp.APIKey(), cp.APIBase(), model, prompt, params)
 	case "openrouter":

--- a/internal/tools/create_video.go
+++ b/internal/tools/create_video.go
@@ -150,7 +150,7 @@ func (t *CreateVideoTool) callProvider(ctx context.Context, cp credentialProvide
 	slog.Info("create_video: calling video generation API",
 		"provider", providerName, "model", model, "duration", duration, "aspect_ratio", aspectRatio)
 
-	switch ProviderTypeFromName(providerName) {
+	switch GetParamString(params, "_provider_type", providerTypeFromName(providerName)) {
 	case "gemini":
 		return t.callGeminiVideoGen(ctx, cp.APIKey(), cp.APIBase(), model, prompt, duration, aspectRatio, params)
 	case "minimax":

--- a/internal/tools/media_provider_chain.go
+++ b/internal/tools/media_provider_chain.go
@@ -174,6 +174,14 @@ func ExecuteWithChain(
 		// callProvider falls back to using the provider's Chat() API.
 		cp, _ := p.(credentialProvider)
 
+		// Inject resolved provider type into params so callProvider can route correctly.
+		// This uses the actual DB provider_type instead of guessing from the name.
+		resolvedType := ResolveProviderType(p)
+		if entry.Params == nil {
+			entry.Params = make(map[string]any)
+		}
+		entry.Params["_provider_type"] = resolvedType
+
 		// Retry loop for this provider
 		for attempt := 1; attempt <= entry.MaxRetries; attempt++ {
 			timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(entry.Timeout)*time.Second)
@@ -281,9 +289,42 @@ func GetParamInt(params map[string]any, key string, fallback int) int {
 	return fallback
 }
 
-// ProviderTypeFromName returns the provider_type based on known provider naming patterns.
-// Used to determine which API endpoint to call.
-func ProviderTypeFromName(name string) string {
+// typedProvider is optionally implemented by providers that carry their DB provider_type.
+type typedProvider interface {
+	ProviderType() string
+}
+
+// dbTypeToMediaType maps DB provider_type values to the media routing type
+// used by callProvider switch statements.
+var dbTypeToMediaType = map[string]string{
+	"gemini_native":    "gemini",
+	"openai":           "openai",
+	"openrouter":       "openrouter",
+	"minimax_native":   "minimax",
+	"dashscope":        "dashscope",
+	"anthropic_native": "anthropic",
+	"suno":             "suno",
+}
+
+// ResolveProviderType returns the media routing type for a provider.
+// It first checks the provider's DB type (via typedProvider interface),
+// then falls back to name-based heuristics for config-registered providers.
+func ResolveProviderType(p providers.Provider) string {
+	// Prefer the actual DB provider_type when available
+	if tp, ok := p.(typedProvider); ok {
+		if pt := tp.ProviderType(); pt != "" {
+			if mt, found := dbTypeToMediaType[pt]; found {
+				return mt
+			}
+		}
+	}
+	// Fallback: infer from provider name (for config-registered providers)
+	return providerTypeFromName(p.Name())
+}
+
+// providerTypeFromName infers provider type from naming patterns.
+// Used as fallback when the provider doesn't carry its DB type.
+func providerTypeFromName(name string) string {
 	switch {
 	case name == "gemini" || strings.HasPrefix(name, "gemini"):
 		return "gemini"

--- a/internal/tools/read_audio_resolve.go
+++ b/internal/tools/read_audio_resolve.go
@@ -62,12 +62,13 @@ func (t *ReadAudioTool) callProvider(ctx context.Context, cp credentialProvider,
 
 	// Provider-specific paths require API credentials; skip when cp is nil
 	// (e.g. OAuth-based providers that don't expose static keys).
-	if cp == nil && (strings.HasPrefix(providerName, "gemini") || strings.HasPrefix(providerName, "openai")) {
+	ptype := GetParamString(params, "_provider_type", providerTypeFromName(providerName))
+	if cp == nil && (ptype == "gemini" || ptype == "openai") {
 		slog.Info("read_audio: no API credentials, falling back to Chat API", "provider", providerName)
 	}
 	if cp != nil {
 		// Gemini: use File API (inlineData doesn't work for audio).
-		if strings.HasPrefix(providerName, "gemini") {
+		if ptype == "gemini" {
 			slog.Info("read_audio: using gemini file API", "provider", providerName, "model", model, "size", len(data), "mime", mime)
 			resp, err := geminiFileAPICall(ctx, cp.APIKey(), model, prompt, data, mime, 120*time.Second)
 			if err != nil {
@@ -77,7 +78,7 @@ func (t *ReadAudioTool) callProvider(ctx context.Context, cp credentialProvider,
 		}
 
 		// OpenAI: use input_audio content part (supports wav, mp3).
-		if strings.HasPrefix(providerName, "openai") {
+		if ptype == "openai" {
 			slog.Info("read_audio: using openai input_audio API", "provider", providerName, "model", model, "size", len(data), "mime", mime)
 			resp, err := openaiAudioCall(ctx, cp.APIKey(), cp.APIBase(), model, prompt, data, mime)
 			if err != nil {

--- a/internal/tools/read_document_resolve.go
+++ b/internal/tools/read_document_resolve.go
@@ -62,7 +62,8 @@ func (t *ReadDocumentTool) callProvider(ctx context.Context, cp credentialProvid
 	mime := GetParamString(params, "mime", "application/octet-stream")
 
 	// Gemini: use native API (requires credentials; OpenAI-compat endpoint doesn't support non-image MIME types).
-	if cp != nil && strings.HasPrefix(providerName, "gemini") {
+	ptype := GetParamString(params, "_provider_type", providerTypeFromName(providerName))
+	if cp != nil && ptype == "gemini" {
 		slog.Info("read_document: using gemini native API",
 			"provider", providerName, "model", model,
 			"doc_size", len(data), "mime", mime)

--- a/internal/tools/read_video_resolve.go
+++ b/internal/tools/read_video_resolve.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
@@ -60,7 +59,8 @@ func (t *ReadVideoTool) callProvider(ctx context.Context, cp credentialProvider,
 	mime := GetParamString(params, "mime", "video/mp4")
 
 	// Gemini: use File API (requires credentials).
-	if cp != nil && strings.HasPrefix(providerName, "gemini") {
+	ptype := GetParamString(params, "_provider_type", providerTypeFromName(providerName))
+	if cp != nil && ptype == "gemini" {
 		slog.Info("read_video: using gemini file API", "provider", providerName, "model", model, "size", len(data), "mime", mime)
 		resp, err := geminiFileAPICall(ctx, cp.APIKey(), model, prompt, data, mime, 180*time.Second)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Media tools (`create_image`, `create_video`, `create_audio`, `read_audio`, `read_video`, `read_document`) routed API calls based on **provider name pattern matching** (`strings.HasPrefix(name, "gemini")`). This breaks when users give custom names to DB providers — e.g. a `gemini_native` provider named `"chatgpt-sap-het"` gets misrouted to the OpenAI-compat `/images/generations` endpoint instead of Gemini's native `generateContent`, causing 404 errors.
- The `provider_type` is already stored correctly in the DB (`llm_providers.provider_type`), but it was **lost during provider registration** — `OpenAIProvider` struct didn't carry it, so the chain code had no way to access it and fell back to name guessing.

## Changes

1. **`OpenAIProvider`** — added `providerType` field + `ProviderType()` accessor + `WithProviderType()` setter
2. **`registerProvidersFromDB`** — calls `prov.WithProviderType(p.ProviderType)` in the default case so DB type is preserved
3. **`media_provider_chain.go`** — new `ResolveProviderType()` checks the provider's DB type via `typedProvider` interface, falls back to name heuristics for config-file providers. `ExecuteWithChain()` injects resolved type as `_provider_type` param
4. **All `callProvider()` functions** — read `_provider_type` from params instead of calling `ProviderTypeFromName(providerName)` directly. Affects: `create_image`, `create_video`, `create_audio`, `read_audio`, `read_video`, `read_document`
5. **`ProviderTypeFromName`** → renamed to unexported `providerTypeFromName` (fallback only, no external callers)

## Reproduction

1. Create a provider via UI with `provider_type = gemini_native` but a non-standard name (e.g. `"chatgpt-sap-het"`)
2. Configure `create_image` chain to use this provider with model `gemini-3.1-flash-image-preview`
3. Try generating an image → **Before fix:** 404 error (`models/gemini-3.1-flash-image-preview is not found`). **After fix:** routes correctly to Gemini native API

## Test plan

- [ ] Create image with custom-named Gemini provider → should route to native `generateContent`
- [ ] Create image with config-file `gemini` provider → should still work (fallback)
- [ ] Create video with Gemini/MiniMax → verify routing unchanged
- [ ] Read audio/video/document with custom-named provider → verify correct API path

🤖 Generated with [Claude Code](https://claude.com/claude-code)