### PR TITLE
fix(ui): support comma separator in allowed users field

### DIFF
--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -169,7 +169,7 @@
       "requireMention": "Require @mention",
       "enabled": "Enabled",
       "allowedUsers": "Allowed Users",
-      "allowedUsersPlaceholder": "One user ID per line",
+      "allowedUsersPlaceholder": "One user ID per line or comma-separated",
       "skillsFilter": "Skills Filter",
       "skillsPlaceholder": "One skill name per line (empty = inherit)",
       "toolAllow": "Tool Allow",

--- a/ui/web/src/pages/channels/channel-fields.tsx
+++ b/ui/web/src/pages/channels/channel-fields.tsx
@@ -132,7 +132,7 @@ function FieldRenderer({
             id={id}
             value={Array.isArray(value) ? (value as string[]).join("\n") : ""}
             onChange={(e) => {
-              const lines = e.target.value.split("\n").map((l) => l.trim()).filter(Boolean);
+              const lines = e.target.value.split(/[\n,]/).map((l) => l.trim()).filter(Boolean);
               onChange(lines.length > 0 ? lines : undefined);
             }}
             placeholder={t("groupOverrides.fields.allowedUsersPlaceholder")}

--- a/ui/web/src/pages/channels/channel-schemas.ts
+++ b/ui/web/src/pages/channels/channel-schemas.ts
@@ -78,7 +78,7 @@ export const configSchema: Record<string, FieldDef[]> = {
     { key: "reaction_level", label: "Reaction Level", type: "select", options: [{ value: "off", label: "Off" }, { value: "minimal", label: "Minimal" }, { value: "full", label: "Full" }], defaultValue: "full" },
     { key: "media_max_bytes", label: "Max Media Size (bytes)", type: "number", defaultValue: 20971520, help: "Default: 20MB" },
     { key: "link_preview", label: "Link Preview", type: "boolean", defaultValue: true },
-    { key: "allow_from", label: "Allowed Users", type: "tags", help: "User IDs or @usernames, one per line" },
+    { key: "allow_from", label: "Allowed Users", type: "tags", help: "User IDs or @usernames, one per line or comma-separated" },
     { key: "block_reply", label: "Block Reply", type: "select", options: blockReplyOptions, defaultValue: "inherit", help: "Deliver intermediate text during tool iterations" },
   ],
   discord: [


### PR DESCRIPTION
## Summary

- Support comma separator in the \"Allowed Users\" textarea field in channel config
- Users can now enter entries separated by commas or newlines
- Fixes issue where Enter key was not working in some browsers (Brave on Linux)

## Test plan

- [ ] Rebuild UI and verify comma-separated entries work
- [ ] Verify newline-separated entries still work
- [ ] Test on affected browser (Brave on Linux)

💘 Generated with Crush