### PR TITLE
fix: agent update API silently drops is_default, budget, subagents fields

### DIFF
--- a/internal/http/validate.go
+++ b/internal/http/validate.go
@@ -38,6 +38,7 @@ var agentAllowedFields = map[string]bool{
 	"workspace": true, "restrict_to_workspace": true,
 	"frontmatter": true, "compaction_config": true,
 	"memory_config": true, "other_config": true, "tools_config": true,
+	"is_default": true, "budget_monthly_cents": true, "subagents_config": true,
 }
 
 var providerAllowedFields = map[string]bool{

--- a/internal/store/pg/agents.go
+++ b/internal/store/pg/agents.go
@@ -164,6 +164,17 @@ func (s *PGAgentStore) Update(ctx context.Context, id uuid.UUID, updates map[str
 	if len(updates) == 0 {
 		return nil
 	}
+
+	// If setting this agent as default, unset any existing default first.
+	if v, ok := updates["is_default"]; ok {
+		if isDefault, _ := v.(bool); isDefault {
+			if _, err := s.db.ExecContext(ctx,
+				"UPDATE agents SET is_default = false WHERE is_default = true AND id != $1 AND deleted_at IS NULL", id); err != nil {
+				slog.Warn("agents.unset_default", "error", err)
+			}
+		}
+	}
+
 	updates["updated_at"] = time.Now()
 	err := execMapUpdateWhere(ctx, s.db, "agents", updates, "id = $IDX AND deleted_at IS NULL", id)
 	if err != nil {


### PR DESCRIPTION
## Summary
- **Bug:** `agentAllowedFields` in `internal/http/validate.go` was missing `is_default`, `budget_monthly_cents`, and `subagents_config`. The web UI sends these fields when saving agent settings, but `filterAllowedKeys()` silently stripped them — saves appeared successful but values never persisted.
- **Fix:** Added the three missing fields to the allowlist.
- **Bonus:** Added exclusive-default logic in `PGAgentStore.Update()` — when setting `is_default=true`, any previously-default agent is automatically unset first, preventing multiple defaults.

## Files changed
- `internal/http/validate.go` — add `is_default`, `budget_monthly_cents`, `subagents_config` to `agentAllowedFields`
- `internal/store/pg/agents.go` — unset old default agent before setting new one

## Test plan
- [ ] Edit an agent in web UI → toggle "Default Agent" switch → Save → Reload page → verify toggle persists
- [ ] Change monthly budget → Save → Reload → verify budget persists
- [ ] Toggle subagent capabilities → Save → Reload → verify config persists
- [ ] Set agent A as default, then set agent B as default → verify agent A is no longer default