### PR TITLE
fix(providers): auto-clamp max_tokens on model rejection

### DIFF
--- a/internal/http/provider_verify.go
+++ b/internal/http/provider_verify.go
@@ -98,7 +98,7 @@ func (h *ProvidersHandler) handleVerifyProvider(w http.ResponseWriter, r *http.R
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
-	resp, err := provider.Chat(ctx, providers.ChatRequest{
+	_, err = provider.Chat(ctx, providers.ChatRequest{
 		Messages: []providers.Message{
 			{Role: "user", Content: "hi"},
 		},
@@ -112,9 +112,6 @@ func (h *ProvidersHandler) handleVerifyProvider(w http.ResponseWriter, r *http.R
 		writeJSON(w, http.StatusOK, map[string]any{"valid": false, "error": friendlyVerifyError(err)})
 		return
 	}
-
-	// Any response (even truncated) proves the model is reachable and valid.
-	_ = resp
 	writeJSON(w, http.StatusOK, map[string]any{"valid": true})
 }
 

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -82,7 +82,25 @@ func (p *OpenAIProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 	model := p.resolveModel(req.Model)
 	body := p.buildRequestBody(model, req, false)
 
-	resp, err := RetryDo(ctx, p.retryConfig, func() (*ChatResponse, error) {
+	chatFn := p.chatRequestFn(ctx, body)
+
+	resp, err := RetryDo(ctx, p.retryConfig, chatFn)
+
+	// Auto-clamp max_tokens and retry once if the model rejects the value
+	if err != nil {
+		if clamped := clampMaxTokensFromError(err, body); clamped {
+			slog.Info("max_tokens clamped, retrying", "model", model, "limit", clampedLimit(body))
+			return RetryDo(ctx, p.retryConfig, chatFn)
+		}
+	}
+
+	return resp, err
+}
+
+// chatRequestFn returns a closure that performs a single non-streaming chat request.
+// Shared between initial attempt and post-clamp retry to avoid duplication.
+func (p *OpenAIProvider) chatRequestFn(ctx context.Context, body map[string]any) func() (*ChatResponse, error) {
+	return func() (*ChatResponse, error) {
 		respBody, err := p.doRequest(ctx, body)
 		if err != nil {
 			return nil, err
@@ -95,30 +113,7 @@ func (p *OpenAIProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 		}
 
 		return p.parseResponse(&oaiResp), nil
-	})
-
-	// Auto-clamp max_tokens and retry once if the model rejects the value
-	if err != nil {
-		if clamped := clampMaxTokensFromError(err, body); clamped {
-			slog.Info("max_tokens clamped, retrying", "model", model, "max_tokens", body["max_tokens"])
-			return RetryDo(ctx, p.retryConfig, func() (*ChatResponse, error) {
-				respBody, err := p.doRequest(ctx, body)
-				if err != nil {
-					return nil, err
-				}
-				defer respBody.Close()
-
-				var oaiResp openAIResponse
-				if err := json.NewDecoder(respBody).Decode(&oaiResp); err != nil {
-					return nil, fmt.Errorf("%s: decode response: %w", p.name, err)
-				}
-
-				return p.parseResponse(&oaiResp), nil
-			})
-		}
 	}
-
-	return resp, err
 }
 
 func (p *OpenAIProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk func(StreamChunk)) (*ChatResponse, error) {
@@ -133,7 +128,7 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, req ChatRequest, onChun
 	// Auto-clamp max_tokens and retry once if the model rejects the value
 	if err != nil {
 		if clamped := clampMaxTokensFromError(err, body); clamped {
-			slog.Info("max_tokens clamped, retrying stream", "model", model, "max_tokens", body["max_tokens"])
+			slog.Info("max_tokens clamped, retrying stream", "model", model, "limit", clampedLimit(body))
 			respBody, err = RetryDo(ctx, p.retryConfig, func() (io.ReadCloser, error) {
 				return p.doRequest(ctx, body)
 			})
@@ -506,4 +501,12 @@ func clampMaxTokensFromError(err error, body map[string]any) bool {
 		body["max_tokens"] = limit
 	}
 	return true
+}
+
+// clampedLimit returns the clamped max_tokens or max_completion_tokens value for logging.
+func clampedLimit(body map[string]any) any {
+	if v, ok := body["max_completion_tokens"]; ok {
+		return v
+	}
+	return body["max_tokens"]
 }


### PR DESCRIPTION
## Summary
- **Auto-clamp max_tokens on 400 rejection** — when OpenAI-compat models reject `max_tokens` as too large (e.g. gpt-3.5-turbo supports 4096 but default is 8192), parse the model's stated limit from the error, clamp, and retry once. No model name hardcoding needed.
- **Fix provider verify for reasoning models** — increase verify endpoint's `max_tokens` from 1 to 50 so reasoning models (gpt-5, o-series) have enough headroom for internal reasoning during the "Check" call.

Closes #248, closes #245

## Test plan
- [x] Create agent with `gpt-3.5-turbo` via OpenAI provider — succeeds (logs show `max_tokens clamped, retrying`)
- [x] Click "Check" on `gpt-5` model — shows valid (green check)
- [x] Create agent with `gpt-5` — summoning completes without max_tokens error
- [x] Existing models (Claude, GPT-4o, etc.) unaffected — no behavior change