### PR TITLE
fix(openai): use max_completion_tokens and skip temperature for GPT-5/o-series models

### DIFF
--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -313,10 +313,18 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 
 	// Merge options
 	if v, ok := req.Options[OptMaxTokens]; ok {
-		body["max_tokens"] = v
+		if strings.HasPrefix(model, "gpt-5") || strings.HasPrefix(model, "o1") || strings.HasPrefix(model, "o3") || strings.HasPrefix(model, "o4") {
+			body["max_completion_tokens"] = v
+		} else {
+			body["max_tokens"] = v
+		}
 	}
 	if v, ok := req.Options[OptTemperature]; ok {
-		body["temperature"] = v
+		// GPT-5 mini/nano and o-series models only support default temperature
+		skipTemp := strings.HasPrefix(model, "gpt-5-mini") || strings.HasPrefix(model, "gpt-5-nano") || strings.HasPrefix(model, "o1") || strings.HasPrefix(model, "o3") || strings.HasPrefix(model, "o4")
+		if !skipTemp {
+			body["temperature"] = v
+		}
 	}
 
 	// Inject reasoning_effort for o-series models (ignored by models that don't support it)


### PR DESCRIPTION
## Problem

The OpenAI provider in `buildRequestBody()` unconditionally sends `max_tokens` and `temperature` for all models. Newer OpenAI models reject these:

- **GPT-5, o1, o3, o4 models:** require `max_completion_tokens` instead of `max_tokens`
- **GPT-5 mini, GPT-5 nano, o-series:** only support default temperature (1)

### Errors

```
Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

```
Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.
```

## Fix

Adds model-aware branching in `buildRequestBody()`:

- `gpt-5*`, `o1*`, `o3*`, `o4*` → send `max_completion_tokens` instead of `max_tokens`
- `gpt-5-mini*`, `gpt-5-nano*`, `o1*`, `o3*`, `o4*` → skip `temperature` parameter

## Tested with

- `gpt-5-mini` on GoClaw built from `main` (b9a1808), Ubuntu 24.04 arm64

Note: The Codex provider already references `gpt-5.3-codex`, so GoClaw is GPT-5 aware — this gap is only in the standard OpenAI chat completions path.