### PR TITLE
fix: read_audio fails when LLM passes literal media tag as media_id

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -259,6 +259,8 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 	}
 	if len(audioRefs) > 0 {
 		ctx = tools.WithMediaAudioRefs(ctx, audioRefs)
+		// Embed media IDs into <media:audio> tags so LLM can reference them.
+		l.enrichAudioIDs(messages, mediaRefs)
 	}
 
 	// 2d. Collect video MediaRefs (historical + current) for read_video tool.

--- a/internal/agent/media.go
+++ b/internal/agent/media.go
@@ -163,6 +163,47 @@ func (l *Loop) enrichDocumentPaths(messages []providers.Message, refs []provider
 	messages[lastIdx].Content = content
 }
 
+// enrichAudioIDs updates the last user message to embed persisted media IDs
+// in <media:audio> and <media:voice> tags so the LLM can reference them.
+// Without this, the LLM sees plain <media:audio> and cannot pass a valid media_id.
+func (l *Loop) enrichAudioIDs(messages []providers.Message, refs []providers.MediaRef) {
+	if len(messages) == 0 {
+		return
+	}
+	lastIdx := -1
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" {
+			lastIdx = i
+			break
+		}
+	}
+	if lastIdx < 0 {
+		return
+	}
+
+	content := messages[lastIdx].Content
+	for _, ref := range refs {
+		if ref.Kind != "audio" {
+			continue
+		}
+		idAttr := fmt.Sprintf(" id=%q", ref.ID)
+
+		// Replace bare <media:audio> with <media:audio id="uuid">
+		bare := "<media:audio>"
+		if strings.Contains(content, bare) {
+			content = strings.Replace(content, bare, "<media:audio"+idAttr+">", 1)
+			continue
+		}
+		// Replace bare <media:voice> with <media:voice id="uuid">
+		bareVoice := "<media:voice>"
+		if strings.Contains(content, bareVoice) {
+			content = strings.Replace(content, bareVoice, "<media:voice"+idAttr+">", 1)
+			continue
+		}
+	}
+	messages[lastIdx].Content = content
+}
+
 // mediaKindFromMime returns the media kind ("image", "video", "audio", "document")
 // based on MIME type prefix.
 func mediaKindFromMime(mime string) string {

--- a/internal/tools/read_audio_resolve.go
+++ b/internal/tools/read_audio_resolve.go
@@ -23,6 +23,13 @@ func (t *ReadAudioTool) resolveAudioFile(ctx context.Context, mediaID string) (p
 		return "", "", fmt.Errorf("no audio files available in this conversation. The user may not have sent an audio file.")
 	}
 
+	// Sanitize media_id: LLM may pass the literal tag string (e.g. "<media:audio>")
+	// instead of a UUID. Treat tag-like values as empty to fall back to most recent.
+	if strings.Contains(mediaID, "<") || strings.Contains(mediaID, "media:") {
+		slog.Debug("read_audio: sanitizing tag-like media_id", "raw", mediaID)
+		mediaID = ""
+	}
+
 	var ref *providers.MediaRef
 	if mediaID != "" {
 		for i := range refs {
@@ -32,7 +39,10 @@ func (t *ReadAudioTool) resolveAudioFile(ctx context.Context, mediaID string) (p
 			}
 		}
 		if ref == nil {
-			return "", "", fmt.Errorf("audio with media_id %q not found in conversation", mediaID)
+			// Fallback to most recent audio instead of hard error,
+			// since LLM may generate invalid IDs.
+			slog.Warn("read_audio: media_id not found, falling back to most recent", "media_id", mediaID)
+			ref = &refs[len(refs)-1]
 		}
 	} else {
 		ref = &refs[len(refs)-1]


### PR DESCRIPTION
## Summary

- **Bug:** `read_audio` tool always errors with `"audio with media_id '<media:audio>' not found in conversation"` because the LLM passes the literal `<media:audio>` placeholder tag as `media_id` — which never matches any UUID in the stored MediaRefs.
- **Root cause:** `BuildMediaTags()` creates bare `<media:audio>` tags without IDs. `persistMedia()` generates UUIDs later but never embeds them back into the message content. The LLM has no way to know the actual media ID.
- **Fix (two parts):**
  1. `enrichAudioIDs()` — embeds persisted UUIDs into `<media:audio>` / `<media:voice>` tags (following the existing `enrichDocumentPaths()` pattern for documents), so the LLM sees `<media:audio id="uuid">` and can pass valid IDs
  2. `resolveAudioFile()` — sanitizes tag-like `media_id` values (containing `<` or `media:`) and falls back to the most recent audio instead of returning a hard error on unmatched IDs

## Test plan

- [ ] Send audio/voice message via Telegram → agent should transcribe without error
- [ ] Send multiple audio messages in same conversation → verify correct audio is referenced
- [ ] Verify `<media:audio id="...">` appears in LLM message content (check trace/logs)
- [ ] Verify fallback: if LLM still passes invalid media_id, it gracefully uses most recent audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)