### PR TITLE
fix(cron): auto-default deliver=true when job created from channel chat

### DIFF
--- a/internal/tools/cron.go
+++ b/internal/tools/cron.go
@@ -230,6 +230,20 @@ func (t *CronTool) handleAdd(ctx context.Context, args map[string]any, agentID, 
 	channel, _ := jobObj["channel"].(string)
 	to, _ := jobObj["to"].(string)
 
+	// Auto-default deliver=true when the request comes from a real channel
+	// (not CLI/system/subagent). Users chatting on Zalo/Telegram expect
+	// cron results delivered back to the same chat.
+	if !deliver {
+		if ctxChannel := ToolChannelFromCtx(ctx); ctxChannel != "" {
+			switch ctxChannel {
+			case "cli", "system", "subagent", "cron", "delegate":
+				// internal channels — don't auto-deliver
+			default:
+				deliver = true
+			}
+		}
+	}
+
 	// Auto-fill channel and to from context when deliver is requested.
 	// Always prefer context values over LLM-provided values to prevent
 	// misrouted deliveries (e.g. LLM confusing guild ID with channel ID).


### PR DESCRIPTION
## Summary

- When users create cron jobs from channel chats (Zalo, Telegram, Discord, etc.), the LLM often omits the `deliver` flag since it defaults to `false`
- This causes cron jobs to run successfully but **silently discard results** — the response never reaches the chat where the user requested it
- The existing auto-fill logic for `channel` and `to` only runs when `deliver=true`, so both delivery target fields are also lost

**Fix:** Auto-detect channel context before the auto-fill block. If the request comes from a real channel (not internal: cli/system/subagent/cron/delegate), default `deliver=true`. The existing auto-fill logic then captures `channel` and `chatID` from context as expected.

## Test plan

- [ ] Create a cron job from a channel chat (e.g. Zalo/Telegram) without explicitly setting `deliver: true` → verify job is saved with `deliver=true` and correct `channel`/`to`
- [ ] Create a cron job from CLI → verify `deliver` remains `false` (no auto-delivery)
- [ ] Create a cron job with explicit `deliver: false` from a channel → verify it stays `false` (user intent respected)
- [ ] Existing cron jobs with explicit `deliver: true` continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)