### PR TITLE
fix(routing): allow handoff routes to override channel instance agent

### DIFF
--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -44,7 +44,7 @@ func processNormalMessage(
 	}
 
 	// Check handoff routing override
-	if teamStore != nil && msg.AgentID == "" {
+	if teamStore != nil {
 		if route, _ := teamStore.GetHandoffRoute(ctx, msg.Channel, msg.ChatID); route != nil {
 			agentID = route.ToAgentKey
 			slog.Info("inbound: handoff route active",


### PR DESCRIPTION
## Problem

When a channel instance has an explicit `agent_id`, the Slack adapter always sets `msg.AgentID` on inbound messages. The handoff route check at `gateway_consumer_normal.go:47` has a guard `msg.AgentID == ""` that prevents handoff routes from ever activating for these channels.

This makes it impossible to route messages from different Slack channels to different agents through a single channel instance + handoff routes — which is the natural pattern for multi-agent setups where you want one Slack bot serving multiple agents in different channels.

## Fix

Remove the `msg.AgentID == ""` guard so handoff routes can override the channel's default agent. The handoff route lookup is a cheap DB call (already indexed by channel + chat_id), and returning `nil` when no route exists means the default agent is preserved.

## Before
```go
if teamStore != nil && msg.AgentID == "" {
```

## After
```go
if teamStore != nil {
```

## Use Case

Single Slack bot app with one Socket Mode connection. Mother agent handles DMs. Other agents (weather, invoices, etc.) handle their own `#cell-*` channels via handoff routes. No need for separate bot apps per agent.