### PR TITLE
fix: use resolved workspace dir for StorageHandler

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -753,8 +753,10 @@ func runGateway() {
 	// Supports media from any agent workspace (each agent has its own workspace from DB).
 	server.SetFilesHandler(httpapi.NewFilesHandler(cfg.Gateway.Token))
 
-	// Storage file management — browse/delete files under ~/.goclaw/ (excluding skills dirs).
-	server.SetStorageHandler(httpapi.NewStorageHandler(config.ExpandHome("~/.goclaw"), cfg.Gateway.Token))
+	// Storage file management — browse/delete files under the resolved workspace directory.
+	// Uses GOCLAW_WORKSPACE (or default ~/.goclaw/workspace) so it works correctly
+	// in Docker deployments where volumes are mounted outside ~/.goclaw/.
+	server.SetStorageHandler(httpapi.NewStorageHandler(workspace, cfg.Gateway.Token))
 
 	// Media upload endpoint — accepts multipart file uploads, returns temp path + MIME type.
 	server.SetMediaUploadHandler(httpapi.NewMediaUploadHandler(cfg.Gateway.Token))


### PR DESCRIPTION
## Summary

- StorageHandler was hardcoded to browse `~/.goclaw/`, which is empty in Docker deployments where volumes are mounted to separate paths (e.g. `GOCLAW_WORKSPACE=/app/workspace`)
- Changed to use the already-resolved `workspace` variable (from `GOCLAW_WORKSPACE` env / config `Agents.Defaults.Workspace`, defaulting to `~/.goclaw/workspace`)
- The Storage page in Dashboard UI now correctly shows workspace files (team workspaces, media, agent files) regardless of deployment layout

## Context

In Docker Compose setups with named volumes:
```yaml
volumes:
  - goclaw-workspace:/app/workspace  # actual workspace files
```

`HOME=/app` → `~/.goclaw` = `/app/.goclaw/` (empty), while real files live at `/app/workspace/`. The Storage API returned zero files, making the Dashboard Storage page useless.

## Behavior change for non-Docker users

Storage now browses `~/.goclaw/workspace/` instead of `~/.goclaw/`. This is more focused — skills are already managed via the dedicated Skills page, and `data/` contains internal runtime state that isn't user-facing.

## Test plan

- [x] Built and deployed in Docker Compose with `GOCLAW_WORKSPACE=/app/workspace`
- [x] Verified `GET /v1/storage/files` returns workspace content (teams/, .media/, etc.)
- [x] Confirmed team workspace files (audit reports with versions) visible in API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)