### PR TITLE
fix(providers): robust Gemini thought_signature detection and history mapping

### DIFF
--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -260,8 +260,9 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 	inputMessages := req.Messages
 
 	// Compute provider capability once: does this endpoint support Google's thought_signature?
-	// We check name, apiBase, and the model string (which covers OpenRouter/LiteLLM routing to Gemini).
-	supportsThoughtSignature := strings.Contains(strings.ToLower(p.name), "gemini") ||
+	// We check providerType, name, apiBase, and the model string (robust detection for proxies/OpenRouter).
+	supportsThoughtSignature := strings.Contains(strings.ToLower(p.providerType), "gemini") ||
+		strings.Contains(strings.ToLower(p.name), "gemini") ||
 		strings.Contains(strings.ToLower(p.apiBase), "generativelanguage") ||
 		strings.Contains(strings.ToLower(model), "gemini")
 

--- a/internal/providers/openai_gemini.go
+++ b/internal/providers/openai_gemini.go
@@ -17,7 +17,17 @@ func collapseToolCallsWithoutSig(msgs []Message) []Message {
 			continue
 		}
 		for _, tc := range m.ToolCalls {
-			if tc.Metadata["thought_signature"] == "" {
+			// If meta is nil or signature is empty/whitespace, collapse the whole message's tool cycle.
+			// Checks both snake_case and camelCase for cross-proxy reliability.
+			sig := ""
+			if tc.Metadata != nil {
+				sig = tc.Metadata["thought_signature"]
+				if sig == "" {
+					sig = tc.Metadata["thoughtSignature"]
+				}
+			}
+
+			if strings.TrimSpace(sig) == "" {
 				for _, tc2 := range m.ToolCalls {
 					collapseIDs[tc2.ID] = true
 				}


### PR DESCRIPTION
## Problem
The initial fix for Gemini's thought_signature leakage was failing in several edge cases, leading to continued HTTP 400 errors specifically for users using local proxies or running with `Extended Thinking = OFF`.

## Related Issue
https://github.com/nextlevelbuilder/goclaw/pull/230#issuecomment-4087654506

## Key Improvements
1. `Extended Thinking = OFF` Edge Case: When Thinking is disabled, Gemini-3-Flash emits tool calls but often omits the `thought_signature`. GoClaw previously saved these "clean" calls, but the Google backend then rejected that same history on the next turn as "missing signature." We now force-collapse any tool cycles in the history that lack a valid, non-whitespace signature when talking to Gemini.
2. Eliminated Naming Blind Spots: Detection was previously too reliant on the provider being named exactly "gemini." We now aggressively identify Gemini capability by checking the model name (gemini-3...), the API Base URL, and the `providerType` from the database. This ensures the safety logic triggers even for custom-named providers like `goclaw-local`.
3. Proxy Key Compatibility: Local gateways (like LiteLLM or OneAPI) frequently translate thought_signature to thoughtSignature (camelCase). We now validate against both naming conventions to ensure signatures are never "missed" during the history repair phase.
4. Whitespace Resiliency: Added `strings.TrimSpace()` to the signature check. This prevents "invisible" signatures (e.g., a single space or newline returned when thinking is off) from leaking past the filter and triggering a backend crash.

## Impact
Conversation history is now dynamically "remapped" based on the target provider's specific requirements. Switching between Gemini and standard OpenAI-compatible models (DeepSeek, GPT-4, etc.) is now transparent and robust, preventing strict JSON schema validation errors across all supported backends.