### PR TITLE
feat: add Party Mode — multi-persona collaborative discussion engine

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -475,6 +475,12 @@ func runGateway() {
 	// Register config-based channels as fallback when no DB instances loaded.
 	registerConfigChannels(cfg, channelMgr, msgBus, pgStores, instanceLoader)
 
+	// Party Mode RPC methods
+	if pgStores.Party != nil {
+		methods.NewPartyMethods(pgStores.Party, pgStores.Agents, providerRegistry, msgBus).Register(server.Router())
+		slog.Info("party mode enabled")
+	}
+
 	// Register channels/instances/links/teams RPC methods
 	wireChannelRPCMethods(server, pgStores, channelMgr, agentRouter, msgBus, workspace)
 

--- a/internal/gateway/methods/party.go
+++ b/internal/gateway/methods/party.go
@@ -1,0 +1,564 @@
+package methods
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/gateway"
+	"github.com/nextlevelbuilder/goclaw/internal/party"
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+// PartyMethods handles party.* WebSocket RPC methods.
+type PartyMethods struct {
+	partyStore   store.PartyStore
+	agentStore   store.AgentStore
+	providerReg  *providers.Registry
+	msgBus       *bus.MessageBus
+}
+
+// NewPartyMethods creates a new PartyMethods handler.
+func NewPartyMethods(partyStore store.PartyStore, agentStore store.AgentStore, providerReg *providers.Registry, msgBus *bus.MessageBus) *PartyMethods {
+	return &PartyMethods{
+		partyStore:  partyStore,
+		agentStore:  agentStore,
+		providerReg: providerReg,
+		msgBus:      msgBus,
+	}
+}
+
+// Register registers all party.* methods on the router.
+func (m *PartyMethods) Register(router *gateway.MethodRouter) {
+	router.Register(protocol.MethodPartyStart, m.handleStart)
+	router.Register(protocol.MethodPartyRound, m.handleRound)
+	router.Register(protocol.MethodPartyQuestion, m.handleQuestion)
+	router.Register(protocol.MethodPartyAddContext, m.handleAddContext)
+	router.Register(protocol.MethodPartySummary, m.handleSummary)
+	router.Register(protocol.MethodPartyExit, m.handleExit)
+	router.Register(protocol.MethodPartyList, m.handleList)
+}
+
+// getEngine returns a party engine using the best available provider.
+// Prefers providers with a non-empty DefaultModel (DB providers with settings),
+// falling back to the first name alphabetically for deterministic selection.
+func (m *PartyMethods) getEngine() (*party.Engine, error) {
+	names := m.providerReg.List()
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no LLM providers available")
+	}
+
+	// Prefer a provider with DefaultModel set (typically DB providers with settings.default_model)
+	var bestName string
+	for _, name := range names {
+		p, err := m.providerReg.Get(name)
+		if err != nil {
+			continue
+		}
+		if p.DefaultModel() != "" {
+			if bestName == "" || name < bestName {
+				bestName = name
+			}
+		}
+	}
+	// Fallback: pick first alphabetically for determinism
+	if bestName == "" {
+		sort.Strings(names)
+		bestName = names[0]
+	}
+
+	provider, err := m.providerReg.Get(bestName)
+	if err != nil {
+		return nil, fmt.Errorf("provider %s: %w", bestName, err)
+	}
+	return party.NewEngine(m.partyStore, m.agentStore, provider), nil
+}
+
+// emitterForClient creates an EventEmitter that broadcasts to all connected WS clients.
+func (m *PartyMethods) emitterForClient(client *gateway.Client) party.EventEmitter {
+	return func(event protocol.EventFrame) {
+		client.SendEvent(event)
+	}
+}
+
+type partyStartParams struct {
+	Topic       string   `json:"topic"`
+	TeamPreset  string   `json:"team_preset,omitempty"`
+	Personas    []string `json:"personas,omitempty"`
+	ContextURLs []string `json:"context_urls,omitempty"`
+}
+
+func (m *PartyMethods) handleStart(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params partyStartParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+		return
+	}
+
+	if params.Topic == "" {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "topic is required"))
+		return
+	}
+
+	// Resolve personas from preset or custom list
+	personaKeys := params.Personas
+	if params.TeamPreset != "" {
+		for _, preset := range party.PresetTeams() {
+			if preset.Key == params.TeamPreset {
+				personaKeys = preset.Personas
+				break
+			}
+		}
+	}
+	if len(personaKeys) == 0 {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "no personas selected"))
+		return
+	}
+
+	engine, err := m.getEngine()
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	// Load persona info from DB
+	personas, err := engine.LoadPersonas(ctx, personaKeys)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	// Marshal persona keys for storage
+	personasJSON, _ := json.Marshal(personaKeys)
+
+	// Create session
+	sess := &store.PartySessionData{
+		Topic:      params.Topic,
+		TeamPreset: params.TeamPreset,
+		Status:     store.PartyStatusDiscussing,
+		Mode:       store.PartyModeStandard,
+		MaxRounds:  10,
+		UserID:     client.UserID(),
+		Personas:   personasJSON,
+	}
+	if err := m.partyStore.CreateSession(ctx, sess); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	slog.Info("party: session started", "session_id", sess.ID, "topic", params.Topic, "personas", len(personas))
+
+	// Emit started event
+	emit := m.emitterForClient(client)
+	personaInfos := make([]map[string]string, len(personas))
+	for i, p := range personas {
+		personaInfos[i] = map[string]string{
+			"agent_key":    p.AgentKey,
+			"display_name": p.DisplayName,
+			"emoji":        p.Emoji,
+			"movie_ref":    p.MovieRef,
+		}
+	}
+	emit(*protocol.NewEvent(protocol.EventPartyStarted, map[string]any{
+		"session_id": sess.ID,
+		"topic":      params.Topic,
+		"personas":   personaInfos,
+	}))
+
+	// Generate introductions for each persona
+	for _, p := range personas {
+		intro := fmt.Sprintf("%s %s reporting in. Ready to discuss: %s", p.Emoji, p.DisplayName, params.Topic)
+		emit(*protocol.NewEvent(protocol.EventPartyPersonaIntro, map[string]any{
+			"session_id": sess.ID,
+			"persona":    p.AgentKey,
+			"emoji":      p.Emoji,
+			"content":    intro,
+		}))
+	}
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		"session_id": sess.ID,
+		"personas":   personaInfos,
+		"status":     sess.Status,
+	}))
+}
+
+type partyRoundParams struct {
+	SessionID string `json:"session_id"`
+	Mode      string `json:"mode,omitempty"`
+}
+
+func (m *PartyMethods) handleRound(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params partyRoundParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+		return
+	}
+
+	sessID, err := uuid.Parse(params.SessionID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid session_id"))
+		return
+	}
+
+	sess, err := m.partyStore.GetSession(ctx, sessID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, "session not found"))
+		return
+	}
+
+	if sess.Status != store.PartyStatusDiscussing {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "session is not in discussing state"))
+		return
+	}
+
+	// Increment round
+	sess.Round++
+	mode := params.Mode
+	if mode == "" {
+		mode = sess.Mode
+	}
+
+	engine, err := m.getEngine()
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	// Load personas
+	var personaKeys []string
+	json.Unmarshal(sess.Personas, &personaKeys)
+	personas, err := engine.LoadPersonas(ctx, personaKeys)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	emit := m.emitterForClient(client)
+	emit(*protocol.NewEvent(protocol.EventPartyRoundStarted, map[string]any{
+		"session_id": sess.ID,
+		"round":      sess.Round,
+		"mode":       mode,
+	}))
+
+	// Run the round
+	var result *party.RoundResult
+	switch mode {
+	case store.PartyModeDeep:
+		result, err = engine.RunDeepRound(ctx, sess, personas, emit)
+	case store.PartyModeTokenRing:
+		result, err = engine.RunTokenRingRound(ctx, sess, personas, emit)
+	default:
+		result, err = engine.RunStandardRound(ctx, sess, personas, emit)
+	}
+	if err != nil {
+		slog.Error("party: round failed", "session", sess.ID, "round", sess.Round, "mode", mode, "error", err)
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	// Append to history
+	var history []party.RoundResult
+	json.Unmarshal(sess.History, &history)
+	history = append(history, *result)
+	historyJSON, _ := json.Marshal(history)
+
+	// Update session
+	if err := m.partyStore.UpdateSession(ctx, sess.ID, map[string]any{
+		"round":   sess.Round,
+		"mode":    mode,
+		"history": historyJSON,
+	}); err != nil {
+		slog.Warn("party: failed to update session", "error", err)
+	}
+
+	emit(*protocol.NewEvent(protocol.EventPartyRoundComplete, map[string]any{
+		"session_id": sess.ID,
+		"round":      sess.Round,
+		"mode":       mode,
+	}))
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		"round":    sess.Round,
+		"mode":     mode,
+		"messages": result.Messages,
+	}))
+}
+
+type partyQuestionParams struct {
+	SessionID string `json:"session_id"`
+	Text      string `json:"text"`
+}
+
+func (m *PartyMethods) handleQuestion(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params partyQuestionParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+		return
+	}
+
+	sessID, err := uuid.Parse(params.SessionID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid session_id"))
+		return
+	}
+
+	sess, err := m.partyStore.GetSession(ctx, sessID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, "session not found"))
+		return
+	}
+
+	// Temporarily set topic to the question for this round
+	originalTopic := sess.Topic
+	sess.Topic = fmt.Sprintf("%s\n\nUser question: %s", originalTopic, params.Text)
+	sess.Round++
+
+	engine, err := m.getEngine()
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	var personaKeys []string
+	json.Unmarshal(sess.Personas, &personaKeys)
+	personas, err := engine.LoadPersonas(ctx, personaKeys)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	emit := m.emitterForClient(client)
+	result, err := engine.RunStandardRound(ctx, sess, personas, emit)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	// Restore topic and update session
+	sess.Topic = originalTopic
+	var history []party.RoundResult
+	json.Unmarshal(sess.History, &history)
+	history = append(history, *result)
+	historyJSON, _ := json.Marshal(history)
+
+	if err := m.partyStore.UpdateSession(ctx, sess.ID, map[string]any{
+		"round":   sess.Round,
+		"history": historyJSON,
+	}); err != nil {
+		slog.Warn("party: failed to update session", "error", err)
+	}
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		"round":    sess.Round,
+		"messages": result.Messages,
+	}))
+}
+
+type partyAddContextParams struct {
+	SessionID string `json:"session_id"`
+	Type      string `json:"type"`
+	Name      string `json:"name,omitempty"`
+	Content   string `json:"content,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+func (m *PartyMethods) handleAddContext(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params partyAddContextParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+		return
+	}
+
+	sessID, err := uuid.Parse(params.SessionID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid session_id"))
+		return
+	}
+
+	sess, err := m.partyStore.GetSession(ctx, sessID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, "session not found"))
+		return
+	}
+
+	// Parse existing context
+	var sessionCtx map[string]any
+	if json.Unmarshal(sess.Context, &sessionCtx) != nil {
+		sessionCtx = make(map[string]any)
+	}
+
+	// Add new context based on type
+	switch params.Type {
+	case "document":
+		docs, _ := sessionCtx["documents"].([]any)
+		docs = append(docs, map[string]string{"name": params.Name, "content": params.Content, "source": "upload"})
+		sessionCtx["documents"] = docs
+	case "meeting_notes":
+		sessionCtx["meeting_notes"] = params.Content
+	case "custom":
+		sessionCtx["custom"] = params.Content
+	default:
+		sessionCtx[params.Type] = params.Content
+	}
+
+	contextJSON, _ := json.Marshal(sessionCtx)
+	if err := m.partyStore.UpdateSession(ctx, sess.ID, map[string]any{
+		"context": contextJSON,
+	}); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	emit := m.emitterForClient(client)
+	emit(*protocol.NewEvent(protocol.EventPartyContextAdded, map[string]any{
+		"session_id": sess.ID,
+		"name":       params.Name,
+		"type":       params.Type,
+	}))
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		"ok":            true,
+		"context_count": len(sessionCtx),
+	}))
+}
+
+func (m *PartyMethods) handleSummary(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+		return
+	}
+
+	sessID, err := uuid.Parse(params.SessionID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid session_id"))
+		return
+	}
+
+	sess, err := m.partyStore.GetSession(ctx, sessID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, "session not found"))
+		return
+	}
+
+	engine, err := m.getEngine()
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	summary, err := engine.GenerateSummary(ctx, sess)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	// Store summary in session
+	summaryJSON, _ := json.Marshal(summary)
+	m.partyStore.UpdateSession(ctx, sess.ID, map[string]any{
+		"summary": summaryJSON,
+		"status":  store.PartyStatusSummarizing,
+	})
+
+	emit := m.emitterForClient(client)
+	emit(*protocol.NewEvent(protocol.EventPartySummaryReady, map[string]any{
+		"session_id": sess.ID,
+		"summary":    summary,
+	}))
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, summary))
+}
+
+func (m *PartyMethods) handleExit(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params struct {
+		SessionID string `json:"session_id"`
+		FollowUp  string `json:"follow_up,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+		return
+	}
+
+	sessID, err := uuid.Parse(params.SessionID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid session_id"))
+		return
+	}
+
+	sess, err := m.partyStore.GetSession(ctx, sessID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, "session not found"))
+		return
+	}
+
+	// Generate summary if not yet done
+	var summary *party.SummaryResult
+	if sess.Summary == nil || string(sess.Summary) == "null" {
+		engine, err := m.getEngine()
+		if err == nil {
+			summary, _ = engine.GenerateSummary(ctx, sess)
+		}
+	} else {
+		json.Unmarshal(sess.Summary, &summary)
+	}
+
+	// Close session
+	updates := map[string]any{"status": store.PartyStatusClosed}
+	if summary != nil {
+		summaryJSON, _ := json.Marshal(summary)
+		updates["summary"] = summaryJSON
+	}
+	m.partyStore.UpdateSession(ctx, sess.ID, updates)
+
+	emit := m.emitterForClient(client)
+	emit(*protocol.NewEvent(protocol.EventPartyClosed, map[string]any{
+		"session_id": sess.ID,
+	}))
+
+	response := map[string]any{
+		"session_id": sess.ID,
+		"status":     store.PartyStatusClosed,
+	}
+	if summary != nil {
+		response["summary"] = summary
+	}
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, response))
+}
+
+func (m *PartyMethods) handleList(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params struct {
+		Status string `json:"status,omitempty"`
+		Limit  int    `json:"limit,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+		return
+	}
+
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	sessions, err := m.partyStore.ListSessions(ctx, client.UserID(), params.Status, limit)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		"sessions": sessions,
+		"count":    len(sessions),
+	}))
+}

--- a/internal/party/engine.go
+++ b/internal/party/engine.go
@@ -1,0 +1,307 @@
+package party
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+// EventEmitter sends party events to connected clients.
+type EventEmitter func(event protocol.EventFrame)
+
+// Engine orchestrates party mode discussions.
+type Engine struct {
+	partyStore store.PartyStore
+	agentStore store.AgentStore
+	provider   providers.Provider
+}
+
+// NewEngine creates a new party engine.
+func NewEngine(partyStore store.PartyStore, agentStore store.AgentStore, provider providers.Provider) *Engine {
+	return &Engine{
+		partyStore: partyStore,
+		agentStore: agentStore,
+		provider:   provider,
+	}
+}
+
+// LoadPersonas loads persona info from agent DB for the given keys.
+func (e *Engine) LoadPersonas(ctx context.Context, keys []string) ([]PersonaInfo, error) {
+	var personas []PersonaInfo
+	for _, key := range keys {
+		agent, err := e.agentStore.GetByKey(ctx, key)
+		if err != nil {
+			return nil, fmt.Errorf("persona %s not found: %w", key, err)
+		}
+		pi := PersonaInfo{
+			AgentKey:    key,
+			DisplayName: agent.DisplayName,
+		}
+		// Extract persona metadata from other_config
+		var cfg map[string]json.RawMessage
+		if json.Unmarshal(agent.OtherConfig, &cfg) == nil {
+			if personaJSON, ok := cfg["persona"]; ok {
+				var pm struct {
+					Emoji           string             `json:"emoji"`
+					MovieRef        string             `json:"movie_ref"`
+					SpeakingStyle   string             `json:"speaking_style"`
+					ExpertiseWeight map[string]float64 `json:"expertise_weight"`
+				}
+				if json.Unmarshal(personaJSON, &pm) == nil {
+					pi.Emoji = pm.Emoji
+					pi.MovieRef = pm.MovieRef
+					pi.SpeakingStyle = pm.SpeakingStyle
+					pi.ExpertiseWeight = pm.ExpertiseWeight
+				}
+			}
+		}
+		if pi.Emoji == "" {
+			pi.Emoji = "🤖"
+		}
+		personas = append(personas, pi)
+	}
+	return personas, nil
+}
+
+// RunStandardRound executes a standard mode round (1 LLM call, all personas).
+func (e *Engine) RunStandardRound(ctx context.Context, session *store.PartySessionData, personas []PersonaInfo, emit EventEmitter) (*RoundResult, error) {
+	slog.Info("party: standard round", "session", session.ID, "round", session.Round)
+
+	systemPrompt := "You are a party mode facilitator. Generate responses for each persona in character."
+	userPrompt := BuildStandardRoundPrompt(session, personas)
+
+	resp, err := e.llmCall(ctx, systemPrompt, userPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("standard round LLM call: %w", err)
+	}
+
+	messages := parsePersonaMessages(resp, personas)
+	for _, m := range messages {
+		emit(*protocol.NewEvent(protocol.EventPartyPersonaSpoke, map[string]any{
+			"session_id": session.ID, "persona": m.PersonaKey,
+			"emoji": m.Emoji, "content": m.Content,
+		}))
+	}
+
+	return &RoundResult{Round: session.Round, Mode: store.PartyModeStandard, Messages: messages}, nil
+}
+
+// RunDeepRound executes Deep Mode: parallel thinking → cross-talk.
+func (e *Engine) RunDeepRound(ctx context.Context, session *store.PartySessionData, personas []PersonaInfo, emit EventEmitter) (*RoundResult, error) {
+	slog.Info("party: deep round (parallel)", "session", session.ID, "round", session.Round, "personas", len(personas))
+
+	// Step 1: Parallel thinking
+	thoughts, err := e.runParallelThinking(ctx, session, personas, emit)
+	if err != nil {
+		return nil, fmt.Errorf("parallel thinking: %w", err)
+	}
+
+	// Step 2: Cross-talk (1 LLM call)
+	systemPrompt := "You are a party mode facilitator generating cross-talk between personas."
+	userPrompt := BuildCrossTalkPrompt(session, personas, thoughts)
+
+	resp, err := e.llmCall(ctx, systemPrompt, userPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("cross-talk LLM call: %w", err)
+	}
+
+	messages := parsePersonaMessages(resp, personas)
+	for i := range messages {
+		// Attach thinking from Step 1
+		for _, t := range thoughts {
+			if t.PersonaKey == messages[i].PersonaKey {
+				messages[i].Thinking = t.Content
+				break
+			}
+		}
+		emit(*protocol.NewEvent(protocol.EventPartyPersonaSpoke, map[string]any{
+			"session_id": session.ID, "persona": messages[i].PersonaKey,
+			"emoji": messages[i].Emoji, "content": messages[i].Content,
+		}))
+	}
+
+	return &RoundResult{Round: session.Round, Mode: store.PartyModeDeep, Messages: messages}, nil
+}
+
+// RunTokenRingRound executes Token-Ring: parallel thinking → sequential turns.
+func (e *Engine) RunTokenRingRound(ctx context.Context, session *store.PartySessionData, personas []PersonaInfo, emit EventEmitter) (*RoundResult, error) {
+	slog.Info("party: token-ring round", "session", session.ID, "round", session.Round, "personas", len(personas))
+
+	// Step 1: Parallel thinking
+	thoughts, err := e.runParallelThinking(ctx, session, personas, emit)
+	if err != nil {
+		return nil, fmt.Errorf("parallel thinking: %w", err)
+	}
+
+	// Step 2: Sequential turns
+	var messages []PersonaMessage
+	var priorTurns []PersonaMessage
+
+	for i, persona := range personas {
+		isLast := i == len(personas)-1
+
+		soulMD := e.loadPersonaSoulMD(ctx, persona.AgentKey)
+		systemPrompt := BuildPersonaSystemPrompt(persona, session, soulMD)
+		userPrompt := BuildTokenRingTurnPrompt(session, persona, thoughts, priorTurns, isLast)
+
+		resp, err := e.llmCall(ctx, systemPrompt, userPrompt)
+		if err != nil {
+			slog.Warn("party: token-ring turn failed", "persona", persona.AgentKey, "error", err)
+			continue
+		}
+
+		msg := PersonaMessage{
+			PersonaKey:  persona.AgentKey,
+			DisplayName: persona.DisplayName,
+			Emoji:       persona.Emoji,
+			Content:     strings.TrimSpace(resp),
+		}
+		messages = append(messages, msg)
+		priorTurns = append(priorTurns, msg)
+
+		// Emit immediately — user sees each persona respond in real-time
+		emit(*protocol.NewEvent(protocol.EventPartyPersonaSpoke, map[string]any{
+			"session_id": session.ID, "persona": msg.PersonaKey,
+			"emoji": msg.Emoji, "content": msg.Content,
+		}))
+	}
+
+	return &RoundResult{Round: session.Round, Mode: store.PartyModeTokenRing, Messages: messages}, nil
+}
+
+// runParallelThinking executes independent thinking for all personas in parallel.
+func (e *Engine) runParallelThinking(ctx context.Context, session *store.PartySessionData, personas []PersonaInfo, emit EventEmitter) ([]PersonaThought, error) {
+	thoughts := make([]PersonaThought, len(personas))
+	errs := make([]error, len(personas))
+	var wg sync.WaitGroup
+
+	for i, persona := range personas {
+		wg.Add(1)
+		go func(idx int, p PersonaInfo) {
+			defer wg.Done()
+
+			emit(*protocol.NewEvent(protocol.EventPartyPersonaThinking, map[string]any{
+				"session_id": session.ID, "persona": p.AgentKey, "emoji": p.Emoji,
+			}))
+
+			soulMD := e.loadPersonaSoulMD(ctx, p.AgentKey)
+			systemPrompt := BuildPersonaSystemPrompt(p, session, soulMD)
+			userPrompt := BuildThinkingPrompt(session, p)
+
+			resp, err := e.llmCall(ctx, systemPrompt, userPrompt)
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			thoughts[idx] = PersonaThought{PersonaKey: p.AgentKey, Emoji: p.Emoji, Content: strings.TrimSpace(resp)}
+		}(i, persona)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			return nil, fmt.Errorf("persona %s thinking failed: %w", personas[i].AgentKey, err)
+		}
+	}
+
+	return thoughts, nil
+}
+
+// GenerateSummary generates a discussion summary.
+func (e *Engine) GenerateSummary(ctx context.Context, session *store.PartySessionData) (*SummaryResult, error) {
+	prompt := BuildSummaryPrompt(session)
+	resp, err := e.llmCall(ctx, "You are a discussion summarizer. Generate structured markdown summaries.", prompt)
+	if err != nil {
+		return nil, fmt.Errorf("summary LLM call: %w", err)
+	}
+
+	var personaKeys []string
+	json.Unmarshal(session.Personas, &personaKeys)
+
+	return &SummaryResult{
+		Topic:    session.Topic,
+		Rounds:   session.Round,
+		Personas: personaKeys,
+		Markdown: resp,
+	}, nil
+}
+
+func (e *Engine) llmCall(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	req := providers.ChatRequest{
+		Messages: []providers.Message{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: userPrompt},
+		},
+		Options: map[string]any{
+			"max_tokens": 4096,
+		},
+	}
+	resp, err := e.provider.Chat(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	return resp.Content, nil
+}
+
+func (e *Engine) loadPersonaSoulMD(ctx context.Context, agentKey string) string {
+	agent, err := e.agentStore.GetByKey(ctx, agentKey)
+	if err != nil {
+		return ""
+	}
+	files, _ := e.agentStore.GetAgentContextFiles(ctx, agent.ID)
+	for _, f := range files {
+		if f.FileName == "SOUL.md" {
+			return f.Content
+		}
+	}
+	return ""
+}
+
+// parsePersonaMessages parses LLM output into individual persona messages.
+func parsePersonaMessages(resp string, personas []PersonaInfo) []PersonaMessage {
+	var messages []PersonaMessage
+	lines := strings.Split(resp, "\n")
+
+	var current *PersonaMessage
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		matched := false
+		for _, p := range personas {
+			if strings.HasPrefix(line, p.Emoji) {
+				if current != nil {
+					messages = append(messages, *current)
+				}
+				content := line
+				prefix := p.Emoji + " " + p.DisplayName + ":"
+				if strings.HasPrefix(line, prefix) {
+					content = strings.TrimSpace(line[len(prefix):])
+				}
+				current = &PersonaMessage{
+					PersonaKey:  p.AgentKey,
+					DisplayName: p.DisplayName,
+					Emoji:       p.Emoji,
+					Content:     content,
+				}
+				matched = true
+				break
+			}
+		}
+		if !matched && current != nil {
+			current.Content += "\n" + line
+		}
+	}
+	if current != nil {
+		messages = append(messages, *current)
+	}
+	return messages
+}

--- a/internal/party/prompt.go
+++ b/internal/party/prompt.go
@@ -1,0 +1,161 @@
+package party
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// BuildPersonaSystemPrompt builds the system prompt for a persona in a party round.
+func BuildPersonaSystemPrompt(persona PersonaInfo, session *store.PartySessionData, soulMD string) string {
+	var sb strings.Builder
+
+	// Persona identity
+	sb.WriteString(soulMD)
+	sb.WriteString("\n\n")
+
+	// Party context
+	sb.WriteString("<party-context>\n")
+	sb.WriteString(fmt.Sprintf("<topic>%s</topic>\n", session.Topic))
+
+	var ctx map[string]json.RawMessage
+	if json.Unmarshal(session.Context, &ctx) == nil {
+		if docs, ok := ctx["documents"]; ok {
+			sb.WriteString("<documents>\n")
+			sb.Write(docs)
+			sb.WriteString("\n</documents>\n")
+		}
+		if code, ok := ctx["codebase"]; ok {
+			sb.WriteString("<codebase>\n")
+			sb.Write(code)
+			sb.WriteString("\n</codebase>\n")
+		}
+		if notes, ok := ctx["meeting_notes"]; ok {
+			sb.WriteString("<meeting-notes>\n")
+			sb.Write(notes)
+			sb.WriteString("\n</meeting-notes>\n")
+		}
+		if custom, ok := ctx["custom"]; ok {
+			sb.WriteString("<additional>\n")
+			sb.Write(custom)
+			sb.WriteString("\n</additional>\n")
+		}
+	}
+	sb.WriteString("</party-context>\n\n")
+
+	// Round history (sliding window — last 3 rounds)
+	var history []RoundResult
+	if json.Unmarshal(session.History, &history) == nil && len(history) > 0 {
+		start := 0
+		if len(history) > 3 {
+			start = len(history) - 3
+		}
+		sb.WriteString("<round-history>\n")
+		for _, r := range history[start:] {
+			sb.WriteString(fmt.Sprintf("Round %d [%s]:\n", r.Round, r.Mode))
+			for _, m := range r.Messages {
+				sb.WriteString(fmt.Sprintf("  %s %s: %s\n", m.Emoji, m.DisplayName, truncate(m.Content, 500)))
+			}
+		}
+		sb.WriteString("</round-history>\n")
+	}
+
+	return sb.String()
+}
+
+// BuildStandardRoundPrompt builds the user message for a standard round.
+func BuildStandardRoundPrompt(session *store.PartySessionData, personas []PersonaInfo) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Round %d discussion about: %s\n\n", session.Round, session.Topic))
+	sb.WriteString("Respond as each of these personas IN CHARACTER. Each persona gives their expert analysis.\n")
+	sb.WriteString("Format each response as: {emoji} {name}: {response}\n")
+	sb.WriteString("Encourage genuine disagreement where expertise conflicts.\n\n")
+	sb.WriteString("Personas:\n")
+	for _, p := range personas {
+		sb.WriteString(fmt.Sprintf("- %s %s (%s)\n", p.Emoji, p.DisplayName, p.SpeakingStyle))
+	}
+	return sb.String()
+}
+
+// BuildThinkingPrompt builds the user message for Deep Mode Step 1 (independent thinking).
+func BuildThinkingPrompt(session *store.PartySessionData, persona PersonaInfo) string {
+	return fmt.Sprintf(
+		"Round %d: Think independently about \"%s\".\n"+
+			"Share your analysis from your %s expertise.\n"+
+			"Be specific, cite relevant standards/principles.\n"+
+			"Identify risks, opportunities, and trade-offs.\n"+
+			"Stay completely in character as %s.",
+		session.Round, session.Topic, persona.DisplayName, persona.DisplayName)
+}
+
+// BuildCrossTalkPrompt builds the prompt for Deep Mode Step 2 (cross-talk from collected thoughts).
+func BuildCrossTalkPrompt(session *store.PartySessionData, personas []PersonaInfo, thoughts []PersonaThought) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Round %d cross-talk about: %s\n\n", session.Round, session.Topic))
+	sb.WriteString("Each persona has shared their independent thinking below.\n")
+	sb.WriteString("Now generate cross-talk: personas respond to EACH OTHER.\n")
+	sb.WriteString("Challenge disagreements explicitly. Build on agreements.\n")
+	sb.WriteString("Stay in character. Format: {emoji} {name}: {response}\n\n")
+
+	sb.WriteString("<persona-thoughts>\n")
+	for _, t := range thoughts {
+		sb.WriteString(fmt.Sprintf("<%s>\n%s\n</%s>\n", t.PersonaKey, t.Content, t.PersonaKey))
+	}
+	sb.WriteString("</persona-thoughts>\n")
+	return sb.String()
+}
+
+// BuildTokenRingTurnPrompt builds the prompt for one persona's turn in Token-Ring mode.
+func BuildTokenRingTurnPrompt(session *store.PartySessionData, persona PersonaInfo, thoughts []PersonaThought, priorTurns []PersonaMessage, isLast bool) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Round %d, your turn in the discussion about: %s\n\n", session.Round, session.Topic))
+
+	sb.WriteString("Independent thoughts from all personas:\n")
+	for _, t := range thoughts {
+		sb.WriteString(fmt.Sprintf("- %s: %s\n", t.PersonaKey, truncate(t.Content, 300)))
+	}
+
+	if len(priorTurns) > 0 {
+		sb.WriteString("\nPrior responses this round:\n")
+		for _, m := range priorTurns {
+			sb.WriteString(fmt.Sprintf("  %s %s: %s\n", m.Emoji, m.DisplayName, m.Content))
+		}
+		sb.WriteString("\nRespond to what others have said. Challenge or build on their points.\n")
+	}
+
+	if isLast {
+		sb.WriteString("\nYou are the LAST speaker. Synthesize: what does the team agree on? What remains unresolved?\n")
+	}
+
+	sb.WriteString("\nStay completely in character. Be direct and specific.")
+	return sb.String()
+}
+
+// BuildSummaryPrompt builds the prompt for generating the discussion summary.
+func BuildSummaryPrompt(session *store.PartySessionData) string {
+	return fmt.Sprintf(`Summarize this party mode discussion.
+
+Topic: %s
+Rounds: %d
+
+Discussion history:
+%s
+
+Generate a structured summary with:
+1. Points of Agreement (unanimous decisions)
+2. Points of Disagreement (who disagrees, why)
+3. Decisions Made
+4. Action Items (action, assignee persona, deadline suggestion, checkpoint link)
+5. Compliance Notes (if any security/PCI-DSS/SBV items)
+
+Format as clean markdown.`, session.Topic, session.Round, string(session.History))
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/party/types.go
+++ b/internal/party/types.go
@@ -1,0 +1,77 @@
+package party
+
+// PersonaInfo holds runtime persona metadata loaded from agent DB.
+type PersonaInfo struct {
+	AgentKey        string             `json:"agent_key"`
+	DisplayName     string             `json:"display_name"`
+	Emoji           string             `json:"emoji"`
+	MovieRef        string             `json:"movie_ref"`
+	SpeakingStyle   string             `json:"speaking_style"`
+	ExpertiseWeight map[string]float64 `json:"expertise_weight,omitempty"`
+}
+
+// PersonaThought is one persona's independent thinking output (Deep Mode Step 1).
+type PersonaThought struct {
+	PersonaKey string `json:"persona_key"`
+	Emoji      string `json:"emoji"`
+	Content    string `json:"content"`
+}
+
+// PersonaMessage is a persona's spoken message in a round.
+type PersonaMessage struct {
+	PersonaKey  string `json:"persona_key"`
+	DisplayName string `json:"display_name"`
+	Emoji       string `json:"emoji"`
+	Content     string `json:"content"`
+	Thinking    string `json:"thinking,omitempty"`
+}
+
+// RoundResult contains all persona messages for one round.
+type RoundResult struct {
+	Round    int              `json:"round"`
+	Mode     string           `json:"mode"`
+	Messages []PersonaMessage `json:"messages"`
+}
+
+// SummaryResult contains the party discussion summary.
+type SummaryResult struct {
+	Topic         string       `json:"topic"`
+	Rounds        int          `json:"rounds"`
+	Personas      []string     `json:"personas"`
+	Agreements    []string     `json:"agreements"`
+	Disagreements []string     `json:"disagreements"`
+	Decisions     []string     `json:"decisions"`
+	ActionItems   []ActionItem `json:"action_items"`
+	Compliance    []string     `json:"compliance_notes,omitempty"`
+	Markdown      string       `json:"markdown"`
+}
+
+// ActionItem is a follow-up task from the discussion.
+type ActionItem struct {
+	Action   string `json:"action"`
+	Assignee string `json:"assignee"`
+	Deadline string `json:"deadline,omitempty"`
+	CPLink   string `json:"cp_link,omitempty"`
+}
+
+// PresetTeam defines a preset team composition.
+type PresetTeam struct {
+	Key         string   `json:"key"`
+	Name        string   `json:"name"`
+	Personas    []string `json:"personas"`
+	UseCase     string   `json:"use_case"`
+	Facilitator string   `json:"facilitator"`
+	Mandatory   []string `json:"mandatory,omitempty"`
+}
+
+// PresetTeams returns the 6 preset team compositions.
+func PresetTeams() []PresetTeam {
+	return []PresetTeam{
+		{Key: "payment_feature", Name: "Payment Feature", Personas: []string{"tony-stark-persona", "neo-persona", "batman-persona", "judge-dredd-persona", "columbo-persona"}, UseCase: "Payment flows, settlement", Facilitator: "gandalf-persona"},
+		{Key: "security_review", Name: "Security Review", Personas: []string{"batman-persona", "judge-dredd-persona", "neo-persona", "scotty-persona"}, UseCase: "Threat modeling, pre-CP3", Facilitator: "batman-persona"},
+		{Key: "sprint_planning", Name: "Sprint Planning", Personas: []string{"tony-stark-persona", "sherlock-persona", "neo-persona", "gandalf-persona", "columbo-persona"}, UseCase: "Sprint kickoff, PRD review", Facilitator: "gandalf-persona"},
+		{Key: "architecture_decision", Name: "Architecture Decision", Personas: []string{"neo-persona", "spock-persona", "scotty-persona", "batman-persona"}, UseCase: "ADR, tech stack eval", Facilitator: "morpheus-persona"},
+		{Key: "ux_review", Name: "UX Review", Personas: []string{"edna-mode-persona", "tony-stark-persona", "spider-man-persona", "ethan-hunt-persona", "columbo-persona"}, UseCase: "Design review", Facilitator: "edna-mode-persona"},
+		{Key: "incident_response", Name: "Incident Response", Personas: []string{"scotty-persona", "neo-persona", "batman-persona", "nick-fury-persona"}, UseCase: "Production incidents", Facilitator: "nick-fury-persona"},
+	}
+}

--- a/internal/store/party_store.go
+++ b/internal/store/party_store.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Party session statuses.
+const (
+	PartyStatusAssembling  = "assembling"
+	PartyStatusDiscussing  = "discussing"
+	PartyStatusSummarizing = "summarizing"
+	PartyStatusClosed      = "closed"
+)
+
+// Party discussion modes.
+const (
+	PartyModeStandard  = "standard"
+	PartyModeDeep      = "deep"
+	PartyModeTokenRing = "token_ring"
+)
+
+// PartySessionData represents a party mode session.
+type PartySessionData struct {
+	ID         uuid.UUID       `json:"id"`
+	Topic      string          `json:"topic"`
+	TeamPreset string          `json:"team_preset,omitempty"`
+	Status     string          `json:"status"`
+	Mode       string          `json:"mode"`
+	Round      int             `json:"round"`
+	MaxRounds  int             `json:"max_rounds"`
+	UserID     string          `json:"user_id"`
+	Channel    string          `json:"channel,omitempty"`
+	ChatID     string          `json:"chat_id,omitempty"`
+	Personas   json.RawMessage `json:"personas"`
+	Context    json.RawMessage `json:"context"`
+	History    json.RawMessage `json:"history"`
+	Summary    json.RawMessage `json:"summary,omitempty"`
+	Artifacts  json.RawMessage `json:"artifacts"`
+	CreatedAt  time.Time       `json:"created_at"`
+	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
+// PartyStore manages party mode sessions.
+type PartyStore interface {
+	CreateSession(ctx context.Context, session *PartySessionData) error
+	GetSession(ctx context.Context, id uuid.UUID) (*PartySessionData, error)
+	UpdateSession(ctx context.Context, id uuid.UUID, updates map[string]any) error
+	ListSessions(ctx context.Context, userID string, status string, limit int) ([]*PartySessionData, error)
+	// GetActiveSession returns the active (assembling/discussing) session for a user+channel+chat.
+	GetActiveSession(ctx context.Context, userID, channel, chatID string) (*PartySessionData, error)
+	DeleteSession(ctx context.Context, id uuid.UUID) error
+}

--- a/internal/store/pg/factory.go
+++ b/internal/store/pg/factory.go
@@ -43,6 +43,7 @@ func NewPGStores(cfg store.StoreConfig) (*store.Stores, error) {
 		Contacts:         NewPGContactStore(db),
 		Activity:         NewPGActivityStore(db),
 		Snapshots:        NewPGSnapshotStore(db),
+		Party:            NewPGPartyStore(db),
 		SecureCLI:        NewPGSecureCLIStore(db, cfg.EncryptionKey),
 		APIKeys:           NewPGAPIKeyStore(db),
 		Heartbeats:        NewPGHeartbeatStore(db),

--- a/internal/store/pg/party.go
+++ b/internal/store/pg/party.go
@@ -1,0 +1,140 @@
+package pg
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+const partySelectCols = `id, topic, team_preset, status, mode, round, max_rounds,
+    user_id, channel, chat_id, personas, context, history,
+    COALESCE(summary, 'null'), artifacts, created_at, updated_at`
+
+// PGPartyStore implements PartyStore backed by PostgreSQL.
+type PGPartyStore struct {
+	db *sql.DB
+}
+
+// NewPGPartyStore creates a new PGPartyStore.
+func NewPGPartyStore(db *sql.DB) *PGPartyStore {
+	return &PGPartyStore{db: db}
+}
+
+func (s *PGPartyStore) CreateSession(ctx context.Context, sess *store.PartySessionData) error {
+	if sess.ID == uuid.Nil {
+		sess.ID = store.GenNewID()
+	}
+	now := time.Now()
+	sess.CreatedAt = now
+	sess.UpdatedAt = now
+	if len(sess.Personas) == 0 {
+		sess.Personas = json.RawMessage("[]")
+	}
+	if len(sess.Context) == 0 {
+		sess.Context = json.RawMessage("{}")
+	}
+	if len(sess.History) == 0 {
+		sess.History = json.RawMessage("[]")
+	}
+	if len(sess.Artifacts) == 0 {
+		sess.Artifacts = json.RawMessage("[]")
+	}
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO party_sessions
+            (id, topic, team_preset, status, mode, round, max_rounds,
+             user_id, channel, chat_id, personas, context, history, artifacts, created_at, updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+		sess.ID, sess.Topic, sess.TeamPreset, sess.Status, sess.Mode,
+		sess.Round, sess.MaxRounds, sess.UserID, sess.Channel, sess.ChatID,
+		sess.Personas, sess.Context, sess.History, sess.Artifacts,
+		sess.CreatedAt, sess.UpdatedAt)
+	return err
+}
+
+func (s *PGPartyStore) GetSession(ctx context.Context, id uuid.UUID) (*store.PartySessionData, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+partySelectCols+` FROM party_sessions WHERE id = $1`, id)
+	return scanPartyRow(row)
+}
+
+func (s *PGPartyStore) GetActiveSession(ctx context.Context, userID, channel, chatID string) (*store.PartySessionData, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+partySelectCols+` FROM party_sessions
+         WHERE user_id = $1 AND channel = $2 AND chat_id = $3
+           AND status IN ('assembling', 'discussing')
+         ORDER BY created_at DESC LIMIT 1`, userID, channel, chatID)
+	sess, err := scanPartyRow(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return sess, err
+}
+
+func (s *PGPartyStore) UpdateSession(ctx context.Context, id uuid.UUID, updates map[string]any) error {
+	updates["updated_at"] = time.Now()
+	return execMapUpdate(ctx, s.db, "party_sessions", id, updates)
+}
+
+func (s *PGPartyStore) ListSessions(ctx context.Context, userID string, status string, limit int) ([]*store.PartySessionData, error) {
+	query := `SELECT ` + partySelectCols + ` FROM party_sessions WHERE user_id = $1`
+	args := []any{userID}
+	if status != "" {
+		query += ` AND status = $2`
+		args = append(args, status)
+	}
+	query += ` ORDER BY created_at DESC`
+	if limit > 0 {
+		query += fmt.Sprintf(` LIMIT %d`, limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var sessions []*store.PartySessionData
+	for rows.Next() {
+		sess, err := scanPartyRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, sess)
+	}
+	return sessions, rows.Err()
+}
+
+func (s *PGPartyStore) DeleteSession(ctx context.Context, id uuid.UUID) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM party_sessions WHERE id = $1`, id)
+	return err
+}
+
+func scanPartyRow(row *sql.Row) (*store.PartySessionData, error) {
+	var s store.PartySessionData
+	err := row.Scan(&s.ID, &s.Topic, &s.TeamPreset, &s.Status, &s.Mode,
+		&s.Round, &s.MaxRounds, &s.UserID, &s.Channel, &s.ChatID,
+		&s.Personas, &s.Context, &s.History, &s.Summary, &s.Artifacts,
+		&s.CreatedAt, &s.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func scanPartyRows(rows *sql.Rows) (*store.PartySessionData, error) {
+	var s store.PartySessionData
+	err := rows.Scan(&s.ID, &s.Topic, &s.TeamPreset, &s.Status, &s.Mode,
+		&s.Round, &s.MaxRounds, &s.UserID, &s.Channel, &s.ChatID,
+		&s.Personas, &s.Context, &s.History, &s.Summary, &s.Artifacts,
+		&s.CreatedAt, &s.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/internal/store/stores.go
+++ b/internal/store/stores.go
@@ -25,6 +25,7 @@ type Stores struct {
 	Contacts         ContactStore
 	Activity         ActivityStore
 	Snapshots        SnapshotStore
+	Party            PartyStore
 	SecureCLI        SecureCLIStore
 	APIKeys           APIKeyStore
 	Heartbeats        HeartbeatStore

--- a/migrations/000018_party_sessions.down.sql
+++ b/migrations/000018_party_sessions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS party_sessions;

--- a/migrations/000018_party_sessions.up.sql
+++ b/migrations/000018_party_sessions.up.sql
@@ -1,0 +1,23 @@
+-- 000014_party_sessions.up.sql
+CREATE TABLE IF NOT EXISTS party_sessions (
+    id          UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    topic       TEXT NOT NULL,
+    team_preset VARCHAR(50),
+    status      VARCHAR(20) NOT NULL DEFAULT 'assembling',
+    mode        VARCHAR(10) NOT NULL DEFAULT 'standard',
+    round       INT NOT NULL DEFAULT 0,
+    max_rounds  INT NOT NULL DEFAULT 10,
+    user_id     VARCHAR(200) NOT NULL,
+    channel     VARCHAR(255),
+    chat_id     VARCHAR(200),
+    personas    JSONB NOT NULL DEFAULT '[]',
+    context     JSONB NOT NULL DEFAULT '{}',
+    history     JSONB NOT NULL DEFAULT '[]',
+    summary     JSONB,
+    artifacts   JSONB NOT NULL DEFAULT '[]',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_party_sessions_user ON party_sessions(user_id, status);
+CREATE INDEX IF NOT EXISTS idx_party_sessions_channel ON party_sessions(channel, chat_id, status);

--- a/pkg/protocol/party.go
+++ b/pkg/protocol/party.go
@@ -1,0 +1,26 @@
+package protocol
+
+// Party Mode methods.
+const (
+	MethodPartyStart      = "party.start"
+	MethodPartyRound      = "party.round"
+	MethodPartyQuestion   = "party.question"
+	MethodPartyAddContext = "party.add_context"
+	MethodPartySummary    = "party.summary"
+	MethodPartyExit       = "party.exit"
+	MethodPartyList       = "party.list"
+)
+
+// Party Mode events.
+const (
+	EventPartyStarted         = "party.started"
+	EventPartyPersonaIntro    = "party.persona.intro"
+	EventPartyRoundStarted    = "party.round.started"
+	EventPartyPersonaThinking = "party.persona.thinking"
+	EventPartyPersonaSpoke    = "party.persona.spoke"
+	EventPartyRoundComplete   = "party.round.complete"
+	EventPartyContextAdded    = "party.context.added"
+	EventPartySummaryReady    = "party.summary.ready"
+	EventPartyArtifact        = "party.artifact"
+	EventPartyClosed          = "party.closed"
+)

--- a/ui/web/src/api/protocol.ts
+++ b/ui/web/src/api/protocol.ts
@@ -167,6 +167,15 @@ export const Methods = {
   CONFIG_PERMISSIONS_GRANT: "config.permissions.grant",
   CONFIG_PERMISSIONS_REVOKE: "config.permissions.revoke",
 
+  // Party mode
+  PARTY_START: "party.start",
+  PARTY_ROUND: "party.round",
+  PARTY_QUESTION: "party.question",
+  PARTY_ADD_CONTEXT: "party.add_context",
+  PARTY_SUMMARY: "party.summary",
+  PARTY_EXIT: "party.exit",
+  PARTY_LIST: "party.list",
+
   // Phase 3+ - NICE TO HAVE
   LOGS_TAIL: "logs.tail",
 } as const;
@@ -242,6 +251,18 @@ export const Events = {
   SKILL_DEPS_INSTALLED: "skill.deps.installed",
 
   HEARTBEAT: "heartbeat",
+
+  // Party mode
+  PARTY_STARTED: "party.started",
+  PARTY_PERSONA_INTRO: "party.persona.intro",
+  PARTY_ROUND_STARTED: "party.round.started",
+  PARTY_PERSONA_THINKING: "party.persona.thinking",
+  PARTY_PERSONA_SPOKE: "party.persona.spoke",
+  PARTY_ROUND_COMPLETE: "party.round.complete",
+  PARTY_CONTEXT_ADDED: "party.context.added",
+  PARTY_SUMMARY_READY: "party.summary.ready",
+  PARTY_ARTIFACT: "party.artifact",
+  PARTY_CLOSED: "party.closed",
 } as const;
 
 /** All event names relevant to team debug view */

--- a/ui/web/src/components/layout/sidebar.tsx
+++ b/ui/web/src/components/layout/sidebar.tsx
@@ -26,6 +26,7 @@ import {
   Contact,
   KeyRound,
   FileText,
+  PartyPopper,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { SidebarGroup } from "./sidebar-group";
@@ -76,6 +77,7 @@ export function Sidebar({ collapsed, onNavItemClick }: SidebarProps) {
           <SidebarItem to={ROUTES.CHAT} icon={MessageSquare} label={t("nav.chat")} collapsed={collapsed} />
           <SidebarItem to={ROUTES.AGENTS} icon={Bot} label={t("nav.agents")} collapsed={collapsed} />
           <SidebarItem to={ROUTES.TEAMS} icon={Users} label={t("nav.agentTeams")} collapsed={collapsed} />
+          <SidebarItem to={ROUTES.PARTY} icon={PartyPopper} label={t("nav.party")} collapsed={collapsed} />
         </SidebarGroup>
 
         <SidebarGroup label={t("groups.conversations")} collapsed={collapsed}>

--- a/ui/web/src/i18n/index.ts
+++ b/ui/web/src/i18n/index.ts
@@ -34,6 +34,7 @@ import enActivity from "./locales/en/activity.json";
 import enApiKeys from "./locales/en/api-keys.json";
 import enCliCredentials from "./locales/en/cli-credentials.json";
 import enPackages from "./locales/en/packages.json";
+import enParty from "./locales/en/party.json";
 
 // --- VI namespaces ---
 import viCommon from "./locales/vi/common.json";
@@ -68,6 +69,7 @@ import viActivity from "./locales/vi/activity.json";
 import viApiKeys from "./locales/vi/api-keys.json";
 import viCliCredentials from "./locales/vi/cli-credentials.json";
 import viPackages from "./locales/vi/packages.json";
+import viParty from "./locales/vi/party.json";
 
 // --- ZH namespaces ---
 import zhCommon from "./locales/zh/common.json";
@@ -102,6 +104,7 @@ import zhActivity from "./locales/zh/activity.json";
 import zhApiKeys from "./locales/zh/api-keys.json";
 import zhCliCredentials from "./locales/zh/cli-credentials.json";
 import zhPackages from "./locales/zh/packages.json";
+import zhParty from "./locales/zh/party.json";
 
 const STORAGE_KEY = "goclaw:language";
 
@@ -120,7 +123,7 @@ const ns = [
   "channels", "providers", "traces", "events",
   "usage", "approvals", "nodes", "logs", "tools", "mcp", "tts",
   "setup", "memory", "storage", "pending-messages", "contacts", "activity", "api-keys",
-  "cli-credentials", "packages",
+  "cli-credentials", "packages", "party",
 ] as const;
 
 i18n.use(initReactI18next).init({
@@ -136,7 +139,7 @@ i18n.use(initReactI18next).init({
       "pending-messages": enPendingMessages,
       contacts: enContacts, activity: enActivity, "api-keys": enApiKeys,
       "cli-credentials": enCliCredentials,
-      packages: enPackages,
+      packages: enPackages, party: enParty,
     },
     vi: {
       common: viCommon, sidebar: viSidebar, topbar: viTopbar, login: viLogin,
@@ -149,7 +152,7 @@ i18n.use(initReactI18next).init({
       "pending-messages": viPendingMessages,
       contacts: viContacts, activity: viActivity, "api-keys": viApiKeys,
       "cli-credentials": viCliCredentials,
-      packages: viPackages,
+      packages: viPackages, party: viParty,
     },
     zh: {
       common: zhCommon, sidebar: zhSidebar, topbar: zhTopbar, login: zhLogin,
@@ -162,7 +165,7 @@ i18n.use(initReactI18next).init({
       "pending-messages": zhPendingMessages,
       contacts: zhContacts, activity: zhActivity, "api-keys": zhApiKeys,
       "cli-credentials": zhCliCredentials,
-      packages: zhPackages,
+      packages: zhPackages, party: zhParty,
     },
   },
   ns: [...ns],

--- a/ui/web/src/i18n/locales/en/party.json
+++ b/ui/web/src/i18n/locales/en/party.json
@@ -1,0 +1,46 @@
+{
+  "title": "Party Mode",
+  "newParty": "New Party",
+  "topic": "Discussion Topic",
+  "selectTeam": "Select Team",
+  "customTeam": "Custom Team",
+  "start": "Start Discussion",
+  "presets": {
+    "payment_feature": "Payment Feature",
+    "security_review": "Security Review",
+    "sprint_planning": "Sprint Planning",
+    "architecture_decision": "Architecture Decision",
+    "ux_review": "UX Review",
+    "incident_response": "Incident Response"
+  },
+  "controls": {
+    "continue": "Continue",
+    "deepMode": "Deep Mode [P]",
+    "tokenRing": "Token Ring [R]",
+    "question": "Question [Q]",
+    "summary": "Summary [D]",
+    "exit": "Exit [E]"
+  },
+  "status": {
+    "thinking": "Thinking...",
+    "speaking": "Speaking",
+    "idle": "Idle"
+  },
+  "round": "Round {{n}}",
+  "mode": {
+    "standard": "Standard",
+    "deep": "Deep",
+    "token_ring": "Token Ring"
+  },
+  "noSessions": "No party sessions yet",
+  "description": "Multi-persona AI discussions with structured rounds",
+  "exitConfirm": "Exit this party session?",
+  "summary": {
+    "title": "Discussion Summary",
+    "agreements": "Points of Agreement",
+    "disagreements": "Points of Disagreement",
+    "decisions": "Decisions Made",
+    "actionItems": "Action Items",
+    "compliance": "Compliance Notes"
+  }
+}

--- a/ui/web/src/i18n/locales/en/sidebar.json
+++ b/ui/web/src/i18n/locales/en/sidebar.json
@@ -38,6 +38,7 @@
     "cliCredentials": "CLI Credentials",
     "apiKeys": "API Keys",
     "apiDocs": "API Docs",
-    "packages": "Packages"
+    "packages": "Packages",
+    "party": "Party Mode"
   }
 }

--- a/ui/web/src/i18n/locales/vi/party.json
+++ b/ui/web/src/i18n/locales/vi/party.json
@@ -1,0 +1,46 @@
+{
+  "title": "Ch\u1ebf \u0111\u1ed9 Party",
+  "newParty": "T\u1ea1o Party m\u1edbi",
+  "topic": "Ch\u1ee7 \u0111\u1ec1 th\u1ea3o lu\u1eadn",
+  "selectTeam": "Ch\u1ecdn \u0111\u1ed9i",
+  "customTeam": "\u0110\u1ed9i tu\u1ef3 ch\u1ec9nh",
+  "start": "B\u1eaft \u0111\u1ea7u th\u1ea3o lu\u1eadn",
+  "presets": {
+    "payment_feature": "T\u00ednh n\u0103ng Thanh to\u00e1n",
+    "security_review": "\u0110\u00e1nh gi\u00e1 B\u1ea3o m\u1eadt",
+    "sprint_planning": "L\u1eadp k\u1ebf ho\u1ea1ch Sprint",
+    "architecture_decision": "Quy\u1ebft \u0111\u1ecbnh Ki\u1ebfn tr\u00fac",
+    "ux_review": "\u0110\u00e1nh gi\u00e1 UX",
+    "incident_response": "X\u1eed l\u00fd s\u1ef1 c\u1ed1"
+  },
+  "controls": {
+    "continue": "Ti\u1ebfp t\u1ee5c",
+    "deepMode": "Ch\u1ebf \u0111\u1ed9 Deep [P]",
+    "tokenRing": "Token Ring [R]",
+    "question": "C\u00e2u h\u1ecfi [Q]",
+    "summary": "T\u00f3m t\u1eaft [D]",
+    "exit": "Tho\u00e1t [E]"
+  },
+  "status": {
+    "thinking": "\u0110ang suy ngh\u0129...",
+    "speaking": "\u0110ang n\u00f3i",
+    "idle": "Ch\u1edd"
+  },
+  "round": "V\u00f2ng {{n}}",
+  "mode": {
+    "standard": "Ti\u00eau chu\u1ea9n",
+    "deep": "Deep",
+    "token_ring": "Token Ring"
+  },
+  "noSessions": "Ch\u01b0a c\u00f3 phi\u00ean party n\u00e0o",
+  "description": "Th\u1ea3o lu\u1eadn AI \u0111a nh\u00e2n v\u1eadt v\u1edbi c\u00e1c v\u00f2ng c\u00f3 c\u1ea5u tr\u00fac",
+  "exitConfirm": "Tho\u00e1t phi\u00ean party n\u00e0y?",
+  "summary": {
+    "title": "T\u00f3m t\u1eaft th\u1ea3o lu\u1eadn",
+    "agreements": "\u0110i\u1ec3m \u0111\u1ed3ng thu\u1eadn",
+    "disagreements": "\u0110i\u1ec3m b\u1ea5t \u0111\u1ed3ng",
+    "decisions": "Quy\u1ebft \u0111\u1ecbnh",
+    "actionItems": "H\u1ea1ng m\u1ee5c h\u00e0nh \u0111\u1ed9ng",
+    "compliance": "Ghi ch\u00fa tu\u00e2n th\u1ee7"
+  }
+}

--- a/ui/web/src/i18n/locales/vi/sidebar.json
+++ b/ui/web/src/i18n/locales/vi/sidebar.json
@@ -38,6 +38,7 @@
     "cliCredentials": "Xác thực CLI",
     "apiKeys": "Khóa API",
     "apiDocs": "Tài liệu API",
-    "packages": "Gói phần mềm"
+    "packages": "Gói phần mềm",
+    "party": "Chế độ Party"
   }
 }

--- a/ui/web/src/i18n/locales/zh/party.json
+++ b/ui/web/src/i18n/locales/zh/party.json
@@ -1,0 +1,46 @@
+{
+  "title": "Party 模式",
+  "newParty": "新建 Party",
+  "topic": "讨论主题",
+  "selectTeam": "选择团队",
+  "customTeam": "自定义团队",
+  "start": "开始讨论",
+  "presets": {
+    "payment_feature": "支付功能",
+    "security_review": "安全审查",
+    "sprint_planning": "Sprint 规划",
+    "architecture_decision": "架构决策",
+    "ux_review": "UX 审查",
+    "incident_response": "事件响应"
+  },
+  "controls": {
+    "continue": "继续",
+    "deepMode": "深度模式 [P]",
+    "tokenRing": "令牌环 [R]",
+    "question": "提问 [Q]",
+    "summary": "总结 [D]",
+    "exit": "退出 [E]"
+  },
+  "status": {
+    "thinking": "思考中...",
+    "speaking": "发言中",
+    "idle": "空闲"
+  },
+  "round": "第 {{n}} 轮",
+  "mode": {
+    "standard": "标准",
+    "deep": "深度",
+    "token_ring": "令牌环"
+  },
+  "noSessions": "暂无 Party 会话",
+  "description": "多角色 AI 讨论，结构化轮次",
+  "exitConfirm": "退出此 Party 会话？",
+  "summary": {
+    "title": "讨论总结",
+    "agreements": "共识要点",
+    "disagreements": "分歧要点",
+    "decisions": "已做决策",
+    "actionItems": "行动项",
+    "compliance": "合规备注"
+  }
+}

--- a/ui/web/src/i18n/locales/zh/sidebar.json
+++ b/ui/web/src/i18n/locales/zh/sidebar.json
@@ -38,6 +38,7 @@
     "cliCredentials": "CLI 凭证",
     "apiKeys": "API 密钥",
     "apiDocs": "API 文档",
-    "packages": "软件包"
+    "packages": "软件包",
+    "party": "Party 模式"
   }
 }

--- a/ui/web/src/lib/constants.ts
+++ b/ui/web/src/lib/constants.ts
@@ -37,6 +37,7 @@ export const ROUTES = {
   ACTIVITY: "/activity",
   API_KEYS: "/api-keys",
   PACKAGES: "/packages",
+  PARTY: "/party",
   SETUP: "/setup",
 } as const;
 

--- a/ui/web/src/pages/party/hooks/use-party.ts
+++ b/ui/web/src/pages/party/hooks/use-party.ts
@@ -1,0 +1,453 @@
+import { useState, useCallback, useRef } from "react";
+import { useWs } from "@/hooks/use-ws";
+import { useWsEvent } from "@/hooks/use-ws-event";
+import { useAuthStore } from "@/stores/use-auth-store";
+import { Methods, Events } from "@/api/protocol";
+
+// --- Types ---
+
+export type PartyMode = "standard" | "deep" | "token_ring";
+
+export interface PersonaInfo {
+  key: string;
+  emoji: string;
+  name: string;
+  role: string;
+  color: string;
+}
+
+export interface PartyMessage {
+  id: string;
+  type: "intro" | "spoke" | "thinking" | "round_header" | "context" | "summary" | "artifact";
+  personaKey?: string;
+  personaEmoji?: string;
+  personaName?: string;
+  content: string;
+  round?: number;
+  mode?: PartyMode;
+  timestamp: number;
+}
+
+export interface PartySession {
+  id: string;
+  topic: string;
+  status: "active" | "closed";
+  personas: PersonaInfo[];
+  round: number;
+  mode: PartyMode;
+  createdAt: string;
+  // Preserved from backend for session restore
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _history?: any[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _summary?: any;
+}
+
+export interface PartySummary {
+  agreements?: string[];
+  disagreements?: string[];
+  decisions?: string[];
+  actionItems?: string[];
+  compliance?: string[];
+  markdown?: string;
+}
+
+// Persona color palette for left-border styling
+const PERSONA_COLORS = [
+  "#3b82f6", "#ef4444", "#10b981", "#f59e0b", "#8b5cf6",
+  "#ec4899", "#06b6d4", "#f97316", "#6366f1", "#14b8a6",
+  "#e11d48", "#84cc16", "#a855f7", "#0ea5e9",
+];
+
+// Map backend status to frontend display status
+function mapStatus(backendStatus: string): "active" | "closed" {
+  return backendStatus === "closed" ? "closed" : "active";
+}
+
+// Transform backend session (snake_case) to frontend PartySession
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformSession(raw: any): PartySession {
+  const personaKeys: string[] = Array.isArray(raw.personas)
+    ? raw.personas
+    : [];
+  return {
+    id: raw.id,
+    topic: raw.topic ?? "",
+    status: mapStatus(raw.status ?? ""),
+    personas: personaKeys.map((k: string) => ({
+      key: k,
+      emoji: "",
+      name: k,
+      role: "",
+      color: "",
+    })),
+    round: raw.round ?? 0,
+    mode: raw.mode ?? "standard",
+    createdAt: raw.created_at ?? raw.createdAt ?? "",
+    _history: Array.isArray(raw.history) ? raw.history : undefined,
+    _summary: raw.summary ?? undefined,
+  };
+}
+
+// Hydrate PartyMessage[] from backend history (RoundResult[]) and summary
+function hydrateMessages(
+  history: any[] | undefined, // eslint-disable-line @typescript-eslint/no-explicit-any
+  summary: any | undefined, // eslint-disable-line @typescript-eslint/no-explicit-any
+  startId: number,
+): { msgs: PartyMessage[]; nextId: number } {
+  let id = startId;
+  const msgs: PartyMessage[] = [];
+  if (!history) return { msgs, nextId: id };
+
+  for (const round of history) {
+    // Round header
+    msgs.push({
+      id: `pm-${++id}`,
+      type: "round_header",
+      content: "",
+      round: round.round,
+      mode: round.mode as PartyMode,
+      timestamp: Date.now(),
+    });
+    // Persona messages
+    for (const m of round.messages ?? []) {
+      msgs.push({
+        id: `pm-${++id}`,
+        type: "spoke",
+        personaKey: m.persona_key,
+        personaEmoji: m.emoji ?? "",
+        personaName: m.display_name ?? m.persona_key,
+        content: m.content ?? "",
+        round: round.round,
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  // Summary (if exists and has markdown)
+  if (summary && typeof summary === "object" && summary.markdown) {
+    msgs.push({
+      id: `pm-${++id}`,
+      type: "summary",
+      content: summary.markdown,
+      timestamp: Date.now(),
+    });
+  }
+
+  return { msgs, nextId: id };
+}
+
+export function useParty() {
+  const ws = useWs();
+  const connected = useAuthStore((s) => s.connected);
+
+  const [sessions, setSessions] = useState<PartySession[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<PartyMessage[]>([]);
+  const [personas, setPersonas] = useState<PersonaInfo[]>([]);
+  const [thinkingPersonas, setThinkingPersonas] = useState<Set<string>>(new Set());
+  const [round, setRound] = useState(0);
+  const [mode, setMode] = useState<PartyMode>("standard");
+  const [status, setStatus] = useState<"idle" | "active" | "closed">("idle");
+  const [summary, setSummary] = useState<PartySummary | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const msgIdCounter = useRef(0);
+  const personaColorMap = useRef<Map<string, string>>(new Map());
+
+  const getPersonaColor = useCallback((key: string): string => {
+    if (personaColorMap.current.has(key)) {
+      return personaColorMap.current.get(key)!;
+    }
+    const idx = personaColorMap.current.size % PERSONA_COLORS.length;
+    const color = PERSONA_COLORS[idx] ?? "#3b82f6";
+    personaColorMap.current.set(key, color);
+    return color;
+  }, []);
+
+  const addMessage = useCallback((msg: Omit<PartyMessage, "id" | "timestamp">) => {
+    const id = `pm-${++msgIdCounter.current}`;
+    setMessages((prev) => [...prev, { ...msg, id, timestamp: Date.now() }]);
+  }, []);
+
+  // --- Event handlers ---
+  // Backend sends snake_case field names (Go json tags)
+
+  const handlePartyStarted = useCallback((payload: unknown) => {
+    // Backend: { session_id, topic, personas: [{ agent_key, display_name, emoji, movie_ref }] }
+    const p = payload as {
+      session_id: string;
+      topic: string;
+      personas: Array<{ agent_key: string; display_name: string; emoji: string; movie_ref: string }>;
+    };
+    const sessionId = p.session_id;
+    setActiveSessionId(sessionId);
+    const enriched: PersonaInfo[] = (p.personas ?? []).map((pe) => ({
+      key: pe.agent_key,
+      emoji: pe.emoji ?? "",
+      name: pe.display_name ?? pe.agent_key,
+      role: pe.movie_ref ?? "",
+      color: getPersonaColor(pe.agent_key),
+    }));
+    setPersonas(enriched);
+    setRound(0);
+    setMode("standard");
+    setStatus("active");
+    setSummary(null);
+    setMessages([]);
+    personaColorMap.current.clear();
+    enriched.forEach((pe) => personaColorMap.current.set(pe.key, pe.color));
+
+    // Add new session to sessions list for sidebar
+    setSessions((prev) => [
+      {
+        id: sessionId,
+        topic: p.topic ?? "",
+        status: "active",
+        personas: enriched,
+        round: 0,
+        mode: "standard",
+        createdAt: new Date().toISOString(),
+      },
+      ...prev,
+    ]);
+  }, [getPersonaColor]);
+
+  const handlePersonaIntro = useCallback((payload: unknown) => {
+    // Backend: { session_id, persona, emoji, content }
+    const p = payload as { persona: string; emoji: string; content: string };
+    addMessage({
+      type: "intro",
+      personaKey: p.persona,
+      personaEmoji: p.emoji ?? "",
+      personaName: p.persona,
+      content: p.content ?? "",
+    });
+  }, [addMessage]);
+
+  const handleRoundStarted = useCallback((payload: unknown) => {
+    const p = payload as { round: number; mode: string };
+    setRound(p.round);
+    setMode(p.mode as PartyMode);
+    addMessage({
+      type: "round_header",
+      content: "",
+      round: p.round,
+      mode: p.mode as PartyMode,
+    });
+  }, [addMessage]);
+
+  const handlePersonaThinking = useCallback((payload: unknown) => {
+    // Backend: { session_id, persona, emoji }
+    const p = payload as { persona: string };
+    setThinkingPersonas((prev) => new Set(prev).add(p.persona));
+  }, []);
+
+  const handlePersonaSpoke = useCallback((payload: unknown) => {
+    // Backend: { session_id, persona, emoji, content }
+    const p = payload as { persona: string; emoji: string; content: string };
+    setThinkingPersonas((prev) => {
+      const next = new Set(prev);
+      next.delete(p.persona);
+      return next;
+    });
+    addMessage({
+      type: "spoke",
+      personaKey: p.persona,
+      personaEmoji: p.emoji ?? "",
+      personaName: p.persona,
+      content: p.content ?? "",
+    });
+  }, [addMessage]);
+
+  const handleRoundComplete = useCallback((payload: unknown) => {
+    const p = payload as { round: number };
+    setThinkingPersonas(new Set());
+    void p;
+  }, []);
+
+  const handleContextAdded = useCallback((payload: unknown) => {
+    const p = payload as { type: string; name?: string };
+    addMessage({
+      type: "context",
+      content: `Context added: ${p.type}${p.name ? ` (${p.name})` : ""}`,
+    });
+  }, [addMessage]);
+
+  const handleSummaryReady = useCallback((payload: unknown) => {
+    // Backend: { session_id, summary: { markdown, ... } }
+    const raw = payload as { summary?: PartySummary; markdown?: string };
+    const s: PartySummary = raw.summary ?? raw as PartySummary;
+    setSummary(s);
+    addMessage({
+      type: "summary",
+      content: s.markdown ?? "",
+    });
+  }, [addMessage]);
+
+  const handleArtifact = useCallback((payload: unknown) => {
+    const p = payload as { name: string; content: string };
+    addMessage({
+      type: "artifact",
+      content: `**${p.name}**\n\n${p.content}`,
+    });
+  }, [addMessage]);
+
+  const handlePartyClosed = useCallback((payload: unknown) => {
+    const p = payload as { session_id?: string };
+    setStatus("closed");
+    setThinkingPersonas(new Set());
+    // Update session status in the list
+    if (p.session_id) {
+      setSessions((prev) =>
+        prev.map((s) => (s.id === p.session_id ? { ...s, status: "closed" as const } : s)),
+      );
+    }
+  }, []);
+
+  // --- Subscribe to events ---
+  useWsEvent(Events.PARTY_STARTED, handlePartyStarted);
+  useWsEvent(Events.PARTY_PERSONA_INTRO, handlePersonaIntro);
+  useWsEvent(Events.PARTY_ROUND_STARTED, handleRoundStarted);
+  useWsEvent(Events.PARTY_PERSONA_THINKING, handlePersonaThinking);
+  useWsEvent(Events.PARTY_PERSONA_SPOKE, handlePersonaSpoke);
+  useWsEvent(Events.PARTY_ROUND_COMPLETE, handleRoundComplete);
+  useWsEvent(Events.PARTY_CONTEXT_ADDED, handleContextAdded);
+  useWsEvent(Events.PARTY_SUMMARY_READY, handleSummaryReady);
+  useWsEvent(Events.PARTY_ARTIFACT, handleArtifact);
+  useWsEvent(Events.PARTY_CLOSED, handlePartyClosed);
+
+  // --- RPC calls ---
+  // Backend expects snake_case field names (Go json tags)
+
+  const listSessions = useCallback(async () => {
+    if (!connected) return;
+    setLoading(true);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const res = await ws.call<{ sessions: any[] }>(Methods.PARTY_LIST, {});
+      setSessions((res.sessions ?? []).map(transformSession));
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, [ws, connected]);
+
+  const startParty = useCallback(
+    async (topic: string, teamPreset?: string, personaKeys?: string[]) => {
+      if (!connected) return;
+      setLoading(true);
+      try {
+        await ws.call(Methods.PARTY_START, {
+          topic,
+          team_preset: teamPreset ?? undefined,
+          personas: personaKeys ?? undefined,
+        });
+      } catch {
+        // ignore
+      } finally {
+        setLoading(false);
+      }
+    },
+    [ws, connected],
+  );
+
+  const runRound = useCallback(
+    async (sessionId: string, roundMode?: PartyMode) => {
+      await ws.call(Methods.PARTY_ROUND, {
+        session_id: sessionId,
+        mode: roundMode ?? undefined,
+      });
+    },
+    [ws],
+  );
+
+  const askQuestion = useCallback(
+    async (sessionId: string, text: string) => {
+      await ws.call(Methods.PARTY_QUESTION, { session_id: sessionId, text });
+    },
+    [ws],
+  );
+
+  const addContext = useCallback(
+    async (sessionId: string, type: string, name?: string, content?: string) => {
+      await ws.call(Methods.PARTY_ADD_CONTEXT, { session_id: sessionId, type, name, content });
+    },
+    [ws],
+  );
+
+  const getSummary = useCallback(
+    async (sessionId: string) => {
+      await ws.call(Methods.PARTY_SUMMARY, { session_id: sessionId });
+    },
+    [ws],
+  );
+
+  const exitParty = useCallback(
+    async (sessionId: string) => {
+      await ws.call(Methods.PARTY_EXIT, { session_id: sessionId });
+    },
+    [ws],
+  );
+
+  // Activate an existing session from the list (hydrates all state including history)
+  const selectSession = useCallback(
+    (session: PartySession) => {
+      setActiveSessionId(session.id);
+      const enriched = session.personas.map((pe) => ({
+        ...pe,
+        color: getPersonaColor(pe.key),
+      }));
+      setPersonas(enriched);
+      setRound(session.round);
+      setMode(session.mode);
+      setStatus(session.status === "closed" ? "closed" : "active");
+      personaColorMap.current.clear();
+      enriched.forEach((pe) => personaColorMap.current.set(pe.key, pe.color));
+
+      // Hydrate messages from stored history
+      const { msgs: restored, nextId } = hydrateMessages(session._history, session._summary, msgIdCounter.current);
+      if (restored.length > 0) {
+        msgIdCounter.current = nextId;
+        setMessages(restored);
+        // Restore summary state
+        if (session._summary && typeof session._summary === "object" && session._summary.markdown) {
+          setSummary(session._summary as PartySummary);
+        } else {
+          setSummary(null);
+        }
+      } else {
+        setMessages([]);
+        setSummary(null);
+      }
+    },
+    [getPersonaColor],
+  );
+
+  return {
+    // state
+    sessions,
+    activeSessionId,
+    messages,
+    personas,
+    thinkingPersonas,
+    round,
+    mode,
+    status,
+    summary,
+    loading,
+
+    // actions
+    listSessions,
+    startParty,
+    runRound,
+    askQuestion,
+    addContext,
+    getSummary,
+    exitParty,
+    selectSession,
+    setActiveSessionId,
+    getPersonaColor,
+  };
+}

--- a/ui/web/src/pages/party/party-controls.tsx
+++ b/ui/web/src/pages/party/party-controls.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Play, MessageCircleQuestion, FileText, LogOut } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { cn } from "@/lib/utils";
+import type { PartyMode } from "./hooks/use-party";
+
+interface PartyControlsProps {
+  sessionId: string;
+  currentMode: PartyMode;
+  status: "idle" | "active" | "closed";
+  onRunRound: (sessionId: string, mode?: PartyMode) => Promise<void>;
+  onAskQuestion: (sessionId: string, text: string) => Promise<void>;
+  onGetSummary: (sessionId: string) => Promise<void>;
+  onExit: (sessionId: string) => Promise<void>;
+}
+
+const MODE_OPTIONS: { value: PartyMode; labelKey: string }[] = [
+  { value: "standard", labelKey: "mode.standard" },
+  { value: "deep", labelKey: "mode.deep" },
+  { value: "token_ring", labelKey: "mode.token_ring" },
+];
+
+export function PartyControls({
+  sessionId,
+  currentMode,
+  status,
+  onRunRound,
+  onAskQuestion,
+  onGetSummary,
+  onExit,
+}: PartyControlsProps) {
+  const { t } = useTranslation("party");
+  const [selectedMode, setSelectedMode] = useState<PartyMode>(currentMode);
+  const [questionOpen, setQuestionOpen] = useState(false);
+  const [questionText, setQuestionText] = useState("");
+  const [exitOpen, setExitOpen] = useState(false);
+  const [runningAction, setRunningAction] = useState<string | null>(null);
+
+  const isClosed = status === "closed";
+
+  const handleRunRound = async () => {
+    setRunningAction("round");
+    try {
+      await onRunRound(sessionId, selectedMode);
+    } finally {
+      setRunningAction(null);
+    }
+  };
+
+  const handleQuestion = async () => {
+    if (!questionText.trim()) return;
+    setRunningAction("question");
+    try {
+      await onAskQuestion(sessionId, questionText.trim());
+      setQuestionText("");
+      setQuestionOpen(false);
+    } finally {
+      setRunningAction(null);
+    }
+  };
+
+  const handleSummary = async () => {
+    setRunningAction("summary");
+    try {
+      await onGetSummary(sessionId);
+    } finally {
+      setRunningAction(null);
+    }
+  };
+
+  const handleExit = async () => {
+    setRunningAction("exit");
+    try {
+      await onExit(sessionId);
+      setExitOpen(false);
+    } finally {
+      setRunningAction(null);
+    }
+  };
+
+  return (
+    <div className="border-t bg-background px-4 py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        {/* Mode toggle */}
+        <div className="flex rounded-md border bg-muted/30">
+          {MODE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              data-testid={`mode-${opt.value}`}
+              type="button"
+              disabled={isClosed}
+              onClick={() => setSelectedMode(opt.value)}
+              className={cn(
+                "px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer first:rounded-l-md last:rounded-r-md",
+                selectedMode === opt.value
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+                isClosed && "opacity-50 cursor-not-allowed",
+              )}
+            >
+              {t(opt.labelKey)}
+            </button>
+          ))}
+        </div>
+
+        <div className="h-5 w-px bg-border" />
+
+        {/* Continue [C] */}
+        <Button
+          size="sm"
+          onClick={handleRunRound}
+          disabled={isClosed || runningAction !== null}
+          className="gap-1"
+        >
+          <Play className="h-3.5 w-3.5" />
+          {t("controls.continue")}
+        </Button>
+
+        {/* Question [Q] */}
+        {questionOpen ? (
+          <div className="flex items-center gap-1.5">
+            <Input
+              value={questionText}
+              onChange={(e) => setQuestionText(e.target.value)}
+              placeholder="Ask a question..."
+              className="h-8 w-48 text-xs"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleQuestion();
+                if (e.key === "Escape") setQuestionOpen(false);
+              }}
+              autoFocus
+            />
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={handleQuestion}
+              disabled={!questionText.trim() || runningAction !== null}
+            >
+              Send
+            </Button>
+          </div>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setQuestionOpen(true)}
+            disabled={isClosed || runningAction !== null}
+            className="gap-1"
+          >
+            <MessageCircleQuestion className="h-3.5 w-3.5" />
+            {t("controls.question")}
+          </Button>
+        )}
+
+        {/* Summary [D] */}
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleSummary}
+          disabled={isClosed || runningAction !== null}
+          className="gap-1"
+        >
+          <FileText className="h-3.5 w-3.5" />
+          {t("controls.summary")}
+        </Button>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Exit [E] */}
+        <Button
+          size="sm"
+          variant="destructive"
+          onClick={() => setExitOpen(true)}
+          disabled={isClosed || runningAction !== null}
+          className="gap-1"
+        >
+          <LogOut className="h-3.5 w-3.5" />
+          {t("controls.exit")}
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        open={exitOpen}
+        onOpenChange={setExitOpen}
+        title={t("controls.exit")}
+        description={t("exitConfirm")}
+        variant="destructive"
+        onConfirm={handleExit}
+        loading={runningAction === "exit"}
+      />
+    </div>
+  );
+}

--- a/ui/web/src/pages/party/party-page.tsx
+++ b/ui/web/src/pages/party/party-page.tsx
@@ -1,0 +1,171 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { PartyPopper, Plus } from "lucide-react";
+import { PageHeader } from "@/components/shared/page-header";
+import { EmptyState } from "@/components/shared/empty-state";
+import { CardSkeleton } from "@/components/shared/loading-skeleton";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useDeferredLoading } from "@/hooks/use-deferred-loading";
+import { cn } from "@/lib/utils";
+import { useParty } from "./hooks/use-party";
+import { PartyStartDialog } from "./party-start-dialog";
+import { PartySession } from "./party-session";
+import { PersonaSidebar } from "./persona-sidebar";
+import { PartyControls } from "./party-controls";
+
+export function PartyPage() {
+  const { t } = useTranslation("party");
+  const {
+    sessions,
+    activeSessionId,
+    messages,
+    personas,
+    thinkingPersonas,
+    mode,
+    status,
+    loading,
+    listSessions,
+    startParty,
+    runRound,
+    askQuestion,
+    getSummary,
+    exitParty,
+    selectSession,
+    getPersonaColor,
+  } = useParty();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const showSkeleton = useDeferredLoading(loading && sessions.length === 0);
+
+  useEffect(() => {
+    listSessions();
+  }, [listSessions]);
+
+  const hasActiveSession = activeSessionId !== null && status !== "idle";
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header area */}
+      <div className="shrink-0 p-4 sm:p-6 pb-0 sm:pb-0">
+        <PageHeader
+          title={t("title")}
+          description={t("description")}
+          actions={
+            <Button onClick={() => setCreateOpen(true)} className="gap-1">
+              <Plus className="h-4 w-4" /> {t("newParty")}
+            </Button>
+          }
+        />
+      </div>
+
+      {/* Main content */}
+      <div className="flex flex-1 min-h-0 mt-4">
+        {/* Session list panel */}
+        <div className="w-64 shrink-0 border-r">
+          <div className="border-b px-3 py-2">
+            <h3 className="text-xs font-semibold uppercase text-muted-foreground tracking-wider">
+              Sessions
+            </h3>
+          </div>
+          <ScrollArea className="h-full">
+            <div className="space-y-1 p-2">
+              {showSkeleton ? (
+                Array.from({ length: 3 }).map((_, i) => (
+                  <CardSkeleton key={i} />
+                ))
+              ) : sessions.length === 0 ? (
+                <p className="px-2 py-4 text-center text-xs text-muted-foreground">
+                  {t("noSessions")}
+                </p>
+              ) : (
+                sessions.map((session) => (
+                  <button
+                    key={session.id}
+                    data-testid="session-item"
+                    type="button"
+                    onClick={() => selectSession(session)}
+                    className={cn(
+                      "w-full rounded-md px-3 py-2 text-left transition-colors cursor-pointer",
+                      activeSessionId === session.id
+                        ? "bg-primary/10 text-primary"
+                        : "hover:bg-muted/50",
+                    )}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate text-sm font-medium">
+                        {session.topic}
+                      </span>
+                      <Badge
+                        variant={session.status === "active" ? "success" : "secondary"}
+                        className="shrink-0 text-[10px]"
+                      >
+                        {session.status}
+                      </Badge>
+                    </div>
+                    <div className="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground">
+                      <span>{t("round", { n: session.round })}</span>
+                      <span>{session.personas.length} personas</span>
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* Active session area */}
+        {hasActiveSession ? (
+          <div className="flex flex-1 min-w-0 flex-col">
+            {/* Chat + persona sidebar */}
+            <div className="flex flex-1 min-h-0">
+              {/* Chat messages */}
+              <PartySession
+                messages={messages}
+                getPersonaColor={getPersonaColor}
+              />
+
+              {/* Right sidebar with persona list */}
+              <PersonaSidebar
+                personas={personas}
+                thinkingPersonas={thinkingPersonas}
+              />
+            </div>
+
+            {/* Bottom controls */}
+            <PartyControls
+              sessionId={activeSessionId!}
+              currentMode={mode}
+              status={status}
+              onRunRound={runRound}
+              onAskQuestion={askQuestion}
+              onGetSummary={getSummary}
+              onExit={exitParty}
+            />
+          </div>
+        ) : (
+          <div className="flex flex-1 items-center justify-center">
+            <EmptyState
+              icon={PartyPopper}
+              title={t("noSessions")}
+              description={t("description")}
+              action={
+                <Button onClick={() => setCreateOpen(true)} className="gap-1">
+                  <Plus className="h-4 w-4" /> {t("newParty")}
+                </Button>
+              }
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Start dialog */}
+      <PartyStartDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onStart={startParty}
+      />
+    </div>
+  );
+}

--- a/ui/web/src/pages/party/party-session.tsx
+++ b/ui/web/src/pages/party/party-session.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { MarkdownRenderer } from "@/components/shared/markdown-renderer";
+import { cn } from "@/lib/utils";
+import type { PartyMessage, PartyMode } from "./hooks/use-party";
+
+interface PartySessionProps {
+  messages: PartyMessage[];
+  getPersonaColor: (key: string) => string;
+}
+
+function RoundHeader({ round, mode, t }: { round: number; mode?: PartyMode; t: (k: string, opts?: Record<string, unknown>) => string }) {
+  const modeLabel = mode ? t(`mode.${mode}`) : "";
+  return (
+    <div data-testid="round-header" className="flex items-center gap-2 py-3">
+      <div className="h-px flex-1 bg-border" />
+      <span className="text-xs font-medium text-muted-foreground">
+        {t("round", { n: round })} {modeLabel && `[${modeLabel}]`}
+      </span>
+      <div className="h-px flex-1 bg-border" />
+    </div>
+  );
+}
+
+function PersonaMessage({
+  message,
+  borderColor,
+}: {
+  message: PartyMessage;
+  borderColor: string;
+}) {
+  const isIntro = message.type === "intro";
+
+  return (
+    <div
+      data-testid="persona-message"
+      className={cn(
+        "rounded-md border-l-[3px] bg-muted/30 p-3",
+        isIntro && "opacity-80",
+      )}
+      style={{ borderLeftColor: borderColor }}
+    >
+      <div className="mb-1 flex items-center gap-1.5">
+        <span className="text-sm">{message.personaEmoji}</span>
+        <span className="text-sm font-medium">{message.personaName}</span>
+        {isIntro && (
+          <span className="text-xs text-muted-foreground italic">intro</span>
+        )}
+      </div>
+      <div className="text-sm">
+        <MarkdownRenderer content={message.content} />
+      </div>
+    </div>
+  );
+}
+
+function ContextMessage({ message }: { message: PartyMessage }) {
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <span className="text-xs text-muted-foreground italic">
+        {message.content}
+      </span>
+    </div>
+  );
+}
+
+function SummaryMessage({ message }: { message: PartyMessage }) {
+  return (
+    <div data-testid="summary-message" className="rounded-md border border-primary/20 bg-primary/5 p-4">
+      <MarkdownRenderer content={message.content} />
+    </div>
+  );
+}
+
+function ArtifactMessage({ message }: { message: PartyMessage }) {
+  return (
+    <div className="rounded-md border border-amber-500/20 bg-amber-500/5 p-4">
+      <MarkdownRenderer content={message.content} />
+    </div>
+  );
+}
+
+export function PartySession({ messages, getPersonaColor }: PartySessionProps) {
+  const { t } = useTranslation("party");
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length]);
+
+  return (
+    <ScrollArea className="flex-1">
+      <div className="space-y-3 p-4">
+        {messages.map((msg) => {
+          switch (msg.type) {
+            case "round_header":
+              return (
+                <RoundHeader
+                  key={msg.id}
+                  round={msg.round ?? 0}
+                  mode={msg.mode}
+                  t={t}
+                />
+              );
+            case "intro":
+            case "spoke":
+              return (
+                <PersonaMessage
+                  key={msg.id}
+                  message={msg}
+                  borderColor={msg.personaKey ? getPersonaColor(msg.personaKey) : "#6b7280"}
+                />
+              );
+            case "context":
+              return <ContextMessage key={msg.id} message={msg} />;
+            case "summary":
+              return <SummaryMessage key={msg.id} message={msg} />;
+            case "artifact":
+              return <ArtifactMessage key={msg.id} message={msg} />;
+            default:
+              return null;
+          }
+        })}
+        <div ref={bottomRef} />
+      </div>
+    </ScrollArea>
+  );
+}

--- a/ui/web/src/pages/party/party-start-dialog.tsx
+++ b/ui/web/src/pages/party/party-start-dialog.tsx
@@ -1,0 +1,191 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const TEAM_PRESETS = [
+  "payment_feature",
+  "security_review",
+  "sprint_planning",
+  "architecture_decision",
+  "ux_review",
+  "incident_response",
+] as const;
+
+const ALL_PERSONAS = [
+  { key: "tony-stark-persona", emoji: "\ud83d\udcca", label: "Product Manager" },
+  { key: "morpheus-persona", emoji: "\ud83d\udd27", label: "Tech Lead" },
+  { key: "batman-persona", emoji: "\ud83d\udd12", label: "Security Analyst" },
+  { key: "columbo-persona", emoji: "\ud83e\uddea", label: "QA Engineer" },
+  { key: "scotty-persona", emoji: "\u2699\ufe0f", label: "DevOps Engineer" },
+  { key: "edna-mode-persona", emoji: "\ud83c\udfa8", label: "UX Designer" },
+  { key: "spider-man-persona", emoji: "\ud83c\udf10", label: "Frontend Dev" },
+  { key: "ethan-hunt-persona", emoji: "\ud83d\udcf1", label: "Mobile Dev" },
+  { key: "sherlock-persona", emoji: "\ud83d\udcbc", label: "Business Analyst" },
+  { key: "judge-dredd-persona", emoji: "\ud83d\udccb", label: "Compliance Officer" },
+  { key: "gandalf-persona", emoji: "\ud83c\udfc3", label: "Scrum Master" },
+  { key: "neo-persona", emoji: "\ud83c\udfd7\ufe0f", label: "Architect" },
+  { key: "spock-persona", emoji: "\ud83d\uddc4\ufe0f", label: "DBA" },
+  { key: "nick-fury-persona", emoji: "\ud83d\udc54", label: "Executive" },
+] as const;
+
+interface PartyStartDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onStart: (topic: string, teamPreset?: string, personaKeys?: string[]) => Promise<void>;
+}
+
+export function PartyStartDialog({ open, onOpenChange, onStart }: PartyStartDialogProps) {
+  const { t } = useTranslation("party");
+  const [topic, setTopic] = useState("");
+  const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+  const [isCustom, setIsCustom] = useState(false);
+  const [selectedPersonas, setSelectedPersonas] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+
+  const togglePersona = (key: string) => {
+    setSelectedPersonas((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  const handleSelectPreset = (preset: string) => {
+    setSelectedPreset(preset);
+    setIsCustom(false);
+    setSelectedPersonas(new Set());
+  };
+
+  const handleSelectCustom = () => {
+    setSelectedPreset(null);
+    setIsCustom(true);
+  };
+
+  const canStart = topic.trim().length > 0 && (selectedPreset || (isCustom && selectedPersonas.size >= 2));
+
+  const handleStart = async () => {
+    if (!canStart) return;
+    setLoading(true);
+    try {
+      await onStart(
+        topic.trim(),
+        selectedPreset ?? undefined,
+        isCustom ? Array.from(selectedPersonas) : undefined,
+      );
+      onOpenChange(false);
+      setTopic("");
+      setSelectedPreset(null);
+      setIsCustom(false);
+      setSelectedPersonas(new Set());
+    } catch {
+      // error handled upstream
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] flex flex-col sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{t("newParty")}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4 px-0.5 -mx-0.5 overflow-y-auto min-h-0">
+          {/* Topic input */}
+          <div className="space-y-2">
+            <Label htmlFor="partyTopic">{t("topic")}</Label>
+            <Input
+              id="partyTopic"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              placeholder="e.g., Design payment reconciliation service..."
+            />
+          </div>
+
+          {/* Team presets */}
+          <div className="space-y-2">
+            <Label>{t("selectTeam")}</Label>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {TEAM_PRESETS.map((preset) => (
+                <button
+                  key={preset}
+                  type="button"
+                  onClick={() => handleSelectPreset(preset)}
+                  className={cn(
+                    "rounded-md border px-3 py-2 text-sm text-left transition-colors cursor-pointer",
+                    selectedPreset === preset
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border hover:border-primary/50 hover:bg-muted/50",
+                  )}
+                >
+                  {t(`presets.${preset}`)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Custom team option */}
+          <div className="space-y-2">
+            <button
+              type="button"
+              onClick={handleSelectCustom}
+              className={cn(
+                "w-full rounded-md border px-3 py-2 text-sm text-left transition-colors cursor-pointer",
+                isCustom
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border hover:border-primary/50 hover:bg-muted/50",
+              )}
+            >
+              {t("customTeam")}
+            </button>
+
+            {isCustom && (
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+                {ALL_PERSONAS.map((persona) => (
+                  <button
+                    key={persona.key}
+                    type="button"
+                    onClick={() => togglePersona(persona.key)}
+                    className={cn(
+                      "flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors cursor-pointer",
+                      selectedPersonas.has(persona.key)
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-border hover:border-primary/50 hover:bg-muted/50",
+                    )}
+                  >
+                    <span>{persona.emoji}</span>
+                    <span className="truncate">{persona.label}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleStart} disabled={!canStart || loading}>
+            {loading ? "..." : t("start")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/web/src/pages/party/persona-sidebar.tsx
+++ b/ui/web/src/pages/party/persona-sidebar.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import type { PersonaInfo } from "./hooks/use-party";
+
+interface PersonaSidebarProps {
+  personas: PersonaInfo[];
+  thinkingPersonas: Set<string>;
+}
+
+export function PersonaSidebar({ personas, thinkingPersonas }: PersonaSidebarProps) {
+  const { t } = useTranslation("party");
+
+  if (personas.length === 0) return null;
+
+  return (
+    <div className="w-56 shrink-0 border-l bg-muted/20">
+      <div className="border-b px-3 py-2">
+        <h3 className="text-xs font-semibold uppercase text-muted-foreground tracking-wider">
+          Personas
+        </h3>
+      </div>
+      <div className="space-y-1 p-2">
+        {personas.map((persona) => {
+          const isThinking = thinkingPersonas.has(persona.key);
+          return (
+            <div
+              key={persona.key}
+              data-testid="persona-item"
+              className="flex items-center gap-2 rounded-md px-2 py-1.5"
+            >
+              {/* Status indicator */}
+              <span
+                className={cn(
+                  "inline-block h-2 w-2 shrink-0 rounded-full",
+                  isThinking
+                    ? "animate-pulse bg-emerald-500"
+                    : "bg-muted-foreground/30",
+                )}
+              />
+              {/* Persona info */}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1">
+                  <span className="text-sm">{persona.emoji}</span>
+                  <span className="truncate text-xs font-medium">
+                    {persona.name}
+                  </span>
+                </div>
+                <p className="truncate text-[10px] text-muted-foreground">
+                  {persona.role}
+                </p>
+              </div>
+              {/* Status label */}
+              {isThinking && (
+                <span className="text-[10px] text-emerald-600 dark:text-emerald-400">
+                  {t("status.thinking")}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/web/src/routes.tsx
+++ b/ui/web/src/routes.tsx
@@ -98,6 +98,9 @@ const ApiKeysPage = lazyWithRetry(() =>
 const PackagesPage = lazyWithRetry(() =>
   import("@/pages/packages/packages-page").then((m) => ({ default: m.PackagesPage })),
 );
+const PartyPage = lazyWithRetry(() =>
+  import("@/pages/party/party-page").then((m) => ({ default: m.PartyPage })),
+);
 
 function PageLoader() {
   return (
@@ -172,6 +175,7 @@ export function AppRoutes() {
           <Route path={ROUTES.CLI_CREDENTIALS} element={<CliCredentialsPage />} />
           <Route path={ROUTES.API_KEYS} element={<ApiKeysPage />} />
           <Route path={ROUTES.PACKAGES} element={<PackagesPage />} />
+          <Route path={ROUTES.PARTY} element={<PartyPage />} />
         </Route>
 
         {/* Catch-all → overview */}


### PR DESCRIPTION
## Summary

Party Mode enables **multi-persona collaborative discussions** where multiple AI personas (based on existing agents) discuss a topic in structured rounds.

- **Engine**: Orchestrates persona introductions → structured rounds → summaries
- **WebSocket RPC**: 7 methods (`party.start`, `party.round`, `party.question`, `party.summary`, `party.exit`, `party.add_context`, `party.list`)
- **10 real-time events**: persona thinking/speaking, round progress, artifacts, summaries
- **Persistence**: `party_sessions` table with full conversation history
- **Full UI**: React page with controls, persona sidebar, session management
- **i18n**: English, Vietnamese, Chinese translations

## Architecture

```
internal/party/
├── engine.go      # Orchestration: round management, persona dispatch
├── prompt.go      # System prompt builder for each persona
├── types.go       # PartySession, Persona, Round types

internal/gateway/methods/party.go   # WS RPC handler
internal/store/party_store.go       # Store interface
internal/store/pg/party.go          # PostgreSQL implementation
pkg/protocol/party.go               # Wire types

ui/web/src/pages/party/             # React UI (6 components)
```

## Wiring changes (minimal)

- `gateway.go`: 3 lines — register PartyMethods
- `stores.go` + `pg/factory.go`: 1 line each — Party store
- `protocol.ts`: method + event constants
- `routes.tsx`, `sidebar.tsx`, `constants.ts`, `i18n/index.ts`: navigation

## Test plan

- [x] `go build ./cmd/` passes
- [x] Start a party session with 3+ personas, run multiple rounds
- [x] Verify real-time events render correctly in UI
- [x] Test session persistence across browser refreshes