### PR TITLE
fix: null-safe access on changes array in events page

### DIFF
--- a/ui/web/src/pages/events/event-sections/team-crud-event-cards.tsx
+++ b/ui/web/src/pages/events/event-sections/team-crud-event-cards.tsx
@@ -63,7 +63,7 @@ function TeamUpdatedCard({ payload: p }: { payload: TeamUpdatedPayload }) {
       <span>Team </span>
       <span className="font-medium">{p.team_name}</span>
       <span> updated</span>
-      {p.changes.length > 0 && (
+      {p.changes?.length > 0 && (
         <span className="ml-1 text-xs text-muted-foreground">({p.changes.join(", ")})</span>
       )}
     </div>
@@ -120,7 +120,7 @@ function LinkUpdatedCard({ payload: p, resolveAgent }: { payload: AgentLinkUpdat
       <span className="font-medium">
         {resolveAgent(p.source_agent_key)} &rarr; {resolveAgent(p.target_agent_key)}
       </span>
-      {p.changes.length > 0 && (
+      {p.changes?.length > 0 && (
         <span className="ml-1 text-xs text-muted-foreground">({p.changes.join(", ")})</span>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Add optional chaining (`?.`) on `p.changes.length` in `TeamUpdatedCard` and `LinkUpdatedCard` components
- Go can serialize empty `[]string` slices as `null` in JSON — the frontend accessed `.length` without null checking, causing a crash on the events page

Fixes #192

## Test plan
- [ ] Delete an agent team
- [ ] Navigate to Events page → no crash
- [ ] Verify team.updated events with changes still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)