### PR TITLE
fix: allow reusing agent_key after soft delete

### DIFF
--- a/internal/upgrade/version.go
+++ b/internal/upgrade/version.go
@@ -2,4 +2,4 @@ package upgrade
 
 // RequiredSchemaVersion is the schema migration version this binary requires.
 // Bump this whenever adding a new SQL migration file.
-const RequiredSchemaVersion uint = 22
+const RequiredSchemaVersion uint = 23

--- a/migrations/000023_agent_key_soft_delete_unique.down.sql
+++ b/migrations/000023_agent_key_soft_delete_unique.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_agents_agent_key_active;
+ALTER TABLE agents ADD CONSTRAINT agents_agent_key_key UNIQUE (agent_key);

--- a/migrations/000023_agent_key_soft_delete_unique.up.sql
+++ b/migrations/000023_agent_key_soft_delete_unique.up.sql
@@ -1,0 +1,8 @@
+-- Replace hard UNIQUE constraint on agent_key with a partial unique index
+-- that excludes soft-deleted rows. This allows reusing an agent_key after
+-- the original agent has been deleted (soft-deleted via deleted_at).
+-- Fixes: https://github.com/nextlevelbuilder/goclaw/issues/180
+-- Fixes: https://github.com/nextlevelbuilder/goclaw/issues/181
+
+ALTER TABLE agents DROP CONSTRAINT agents_agent_key_key;
+CREATE UNIQUE INDEX idx_agents_agent_key_active ON agents(agent_key) WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Summary
- Replace hard `UNIQUE` constraint on `agents.agent_key` with a partial unique index (`WHERE deleted_at IS NULL`)
- This allows creating a new agent with the same key after the original has been soft-deleted
- Added migration 000023 (up + down) and bumped `RequiredSchemaVersion` to 23

**Root cause:** The `agent_key` column had a plain `UNIQUE` constraint that included soft-deleted rows. Since `DELETE` only sets `deleted_at = NOW()`, the old row still occupied the unique slot, blocking reuse.

Fixes #180, fixes #181

## Test plan
- [ ] Run `./goclaw migrate up` — migration 23 applies cleanly
- [ ] Create agent with key `test-agent` → succeeds
- [ ] Delete agent → soft-deleted (`deleted_at` set)
- [ ] Create new agent with key `test-agent` → succeeds (previously failed with unique violation)
- [ ] Run `./goclaw migrate down 1` — rollback restores original constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)