### PR TITLE
fix: ui is wrong display tool calling status

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -991,6 +991,7 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 				Role:       "tool",
 				Content:    result.ForLLM,
 				ToolCallID: tc.ID,
+				IsError:    result.IsError,
 			}
 			messages = append(messages, toolMsg)
 			pendingMsgs = append(pendingMsgs, toolMsg)

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -92,13 +92,14 @@ type MediaRef struct {
 
 // Message represents a conversation message.
 type Message struct {
-	Role       string         `json:"role"` // "system", "user", "assistant", "tool"
-	Content    string         `json:"content"`
-	Thinking   string         `json:"thinking,omitempty"`   // reasoning_content for thinking models (Kimi, DeepSeek, etc.)
-	Images     []ImageContent `json:"images,omitempty"`     // vision: base64 images (runtime only, not persisted)
-	MediaRefs  []MediaRef     `json:"media_refs,omitempty"` // persistent media file references
-	ToolCalls  []ToolCall     `json:"tool_calls,omitempty"`
-	ToolCallID string         `json:"tool_call_id,omitempty"` // for role="tool" responses
+	Role            string         `json:"role"` // "system", "user", "assistant", "tool"
+	Content         string         `json:"content"`
+	Thinking        string         `json:"thinking,omitempty"`   // reasoning_content for thinking models (Kimi, DeepSeek, etc.)
+	Images          []ImageContent `json:"images,omitempty"`     // vision: base64 images (runtime only, not persisted)
+	MediaRefs       []MediaRef     `json:"media_refs,omitempty"` // persistent media file references
+	ToolCalls       []ToolCall     `json:"tool_calls,omitempty"`
+	ToolCallID      string         `json:"tool_call_id,omitempty"`      // for role="tool" responses
+	IsError         bool           `json:"is_error,omitempty"`          // for role="tool" responses
 
 	// Phase is a Codex-specific field (gpt-5.3-codex) indicating message purpose.
 	// Values: "commentary" (intermediate), "final_answer" (closeout), or "" (unset).

--- a/ui/web/src/pages/chat/hooks/use-chat-messages.ts
+++ b/ui/web/src/pages/chat/hooks/use-chat-messages.ts
@@ -90,7 +90,7 @@ export function useChatMessages(sessionKey: string, agentId: string) {
               toolCallId: tc.id,
               runId: "",
               name: tc.name,
-              phase: (toolMsg ? "completed" : "calling") as ToolStreamEntry["phase"],
+              phase: (toolMsg ? (toolMsg.is_error ? "error" : "completed") : "calling") as ToolStreamEntry["phase"],
               startedAt: 0,
               updatedAt: 0,
               arguments: tc.arguments,

--- a/ui/web/src/types/session.ts
+++ b/ui/web/src/types/session.ts
@@ -32,6 +32,7 @@ export interface Message {
   thinking?: string;
   tool_calls?: ToolCall[];
   tool_call_id?: string;
+  is_error?: boolean;
 }
 
 export interface ToolCall {


### PR DESCRIPTION
Sometime we have a tool call **Failed**, but when the phase is `completed`, the status is turned **Done**
<img width="821" height="298" alt="image" src="https://github.com/user-attachments/assets/858fa120-7bb6-4232-abb0-58ea5e0f329d" />

This fix will correct it:
<img width="814" height="287" alt="image" src="https://github.com/user-attachments/assets/c673b935-589d-4992-a1fa-9028e622ae71" />
