### PR TITLE
fix(slack): preserve auth header on Slack-domain redirects during file download

### DIFF
--- a/internal/channels/slack/handlers_files.go
+++ b/internal/channels/slack/handlers_files.go
@@ -140,7 +140,6 @@ func (c *Channel) downloadFile(name, urlPrivate, urlPrivateDownload string, maxB
 	client := &http.Client{
 		Timeout: 60 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			req.Header.Del("Authorization") // strip auth on redirect (CDN presigned URL)
 			if req.URL.Scheme != "https" {
 				return fmt.Errorf("security: redirect to non-HTTPS URL blocked: %s", req.URL)
 			}
@@ -148,6 +147,11 @@ func (c *Channel) downloadFile(name, urlPrivate, urlPrivateDownload string, maxB
 			host := req.URL.Hostname()
 			if !isAllowedSlackHost(host) {
 				return fmt.Errorf("security: redirect to untrusted host blocked: %s", host)
+			}
+			// Strip auth for CDN edge hosts (presigned URLs don't need it),
+			// but keep it for core Slack API hosts that require the bot token.
+			if !strings.HasSuffix(host, ".slack.com") {
+				req.Header.Del("Authorization")
 			}
 			if len(via) >= 3 {
 				return fmt.Errorf("too many redirects")


### PR DESCRIPTION
## Problem

The `CheckRedirect` handler in `downloadFile()` unconditionally strips the `Authorization` header on **all** redirects. Slack's file download flow redirects through `files.slack.com`, which still requires the bot token. Only the final CDN hop (`*.slack-edge.com`) uses presigned URLs that don't need auth.

This causes all Slack file downloads to receive **HTML login pages** instead of actual file content.

## Fix

Only strip `Authorization` when redirecting to non-`.slack.com` hosts (i.e., CDN edge hosts with presigned URLs). The existing SSRF allowlist already ensures redirects only reach trusted Slack domains.

## Before

```
Auth header stripped on ALL redirects → intermediate Slack redirect loses token → 302 to login page → HTML saved as "PDF"
```

## After

```
Auth header kept for *.slack.com redirects → file downloaded correctly
Auth header stripped for *.slack-edge.com → presigned CDN URLs work as before
```

## Testing

Verified on a live GoClaw instance: before this fix, every Slack file download (PDF, images, etc.) returned Slack's HTML login page. After the fix, files download correctly with proper content.