### PR TITLE
fix: Windows deployment - broken symlinks, missing packages, dep scanner false positives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure shell scripts always use LF line endings (critical for Docker builds on Windows)
+*.sh text eol=lf
+docker-entrypoint.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,10 @@ RUN set -eux; \
         apk add --no-cache docker-cli; \
     fi; \
     if [ "$ENABLE_FULL_SKILLS" = "true" ]; then \
-        apk add --no-cache python3 py3-pip nodejs npm pandoc github-cli; \
+        apk add --no-cache python3 py3-pip nodejs npm pandoc github-cli poppler-utils bash; \
         pip3 install --no-cache-dir --break-system-packages \
-            pypdf openpyxl pandas python-pptx markitdown defusedxml lxml; \
+            pypdf openpyxl pandas python-pptx markitdown defusedxml lxml \
+            pdfplumber pdf2image anthropic; \
         npm install -g --cache /tmp/npm-cache docx pptxgenjs; \
         rm -rf /tmp/npm-cache /root/.cache /var/cache/apk/*; \
     else \
@@ -77,6 +78,22 @@ COPY --from=builder /out/pkg-helper /app/pkg-helper
 COPY --from=builder /src/migrations/ /app/migrations/
 COPY --from=builder /src/skills/ /app/bundled-skills/
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+
+# Fix Windows git clone issues:
+# 1. CRLF line endings in shell scripts (Windows git adds \r)
+# 2. Broken symlinks: On Windows (core.symlinks=false), git creates text files
+#    or skips symlinks entirely. Skills like docx/pptx/xlsx need _shared/office
+#    module in their scripts/ dir (originally symlinked as scripts/office -> ../../_shared/office).
+RUN set -eux; \
+    sed -i 's/\r$//' /app/docker-entrypoint.sh; \
+    cd /app/bundled-skills; \
+    for skill in docx pptx xlsx; do \
+        if [ -d "${skill}/scripts" ] && [ ! -d "${skill}/scripts/office" ]; then \
+            rm -f "${skill}/scripts/office"; \
+            cp -r _shared/office "${skill}/scripts/office"; \
+        fi; \
+    done
+
 RUN chmod +x /app/docker-entrypoint.sh && \
     chmod 755 /app/pkg-helper && chown root:root /app/pkg-helper
 

--- a/internal/skills/dep_scanner.go
+++ b/internal/skills/dep_scanner.go
@@ -42,6 +42,8 @@ func scanScriptsDir(scriptsDir string) *SkillManifest {
 	binaries := make(map[string]bool)
 	// Track subdirectory names — these are local modules and must never be reported as missing.
 	localModules := make(map[string]bool)
+	// The scripts directory itself can be referenced as a module (e.g. "from scripts import utils").
+	localModules[filepath.Base(scriptsDir)] = true
 
 	for _, e := range entries {
 		if e.IsDir() {
@@ -53,6 +55,19 @@ func scanScriptsDir(scriptsDir string) *SkillManifest {
 			}
 			for _, se := range subEntries {
 				if se.IsDir() {
+					// Track nested subdirs as local modules too (e.g. office/helpers, office/validators)
+					// so intra-package imports like "from helpers import ..." don't get falsely reported.
+					localModules[se.Name()] = true
+					// Scan files inside nested subdirs
+					nestedEntries, err := os.ReadDir(filepath.Join(scriptsDir, e.Name(), se.Name()))
+					if err != nil {
+						continue
+					}
+					for _, ne := range nestedEntries {
+						if !ne.IsDir() {
+							scanFile(filepath.Join(scriptsDir, e.Name(), se.Name(), ne.Name()), pyImports, nodeImports, binaries)
+						}
+					}
 					continue
 				}
 				scanFile(filepath.Join(scriptsDir, e.Name(), se.Name()), pyImports, nodeImports, binaries)


### PR DESCRIPTION
## Description

When building GoClaw from source on Windows via Docker Desktop, all 5 core skills show "Missing deps" on the Skills page. This PR fixes 3 root causes.

## Changes

### 1. Dockerfile - Missing skill packages + Windows compatibility

- **Added packages** to ENABLE_FULL_SKILLS install:
-   - poppler-utils, bash (apk)
-   - pdfplumber, pdf2image, anthropic (pip)
- - **CRLF fix**: sed -i 's/\r$//' on entrypoint script at build time
- - **Symlink fix**: On Windows, git clone with core.symlinks=false (default) converts symlinks to text files or drops them entirely. Skills docx/pptx/xlsx have scripts/office -> ../../_shared/office symlinks that break. The new RUN step copies _shared/office directly into each skill's scripts/ dir when the symlink is missing.
### 2. internal/skills/dep_scanner.go - False positive missing deps

Two issues caused the dep scanner to falsely report local modules as missing pip packages:

- **Nested subdirectories**: office/helpers/ and office/validators/ are subdirectories of scripts/office/. Files inside office/ do from helpers import ... - these are intra-package imports. The scanner only tracked first-level subdirs of scripts/ as local modules, so helpers and validators were reported as pip:helpers, pip:validators.
- - **Self-referencing**: skill-creator scripts do from scripts import utils - referencing their own parent directory. The scanner didn't treat scripts (the dir basename) as a local module.
### 3. .gitattributes - Prevent CRLF in shell scripts

Ensures *.sh and docker-entrypoint.sh always use LF line endings regardless of the developer's OS.

## Testing

- Built and deployed on Windows 11 + Docker Desktop
- - All 5 core skills (docx, pdf, pptx, xlsx, skill-creator) show Active status
- - Seeder logs confirm: async dep check complete checked=5 with no skill deps missing warnings
- 