### PR TITLE
fix(anthropic): resolve model aliases for anthropic_native provider

### DIFF
--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -17,6 +17,26 @@ const (
 	anthropicAPIVersion = "2023-06-01"
 )
 
+// claudeModelAliases maps short model aliases to full Anthropic model IDs.
+// This allows agents configured with aliases (e.g. "opus") to work with the
+// anthropic_native provider, consistent with the Claude CLI provider.
+var claudeModelAliases = map[string]string{
+	"opus":   "claude-opus-4-6",
+	"sonnet": "claude-sonnet-4-6",
+	"haiku":  "claude-haiku-4-5-20251001",
+}
+
+// resolveModel expands a short alias to a full model ID, or returns the input unchanged.
+func resolveAnthropicModel(model, defaultModel string) string {
+	if model == "" {
+		return defaultModel
+	}
+	if full, ok := claudeModelAliases[model]; ok {
+		return full
+	}
+	return model
+}
+
 // AnthropicProvider implements Provider using the Anthropic Claude API via net/http.
 type AnthropicProvider struct {
 	apiKey       string
@@ -60,10 +80,7 @@ func (p *AnthropicProvider) DefaultModel() string   { return p.defaultModel }
 func (p *AnthropicProvider) SupportsThinking() bool { return true }
 
 func (p *AnthropicProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
-	model := req.Model
-	if model == "" {
-		model = p.defaultModel
-	}
+	model := resolveAnthropicModel(req.Model, p.defaultModel)
 
 	body := p.buildRequestBody(model, req, false)
 

--- a/internal/providers/anthropic_stream.go
+++ b/internal/providers/anthropic_stream.go
@@ -10,10 +10,7 @@ import (
 )
 
 func (p *AnthropicProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk func(StreamChunk)) (*ChatResponse, error) {
-	model := req.Model
-	if model == "" {
-		model = p.defaultModel
-	}
+	model := resolveAnthropicModel(req.Model, p.defaultModel)
 
 	body := p.buildRequestBody(model, req, true)
 


### PR DESCRIPTION
## Problem

When an agent is configured with a short model alias (e.g. `"opus"`, `"sonnet"`, `"haiku"`) and uses the `anthropic_native` provider, the alias is sent verbatim to the Anthropic API, resulting in a `HTTP 404 not_found_error`:

```
LLM call failed (iteration 1): HTTP 404: anthropic: {"type":"error","error":{"type":"not_found_error","message":"model: opus"}}
```

Short aliases are only valid for the Claude CLI provider, which handles them internally. The `AnthropicProvider` lacked equivalent resolution.

## Solution

Added `resolveAnthropicModel()` in `internal/providers/anthropic.go` — a small helper that expands short aliases to full Anthropic model IDs before the API call. Both `Chat()` and `ChatStream()` now go through this resolver.

**Alias map:**

| Alias | Resolved model ID |
|-------|-------------------|
| `opus` | `claude-opus-4-6` |
| `sonnet` | `claude-sonnet-4-6` |
| `haiku` | `claude-haiku-4-5-20251001` |

Full model IDs (e.g. `claude-sonnet-4-5-20250929`) are passed through unchanged — no breaking change.

## Files changed

- `internal/providers/anthropic.go` — added `claudeModelAliases` map + `resolveAnthropicModel()`, updated `Chat()`
- `internal/providers/anthropic_stream.go` — updated `ChatStream()` to use the resolver