### PR TITLE
fix(providers): pass custom name to DashScopeProvider for correct registry lookup

### DIFF
--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -87,7 +87,7 @@ func registerProviders(registry *providers.Registry, cfg *config.Config) {
 	}
 
 	if cfg.Providers.DashScope.APIKey != "" {
-		registry.Register(providers.NewDashScopeProvider(cfg.Providers.DashScope.APIKey, cfg.Providers.DashScope.APIBase, "qwen3-max"))
+		registry.Register(providers.NewDashScopeProvider("dashscope", cfg.Providers.DashScope.APIKey, cfg.Providers.DashScope.APIBase, "qwen3-max"))
 		slog.Info("registered provider", "name", "dashscope")
 	}
 
@@ -295,7 +295,7 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			registry.Register(providers.NewAnthropicProvider(p.APIKey,
 				providers.WithAnthropicBaseURL(p.APIBase)))
 		case store.ProviderDashScope:
-			registry.Register(providers.NewDashScopeProvider(p.APIKey, p.APIBase, ""))
+			registry.Register(providers.NewDashScopeProvider(p.Name, p.APIKey, p.APIBase, ""))
 		case store.ProviderBailian:
 			base := p.APIBase
 			if base == "" {

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -125,7 +125,7 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 		h.providerReg.Register(providers.NewAnthropicProvider(p.APIKey,
 			providers.WithAnthropicBaseURL(p.APIBase)))
 	case store.ProviderDashScope:
-		h.providerReg.Register(providers.NewDashScopeProvider(p.APIKey, p.APIBase, ""))
+		h.providerReg.Register(providers.NewDashScopeProvider(p.Name, p.APIKey, p.APIBase, ""))
 	case store.ProviderBailian:
 		base := p.APIBase
 		if base == "" {

--- a/internal/providers/dashscope.go
+++ b/internal/providers/dashscope.go
@@ -35,7 +35,7 @@ type DashScopeProvider struct {
 	*OpenAIProvider
 }
 
-func NewDashScopeProvider(apiKey, apiBase, defaultModel string) *DashScopeProvider {
+func NewDashScopeProvider(name, apiKey, apiBase, defaultModel string) *DashScopeProvider {
 	if apiBase == "" {
 		apiBase = dashscopeDefaultBase
 	}
@@ -43,11 +43,11 @@ func NewDashScopeProvider(apiKey, apiBase, defaultModel string) *DashScopeProvid
 		defaultModel = dashscopeDefaultModel
 	}
 	return &DashScopeProvider{
-		OpenAIProvider: NewOpenAIProvider("dashscope", apiKey, apiBase, defaultModel),
+		OpenAIProvider: NewOpenAIProvider(name, apiKey, apiBase, defaultModel),
 	}
 }
 
-func (p *DashScopeProvider) Name() string           { return "dashscope" }
+// Name is inherited from the embedded OpenAIProvider (returns the user-specified name).
 func (p *DashScopeProvider) SupportsThinking() bool { return true }
 
 // ModelSupportsThinking implements ModelThinkingCapable.

--- a/internal/providers/dashscope_test.go
+++ b/internal/providers/dashscope_test.go
@@ -37,7 +37,7 @@ func newDashScopeTestServer(t *testing.T) (*httptest.Server, *map[string]any) {
 func callDashScopeStream(t *testing.T, req ChatRequest) map[string]any {
 	t.Helper()
 	server, captured := newDashScopeTestServer(t)
-	p := NewDashScopeProvider("test-key", server.URL, "")
+	p := NewDashScopeProvider("dashscope-test", "test-key", server.URL, "")
 	p.retryConfig.Attempts = 1
 	p.ChatStream(context.Background(), req, nil) //nolint:errcheck
 	return *captured
@@ -45,7 +45,7 @@ func callDashScopeStream(t *testing.T, req ChatRequest) map[string]any {
 
 // TestDashScopeModelSupportsThinking verifies the whitelist is correct.
 func TestDashScopeModelSupportsThinking(t *testing.T) {
-	p := NewDashScopeProvider("key", "", "")
+	p := NewDashScopeProvider("dashscope", "key", "", "")
 
 	tests := []struct {
 		model string


### PR DESCRIPTION
**Problem**: `DashScopeProvider.Name()` was hardcoded to return `"dashscope"`, so providers created with custom names (e.g. `myqwen`) failed verification with `provider not registered: myqwen`.

**Fix**: Add a `name` parameter to [NewDashScopeProvider](cci:1://file:///c:/Users/vyrgi/OneDrive/Documents/goclaw/internal/providers/dashscope.go:37:0-47:1) (matching the [OpenAIProvider](cci:2://file:///c:/Users/vyrgi/OneDrive/Documents/goclaw/internal/providers/openai.go:17:0-26:1) pattern) and remove the hardcoded [Name()](cci:1://file:///c:/Users/vyrgi/OneDrive/Documents/goclaw/internal/providers/openai.go:51:0-51:66) override, so the provider registers under the correct user-specified name.

**Files changed**: [internal/providers/dashscope.go](cci:7://file:///c:/Users/vyrgi/OneDrive/Documents/goclaw/internal/providers/dashscope.go:0:0-0:0), [internal/http/providers.go](cci:7://file:///c:/Users/vyrgi/OneDrive/Documents/goclaw/internal/http/providers.go:0:0-0:0), [cmd/gateway_providers.go](cci:7://file:///c:/Users/vyrgi/OneDrive/Documents/goclaw/cmd/gateway_providers.go:0:0-0:0), [internal/providers/dashscope_test.go](cci:7://file:///c:/Users/vyrgi/OneDrive/Documents/goclaw/internal/providers/dashscope_test.go:0:0-0:0)

**Related Issue**:
Fixes issue #200 