### PR TITLE
fix(install): bundle migrations in release tarball

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           CGO_ENABLED=0 go build \
             -ldflags="-s -w -X github.com/nextlevelbuilder/goclaw/cmd.Version=${VERSION}" \
             -o goclaw .
-          tar -czf "goclaw-${{ needs.release.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz" goclaw
+          tar -czf "goclaw-${{ needs.release.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz" goclaw migrations/
 
       - name: Upload to release
         env:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 
 REPO="nextlevelbuilder/goclaw"
 INSTALL_DIR="${GOCLAW_INSTALL_DIR:-/usr/local/bin}"
+MIGRATIONS_DIR="/usr/local/share/goclaw/migrations"
 VERSION=""
 
 # ── Parse args ──
@@ -64,25 +65,30 @@ tar -xzf "${TMP}/${ASSET}" -C "$TMP"
 if [ -w "$INSTALL_DIR" ]; then
   cp "${TMP}/goclaw" "${INSTALL_DIR}/goclaw"
   chmod +x "${INSTALL_DIR}/goclaw"
+  mkdir -p "${MIGRATIONS_DIR}"
+  cp -r "${TMP}/migrations/"* "${MIGRATIONS_DIR}/"
 else
   echo "Installing to ${INSTALL_DIR} (requires sudo)..."
   sudo cp "${TMP}/goclaw" "${INSTALL_DIR}/goclaw"
   sudo chmod +x "${INSTALL_DIR}/goclaw"
+  sudo mkdir -p "${MIGRATIONS_DIR}"
+  sudo cp -r "${TMP}/migrations/"* "${MIGRATIONS_DIR}/"
 fi
 
 echo ""
 echo "GoClaw ${VERSION} installed to ${INSTALL_DIR}/goclaw"
+echo "Migrations installed to ${MIGRATIONS_DIR}"
 echo ""
 echo "Next steps:"
 echo "  1. Set up PostgreSQL (pgvector):"
 echo "     docker run -d --name goclaw-pg -p 5432:5432 -e POSTGRES_PASSWORD=goclaw pgvector/pgvector:pg18"
 echo ""
-echo "  2. Run database migrations:"
+echo "  2. Set environment variables:"
 echo "     export GOCLAW_POSTGRES_DSN='postgres://postgres:goclaw@localhost:5432/postgres?sslmode=disable'"
-echo "     goclaw migrate up"
+echo "     export GOCLAW_MIGRATIONS_DIR='${MIGRATIONS_DIR}'"
 echo ""
-echo "  3. Start the onboard wizard:"
+echo "  3. Start the onboard wizard (runs migrations automatically):"
 echo "     goclaw onboard"
 echo ""
 echo "  4. Start the gateway:"
-echo "     goclaw"
+echo "     source .env.local && goclaw"


### PR DESCRIPTION
## Summary
- Release tarball now includes `migrations/` directory alongside the binary
- Install script copies migrations to `/usr/local/share/goclaw/migrations`
- Next-steps guide updated: set `GOCLAW_MIGRATIONS_DIR` before `goclaw onboard`
- Aligned step 4 with onboard's own output (`source .env.local && goclaw`)

## Problem
`goclaw migrate up` and `goclaw onboard` fail after installing via `install.sh` because the binary looks for migrations relative to its location (`/usr/local/bin/migrations`), which doesn't exist.

## Test plan
- [ ] Build binary + tarball locally, simulate install to temp dir
- [ ] Verify `GOCLAW_MIGRATIONS_DIR` is picked up by `goclaw migrate up`
- [ ] Verify `goclaw onboard` runs migrations successfully
- [ ] Verify Docker workflow is unaffected (uses its own `GOCLAW_MIGRATIONS_DIR`)