### PR TITLE
feat(feishu): include reply context in agent input

### DIFF
--- a/internal/channels/feishu/bot.go
+++ b/internal/channels/feishu/bot.go
@@ -110,6 +110,13 @@ func (c *Channel) handleMessageEvent(ctx context.Context, event *MessageEvent) {
 		content = "[empty message]"
 	}
 
+	// 7b. Fetch reply context if this is a reply to another message
+	if mc.ParentID != "" {
+		if replyCtx := c.fetchReplyContext(ctx, mc.ParentID); replyCtx != "" {
+			content += "\n\n" + replyCtx
+		}
+	}
+
 	// 8. Topic session
 	chatID := mc.ChatID
 	if mc.RootID != "" && c.cfg.TopicSessionMode == "enabled" {
@@ -257,4 +264,36 @@ func (c *Channel) handleMessageEvent(ctx context.Context, event *MessageEvent) {
 	if mc.ChatType == "group" {
 		c.groupHistory.Clear(chatID)
 	}
+}
+
+const replyContextMaxLen = 500
+
+// fetchReplyContext fetches the parent message content and returns a formatted
+// reply context string, similar to Telegram's [Replying to ...] format.
+func (c *Channel) fetchReplyContext(ctx context.Context, parentID string) string {
+	resp, err := c.client.GetMessage(ctx, parentID)
+	if err != nil {
+		slog.Debug("feishu: failed to fetch parent message", "parent_id", parentID, "error", err)
+		return ""
+	}
+	if len(resp.Items) == 0 {
+		return ""
+	}
+
+	item := &resp.Items[0]
+	body := parseMessageContent(item.Body.Content, item.MsgType)
+	if body == "" {
+		return ""
+	}
+
+	// Resolve sender name
+	senderName := "unknown"
+	if item.Sender.ID != "" {
+		if name := c.resolveSenderName(ctx, item.Sender.ID); name != "" {
+			senderName = name
+		}
+	}
+
+	body = channels.Truncate(body, replyContextMaxLen)
+	return fmt.Sprintf("[Replying to %s]\n%s\n[/Replying]", senderName, body)
 }

--- a/internal/channels/feishu/larkclient_messaging.go
+++ b/internal/channels/feishu/larkclient_messaging.go
@@ -89,6 +89,42 @@ func (c *LarkClient) UploadFile(ctx context.Context, data io.Reader, fileName, f
 	return result.FileKey, nil
 }
 
+// --- IM API: Get Message ---
+
+// GetMessageResp holds the response from GET /open-apis/im/v1/messages/{message_id}.
+type GetMessageResp struct {
+	Items []struct {
+		MessageID   string `json:"message_id"`
+		MsgType     string `json:"msg_type"`
+		Body        struct {
+			Content string `json:"content"`
+		} `json:"body"`
+		Sender struct {
+			ID         string `json:"id"`
+			IDType     string `json:"id_type"`
+			SenderType string `json:"sender_type"`
+		} `json:"sender"`
+	} `json:"items"`
+}
+
+// GetMessage retrieves a message by ID.
+// Lark API: GET /open-apis/im/v1/messages/{message_id}
+func (c *LarkClient) GetMessage(ctx context.Context, messageID string) (*GetMessageResp, error) {
+	path := fmt.Sprintf("/open-apis/im/v1/messages/%s", messageID)
+	resp, err := c.doJSON(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("get message: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	var data GetMessageResp
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, fmt.Errorf("unmarshal get message: %w", err)
+	}
+	return &data, nil
+}
+
 // --- IM API: Message Resources ---
 
 func (c *LarkClient) DownloadMessageResource(ctx context.Context, messageID, fileKey, resourceType string) ([]byte, string, error) {


### PR DESCRIPTION
## Summary
- When a user replies to a message in Feishu/Lark, the agent now receives the quoted message content
- Adds `GetMessage()` API call to fetch parent message by `parent_id`
- Formats reply context as `[Replying to SenderName]...[/Replying]`, consistent with Telegram channel behavior
- Previously `parent_id` was parsed from the event but the content was silently discarded

## Note
Requires `im:message:readonly` scope on the Lark app.

## Test plan
- [ ] Reply to a text message in Feishu DM → agent sees quoted content
- [ ] Reply to a text message in Feishu group → agent sees quoted content
- [ ] Reply to a post (rich text) message → content is extracted correctly
- [ ] Reply to an image/file message → shows `[image]` / `[file: name]` placeholder
- [ ] Send a non-reply message → no change in behavior
- [ ] Parent message deleted or inaccessible → graceful fallback (no crash, no reply context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)