### PR TITLE
fix(feishu): align WebSocket protocol with Lark SDK + fix incorrect UI labels

### DIFF
--- a/internal/channels/feishu/feishu.go
+++ b/internal/channels/feishu/feishu.go
@@ -212,7 +212,7 @@ func (a *wsEventAdapter) HandleEvent(ctx context.Context, payload []byte) error 
 	var event MessageEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
 		slog.Debug("feishu ws: parse event failed", "error", err)
-		return nil
+		return fmt.Errorf("parse event: %w", err)
 	}
 	if event.Header.EventType == "im.message.receive_v1" {
 		a.ch.handleMessageEvent(ctx, &event)

--- a/internal/channels/feishu/larkws.go
+++ b/internal/channels/feishu/larkws.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -16,12 +17,12 @@ import (
 )
 
 const (
-	defaultPingInterval   = 120 * time.Second
-	defaultReconnectNonce = 30 // seconds max jitter
-	defaultReconnectWait  = 120 * time.Second
-	frameTypeControl      = 0
-	frameTypeData         = 1
-	fragmentBufferTTL     = 5 * time.Second
+	defaultPingInterval      = 120 * time.Second
+	defaultReconnectNonce    = 30 // seconds max jitter
+	defaultReconnectInterval = 5 * time.Second
+	frameTypeControl         = 0
+	frameTypeData            = 1
+	fragmentBufferTTL        = 5 * time.Second
 )
 
 // WSEventHandler processes incoming WebSocket events.
@@ -38,11 +39,13 @@ type WSClient struct {
 	baseURL   string
 	handler   WSEventHandler
 
-	conn         *websocket.Conn
-	connMu       sync.Mutex
-	serviceID    int32
-	pingInterval time.Duration
-	reconnectMax int // -1 = infinite
+	conn               *websocket.Conn
+	connMu             sync.Mutex
+	serviceID          int32
+	pingInterval       time.Duration
+	reconnectMax       int           // -1 = infinite
+	reconnectInterval  time.Duration // wait between retries
+	reconnectNonce     int           // max jitter seconds
 
 	stopCh  chan struct{}
 	stopped bool
@@ -76,13 +79,15 @@ type wsEndpointResp struct {
 // NewWSClient creates a native Lark WebSocket client.
 func NewWSClient(appID, appSecret, baseURL string, handler WSEventHandler) *WSClient {
 	return &WSClient{
-		appID:        appID,
-		appSecret:    appSecret,
-		baseURL:      baseURL,
-		handler:      handler,
-		pingInterval: defaultPingInterval,
-		reconnectMax: -1, // infinite
-		fragments:    make(map[string]*fragmentBuffer),
+		appID:             appID,
+		appSecret:         appSecret,
+		baseURL:           baseURL,
+		handler:           handler,
+		pingInterval:      defaultPingInterval,
+		reconnectMax:      -1, // infinite
+		reconnectInterval: defaultReconnectInterval,
+		reconnectNonce:    defaultReconnectNonce,
+		fragments:         make(map[string]*fragmentBuffer),
 	}
 }
 
@@ -204,7 +209,7 @@ func (c *WSClient) getWSEndpoint(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("ws endpoint error: code=%d msg=%s", result.Code, result.Msg)
 	}
 
-	// Apply config
+	// Apply config from server
 	cfg := result.Data.ClientConfig
 	if cfg.PingInterval > 0 {
 		c.pingInterval = time.Duration(cfg.PingInterval) * time.Second
@@ -212,14 +217,32 @@ func (c *WSClient) getWSEndpoint(ctx context.Context) (string, error) {
 	if cfg.ReconnectCount != 0 {
 		c.reconnectMax = cfg.ReconnectCount
 	}
-	c.serviceID = 0 // will be set from endpoint metadata if available
+	if cfg.ReconnectInterval > 0 {
+		c.reconnectInterval = time.Duration(cfg.ReconnectInterval) * time.Second
+	}
+	if cfg.ReconnectNonce > 0 {
+		c.reconnectNonce = cfg.ReconnectNonce
+	}
+
+	// Parse service_id from WS URL query params
+	if u, err := url.Parse(result.Data.URL); err == nil {
+		if sid := u.Query().Get("service_id"); sid != "" {
+			if v, err := strconv.ParseInt(sid, 10, 32); err == nil {
+				c.serviceID = int32(v)
+			}
+		}
+	}
 
 	return result.Data.URL, nil
 }
 
 func (c *WSClient) waitReconnect() {
-	jitter := time.Duration(rand.Intn(defaultReconnectNonce*1000)) * time.Millisecond
-	wait := defaultReconnectWait + jitter
+	nonce := c.reconnectNonce
+	if nonce <= 0 {
+		nonce = defaultReconnectNonce
+	}
+	jitter := time.Duration(rand.Intn(nonce*1000)) * time.Millisecond
+	wait := c.reconnectInterval + jitter
 	slog.Info("lark ws: reconnecting", "wait", wait)
 
 	select {
@@ -269,17 +292,37 @@ func (c *WSClient) handleFrame(ctx context.Context, f *wsFrame) {
 
 	switch {
 	case f.Method == frameTypeControl && frameType == "pong":
-		// Pong — optionally update config from payload
+		// Pong — update all config values from payload
 		if len(f.Payload) > 0 {
 			var cfg struct {
-				PingInterval int `json:"PingInterval"`
+				PingInterval      int `json:"PingInterval"`
+				ReconnectCount    int `json:"ReconnectCount"`
+				ReconnectInterval int `json:"ReconnectInterval"`
+				ReconnectNonce    int `json:"ReconnectNonce"`
 			}
-			if json.Unmarshal(f.Payload, &cfg) == nil && cfg.PingInterval > 0 {
-				c.pingInterval = time.Duration(cfg.PingInterval) * time.Second
+			if json.Unmarshal(f.Payload, &cfg) == nil {
+				if cfg.PingInterval > 0 {
+					c.pingInterval = time.Duration(cfg.PingInterval) * time.Second
+				}
+				if cfg.ReconnectCount != 0 {
+					c.reconnectMax = cfg.ReconnectCount
+				}
+				if cfg.ReconnectInterval > 0 {
+					c.reconnectInterval = time.Duration(cfg.ReconnectInterval) * time.Second
+				}
+				if cfg.ReconnectNonce > 0 {
+					c.reconnectNonce = cfg.ReconnectNonce
+				}
 			}
 		}
 
 	case f.Method == frameTypeData:
+		// Only process "event" type frames; ignore card, etc.
+		if frameType != "" && frameType != "event" {
+			slog.Debug("lark ws: ignoring non-event data frame", "type", frameType)
+			return
+		}
+
 		msgID := headers["message_id"]
 		sumStr := headers["sum"]
 		seqStr := headers["seq"]
@@ -297,28 +340,37 @@ func (c *WSClient) handleFrame(ctx context.Context, f *wsFrame) {
 			}
 		}
 
-		// Dispatch event
+		// Dispatch event and measure processing time
+		start := time.Now()
+		var handlerErr error
 		if c.handler != nil {
-			if err := c.handler.HandleEvent(ctx, payload); err != nil {
-				slog.Debug("lark ws: event handler error", "error", err)
+			handlerErr = c.handler.HandleEvent(ctx, payload)
+			if handlerErr != nil {
+				slog.Debug("lark ws: event handler error", "error", handlerErr)
 			}
 		}
+		elapsed := time.Since(start)
 
-		// Send response
-		c.sendResponse(f, headers)
+		// Send response with actual processing time and status
+		c.sendResponse(f, headers, elapsed, handlerErr)
 	}
 }
 
-func (c *WSClient) sendResponse(original *wsFrame, headers map[string]string) {
+func (c *WSClient) sendResponse(original *wsFrame, headers map[string]string, elapsed time.Duration, handlerErr error) {
 	respHeaders := make([]wsHeader, 0, len(original.Headers)+1)
 	for _, h := range original.Headers {
 		respHeaders = append(respHeaders, h)
 	}
-	respHeaders = append(respHeaders, wsHeader{Key: "biz_rt", Value: "0"})
+	// biz_rt = negative elapsed ms (Lark SDK convention: startTime - endTime)
+	bizRT := strconv.FormatInt(-elapsed.Milliseconds(), 10)
+	respHeaders = append(respHeaders, wsHeader{Key: "biz_rt", Value: bizRT})
 
+	code := http.StatusOK
+	if handlerErr != nil {
+		code = http.StatusInternalServerError
+	}
 	respPayload, _ := json.Marshal(map[string]any{
-		"code": http.StatusOK,
-		"msg":  "success",
+		"code": code,
 	})
 
 	resp := &wsFrame{

--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -180,7 +180,7 @@
     "allow_from": { "label": "Allowed Users" },
     "block_reply": { "label": "Block Reply", "help": "Deliver intermediate text during tool iterations" },
     "domain": { "label": "Domain" },
-    "connection_mode": { "label": "Connection Mode", "help": "Lark Global only supports Webhook" },
+    "connection_mode": { "label": "Connection Mode", "help": "WebSocket needs no public IP — outbound connection only" },
     "webhook_port": { "label": "Webhook Port", "help": "0 = share main gateway port (recommended)" },
     "webhook_path": { "label": "Webhook Path", "help": "Path on main server for Lark events" },
     "webhook_url": { "label": "Webhook URL" },
@@ -219,12 +219,12 @@
       "full": "Full"
     },
     "domain": {
-      "lark": "Lark (global) — webhook only",
+      "lark": "Lark (Global)",
       "feishu": "Feishu (China)"
     },
     "connection_mode": {
       "webhook": "Webhook",
-      "websocket": "WebSocket (Feishu only)"
+      "websocket": "WebSocket (recommended)"
     },
     "topic_session_mode": {
       "disabled": "Disabled",

--- a/ui/web/src/i18n/locales/vi/channels.json
+++ b/ui/web/src/i18n/locales/vi/channels.json
@@ -180,7 +180,7 @@
     "allow_from": { "label": "Người dùng được phép" },
     "block_reply": { "label": "Phản hồi khối", "help": "Gửi văn bản trung gian trong quá trình lặp công cụ" },
     "domain": { "label": "Tên miền" },
-    "connection_mode": { "label": "Chế độ kết nối", "help": "Lark Global chỉ hỗ trợ Webhook" },
+    "connection_mode": { "label": "Chế độ kết nối", "help": "WebSocket không cần IP công khai — chỉ kết nối ra ngoài" },
     "webhook_port": { "label": "Cổng webhook", "help": "0 = chia sẻ cổng gateway chính (khuyến nghị)" },
     "webhook_path": { "label": "Đường dẫn webhook", "help": "Đường dẫn trên máy chủ chính cho sự kiện Lark" },
     "webhook_url": { "label": "URL Webhook" },
@@ -219,12 +219,12 @@
       "full": "Đầy đủ"
     },
     "domain": {
-      "lark": "Lark (quốc tế) — chỉ webhook",
+      "lark": "Lark (Quốc tế)",
       "feishu": "Feishu (Trung Quốc)"
     },
     "connection_mode": {
       "webhook": "Webhook",
-      "websocket": "WebSocket (chỉ Feishu)"
+      "websocket": "WebSocket (khuyên dùng)"
     },
     "topic_session_mode": {
       "disabled": "Tắt",

--- a/ui/web/src/i18n/locales/zh/channels.json
+++ b/ui/web/src/i18n/locales/zh/channels.json
@@ -180,7 +180,7 @@
     "allow_from": { "label": "允许的用户" },
     "block_reply": { "label": "分块回复", "help": "在工具迭代期间发送中间文本" },
     "domain": { "label": "域名" },
-    "connection_mode": { "label": "连接模式", "help": "Lark 国际版仅支持 Webhook" },
+    "connection_mode": { "label": "连接模式", "help": "WebSocket 无需公网 IP — 仅需出站连接" },
     "webhook_port": { "label": "Webhook 端口", "help": "0 = 共享主网关端口（推荐）" },
     "webhook_path": { "label": "Webhook 路径", "help": "主服务器上 Lark 事件的路径" },
     "webhook_url": { "label": "Webhook URL" },
@@ -219,12 +219,12 @@
       "full": "全部"
     },
     "domain": {
-      "lark": "Lark（国际版）— 仅 Webhook",
+      "lark": "Lark（国际版）",
       "feishu": "飞书（中国版）"
     },
     "connection_mode": {
       "webhook": "Webhook",
-      "websocket": "WebSocket（仅飞书）"
+      "websocket": "WebSocket（推荐）"
     },
     "topic_session_mode": {
       "disabled": "禁用",

--- a/ui/web/src/pages/channels/channel-fields.tsx
+++ b/ui/web/src/pages/channels/channel-fields.tsx
@@ -22,21 +22,31 @@ interface ChannelFieldsProps {
   onChange: (key: string, value: unknown) => void;
   idPrefix: string;
   isEdit?: boolean; // for credentials: show "leave blank to keep" hint
+  /** Extra values for showWhen checks (e.g. config values visible to credential fields) */
+  contextValues?: Record<string, unknown>;
 }
 
-export function ChannelFields({ fields, values, onChange, idPrefix, isEdit }: ChannelFieldsProps) {
+export function ChannelFields({ fields, values, onChange, idPrefix, isEdit, contextValues }: ChannelFieldsProps) {
+  const allValues = contextValues ? { ...contextValues, ...values } : values;
   return (
     <div className="grid gap-3">
-      {fields.map((field) => (
-        <FieldRenderer
-          key={field.key}
-          field={field}
-          value={values[field.key]}
-          onChange={(v) => onChange(field.key, v)}
-          id={`${idPrefix}-${field.key}`}
-          isEdit={isEdit}
-        />
-      ))}
+      {fields.map((field) => {
+        // Conditional visibility: skip field if showWhen condition is not met
+        if (field.showWhen) {
+          const depValue = allValues[field.showWhen.key] ?? fields.find((f) => f.key === field.showWhen!.key)?.defaultValue;
+          if (String(depValue) !== field.showWhen.value) return null;
+        }
+        return (
+          <FieldRenderer
+            key={field.key}
+            field={field}
+            value={values[field.key]}
+            onChange={(v) => onChange(field.key, v)}
+            id={`${idPrefix}-${field.key}`}
+            isEdit={isEdit}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/ui/web/src/pages/channels/channel-instance-form-dialog.tsx
+++ b/ui/web/src/pages/channels/channel-instance-form-dialog.tsx
@@ -302,7 +302,7 @@ export function ChannelInstanceFormDialog({
                     {t("form.credentials")}
                     {instance && <span className="text-xs font-normal text-muted-foreground ml-1">{t("form.credentialsHint")}</span>}
                   </legend>
-                  <ChannelFields fields={credsFields} values={credsValues} onChange={handleCredsChange} idPrefix="ci-cred" isEdit={!!instance} />
+                  <ChannelFields fields={credsFields} values={credsValues} onChange={handleCredsChange} idPrefix="ci-cred" isEdit={!!instance} contextValues={configValues} />
                   <p className="text-xs text-muted-foreground">{t("form.credentialsEncrypted")}</p>
                 </fieldset>
               )}

--- a/ui/web/src/pages/channels/channel-schemas.ts
+++ b/ui/web/src/pages/channels/channel-schemas.ts
@@ -10,6 +10,8 @@ export interface FieldDef {
   defaultValue?: string | number | boolean | string[];
   options?: { value: string; label: string }[];
   help?: string;
+  /** Only show this field when another field has a specific value */
+  showWhen?: { key: string; value: string };
 }
 
 // --- Shared option lists ---
@@ -51,8 +53,8 @@ export const credentialsSchema: Record<string, FieldDef[]> = {
   feishu: [
     { key: "app_id", label: "App ID", type: "text", required: true, placeholder: "cli_xxxxx" },
     { key: "app_secret", label: "App Secret", type: "password", required: true },
-    { key: "encrypt_key", label: "Encrypt Key", type: "password", help: "For webhook mode" },
-    { key: "verification_token", label: "Verification Token", type: "password", help: "For webhook mode" },
+    { key: "encrypt_key", label: "Encrypt Key", type: "password", help: "For webhook event decryption", showWhen: { key: "connection_mode", value: "webhook" } },
+    { key: "verification_token", label: "Verification Token", type: "password", help: "For webhook event verification", showWhen: { key: "connection_mode", value: "webhook" } },
   ],
   zalo_oa: [
     { key: "token", label: "OA Access Token", type: "password", required: true },
@@ -107,10 +109,10 @@ export const configSchema: Record<string, FieldDef[]> = {
     { key: "block_reply", label: "Block Reply", type: "select", options: blockReplyOptions, defaultValue: "inherit", help: "Deliver intermediate text during tool iterations" },
   ],
   feishu: [
-    { key: "domain", label: "Domain", type: "select", options: [{ value: "lark", label: "Lark (global) — webhook only" }, { value: "feishu", label: "Feishu (China)" }], defaultValue: "lark" },
-    { key: "connection_mode", label: "Connection Mode", type: "select", options: [{ value: "webhook", label: "Webhook" }, { value: "websocket", label: "WebSocket (Feishu only)" }], defaultValue: "webhook", help: "Lark Global only supports Webhook" },
-    { key: "webhook_port", label: "Webhook Port", type: "number", defaultValue: 0, help: "0 = share main gateway port (recommended)" },
-    { key: "webhook_path", label: "Webhook Path", type: "text", defaultValue: "/feishu/events", help: "Path on main server for Lark events" },
+    { key: "domain", label: "Domain", type: "select", options: [{ value: "lark", label: "Lark (Global)" }, { value: "feishu", label: "Feishu (China)" }], defaultValue: "lark" },
+    { key: "connection_mode", label: "Connection Mode", type: "select", options: [{ value: "websocket", label: "WebSocket (recommended)" }, { value: "webhook", label: "Webhook (requires public endpoint)" }], defaultValue: "websocket", help: "WebSocket needs no public IP — outbound connection only" },
+    { key: "webhook_port", label: "Webhook Port", type: "number", defaultValue: 0, help: "0 = share main gateway port (recommended)", showWhen: { key: "connection_mode", value: "webhook" } },
+    { key: "webhook_path", label: "Webhook Path", type: "text", defaultValue: "/feishu/events", help: "Path on main server for Lark events", showWhen: { key: "connection_mode", value: "webhook" } },
     { key: "dm_policy", label: "DM Policy", type: "select", options: dmPolicyOptions, defaultValue: "pairing" },
     { key: "group_policy", label: "Group Policy", type: "select", options: groupPolicyOptions, defaultValue: "pairing" },
     { key: "require_mention", label: "Require @mention in groups", type: "boolean", defaultValue: true },


### PR DESCRIPTION
## Summary

The Feishu/Lark WebSocket client has several protocol deviations from the official Lark SDK reference implementation, and the channel creation UI contains incorrect labels that mislead users into thinking Lark Global doesn't support WebSocket.

### Backend — WSClient protocol fixes (`larkws.go`)

**1. `serviceID` always 0 (was never parsed from WS URL)**
The Lark endpoint response returns a WebSocket URL containing `service_id` as a query param (e.g. `wss://...?service_id=7`). The SDK extracts this and uses it in ping frames. GoClaw hardcoded `serviceID = 0` — if Lark starts validating this field, pings would silently fail.

**2. Pong only updated `PingInterval`, ignored 3 other config values**
Lark pong payloads contain `PingInterval`, `ReconnectCount`, `ReconnectInterval`, and `ReconnectNonce`. Only `PingInterval` was being read. This meant reconnect wait was always hardcoded to 120s instead of the server-configured 5s — causing **2 minutes of unnecessary downtime** on disconnect instead of ~5 seconds.

**3. Reconnect used hardcoded 120s wait**
`waitReconnect()` always waited `120s + jitter` regardless of server config. Now uses `reconnectInterval` (from endpoint/pong) + jitter from `reconnectNonce`.

**4. ACK always returned HTTP 200, even on handler failure**
When event processing failed (e.g. JSON parse error), the response still sent `{ code: 200 }`. Lark thought the event was processed successfully and wouldn't retry. Now returns `{ code: 500 }` on error, enabling Lark's retry mechanism.

**5. No `type` header check on data frames**
The Lark SDK checks `type === "event"` before processing data frames. GoClaw processed **all** data frames as events — card action frames, reaction frames etc. would cause spurious parse errors. Now filters by `type` header.

**6. `biz_rt` header always "0"**
The Lark SDK reports actual processing time as a negative millisecond value (e.g. `"-150"` for 150ms). GoClaw hardcoded `"0"`, providing no useful telemetry to Lark's monitoring.

### Backend — event adapter (`feishu.go`)

- `wsEventAdapter.HandleEvent` now returns error on JSON parse failure (was swallowing it with `return nil`), so the ACK correctly reports 500 for unparseable events.

### UI — fix incorrect Feishu channel form labels

- **"Lark (global) — webhook only"** → **"Lark (Global)"** — Lark Global fully supports WebSocket ([confirmed by Lark SDK](https://deepwiki.com/larksuite/node-sdk/5-advanced-usage) and [official docs](https://open.larksuite.com/document/server-docs/event-subscription/overview-of-event-subscription))
- **"WebSocket (Feishu only)"** → **"WebSocket (recommended)"** — WebSocket works on both domains
- Default `connection_mode` changed from `"webhook"` to `"websocket"` (matches backend default at `feishu.go:108`)
- Added `showWhen` conditional field support to `ChannelFields` component
- Webhook-only fields (`webhook_port`, `webhook_path`, `encrypt_key`, `verification_token`) now hidden when WebSocket mode is selected
- Fixed all 3 i18n locale files (en, vi, zh) which had the same incorrect labels

## Test plan

- [ ] Create a new Feishu channel instance → verify default is WebSocket, no "webhook only" labels
- [ ] Switch to Webhook mode → verify webhook fields (port, path, encrypt_key, verification_token) appear
- [ ] Switch back to WebSocket → verify webhook fields hide
- [ ] Connect to Lark Global via WebSocket → verify connection, ping/pong, event receipt
- [ ] Disconnect network briefly → verify reconnect uses server-configured interval (not 120s)
- [ ] Check logs for `service_id` being parsed from WS URL
- [ ] Verify `biz_rt` header shows actual processing time in debug logs