### PR TITLE
fix: add database name to postgres healthcheck

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-goclaw}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-goclaw} -d ${POSTGRES_DB:-goclaw}"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary

- Fix postgres healthcheck to specify `-d ${POSTGRES_DB}` instead of defaulting to username
- Resolves "database does not exist" error when `POSTGRES_USER` differs from `POSTGRES_DB`

## Test plan

- [ ] Verify healthcheck passes with custom POSTGRES_USER/POSTGRES_DB values
- [ ] Verify default behavior unchanged when using defaults (goclaw/goclaw)

💘 Generated with Crush