### PR TITLE
fix(teams): filter empty chat_id scopes to prevent Select crash

### DIFF
--- a/ui/web/src/pages/teams/team-detail-page.tsx
+++ b/ui/web/src/pages/teams/team-detail-page.tsx
@@ -55,7 +55,7 @@ export function TeamDetailPage({ teamId, onBack }: TeamDetailPageProps) {
         if (!cancelled) {
           setTeam(res.team);
           setMembers(res.members ?? []);
-          setScopes(scopeList);
+          setScopes(scopeList.filter((s) => s.chat_id));
         }
       } catch { /* ignore */ }
       finally { if (!cancelled) setLoading(false); }


### PR DESCRIPTION
## Summary
- Filter out scope entries with empty `chat_id` when fetching team scopes in `team-detail-page.tsx`
- Prevents Radix UI `<Select.Item />` crash: "must have a value prop that is not an empty string"

## Test plan
- [ ] Open a team detail page that has scope entries with empty `chat_id`
- [ ] Verify no console errors about Select.Item value
- [ ] Verify scope filter dropdown works correctly in both board toolbar and workspace dialog