### PR TITLE
fix(telegram): enforce transport policy and SSRF guard for media downloads

### DIFF
--- a/internal/channels/telegram/channel.go
+++ b/internal/channels/telegram/channel.go
@@ -71,9 +71,9 @@ func New(cfg config.TelegramConfig, msgBus *bus.MessageBus, pairingSvc store.Pai
 		if parseErr != nil {
 			return nil, fmt.Errorf("invalid proxy URL %q: %w", cfg.Proxy, parseErr)
 		}
-		httpClient.Transport = &http.Transport{
-			Proxy: http.ProxyURL(proxyURL),
-		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.Proxy = http.ProxyURL(proxyURL)
+		httpClient.Transport = transport
 	}
 	opts = append(opts, telego.WithHTTPClient(httpClient))
 

--- a/internal/channels/telegram/media.go
+++ b/internal/channels/telegram/media.go
@@ -237,12 +237,23 @@ func (c *Channel) downloadMedia(ctx context.Context, fileID string, maxBytes int
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)
+	// Use a generous timeout for media downloads (large files via local Bot API
+	// can be up to 200 MB). The shared httpClient has a 30s timeout suited for
+	// API calls, so we override per-request with a dedicated context.
+	dlCtx, dlCancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer dlCancel()
+
+	req, err := http.NewRequestWithContext(dlCtx, "GET", downloadURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("create download request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	// Clone the shared client without the 30s Timeout so the per-request
+	// context (5 min) governs the download duration instead.
+	dlClient := *c.httpClient
+	dlClient.Timeout = 0
+
+	resp, err := dlClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("download file: %w", err)
 	}


### PR DESCRIPTION
### Overview
This PR addresses a security and networking gap in the Telegram channel where media downloads were bypassing the configured transport (proxy) and lacked SSRF protection. It unifies the network stack to ensure consistent and secure behavior.

### The Issue

1.  **Proxy Leak**: The Telegram media downloader was using `http.Get()`. In Go, this uses the `DefaultClient`, which does not inherit the proxy settings configured for the bot. As a result, even if a user specified a proxy, their real IP was being leaked during media downloads.
2.  **SSRF Risk**: The bot would blindly initiate a connection to any URL provided by the Telegram API for file downloads. This lacked any validation, making the bot a potential vector for Server-Side Request Forgery (SSRF) against internal services.
3.  **Unmanaged Resources**: Media downloads lacked explicit timeouts or context handling. This meant a slow or stalled download could hang a goroutine indefinitely, leading to resource exhaustion.


### Key Changes
- **Unified HTTP Client**: Refactored the Telegram channel to utilize a single, shared `*http.Client` configured with the bot’s proxy settings and a standard 30s timeout.
- **Transport-Aware Downloads**: Updated the media downloading logic to use the unified client instead of the global `http.Get`. This ensures that all media fetches correctly respect the user's proxy configuration.
- **SSRF Guard**: Integrated `tools.CheckSSRF` to validate all download URLs before connecting. This prevents the bot from being used to probe or access internal network services.
- **Local Bot API Support**: Added a logical "Trust Filter" that allows the explicitly configured `APIServer` to bypass SSRF checks. This ensures that users hosting their own Telegram backend (local IP/localhost) are not accidentally blocked by the security guard.

### Technical Details
- Replaced standalone `http.Get` calls with `http.NewRequestWithContext` + `c.httpClient.Do`.
- Added `net/url` and `internal/tools` dependencies to `media.go`.
- Ensured the `telego` SDK and the manual media downloader now share the same transport layer.
