### PR TITLE
fix(agent): sanitize runID in uniquifyToolCallIDs for Anthropic compatibility

### DIFF
--- a/internal/agent/loop_utils.go
+++ b/internal/agent/loop_utils.go
@@ -94,7 +94,16 @@ func uniquifyToolCallIDs(calls []providers.ToolCall, runID string, iteration int
 	if len(calls) == 0 {
 		return calls
 	}
-	short := runID
+	// Sanitize runID: Anthropic requires tool_use.id to match ^[a-zA-Z0-9_-]+$
+	// RunIDs like "cron:UUID" or "heartbeat:agentID" contain colons that cause HTTP 400.
+	var sb strings.Builder
+	for _, c := range runID {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '_', c == '-':
+			sb.WriteRune(c)
+		}
+	}
+	short := sb.String()
 	if len(short) > 8 {
 		short = short[:8]
 	}


### PR DESCRIPTION
## Summary

- `uniquifyToolCallIDs()` appends the first 8 chars of `runID` to `tool_use.id`
- RunIDs like `cron:UUID`, `heartbeat:agentID` contain **colons** — invalid per Anthropic's `^[a-zA-Z0-9_-]+$` pattern
- This causes **HTTP 400** on the 2nd+ LLM iteration for any cron job or heartbeat that triggers tool use
- Fix: strip non-`[a-zA-Z0-9_-]` chars from the runID prefix before appending

Complements c6bab9a which fixed the same class of issue in the Codex provider's `toFcID()`.

## Reproducer

Any cron job or heartbeat run that triggers tool use fails on iteration 2+ with:
```
messages.1.content.0.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'
```

## Test plan

- [x] Verified `go vet ./internal/agent/` passes (Linux target)
- [x] Run cron job that triggers tool use — should no longer fail on iteration 2+
- [x] Run heartbeat with tool use — same verification