### PR TITLE
feat: add unified Tools page with managed code-project tools

### DIFF
--- a/internal/gateway/methods/managed_tools.go
+++ b/internal/gateway/methods/managed_tools.go
@@ -1,0 +1,108 @@
+package methods
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/nextlevelbuilder/goclaw/internal/gateway"
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+// ManagedToolsMethods handles managed-tools.list, managed-tools.get.
+type ManagedToolsMethods struct {
+	store store.ManagedToolStore
+}
+
+func NewManagedToolsMethods(s store.ManagedToolStore) *ManagedToolsMethods {
+	return &ManagedToolsMethods{store: s}
+}
+
+func (m *ManagedToolsMethods) Register(router *gateway.MethodRouter) {
+	router.Register(protocol.MethodManagedToolsList, m.handleList)
+	router.Register(protocol.MethodManagedToolsGet, m.handleGet)
+}
+
+func (m *ManagedToolsMethods) handleList(_ context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	allTools := m.store.ListManagedTools()
+
+	result := make([]map[string]any, 0, len(allTools))
+	for _, t := range allTools {
+		entry := map[string]any{
+			"name":        t.Name,
+			"slug":        t.Slug,
+			"description": t.Description,
+			"version":     t.Version,
+			"is_system":   t.IsSystem,
+			"enabled":     t.Enabled,
+		}
+		if t.ID != "" {
+			entry["id"] = t.ID
+		}
+		if t.Visibility != "" {
+			entry["visibility"] = t.Visibility
+		}
+		if len(t.Tags) > 0 {
+			entry["tags"] = t.Tags
+		}
+		if t.Status != "" {
+			entry["status"] = t.Status
+		}
+		if t.Runtime != nil {
+			entry["runtime"] = *t.Runtime
+		}
+		if t.EntryPoint != nil {
+			entry["entry_point"] = *t.EntryPoint
+		}
+		result = append(result, entry)
+	}
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		"tools": result,
+	}))
+}
+
+func (m *ManagedToolsMethods) handleGet(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	locale := store.LocaleFromContext(ctx)
+	var params struct {
+		Name string `json:"name"`
+	}
+	if req.Params != nil {
+		json.Unmarshal(req.Params, &params)
+	}
+	if params.Name == "" {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, i18n.T(locale, i18n.MsgRequired, "name")))
+		return
+	}
+
+	info, ok := m.store.GetManagedTool(params.Name)
+	if !ok {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrNotFound, i18n.T(locale, i18n.MsgNotFound, "managed tool", params.Name)))
+		return
+	}
+
+	resp := map[string]any{
+		"name":        info.Name,
+		"slug":        info.Slug,
+		"description": info.Description,
+		"version":     info.Version,
+		"enabled":     info.Enabled,
+	}
+	if info.ID != "" {
+		resp["id"] = info.ID
+	}
+	if info.Visibility != "" {
+		resp["visibility"] = info.Visibility
+	}
+	if len(info.Tags) > 0 {
+		resp["tags"] = info.Tags
+	}
+	if info.Runtime != nil {
+		resp["runtime"] = *info.Runtime
+	}
+	if info.EntryPoint != nil {
+		resp["entry_point"] = *info.EntryPoint
+	}
+	client.SendResponse(protocol.NewOKResponse(req.ID, resp))
+}

--- a/internal/http/managed_tools.go
+++ b/internal/http/managed_tools.go
@@ -1,0 +1,449 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/store/pg"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+const maxManagedToolUploadSize = 20 << 20 // 20 MB
+const maxManagedToolWriteSize = 10 << 20  // 10 MB
+
+// ManagedToolsHandler handles managed tool management HTTP endpoints.
+type ManagedToolsHandler struct {
+	tools   *pg.PGManagedToolStore
+	baseDir string
+	token   string
+	msgBus  *bus.MessageBus
+}
+
+// NewManagedToolsHandler creates a handler for managed tool management endpoints.
+func NewManagedToolsHandler(tools *pg.PGManagedToolStore, baseDir, token string, msgBus *bus.MessageBus) *ManagedToolsHandler {
+	return &ManagedToolsHandler{tools: tools, baseDir: baseDir, token: token, msgBus: msgBus}
+}
+
+// emitCacheInvalidate broadcasts a cache invalidation event if msgBus is set.
+func (h *ManagedToolsHandler) emitCacheInvalidate(kind, key string) {
+	if h.msgBus == nil {
+		return
+	}
+	h.msgBus.Broadcast(bus.Event{
+		Name:    protocol.EventCacheInvalidate,
+		Payload: bus.CacheInvalidatePayload{Kind: kind, Key: key},
+	})
+}
+
+// RegisterRoutes registers all managed tool management routes on the given mux.
+func (h *ManagedToolsHandler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/managed-tools", h.authMiddleware(h.handleList))
+	mux.HandleFunc("POST /v1/managed-tools/upload", h.authMiddleware(h.handleUpload))
+	mux.HandleFunc("GET /v1/managed-tools/{id}", h.authMiddleware(h.handleGet))
+	mux.HandleFunc("PUT /v1/managed-tools/{id}", h.authMiddleware(h.handleUpdate))
+	mux.HandleFunc("DELETE /v1/managed-tools/{id}", h.authMiddleware(h.handleDelete))
+	mux.HandleFunc("POST /v1/managed-tools/{id}/toggle", h.authMiddleware(h.handleToggle))
+	mux.HandleFunc("GET /v1/managed-tools/{id}/files", h.authMiddleware(h.handleListFiles))
+	mux.HandleFunc("GET /v1/managed-tools/{id}/files/{path...}", h.authMiddleware(h.handleReadFile))
+	mux.HandleFunc("PUT /v1/managed-tools/{id}/files/{path...}", h.authMiddleware(h.handleWriteFile))
+	mux.HandleFunc("GET /v1/managed-tools/{id}/versions", h.authMiddleware(h.handleListVersions))
+}
+
+func (h *ManagedToolsHandler) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if h.token != "" {
+			if extractBearerToken(r) != h.token {
+				locale := extractLocale(r)
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": i18n.T(locale, i18n.MsgUnauthorized)})
+				return
+			}
+		}
+		userID := extractUserID(r)
+		ctx := store.WithLocale(r.Context(), extractLocale(r))
+		if userID != "" {
+			ctx = store.WithUserID(ctx, userID)
+		}
+		r = r.WithContext(ctx)
+		next(w, r)
+	}
+}
+
+func (h *ManagedToolsHandler) handleList(w http.ResponseWriter, r *http.Request) {
+	tools := h.tools.ListManagedTools()
+	writeJSON(w, http.StatusOK, map[string]any{"tools": tools})
+}
+
+func (h *ManagedToolsHandler) handleGet(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id := r.PathValue("id")
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "managed tool")})
+		return
+	}
+	tool, ok := h.tools.GetManagedToolByID(uid)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "managed tool", id)})
+		return
+	}
+	writeJSON(w, http.StatusOK, tool)
+}
+
+func (h *ManagedToolsHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	idStr := r.PathValue("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "managed tool")})
+		return
+	}
+
+	var updates map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidJSON)})
+		return
+	}
+	// Prevent changing sensitive fields (use /toggle endpoint for enabled)
+	delete(updates, "id")
+	delete(updates, "owner_id")
+	delete(updates, "file_path")
+	delete(updates, "is_system")
+	delete(updates, "enabled")
+
+	if err := h.tools.UpdateManagedTool(id, updates); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	h.tools.BumpVersion()
+	h.emitCacheInvalidate("managed_tools", idStr)
+	emitAudit(h.msgBus, r, "managed-tool.updated", "managed_tool", idStr)
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func (h *ManagedToolsHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	idStr := r.PathValue("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "managed tool")})
+		return
+	}
+
+	if err := h.tools.DeleteManagedTool(id); err != nil {
+		if err.Error() == "cannot delete system managed tool" {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "cannot delete system managed tool"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	h.tools.BumpVersion()
+	h.emitCacheInvalidate("managed_tools", idStr)
+	emitAudit(h.msgBus, r, "managed-tool.deleted", "managed_tool", idStr)
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+// handleToggle enables or disables a managed tool.
+// Body: {"enabled": bool}
+func (h *ManagedToolsHandler) handleToggle(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	idStr := r.PathValue("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "managed tool")})
+		return
+	}
+
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidJSON)})
+		return
+	}
+
+	if err := h.tools.ToggleManagedTool(id, body.Enabled); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	newStatus := ""
+	if body.Enabled {
+		newStatus = "active"
+		_ = h.tools.UpdateManagedTool(id, map[string]any{"status": newStatus})
+	}
+
+	h.tools.BumpVersion()
+	h.emitCacheInvalidate("managed_tools", idStr)
+	emitAudit(h.msgBus, r, "managed-tool.toggled", "managed_tool", idStr)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "enabled": body.Enabled, "status": newStatus})
+}
+
+// handleListVersions returns all available version numbers for a managed tool.
+func (h *ManagedToolsHandler) handleListVersions(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "managed tool")})
+		return
+	}
+
+	_, slug, currentVersion, ok := h.tools.GetManagedToolFilePath(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "managed tool", id.String())})
+		return
+	}
+
+	slugDir := filepath.Join(h.baseDir, slug)
+	entries, err := os.ReadDir(slugDir)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"versions": []int{currentVersion},
+			"current":  currentVersion,
+		})
+		return
+	}
+
+	var versions []int
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		v, err := strconv.Atoi(e.Name())
+		if err != nil || v < 1 {
+			continue
+		}
+		versions = append(versions, v)
+	}
+	if len(versions) == 0 {
+		versions = []int{currentVersion}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"versions": versions,
+		"current":  currentVersion,
+	})
+}
+
+// handleListFiles returns all files in a managed tool version directory.
+func (h *ManagedToolsHandler) handleListFiles(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "managed tool")})
+		return
+	}
+
+	_, slug, currentVersion, ok := h.tools.GetManagedToolFilePath(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "managed tool", id.String())})
+		return
+	}
+
+	version := currentVersion
+	if v := r.URL.Query().Get("version"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed < 1 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidVersion)})
+			return
+		}
+		version = parsed
+	}
+
+	versionDir := filepath.Join(h.baseDir, slug, strconv.Itoa(version))
+	if _, err := os.Stat(versionDir); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgVersionNotFound)})
+		return
+	}
+
+	type fileEntry struct {
+		Path  string `json:"path"`
+		Name  string `json:"name"`
+		IsDir bool   `json:"isDir"`
+		Size  int64  `json:"size"`
+	}
+
+	var files []fileEntry
+	filepath.WalkDir(versionDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(versionDir, path)
+		if rel == "." {
+			return nil
+		}
+		// Skip symlinks — prevent escape from tool directory
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		entry := fileEntry{
+			Path:  rel,
+			Name:  d.Name(),
+			IsDir: d.IsDir(),
+		}
+		if !d.IsDir() {
+			if info, err := d.Info(); err == nil {
+				entry.Size = info.Size()
+			}
+		}
+		files = append(files, entry)
+		return nil
+	})
+
+	if files == nil {
+		files = []fileEntry{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"files": files})
+}
+
+// handleReadFile reads a single file from a managed tool version directory.
+func (h *ManagedToolsHandler) handleReadFile(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "managed tool")})
+		return
+	}
+
+	relPath := r.PathValue("path")
+	if relPath == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "path")})
+		return
+	}
+	if strings.Contains(relPath, "..") {
+		slog.Warn("security.managed_tool_files_traversal", "path", relPath)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+
+	_, slug, currentVersion, ok := h.tools.GetManagedToolFilePath(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "managed tool", id.String())})
+		return
+	}
+
+	version := currentVersion
+	if v := r.URL.Query().Get("version"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed < 1 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidVersion)})
+			return
+		}
+		version = parsed
+	}
+
+	versionDir := filepath.Join(h.baseDir, slug, strconv.Itoa(version))
+	absPath := filepath.Join(versionDir, filepath.Clean(relPath))
+
+	// Verify resolved path is within the version directory
+	if !strings.HasPrefix(absPath, versionDir+string(filepath.Separator)) {
+		slog.Warn("security.managed_tool_files_escape", "resolved", absPath, "root", versionDir)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+
+	// Use Lstat to detect symlinks — reject them to prevent directory escape
+	info, err := os.Lstat(absPath)
+	if err != nil || info.IsDir() {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgFileNotFound)})
+		return
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		slog.Warn("security.managed_tool_files_symlink", "path", absPath)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgFailedToReadFile)})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"content": string(data),
+		"path":    relPath,
+		"size":    info.Size(),
+	})
+}
+
+// handleWriteFile writes content to a file in a managed tool version directory.
+func (h *ManagedToolsHandler) handleWriteFile(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "managed tool")})
+		return
+	}
+
+	relPath := r.PathValue("path")
+	if relPath == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "path")})
+		return
+	}
+	if strings.Contains(relPath, "..") {
+		slog.Warn("security.managed_tool_files_traversal", "path", relPath)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+
+	_, slug, currentVersion, ok := h.tools.GetManagedToolFilePath(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "managed tool", id.String())})
+		return
+	}
+
+	version := currentVersion
+	if v := r.URL.Query().Get("version"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed < 1 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidVersion)})
+			return
+		}
+		version = parsed
+	}
+
+	versionDir := filepath.Join(h.baseDir, slug, strconv.Itoa(version))
+	absPath := filepath.Join(versionDir, filepath.Clean(relPath))
+
+	// Verify resolved path is within the version directory
+	if !strings.HasPrefix(absPath, versionDir+string(filepath.Separator)) {
+		slog.Warn("security.managed_tool_files_escape", "resolved", absPath, "root", versionDir)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+
+	// Read request body (limit 10MB)
+	r.Body = http.MaxBytesReader(w, r.Body, maxManagedToolWriteSize)
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidRequest, "request body too large or unreadable")})
+		return
+	}
+
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgInternalError, "failed to create directory")})
+		return
+	}
+
+	if err := os.WriteFile(absPath, data, 0644); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgInternalError, "failed to write file")})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}

--- a/internal/http/managed_tools_upload.go
+++ b/internal/http/managed_tools_upload.go
@@ -1,0 +1,202 @@
+package http
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/skills"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// handleUpload processes a ZIP file upload containing a managed tool (must have TOOL.md at root).
+func (h *ManagedToolsHandler) handleUpload(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	userID := store.UserIDFromContext(r.Context())
+	if userID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgUserIDHeader)})
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxManagedToolUploadSize)
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidRequest, "file is required: "+err.Error())})
+		return
+	}
+	defer file.Close()
+
+	// Save to temp file for zip processing
+	tmp, err := os.CreateTemp("", "managed-tool-upload-*.zip")
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgInternalError, "failed to create temp file")})
+		return
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	hasher := sha256.New()
+	size, err := io.Copy(io.MultiWriter(tmp, hasher), file)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgInternalError, "failed to save upload")})
+		return
+	}
+	fileHash := fmt.Sprintf("%x", hasher.Sum(nil))
+
+	// Open as zip
+	zr, err := zip.OpenReader(tmp.Name())
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidRequest, "invalid ZIP file")})
+		return
+	}
+	defer zr.Close()
+
+	// Validate: must have TOOL.md at root or inside a single top-level directory.
+	var toolMD *zip.File
+	var stripPrefix string
+	for _, f := range zr.File {
+		name := strings.TrimPrefix(f.Name, "./")
+		if name == "TOOL.md" {
+			toolMD = f
+			stripPrefix = ""
+			break
+		}
+		// Allow one level of directory nesting: "dirname/TOOL.md"
+		parts := strings.SplitN(name, "/", 3)
+		if len(parts) == 2 && parts[1] == "TOOL.md" && !f.FileInfo().IsDir() {
+			toolMD = f
+			stripPrefix = parts[0] + "/"
+			break
+		}
+	}
+	if toolMD == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidRequest, "ZIP must contain TOOL.md at root (or inside a single top-level directory)")})
+		return
+	}
+
+	// Read and parse TOOL.md frontmatter
+	toolContent, err := readZipFile(toolMD)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidRequest, "failed to read TOOL.md")})
+		return
+	}
+	if strings.TrimSpace(toolContent) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidRequest, "TOOL.md is empty")})
+		return
+	}
+
+	name, description, slug, frontmatter := skills.ParseSkillFrontmatter(toolContent)
+	if name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "name in TOOL.md frontmatter")})
+		return
+	}
+	if slug == "" {
+		slug = skills.Slugify(name)
+	}
+	if !skills.SlugRegexp.MatchString(slug) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidSlug, "slug")})
+		return
+	}
+
+	// Extract optional runtime and entry_point from frontmatter
+	var runtime, entryPoint *string
+	if v, ok := frontmatter["runtime"]; ok && v != "" {
+		runtime = &v
+	}
+	if v, ok := frontmatter["entry_point"]; ok && v != "" {
+		entryPoint = &v
+	}
+
+	// Determine version (always increment)
+	version := h.tools.GetNextVersion(slug)
+
+	// Extract to filesystem: baseDir/slug/version/
+	destDir := filepath.Join(h.baseDir, slug, fmt.Sprintf("%d", version))
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgInternalError, "failed to create tool directory")})
+		return
+	}
+
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		// Skip symlinks in ZIP — prevent directory escape attacks
+		if f.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		// Strip wrapper directory prefix if ZIP had one
+		entryName := strings.TrimPrefix(f.Name, "./")
+		if stripPrefix != "" {
+			entryName = strings.TrimPrefix(entryName, stripPrefix)
+			if entryName == "" {
+				continue
+			}
+		}
+		// Skip macOS/system artifacts
+		if skills.IsSystemArtifact(entryName) {
+			continue
+		}
+		// Security: prevent path traversal
+		cleanName := filepath.Clean(entryName)
+		if strings.Contains(cleanName, "..") {
+			continue
+		}
+		destPath := filepath.Join(destDir, cleanName)
+		if !strings.HasPrefix(destPath, destDir+string(filepath.Separator)) {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			continue
+		}
+		data, err := readZipFile(f)
+		if err != nil {
+			continue
+		}
+		os.WriteFile(destPath, []byte(data), 0644)
+	}
+
+	// Save metadata to DB
+	desc := description
+	toolParams := store.ManagedToolCreateParams{
+		Name:        name,
+		Slug:        slug,
+		Description: &desc,
+		OwnerID:     userID,
+		Visibility:  "internal",
+		Version:     version,
+		FilePath:    destDir,
+		FileSize:    size,
+		FileHash:    &fileHash,
+		Frontmatter: frontmatter,
+		Runtime:     runtime,
+		EntryPoint:  entryPoint,
+	}
+
+	id, err := h.tools.CreateManagedTool(r.Context(), toolParams)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgFailedToCreate, "managed tool", err.Error())})
+		return
+	}
+
+	h.tools.BumpVersion()
+	emitAudit(h.msgBus, r, "managed-tool.uploaded", "managed_tool", slug)
+	slog.Info("managed tool uploaded", "id", id, "slug", slug, "version", version, "size", header.Size)
+
+	response := map[string]interface{}{
+		"id":      id,
+		"slug":    slug,
+		"version": version,
+		"name":    name,
+	}
+
+	writeJSON(w, http.StatusCreated, response)
+}

--- a/internal/store/managed_tool_store.go
+++ b/internal/store/managed_tool_store.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ManagedToolInfo describes a managed tool.
+type ManagedToolInfo struct {
+	ID          string            `json:"id,omitempty"`
+	Name        string            `json:"name"`
+	Slug        string            `json:"slug"`
+	Description string            `json:"description"`
+	Visibility  string            `json:"visibility,omitempty"`
+	Tags        []string          `json:"tags,omitempty"`
+	Version     int               `json:"version,omitempty"`
+	Status      string            `json:"status,omitempty"`
+	Enabled     bool              `json:"enabled"`
+	Runtime     *string           `json:"runtime,omitempty"`
+	EntryPoint  *string           `json:"entry_point,omitempty"`
+	FilePath    string            `json:"file_path"`
+	IsSystem    bool              `json:"is_system,omitempty"`
+	OwnerID     string            `json:"owner_id,omitempty"`
+	Frontmatter map[string]string `json:"frontmatter,omitempty"`
+	FileSize    int64             `json:"file_size,omitempty"`
+	FileHash    *string           `json:"file_hash,omitempty"`
+	CreatedAt   *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time        `json:"updated_at,omitempty"`
+}
+
+// ManagedToolCreateParams holds parameters for creating a managed tool.
+type ManagedToolCreateParams struct {
+	Name        string
+	Slug        string
+	Description *string
+	OwnerID     string
+	Visibility  string
+	Version     int
+	FilePath    string
+	FileSize    int64
+	FileHash    *string
+	Frontmatter map[string]string
+	Runtime     *string
+	EntryPoint  *string
+}
+
+// ManagedToolStore manages managed tool CRUD and discovery.
+type ManagedToolStore interface {
+	ListManagedTools() []ManagedToolInfo
+	GetManagedTool(slug string) (*ManagedToolInfo, bool)
+	GetManagedToolByID(id uuid.UUID) (ManagedToolInfo, bool)
+	CreateManagedTool(ctx context.Context, p ManagedToolCreateParams) (uuid.UUID, error)
+	UpdateManagedTool(id uuid.UUID, updates map[string]any) error
+	DeleteManagedTool(id uuid.UUID) error
+	ToggleManagedTool(id uuid.UUID, enabled bool) error
+	BumpVersion()
+	Version() int64
+	Dirs() []string
+}

--- a/internal/store/pg/managed_tools.go
+++ b/internal/store/pg/managed_tools.go
@@ -1,0 +1,305 @@
+package pg
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+const defaultManagedToolsCacheTTL = 5 * time.Minute
+
+// PGManagedToolStore implements store.ManagedToolStore backed by Postgres.
+type PGManagedToolStore struct {
+	db      *sql.DB
+	baseDir string
+	mu      sync.RWMutex
+	version atomic.Int64
+
+	// List cache: cached result of ListManagedTools() with version + TTL validation
+	listCache []store.ManagedToolInfo
+	listVer   int64
+	listTime  time.Time
+	ttl       time.Duration
+}
+
+func NewPGManagedToolStore(db *sql.DB, baseDir string) *PGManagedToolStore {
+	return &PGManagedToolStore{
+		db:      db,
+		baseDir: baseDir,
+		ttl:     defaultManagedToolsCacheTTL,
+	}
+}
+
+func (s *PGManagedToolStore) ListManagedTools() []store.ManagedToolInfo {
+	currentVer := s.version.Load()
+
+	s.mu.RLock()
+	if s.listCache != nil && s.listVer == currentVer && time.Since(s.listTime) < s.ttl {
+		result := s.listCache
+		s.mu.RUnlock()
+		return result
+	}
+	s.mu.RUnlock()
+
+	rows, err := s.db.Query(
+		`SELECT id, name, slug, description, visibility, tags, version, is_system, status, enabled,
+		        frontmatter, file_path, file_size, file_hash, owner_id, runtime, entry_point,
+		        created_at, updated_at
+		 FROM managed_tools
+		 WHERE status = 'active' OR is_system = true
+		 ORDER BY name`)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var result []store.ManagedToolInfo
+	for rows.Next() {
+		info, err := scanManagedTool(rows)
+		if err != nil {
+			continue
+		}
+		result = append(result, info)
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("ListManagedTools: rows iteration error", "error", err)
+		return nil
+	}
+
+	s.mu.Lock()
+	s.listCache = result
+	s.listVer = currentVer
+	s.listTime = time.Now()
+	s.mu.Unlock()
+
+	return result
+}
+
+func (s *PGManagedToolStore) GetManagedTool(slug string) (*store.ManagedToolInfo, bool) {
+	var id uuid.UUID
+	var name, vis, status, ownerID string
+	var desc, fileHash, runtime, entryPoint *string
+	var tags []string
+	var version int
+	var isSystem, enabled bool
+	var fmRaw []byte
+	var filePath string
+	var fileSize int64
+	var createdAt, updatedAt time.Time
+
+	err := s.db.QueryRow(
+		`SELECT id, name, slug, description, visibility, tags, version, is_system, status, enabled,
+		        frontmatter, file_path, file_size, file_hash, owner_id, runtime, entry_point,
+		        created_at, updated_at
+		 FROM managed_tools WHERE slug = $1 AND status = 'active'`, slug,
+	).Scan(&id, &name, &slug, &desc, &vis, pq.Array(&tags), &version, &isSystem, &status, &enabled,
+		&fmRaw, &filePath, &fileSize, &fileHash, &ownerID, &runtime, &entryPoint,
+		&createdAt, &updatedAt)
+	if err != nil {
+		return nil, false
+	}
+
+	info := buildManagedToolInfo(id.String(), name, slug, desc, vis, tags, version, isSystem, status,
+		enabled, fmRaw, filePath, fileSize, fileHash, ownerID, runtime, entryPoint, &createdAt, &updatedAt)
+	return &info, true
+}
+
+func (s *PGManagedToolStore) GetManagedToolByID(id uuid.UUID) (store.ManagedToolInfo, bool) {
+	var name, slug, vis, status, ownerID string
+	var desc, fileHash, runtime, entryPoint *string
+	var tags []string
+	var version int
+	var isSystem, enabled bool
+	var fmRaw []byte
+	var filePath string
+	var fileSize int64
+	var createdAt, updatedAt time.Time
+
+	err := s.db.QueryRow(
+		`SELECT name, slug, description, visibility, tags, version, is_system, status, enabled,
+		        frontmatter, file_path, file_size, file_hash, owner_id, runtime, entry_point,
+		        created_at, updated_at
+		 FROM managed_tools WHERE id = $1`, id,
+	).Scan(&name, &slug, &desc, &vis, pq.Array(&tags), &version, &isSystem, &status, &enabled,
+		&fmRaw, &filePath, &fileSize, &fileHash, &ownerID, &runtime, &entryPoint,
+		&createdAt, &updatedAt)
+	if err != nil {
+		return store.ManagedToolInfo{}, false
+	}
+
+	return buildManagedToolInfo(id.String(), name, slug, desc, vis, tags, version, isSystem, status,
+		enabled, fmRaw, filePath, fileSize, fileHash, ownerID, runtime, entryPoint, &createdAt, &updatedAt), true
+}
+
+func (s *PGManagedToolStore) CreateManagedTool(ctx context.Context, p store.ManagedToolCreateParams) (uuid.UUID, error) {
+	if err := store.ValidateUserID(p.OwnerID); err != nil {
+		return uuid.Nil, err
+	}
+	id := store.GenNewID()
+	fmJSON := marshalFrontmatter(p.Frontmatter)
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO managed_tools (id, name, slug, description, owner_id, visibility, version, status,
+		 frontmatter, file_path, file_size, file_hash, runtime, entry_point, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, 'active', $8, $9, $10, $11, $12, $13, NOW(), NOW())
+		 ON CONFLICT (slug) DO UPDATE SET
+		   name = EXCLUDED.name, description = EXCLUDED.description,
+		   version = EXCLUDED.version, frontmatter = EXCLUDED.frontmatter,
+		   file_path = EXCLUDED.file_path,
+		   file_size = EXCLUDED.file_size, file_hash = EXCLUDED.file_hash,
+		   runtime = EXCLUDED.runtime, entry_point = EXCLUDED.entry_point,
+		   visibility = CASE WHEN managed_tools.status = 'archived' THEN 'private' ELSE managed_tools.visibility END,
+		   status = 'active', updated_at = NOW()`,
+		id, p.Name, p.Slug, p.Description, p.OwnerID, p.Visibility, p.Version,
+		fmJSON, p.FilePath, p.FileSize, p.FileHash, p.Runtime, p.EntryPoint,
+	)
+	if err == nil {
+		s.BumpVersion()
+	}
+	return id, err
+}
+
+func (s *PGManagedToolStore) UpdateManagedTool(id uuid.UUID, updates map[string]any) error {
+	if err := execMapUpdate(context.Background(), s.db, "managed_tools", id, updates); err != nil {
+		return err
+	}
+	s.BumpVersion()
+	return nil
+}
+
+func (s *PGManagedToolStore) DeleteManagedTool(id uuid.UUID) error {
+	var isSystem bool
+	if err := s.db.QueryRow("SELECT is_system FROM managed_tools WHERE id = $1", id).Scan(&isSystem); err != nil {
+		return fmt.Errorf("check managed tool: %w", err)
+	}
+	if isSystem {
+		return fmt.Errorf("cannot delete system managed tool")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec("DELETE FROM managed_tool_agent_grants WHERE managed_tool_id = $1", id); err != nil {
+		return fmt.Errorf("delete managed tool grants: %w", err)
+	}
+
+	if _, err := tx.Exec("UPDATE managed_tools SET status = 'archived' WHERE id = $1", id); err != nil {
+		return fmt.Errorf("archive managed tool: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.BumpVersion()
+	return nil
+}
+
+func (s *PGManagedToolStore) ToggleManagedTool(id uuid.UUID, enabled bool) error {
+	_, err := s.db.Exec(
+		`UPDATE managed_tools SET enabled = $1, updated_at = NOW() WHERE id = $2`,
+		enabled, id,
+	)
+	if err == nil {
+		s.BumpVersion()
+	}
+	return err
+}
+
+func (s *PGManagedToolStore) Version() int64 { return s.version.Load() }
+func (s *PGManagedToolStore) BumpVersion()   { s.version.Store(time.Now().UnixMilli()) }
+func (s *PGManagedToolStore) Dirs() []string { return []string{s.baseDir} }
+
+// GetManagedToolFilePath returns the file path, slug, and version for a managed tool by ID.
+func (s *PGManagedToolStore) GetManagedToolFilePath(id uuid.UUID) (filePath string, slug string, version int, ok bool) {
+	t, found := s.GetManagedToolByID(id)
+	if !found {
+		return "", "", 0, false
+	}
+	return t.FilePath, t.Slug, t.Version, true
+}
+
+// GetNextVersion returns the next version number for a slug (max existing version + 1).
+func (s *PGManagedToolStore) GetNextVersion(slug string) int {
+	var maxVer int
+	err := s.db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM managed_tools WHERE slug = $1`, slug).Scan(&maxVer)
+	if err != nil {
+		return 1
+	}
+	return maxVer + 1
+}
+
+// --- Helpers ---
+
+// scanManagedTool scans a managed_tools row from a *sql.Rows cursor.
+func scanManagedTool(rows *sql.Rows) (store.ManagedToolInfo, error) {
+	var id uuid.UUID
+	var name, slug, vis, status, ownerID string
+	var desc, fileHash, runtime, entryPoint *string
+	var tags []string
+	var version int
+	var isSystem, enabled bool
+	var fmRaw []byte
+	var filePath string
+	var fileSize int64
+	var createdAt, updatedAt time.Time
+
+	if err := rows.Scan(&id, &name, &slug, &desc, &vis, pq.Array(&tags), &version, &isSystem, &status, &enabled,
+		&fmRaw, &filePath, &fileSize, &fileHash, &ownerID, &runtime, &entryPoint,
+		&createdAt, &updatedAt); err != nil {
+		return store.ManagedToolInfo{}, err
+	}
+
+	return buildManagedToolInfo(id.String(), name, slug, desc, vis, tags, version, isSystem, status,
+		enabled, fmRaw, filePath, fileSize, fileHash, ownerID, runtime, entryPoint, &createdAt, &updatedAt), nil
+}
+
+func buildManagedToolInfo(id, name, slug string, desc *string, vis string, tags []string,
+	version int, isSystem bool, status string, enabled bool, fmRaw []byte,
+	filePath string, fileSize int64, fileHash *string, ownerID string,
+	runtime, entryPoint *string, createdAt, updatedAt *time.Time) store.ManagedToolInfo {
+
+	d := ""
+	if desc != nil {
+		d = *desc
+	}
+
+	var fm map[string]string
+	if len(fmRaw) > 0 {
+		_ = json.Unmarshal(fmRaw, &fm)
+	}
+
+	return store.ManagedToolInfo{
+		ID:          id,
+		Name:        name,
+		Slug:        slug,
+		Description: d,
+		Visibility:  vis,
+		Tags:        tags,
+		Version:     version,
+		IsSystem:    isSystem,
+		Status:      status,
+		Enabled:     enabled,
+		Runtime:     runtime,
+		EntryPoint:  entryPoint,
+		FilePath:    filePath,
+		FileSize:    fileSize,
+		FileHash:    fileHash,
+		OwnerID:     ownerID,
+		Frontmatter: fm,
+		CreatedAt:   createdAt,
+		UpdatedAt:   updatedAt,
+	}
+}

--- a/internal/store/pg/managed_tools_grants.go
+++ b/internal/store/pg/managed_tools_grants.go
@@ -1,0 +1,66 @@
+package pg
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// ManagedToolGrantInfo is a simplified grant record for API responses.
+type ManagedToolGrantInfo struct {
+	ManagedToolID uuid.UUID `json:"managed_tool_id"`
+	PinnedVersion int       `json:"pinned_version"`
+}
+
+// GrantManagedToolToAgent grants a managed tool to an agent with optional version pinning.
+func (s *PGManagedToolStore) GrantManagedToolToAgent(ctx context.Context, managedToolID, agentID uuid.UUID, version *int) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO managed_tool_agent_grants (id, managed_tool_id, agent_id, pinned_version, created_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (managed_tool_id, agent_id) DO UPDATE SET pinned_version = EXCLUDED.pinned_version`,
+		store.GenNewID(), managedToolID, agentID, version, time.Now(),
+	)
+	if err != nil {
+		return err
+	}
+	s.BumpVersion()
+	return nil
+}
+
+// RevokeManagedToolFromAgent revokes a managed tool grant from an agent.
+func (s *PGManagedToolStore) RevokeManagedToolFromAgent(ctx context.Context, managedToolID, agentID uuid.UUID) error {
+	_, err := s.db.ExecContext(ctx,
+		"DELETE FROM managed_tool_agent_grants WHERE managed_tool_id = $1 AND agent_id = $2",
+		managedToolID, agentID)
+	if err != nil {
+		return err
+	}
+	s.BumpVersion()
+	return nil
+}
+
+// ListManagedToolAgentGrants returns all managed tool grants for an agent.
+func (s *PGManagedToolStore) ListManagedToolAgentGrants(ctx context.Context, agentID uuid.UUID) ([]ManagedToolGrantInfo, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT managed_tool_id, pinned_version FROM managed_tool_agent_grants WHERE agent_id = $1",
+		agentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []ManagedToolGrantInfo
+	for rows.Next() {
+		var g ManagedToolGrantInfo
+		if err := rows.Scan(&g.ManagedToolID, &g.PinnedVersion); err != nil {
+			slog.Warn("managed_tool_grants: scan error in ListManagedToolAgentGrants", "error", err)
+			continue
+		}
+		result = append(result, g)
+	}
+	return result, rows.Err()
+}

--- a/migrations/000018_managed_tools.down.sql
+++ b/migrations/000018_managed_tools.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS managed_tool_agent_grants;
+DROP TABLE IF EXISTS managed_tools;

--- a/migrations/000018_managed_tools.up.sql
+++ b/migrations/000018_managed_tools.up.sql
@@ -1,0 +1,36 @@
+-- Managed tools: uploadable code-project tools with file storage
+CREATE TABLE managed_tools (
+    id           UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    name         VARCHAR(255) NOT NULL,
+    slug         VARCHAR(255) NOT NULL UNIQUE,
+    description  TEXT,
+    owner_id     VARCHAR(255) NOT NULL,
+    visibility   VARCHAR(10) NOT NULL DEFAULT 'private',
+    version      INT NOT NULL DEFAULT 1,
+    status       VARCHAR(20) NOT NULL DEFAULT 'active',
+    frontmatter  JSONB NOT NULL DEFAULT '{}',
+    file_path    TEXT NOT NULL,
+    file_size    BIGINT NOT NULL DEFAULT 0,
+    file_hash    VARCHAR(64),
+    tags         TEXT[],
+    is_system    BOOLEAN NOT NULL DEFAULT false,
+    enabled      BOOLEAN NOT NULL DEFAULT true,
+    runtime      VARCHAR(50),
+    entry_point  VARCHAR(255),
+    created_at   TIMESTAMPTZ DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_managed_tools_owner ON managed_tools(owner_id);
+CREATE INDEX idx_managed_tools_visibility ON managed_tools(visibility) WHERE status = 'active';
+CREATE INDEX idx_managed_tools_slug ON managed_tools(slug);
+CREATE INDEX idx_managed_tools_enabled ON managed_tools(enabled) WHERE enabled = false;
+
+CREATE TABLE managed_tool_agent_grants (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    managed_tool_id UUID NOT NULL REFERENCES managed_tools(id) ON DELETE CASCADE,
+    agent_id        UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    pinned_version  INT,
+    created_at      TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(managed_tool_id, agent_id)
+);

--- a/pkg/protocol/methods.go
+++ b/pkg/protocol/methods.go
@@ -50,6 +50,9 @@ const (
 	MethodSkillsGet   = "skills.get"
 	MethodSkillsUpdate = "skills.update"
 
+	MethodManagedToolsList = "managed-tools.list"
+	MethodManagedToolsGet  = "managed-tools.get"
+
 	MethodCronList   = "cron.list"
 	MethodCronCreate = "cron.create"
 	MethodCronUpdate = "cron.update"

--- a/ui/web/src/api/protocol.ts
+++ b/ui/web/src/api/protocol.ts
@@ -145,6 +145,9 @@ export const Methods = {
 
   // Phase 3+ - NICE TO HAVE
   LOGS_TAIL: "logs.tail",
+
+  MANAGED_TOOLS_LIST: "managed-tools.list",
+  MANAGED_TOOLS_GET: "managed-tools.get",
 } as const;
 
 // --- Event names (from pkg/protocol/events.go) ---

--- a/ui/web/src/components/shared/code-editor.tsx
+++ b/ui/web/src/components/shared/code-editor.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from "react";
+import CodeMirror from "@uiw/react-codemirror";
+import { python } from "@codemirror/lang-python";
+import { javascript } from "@codemirror/lang-javascript";
+import { json } from "@codemirror/lang-json";
+import { oneDark } from "@codemirror/theme-one-dark";
+import { EditorState } from "@uiw/react-codemirror";
+import { cn } from "@/lib/utils";
+
+export type CodeLanguage = "python" | "javascript" | "typescript" | "json" | "text";
+
+interface CodeEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  language?: CodeLanguage;
+  readOnly?: boolean;
+  className?: string;
+}
+
+export function CodeEditor({ value, onChange, language, readOnly, className }: CodeEditorProps) {
+  const extensions = useMemo(() => {
+    const exts = [];
+    switch (language) {
+      case "python":
+        exts.push(python());
+        break;
+      case "javascript":
+        exts.push(javascript());
+        break;
+      case "typescript":
+        exts.push(javascript({ typescript: true }));
+        break;
+      case "json":
+        exts.push(json());
+        break;
+    }
+    if (readOnly) exts.push(EditorState.readOnly.of(true));
+    return exts;
+  }, [language, readOnly]);
+
+  return (
+    <CodeMirror
+      value={value}
+      onChange={onChange}
+      extensions={extensions}
+      theme={oneDark}
+      height="100%"
+      className={cn("h-full overflow-auto text-sm", className)}
+      basicSetup={{
+        lineNumbers: true,
+        highlightActiveLine: true,
+        bracketMatching: true,
+        autocompletion: true,
+        history: true,
+        foldGutter: true,
+        searchKeymap: true,
+      }}
+    />
+  );
+}

--- a/ui/web/src/lib/constants.ts
+++ b/ui/web/src/lib/constants.ts
@@ -28,6 +28,8 @@ export const ROUTES = {
   TEAM_DETAIL: "/teams/:id",
   CUSTOM_TOOLS: "/custom-tools",
   BUILTIN_TOOLS: "/builtin-tools",
+  TOOLS: "/tools",
+  TOOL_DETAIL: "/tools/:id",
   MCP: "/mcp",
   TTS: "/tts",
   STORAGE: "/storage",

--- a/ui/web/src/lib/query-keys.ts
+++ b/ui/web/src/lib/query-keys.ts
@@ -46,6 +46,12 @@ export const queryKeys = {
   builtinTools: {
     all: ["builtinTools"] as const,
   },
+  managedTools: {
+    all: ["managedTools"] as const,
+    detail: (id: string) => ["managedTools", id] as const,
+    files: (id: string) => ["managedTools", id, "files"] as const,
+    fileContent: (id: string, path: string) => ["managedTools", id, "files", path] as const,
+  },
   config: {
     all: ["config"] as const,
   },

--- a/ui/web/src/pages/tools/hooks/use-managed-tools.ts
+++ b/ui/web/src/pages/tools/hooks/use-managed-tools.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useWs, useHttp } from "@/hooks/use-ws";
+import { useAuthStore } from "@/stores/use-auth-store";
+import { Methods } from "@/api/protocol";
+import { ApiError } from "@/api/errors";
+import { queryKeys } from "@/lib/query-keys";
+import type { ManagedToolInfo, ManagedToolFile, ManagedToolVersions } from "@/types/tool";
+
+export type { ManagedToolInfo, ManagedToolFile, ManagedToolVersions };
+
+export function useManagedTools() {
+  const ws = useWs();
+  const http = useHttp();
+  const connected = useAuthStore((s) => s.connected);
+  const token = useAuthStore((s) => s.token);
+  const userId = useAuthStore((s) => s.userId);
+  const queryClient = useQueryClient();
+
+  const { data: managedTools = [], isFetching: loading } = useQuery({
+    queryKey: queryKeys.managedTools.all,
+    queryFn: async () => {
+      const res = await ws.call<{ managed_tools: ManagedToolInfo[] }>(Methods.MANAGED_TOOLS_LIST);
+      return res.managed_tools ?? [];
+    },
+    staleTime: 60_000,
+    enabled: connected,
+  });
+
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: queryKeys.managedTools.all }),
+    [queryClient],
+  );
+
+  useEffect(() => {
+    if (connected) invalidate();
+  }, [connected]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const uploadTool = useCallback(
+    async (file: File) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await http.upload<{ id: string; slug: string; version: number; name: string }>(
+        "/v1/managed-tools/upload",
+        formData,
+      );
+      await invalidate();
+      return res;
+    },
+    [http, invalidate],
+  );
+
+  const updateTool = useCallback(
+    async (id: string, updates: Record<string, unknown>) => {
+      const res = await http.put<{ ok: string }>(`/v1/managed-tools/${id}`, updates);
+      await invalidate();
+      return res;
+    },
+    [http, invalidate],
+  );
+
+  const deleteTool = useCallback(
+    async (id: string) => {
+      const res = await http.delete<{ ok: string }>(`/v1/managed-tools/${id}`);
+      await invalidate();
+      return res;
+    },
+    [http, invalidate],
+  );
+
+  const toggleTool = useCallback(
+    async (id: string, enabled: boolean) => {
+      const res = await http.post<{ ok: boolean; enabled: boolean; status: string }>(
+        `/v1/managed-tools/${id}/toggle`,
+        { enabled },
+      );
+      await invalidate();
+      return res;
+    },
+    [http, invalidate],
+  );
+
+  const getManagedTool = useCallback(
+    (id: string) => http.get<ManagedToolInfo>(`/v1/managed-tools/${id}`),
+    [http],
+  );
+
+  const getFiles = useCallback(
+    async (id: string, version?: number) => {
+      const q = version != null ? `?version=${version}` : "";
+      const res = await http.get<{ files: ManagedToolFile[] }>(`/v1/managed-tools/${id}/files${q}`);
+      return res.files ?? [];
+    },
+    [http],
+  );
+
+  const getFileContent = useCallback(
+    async (id: string, path: string, version?: number) => {
+      const q = version != null ? `?version=${version}` : "";
+      return http.get<{ content: string; path: string; size: number }>(
+        `/v1/managed-tools/${id}/files/${encodeURIComponent(path)}${q}`,
+      );
+    },
+    [http],
+  );
+
+  const getVersions = useCallback(
+    async (id: string) => {
+      return http.get<ManagedToolVersions>(`/v1/managed-tools/${id}/versions`);
+    },
+    [http],
+  );
+
+  const writeFile = useCallback(
+    async (id: string, filePath: string, content: string): Promise<void> => {
+      const encoded = encodeURIComponent(filePath);
+      const url = new URL(`/v1/managed-tools/${id}/files/${encoded}`, window.location.origin);
+
+      const headers: Record<string, string> = {
+        "Content-Type": "text/plain; charset=utf-8",
+      };
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+      if (userId) headers["X-GoClaw-User-Id"] = userId;
+
+      const res = await fetch(url.toString(), {
+        method: "PUT",
+        headers,
+        body: content,
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: res.statusText }));
+        throw new ApiError(
+          err.code ?? "HTTP_ERROR",
+          err.error ?? err.message ?? res.statusText,
+        );
+      }
+    },
+    [token, userId],
+  );
+
+  return {
+    managedTools,
+    loading,
+    refresh: invalidate,
+    uploadTool,
+    updateTool,
+    deleteTool,
+    toggleTool,
+    getManagedTool,
+    getFiles,
+    getManagedToolFiles: getFiles,
+    getFileContent,
+    getVersions,
+    writeFile,
+  };
+}

--- a/ui/web/src/pages/tools/lib/validate-tool-zip.ts
+++ b/ui/web/src/pages/tools/lib/validate-tool-zip.ts
@@ -1,0 +1,94 @@
+/** Client-side validation for managed tool ZIP files before upload. */
+import JSZip from "jszip";
+
+export interface ToolZipValidation {
+  valid: boolean;
+  name?: string;
+  slug?: string;
+  description?: string;
+  /** i18n key under "tools:managed.upload." namespace */
+  error?: string;
+  errorDetail?: string;
+}
+
+const MAX_TOOL_SIZE = 20 * 1024 * 1024; // 20MB
+const SLUG_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+export async function validateToolZip(file: File): Promise<ToolZipValidation> {
+  if (!file.name.toLowerCase().endsWith(".zip")) {
+    return { valid: false, error: "tools:managed.upload.invalidZip" };
+  }
+  if (file.size > MAX_TOOL_SIZE) {
+    return { valid: false, error: "tools:managed.upload.invalidZip" };
+  }
+
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(file);
+  } catch {
+    return { valid: false, error: "tools:managed.upload.invalidZip" };
+  }
+
+  const toolMdContent = await findToolMd(zip);
+  if (toolMdContent === null) {
+    return { valid: false, error: "tools:managed.upload.missingManifest" };
+  }
+  if (!toolMdContent.trim()) {
+    return { valid: false, error: "tools:managed.upload.missingManifest" };
+  }
+
+  const match = toolMdContent.match(FRONTMATTER_REGEX);
+  if (!match?.[1]) {
+    return { valid: false, error: "tools:managed.upload.missingManifest" };
+  }
+  const fields = parseFrontmatterFields(match[1]);
+  if (!fields.name) {
+    return { valid: false, error: "tools:managed.upload.missingManifest" };
+  }
+
+  const slug = fields.slug || slugify(fields.name);
+  if (!SLUG_REGEX.test(slug)) {
+    return { valid: false, error: "tools:managed.upload.invalidZip", errorDetail: slug };
+  }
+
+  return { valid: true, name: fields.name, slug, description: fields.description };
+}
+
+async function findToolMd(zip: JSZip): Promise<string | null> {
+  if (zip.files["TOOL.md"] && !zip.files["TOOL.md"].dir) {
+    return zip.files["TOOL.md"].async("string");
+  }
+  const paths = Object.keys(zip.files);
+  const topDirs = new Set(paths.map((p) => p.split("/")[0]).filter(Boolean));
+  for (const dir of topDirs) {
+    const key = dir + "/TOOL.md";
+    if (zip.files[key] && !zip.files[key].dir) {
+      return zip.files[key].async("string");
+    }
+  }
+  return null;
+}
+
+function parseFrontmatterFields(raw: string): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const idx = line.indexOf(":");
+    if (idx > 0) {
+      const key = line.slice(0, idx).trim();
+      const val = line
+        .slice(idx + 1)
+        .trim()
+        .replace(/^["']|["']$/g, "");
+      if (key && val) fields[key] = val;
+    }
+  }
+  return fields;
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/ui/web/src/pages/tools/managed-tool-edit-dialog.tsx
+++ b/ui/web/src/pages/tools/managed-tool-edit-dialog.tsx
@@ -1,0 +1,188 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ManagedToolInfo } from "@/types/tool";
+
+interface ManagedToolEditDialogProps {
+  tool: ManagedToolInfo;
+  onClose: () => void;
+  onSave: (id: string, updates: Record<string, unknown>) => Promise<unknown>;
+}
+
+export function ManagedToolEditDialog({ tool, onClose, onSave }: ManagedToolEditDialogProps) {
+  const { t } = useTranslation("tools");
+  const [name, setName] = useState(tool.name);
+  const [description, setDescription] = useState(tool.description);
+  const [visibility, setVisibility] = useState(tool.visibility ?? "private");
+  const [runtime, setRuntime] = useState(tool.runtime ?? "");
+  const [entryPoint, setEntryPoint] = useState(tool.entry_point ?? "");
+  const [tags, setTags] = useState<string[]>(tool.tags ?? []);
+  const [tagInput, setTagInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setName(tool.name);
+    setDescription(tool.description);
+    setVisibility(tool.visibility ?? "private");
+    setRuntime(tool.runtime ?? "");
+    setEntryPoint(tool.entry_point ?? "");
+    setTags(tool.tags ?? []);
+  }, [tool]);
+
+  const addTag = () => {
+    const tag = tagInput.trim().toLowerCase();
+    if (tag && !tags.includes(tag)) {
+      setTags([...tags, tag]);
+    }
+    setTagInput("");
+  };
+
+  const removeTag = (tag: string) => {
+    setTags(tags.filter((t) => t !== tag));
+  };
+
+  const handleSave = async () => {
+    if (!tool.id) return;
+    setLoading(true);
+    setError("");
+    try {
+      await onSave(tool.id, { name, description, visibility, runtime, entry_point: entryPoint, tags });
+      onClose();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : t("managed.edit.toast.failed"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={() => onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("managed.edit.title")}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="tool-name">{t("managed.edit.name")}</Label>
+            <Input
+              id="tool-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="text-base md:text-sm"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="tool-desc">{t("managed.edit.description")}</Label>
+            <Textarea
+              id="tool-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t("managed.edit.descriptionPlaceholder")}
+              rows={3}
+              className="text-base md:text-sm"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>{t("managed.edit.visibility")}</Label>
+            <Select value={visibility} onValueChange={setVisibility}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="private">Private</SelectItem>
+                <SelectItem value="internal">Internal</SelectItem>
+                <SelectItem value="public">Public</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="tool-runtime">{t("managed.edit.runtime")}</Label>
+            <Input
+              id="tool-runtime"
+              value={runtime}
+              onChange={(e) => setRuntime(e.target.value)}
+              placeholder={t("managed.edit.runtimePlaceholder")}
+              className="text-base md:text-sm"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="tool-entry-point">{t("managed.edit.entryPoint")}</Label>
+            <Input
+              id="tool-entry-point"
+              value={entryPoint}
+              onChange={(e) => setEntryPoint(e.target.value)}
+              placeholder={t("managed.edit.entryPointPlaceholder")}
+              className="text-base md:text-sm"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>{t("managed.edit.tags")}</Label>
+            <div className="flex gap-2">
+              <Input
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") { e.preventDefault(); addTag(); }
+                }}
+                placeholder="Add tag..."
+                className="flex-1 text-base md:text-sm"
+              />
+              <Button type="button" variant="outline" size="sm" onClick={addTag}>
+                Add
+              </Button>
+            </div>
+            {tags.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1">
+                {tags.map((tag) => (
+                  <Badge key={tag} variant="secondary" className="gap-1">
+                    {tag}
+                    <button type="button" onClick={() => removeTag(tag)} className="hover:text-destructive">
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={loading}>
+            {t("managed.edit.cancel")}
+          </Button>
+          <Button onClick={handleSave} disabled={loading || !name.trim()}>
+            {loading ? t("managed.edit.saving") : t("managed.edit.save")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/web/src/pages/tools/managed-tool-upload-dialog.tsx
+++ b/ui/web/src/pages/tools/managed-tool-upload-dialog.tsx
@@ -1,0 +1,244 @@
+import { useState, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Upload, CheckCircle2, XCircle, Loader2, X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { validateToolZip } from "./lib/validate-tool-zip";
+
+type FileStatus = "validating" | "valid" | "invalid" | "uploading" | "success" | "error";
+
+interface FileEntry {
+  id: string;
+  file: File;
+  status: FileStatus;
+  name?: string;
+  slug?: string;
+  error?: string;
+}
+
+interface ManagedToolUploadDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUpload: (file: File) => Promise<unknown>;
+}
+
+export function ManagedToolUploadDialog({ open, onOpenChange, onUpload }: ManagedToolUploadDialogProps) {
+  const { t } = useTranslation("tools");
+  const [entries, setEntries] = useState<FileEntry[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [done, setDone] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const addFiles = async (fileList: FileList) => {
+    const newFiles = Array.from(fileList);
+    const existingNames = new Set(entries.map((e) => e.file.name));
+    const fresh = newFiles.filter((f) => !existingNames.has(f.name));
+    if (fresh.length === 0) return;
+
+    const pending: FileEntry[] = fresh.map((f) => ({
+      id: crypto.randomUUID(),
+      file: f,
+      status: "validating" as const,
+    }));
+    setEntries((prev) => [...prev, ...pending]);
+
+    const results = await Promise.all(
+      pending.map(async (entry) => {
+        try {
+          return { id: entry.id, result: await validateToolZip(entry.file) };
+        } catch {
+          return { id: entry.id, result: { valid: false, error: "managed.upload.invalidZip" } as const };
+        }
+      }),
+    );
+    setEntries((prev) =>
+      prev.map((e) => {
+        const match = results.find((r) => r.id === e.id);
+        if (!match) return e;
+        const { result } = match;
+        return {
+          ...e,
+          status: result.valid ? "valid" : "invalid",
+          name: "name" in result ? result.name : undefined,
+          slug: "slug" in result ? result.slug : undefined,
+          error: result.error,
+        };
+      }),
+    );
+  };
+
+  const removeEntry = (id: string) => {
+    setEntries((prev) => prev.filter((e) => e.id !== id));
+  };
+
+  const handleSubmit = async () => {
+    const validEntries = entries.filter((e) => e.status === "valid");
+    if (validEntries.length === 0) return;
+    setUploading(true);
+
+    for (const entry of validEntries) {
+      setEntries((prev) =>
+        prev.map((e) => (e.id === entry.id ? { ...e, status: "uploading" } : e)),
+      );
+      try {
+        await onUpload(entry.file);
+        setEntries((prev) =>
+          prev.map((e) => (e.id === entry.id ? { ...e, status: "success" } : e)),
+        );
+      } catch (err) {
+        setEntries((prev) =>
+          prev.map((e) =>
+            e.id === entry.id
+              ? { ...e, status: "error", error: err instanceof Error ? err.message : t("managed.upload.toast.failed") }
+              : e,
+          ),
+        );
+      }
+    }
+    setUploading(false);
+    setDone(true);
+  };
+
+  const handleClose = (v: boolean) => {
+    if (uploading) return;
+    setEntries([]);
+    setDragging(false);
+    setDone(false);
+    onOpenChange(v);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(false);
+    if (e.dataTransfer.files.length > 0) {
+      addFiles(e.dataTransfer.files);
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      addFiles(e.target.files);
+    }
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const validCount = entries.filter((e) => e.status === "valid").length;
+  const successCount = entries.filter((e) => e.status === "success").length;
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-h-[80dvh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>{t("managed.upload.title")}</DialogTitle>
+          <DialogDescription>{t("managed.upload.description")}</DialogDescription>
+        </DialogHeader>
+
+        {!uploading && !done && (
+          <div
+            role="button"
+            tabIndex={0}
+            className={`flex cursor-pointer flex-col items-center gap-2 rounded-md border-2 border-dashed p-6 text-center transition-colors ${
+              dragging ? "border-primary bg-primary/5" : "hover:border-primary/50"
+            }`}
+            onClick={() => inputRef.current?.click()}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); inputRef.current?.click(); } }}
+            onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+            onDragEnter={(e) => { e.preventDefault(); setDragging(true); }}
+            onDragLeave={() => setDragging(false)}
+            onDrop={handleDrop}
+          >
+            <Upload className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              {dragging ? t("managed.upload.dropzoneActive") : t("managed.upload.dropzone")}
+            </p>
+            <input
+              ref={inputRef}
+              type="file"
+              accept=".zip"
+              multiple
+              className="hidden"
+              onChange={handleInputChange}
+            />
+          </div>
+        )}
+
+        {entries.length > 0 && (
+          <div className="flex flex-col gap-1 overflow-y-auto max-h-[40dvh]">
+            {entries.map((entry) => (
+              <div key={entry.id} className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
+                <StatusIcon status={entry.status} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-medium">
+                      {entry.name || entry.file.name}
+                    </span>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {(entry.file.size / 1024).toFixed(1)} KB
+                    </span>
+                  </div>
+                  {(entry.status === "invalid" || entry.status === "error") && (
+                    <p className="text-xs text-destructive truncate">{entry.error ? t(entry.error) : t("managed.upload.toast.failed")}</p>
+                  )}
+                  {entry.status === "validating" && (
+                    <p className="text-xs text-muted-foreground">{t("managed.upload.uploading")}</p>
+                  )}
+                </div>
+                {!uploading && entry.status !== "uploading" && entry.status !== "success" && (
+                  <button
+                    type="button"
+                    onClick={(e) => { e.stopPropagation(); removeEntry(entry.id); }}
+                    className="shrink-0 rounded-sm p-1 text-muted-foreground hover:text-foreground"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {entries.length > 0 && done && (
+          <p className="text-sm font-medium text-muted-foreground">
+            {successCount} / {entries.length} uploaded successfully
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleClose(false)} disabled={uploading}>
+            {t("managed.upload.cancel")}
+          </Button>
+          {done ? (
+            <Button onClick={() => handleClose(false)}>Done</Button>
+          ) : (
+            <Button onClick={handleSubmit} disabled={validCount === 0 || uploading}>
+              {uploading ? t("managed.upload.uploading") : t("managed.upload.upload")}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StatusIcon({ status }: { status: FileStatus }) {
+  switch (status) {
+    case "validating":
+    case "uploading":
+      return <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />;
+    case "valid":
+      return <CheckCircle2 className="h-4 w-4 shrink-0 text-primary" />;
+    case "success":
+      return <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600" />;
+    case "invalid":
+    case "error":
+      return <XCircle className="h-4 w-4 shrink-0 text-destructive" />;
+  }
+}

--- a/ui/web/src/pages/tools/managed-tools-tab.tsx
+++ b/ui/web/src/pages/tools/managed-tools-tab.tsx
@@ -1,0 +1,279 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+import { Package, Pencil, RefreshCw, Upload, Trash2, ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { EmptyState } from "@/components/shared/empty-state";
+import { SearchInput } from "@/components/shared/search-input";
+import { Pagination } from "@/components/shared/pagination";
+import { TableSkeleton } from "@/components/shared/loading-skeleton";
+import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
+import { cn } from "@/lib/utils";
+import { ROUTES } from "@/lib/constants";
+import { useManagedTools, type ManagedToolInfo } from "./hooks/use-managed-tools";
+import { ManagedToolUploadDialog } from "./managed-tool-upload-dialog";
+import { ManagedToolEditDialog } from "./managed-tool-edit-dialog";
+import { useMinLoading } from "@/hooks/use-min-loading";
+import { useDeferredLoading } from "@/hooks/use-deferred-loading";
+import { usePagination } from "@/hooks/use-pagination";
+
+const visibilityColor: Record<string, string> = {
+  public: "default",
+  internal: "secondary",
+  private: "outline",
+};
+
+export function ManagedToolsTab() {
+  const { t } = useTranslation("tools");
+  const navigate = useNavigate();
+  const {
+    managedTools, loading, refresh, uploadTool, updateTool, deleteTool, toggleTool,
+  } = useManagedTools();
+  const spinning = useMinLoading(loading);
+  const showSkeleton = useDeferredLoading(loading && managedTools.length === 0);
+  const [search, setSearch] = useState("");
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<ManagedToolInfo | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<ManagedToolInfo | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [toggling, setToggling] = useState<string | null>(null);
+
+  const filtered = managedTools.filter(
+    (t: ManagedToolInfo) =>
+      t.name.toLowerCase().includes(search.toLowerCase()) ||
+      t.description.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const { pageItems, pagination, setPage, setPageSize, resetPage } = usePagination(filtered);
+
+  useEffect(() => { resetPage(); }, [search, resetPage]);
+
+  const handleUpload = async (file: File) => {
+    await uploadTool(file);
+    refresh();
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget?.id) return;
+    setDeleteLoading(true);
+    try {
+      await deleteTool(deleteTarget.id);
+      setDeleteTarget(null);
+      refresh();
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
+  const handleToggle = async (tool: ManagedToolInfo, enabled: boolean) => {
+    if (!tool.id) return;
+    setToggling(tool.id);
+    try {
+      await toggleTool(tool.id, enabled);
+    } finally {
+      setToggling(null);
+    }
+  };
+
+  const handleCycleVisibility = async (tool: ManagedToolInfo) => {
+    if (!tool.id) return;
+    const order = ["private", "internal", "public"] as const;
+    const idx = order.indexOf(tool.visibility as typeof order[number]);
+    const next = order[(idx + 1) % order.length];
+    await updateTool(tool.id, { visibility: next });
+  };
+
+  const handleOpen = (tool: ManagedToolInfo) => {
+    navigate(ROUTES.TOOL_DETAIL.replace(":id", tool.id));
+  };
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder={t("managed.searchPlaceholder")}
+          className="max-w-sm"
+        />
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => setUploadOpen(true)} className="gap-1">
+            <Upload className="h-3.5 w-3.5" /> {t("managed.uploadButton")}
+          </Button>
+          <Button variant="outline" size="sm" onClick={refresh} disabled={spinning} className="gap-1">
+            <RefreshCw className={"h-3.5 w-3.5" + (spinning ? " animate-spin" : "")} />
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        {showSkeleton ? (
+          <TableSkeleton rows={5} />
+        ) : filtered.length === 0 ? (
+          <EmptyState
+            icon={Package}
+            title={search ? t("managed.noMatchTitle") : t("managed.emptyTitle")}
+            description={search ? t("managed.noMatchDescription") : t("managed.emptyDescription")}
+          />
+        ) : (
+          <div className="overflow-x-auto rounded-md border">
+            <table className="w-full min-w-[600px] text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="px-4 py-3 text-left font-medium">{t("managed.columns.name")}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t("managed.columns.description")}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t("managed.columns.runtime")}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t("managed.columns.version")}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t("managed.columns.status")}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t("managed.columns.visibility")}</th>
+                  <th className="px-4 py-3 text-right font-medium">{t("managed.columns.actions")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pageItems.map((tool: ManagedToolInfo) => {
+                  const isArchived = tool.status === "archived";
+                  const isDisabled = tool.enabled === false;
+                  return (
+                    <tr key={tool.id} className={cn("border-b last:border-0 hover:bg-muted/30", (isArchived || isDisabled) && "opacity-60")}>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <Package className="h-4 w-4 text-muted-foreground shrink-0" />
+                          <button
+                            type="button"
+                            className="font-medium text-left hover:underline cursor-pointer"
+                            onClick={() => handleOpen(tool)}
+                          >
+                            {tool.name}
+                          </button>
+                          {tool.is_system && (
+                            <Badge variant="outline" className="border-blue-500 text-blue-600 text-[10px]">
+                              {t("managed.system")}
+                            </Badge>
+                          )}
+                        </div>
+                      </td>
+                      <td className="max-w-xs truncate px-4 py-3 text-muted-foreground">
+                        {tool.description || t("managed.noDescription")}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {tool.runtime || "—"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-xs text-muted-foreground">v{tool.version}</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "text-[10px] w-fit",
+                            isArchived
+                              ? "border-amber-500 text-amber-600 dark:border-amber-600 dark:text-amber-400"
+                              : "border-emerald-500 text-emerald-600 dark:border-emerald-600 dark:text-emerald-400",
+                          )}
+                        >
+                          {isArchived ? t("managed.status.archived") : t("managed.status.active")}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3">
+                        {tool.visibility && (
+                          <button
+                            type="button"
+                            onClick={() => handleCycleVisibility(tool)}
+                            title={t("managed.visibility.clickToCycle")}
+                          >
+                            <Badge
+                              variant={visibilityColor[tool.visibility] as "default" | "secondary" | "outline"}
+                              className="cursor-pointer hover:opacity-80 transition-opacity"
+                            >
+                              {tool.visibility}
+                            </Badge>
+                          </button>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="flex items-center justify-end gap-2">
+                          <Switch
+                            size="sm"
+                            checked={tool.enabled !== false}
+                            disabled={toggling === tool.id}
+                            onCheckedChange={(checked) => handleToggle(tool, checked)}
+                            title={tool.enabled !== false ? t("managed.toggle.disable") : t("managed.toggle.enable")}
+                          />
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleOpen(tool)}
+                            className="gap-1"
+                            title="Open"
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setEditTarget(tool)}
+                            className="gap-1"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          {!tool.is_system && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setDeleteTarget(tool)}
+                              className="gap-1 text-destructive hover:text-destructive"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            <Pagination
+              page={pagination.page}
+              pageSize={pagination.pageSize}
+              total={pagination.total}
+              totalPages={pagination.totalPages}
+              onPageChange={setPage}
+              onPageSizeChange={setPageSize}
+            />
+          </div>
+        )}
+      </div>
+
+      {editTarget && (
+        <ManagedToolEditDialog
+          tool={editTarget}
+          onClose={() => setEditTarget(null)}
+          onSave={async (id, updates) => {
+            await updateTool(id, updates);
+            setEditTarget(null);
+          }}
+        />
+      )}
+
+      <ManagedToolUploadDialog
+        open={uploadOpen}
+        onOpenChange={setUploadOpen}
+        onUpload={handleUpload}
+      />
+
+      <ConfirmDeleteDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        title={t("managed.delete.title")}
+        description={t("managed.delete.description", { name: deleteTarget?.name })}
+        confirmValue={deleteTarget?.name || ""}
+        confirmLabel={t("managed.delete.confirmLabel")}
+        onConfirm={handleDelete}
+        loading={deleteLoading}
+      />
+    </div>
+  );
+}

--- a/ui/web/src/pages/tools/tool-detail-page.tsx
+++ b/ui/web/src/pages/tools/tool-detail-page.tsx
@@ -1,0 +1,302 @@
+import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from "react";
+import { useParams, useSearchParams, Link } from "react-router";
+import { useTranslation } from "react-i18next";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { FileTreePanel } from "@/components/shared/file-tree";
+import { buildTree } from "@/lib/file-helpers";
+import { ROUTES } from "@/lib/constants";
+import { toast } from "@/stores/use-toast-store";
+import { useManagedTools } from "./hooks/use-managed-tools";
+import type { ManagedToolInfo, ManagedToolFile } from "@/types/tool";
+import type { CodeLanguage } from "@/components/shared/code-editor";
+
+const LazyCodeEditor = lazy(() =>
+  import("@/components/shared/code-editor").then((m) => ({ default: m.CodeEditor })),
+);
+
+const MAX_FILE_SIZE = 500 * 1024; // 500 KB
+
+function detectLanguage(filePath: string): CodeLanguage {
+  const ext = filePath.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "py":
+      return "python";
+    case "js":
+    case "jsx":
+      return "javascript";
+    case "ts":
+    case "tsx":
+      return "typescript";
+    case "json":
+      return "json";
+    default:
+      return "text";
+  }
+}
+
+export function ToolDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { t } = useTranslation(["tools", "common"]);
+  const { getManagedTool, getManagedToolFiles, getFileContent, writeFile } = useManagedTools();
+
+  // Tool metadata
+  const [tool, setTool] = useState<ManagedToolInfo | null>(null);
+  const [files, setFiles] = useState<ManagedToolFile[]>([]);
+  const [filesLoading, setFilesLoading] = useState(true);
+
+  // Editor state
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [fileContent, setFileContent] = useState<string>("");
+  const [savedContent, setSavedContent] = useState<string>("");
+  const [contentLoading, setContentLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [fileTooLarge, setFileTooLarge] = useState(false);
+
+  // Panel resize
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [panelWidth, setPanelWidth] = useState(240);
+  const dragging = useRef(false);
+
+  const hasUnsaved = fileContent !== savedContent;
+  const tree = useMemo(() => buildTree(files), [files]);
+
+  // Load tool metadata + files on mount
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const [toolData, fileList] = await Promise.all([
+          getManagedTool(id!),
+          getManagedToolFiles(id!),
+        ]);
+        if (cancelled) return;
+        setTool(toolData);
+        setFiles(fileList);
+        setFilesLoading(false);
+
+        // Auto-select file from URL param, entry_point, or first file
+        const fileParam = searchParams.get("file");
+        const textFiles = fileList.filter((f: ManagedToolFile) => !f.isDir);
+        let autoSelect: string | null = null;
+
+        if (fileParam && textFiles.some((f: ManagedToolFile) => f.path === fileParam)) {
+          autoSelect = fileParam;
+        } else if (toolData.entry_point && textFiles.some((f: ManagedToolFile) => f.path === toolData.entry_point)) {
+          autoSelect = toolData.entry_point;
+        } else if (textFiles.length > 0) {
+          autoSelect = textFiles[0]!.path;
+        }
+
+        if (autoSelect) {
+          await loadFile(id!, autoSelect, fileList);
+        }
+      } catch {
+        if (!cancelled) setFilesLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const loadFile = useCallback(
+    async (toolId: string, path: string, fileList?: ManagedToolFile[]) => {
+      // Check file size before loading
+      const lookupFiles = fileList ?? files;
+      const file = lookupFiles.find((f) => f.path === path);
+      if (file && file.size > MAX_FILE_SIZE) {
+        setSelectedFile(path);
+        setFileTooLarge(true);
+        setFileContent("");
+        setSavedContent("");
+        setSearchParams({ file: path });
+        return;
+      }
+
+      setContentLoading(true);
+      setFileTooLarge(false);
+      try {
+        const data = await getFileContent(toolId, path);
+        setFileContent(data.content);
+        setSavedContent(data.content);
+        setSelectedFile(path);
+        setSearchParams({ file: path });
+      } finally {
+        setContentLoading(false);
+      }
+    },
+    [files, getFileContent, setSearchParams],
+  );
+
+  const handleSelectFile = useCallback(
+    async (path: string) => {
+      if (path === selectedFile) return;
+      if (hasUnsaved && !window.confirm(t("tools:managed.detail.discardChanges"))) return;
+      if (!id) return;
+      await loadFile(id, path);
+    },
+    [id, selectedFile, hasUnsaved, loadFile, t],
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!id || !selectedFile || !hasUnsaved) return;
+    setSaving(true);
+    try {
+      await writeFile(id, selectedFile, fileContent);
+      setSavedContent(fileContent);
+      toast.success(t("tools:managed.detail.fileSaved"));
+    } catch {
+      toast.error(t("tools:managed.detail.fileSaveFailed"));
+    } finally {
+      setSaving(false);
+    }
+  }, [id, selectedFile, fileContent, hasUnsaved, writeFile, t]);
+
+  // Keyboard shortcut: Ctrl/Cmd+S
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault();
+        handleSave();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [handleSave]);
+
+  // beforeunload warning
+  useEffect(() => {
+    if (!hasUnsaved) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [hasUnsaved]);
+
+  // Panel resize handler
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      dragging.current = true;
+      const startX = e.clientX;
+      const startW = panelWidth;
+
+      const onMove = (ev: MouseEvent) => {
+        if (!dragging.current) return;
+        const container = containerRef.current;
+        if (!container) return;
+        const maxW = container.offsetWidth * 0.5;
+        const newW = Math.max(160, Math.min(maxW, startW + ev.clientX - startX));
+        setPanelWidth(newW);
+      };
+      const onUp = () => {
+        dragging.current = false;
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+      };
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+    },
+    [panelWidth],
+  );
+
+  const language = selectedFile ? detectLanguage(selectedFile) : "text";
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Top bar */}
+      <div className="flex h-12 items-center gap-3 border-b px-4 shrink-0">
+        <Link
+          to={`${ROUTES.TOOLS}?tab=managed`}
+          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {t("tools:managed.detail.backToTools")}
+        </Link>
+        <span className="font-semibold truncate">{tool?.name ?? ""}</span>
+        {tool?.runtime && (
+          <Badge variant="outline" className="text-xs shrink-0">
+            {tool.runtime}
+          </Badge>
+        )}
+        <div className="flex-1" />
+        {hasUnsaved && (
+          <span className="text-xs text-amber-500 shrink-0">
+            {"● "}{t("tools:managed.detail.unsaved")}
+          </span>
+        )}
+        <Button size="sm" onClick={handleSave} disabled={saving || !hasUnsaved}>
+          {saving ? t("tools:managed.detail.saving") : t("tools:managed.detail.save")}
+        </Button>
+      </div>
+
+      {/* Main content: file tree + editor */}
+      <div ref={containerRef} className="flex flex-1 min-h-0 overflow-hidden">
+        {/* File tree panel */}
+        <div
+          className="shrink-0 overflow-y-auto border-r bg-muted/20 py-1"
+          style={{ width: panelWidth }}
+        >
+          <FileTreePanel
+            tree={tree}
+            filesLoading={filesLoading}
+            activePath={selectedFile}
+            onSelect={handleSelectFile}
+          />
+        </div>
+
+        {/* Resize handle */}
+        <div
+          className="w-1 shrink-0 cursor-col-resize bg-border hover:bg-primary/30 active:bg-primary/50 transition-colors"
+          onMouseDown={onMouseDown}
+        />
+
+        {/* Editor panel */}
+        <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
+          {selectedFile && (
+            <div className="flex items-center gap-2 border-b px-3 py-1.5 text-xs text-muted-foreground shrink-0">
+              <span className="font-mono truncate">{selectedFile}</span>
+            </div>
+          )}
+
+          <div className="flex-1 min-h-0 overflow-hidden">
+            {contentLoading ? (
+              <div className="flex items-center justify-center h-full">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : fileTooLarge ? (
+              <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                {t("tools:managed.detail.fileTooLarge")}
+              </div>
+            ) : selectedFile ? (
+              <Suspense
+                fallback={
+                  <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                    {t("tools:managed.detail.loadingEditor")}
+                  </div>
+                }
+              >
+                <LazyCodeEditor
+                  value={fileContent}
+                  onChange={setFileContent}
+                  language={language}
+                />
+              </Suspense>
+            ) : (
+              <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                {t("tools:managed.detail.noFileSelected")}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/web/src/pages/tools/tools-page.tsx
+++ b/ui/web/src/pages/tools/tools-page.tsx
@@ -1,0 +1,66 @@
+import { useSearchParams } from "react-router";
+import { useTranslation } from "react-i18next";
+import { PageHeader } from "@/components/shared/page-header";
+import { cn } from "@/lib/utils";
+import { BuiltinToolsPage } from "@/pages/builtin-tools/builtin-tools-page";
+import { CustomToolsPage } from "@/pages/custom-tools/custom-tools-page";
+import { ManagedToolsTab } from "./managed-tools-tab";
+
+type Tab = "core" | "custom" | "managed";
+const TABS: Tab[] = ["core", "custom", "managed"];
+
+function isValidTab(v: string | null): v is Tab {
+  return v === "core" || v === "custom" || v === "managed";
+}
+
+export function ToolsPage() {
+  const { t } = useTranslation("tools");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawTab = searchParams.get("tab");
+  const tab: Tab = isValidTab(rawTab) ? rawTab : "core";
+
+  const handleTabChange = (newTab: Tab) => {
+    setSearchParams({ tab: newTab }, { replace: true });
+  };
+
+  return (
+    <div className="p-4 sm:p-6">
+      <PageHeader
+        title={t("title")}
+        description={t("description")}
+      />
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b mt-4">
+        {TABS.map((t_) => (
+          <button
+            key={t_}
+            type="button"
+            className={cn(
+              "px-3 py-1.5 text-sm font-medium border-b-2 -mb-px",
+              tab === t_
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+            onClick={() => handleTabChange(t_)}
+          >
+            {t(`tabs.${t_}`)}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {tab === "core" && (
+        <div className="-m-4 sm:-m-6">
+          <BuiltinToolsPage />
+        </div>
+      )}
+      {tab === "custom" && (
+        <div className="-m-4 sm:-m-6">
+          <CustomToolsPage />
+        </div>
+      )}
+      {tab === "managed" && <ManagedToolsTab />}
+    </div>
+  );
+}

--- a/ui/web/src/types/tool.ts
+++ b/ui/web/src/types/tool.ts
@@ -1,0 +1,27 @@
+export interface ManagedToolInfo {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  visibility: string;
+  version: number;
+  status: string;
+  enabled: boolean;
+  is_system?: boolean;
+  runtime?: string;
+  entry_point?: string;
+  tags?: string[];
+  owner_id?: string;
+}
+
+export interface ManagedToolFile {
+  path: string;
+  name: string;
+  isDir: boolean;
+  size: number;
+}
+
+export interface ManagedToolVersions {
+  versions: number[];
+  current: number;
+}


### PR DESCRIPTION
- Add DB migration 000018 for managed_tools + grant tables
- Add ManagedToolStore interface + PG implementation with caching
- Add HTTP endpoints /v1/managed-tools/* (CRUD, upload, file read/write)
- Add WS RPC methods managed-tools.list, managed-tools.get
- Create unified /tools page with 3 tabs: Core, Custom, Managed
- Replace separate Built-in Tools + Custom Tools sidebar items
- Add CodeMirror 6 editor for /tools/:id detail page (lazy-loaded)
- Add Ctrl/Cmd+S save, unsaved indicator, beforeunload warning
- Add i18n translations for en/vi/zh
- Redirect /builtin-tools → /tools?tab=core, /custom-tools → /tools?tab=custom