### PR TITLE
feat: add project-scoped MCP isolation and Projects management

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -303,7 +303,7 @@ func runGateway() {
 	if mcpMgr != nil {
 		mcpToolLister = mcpMgr
 	}
-	agentsH, skillsH, tracesH, mcpH, customToolsH, channelInstancesH, providersH, delegationsH, builtinToolsH, pendingMessagesH, teamEventsH, secureCLIH := wireHTTP(pgStores, cfg.Gateway.Token, cfg.Agents.Defaults.Workspace, msgBus, toolsReg, providerRegistry, permPE.IsOwner, gatewayAddr, mcpToolLister)
+	agentsH, skillsH, tracesH, mcpH, customToolsH, channelInstancesH, providersH, delegationsH, builtinToolsH, pendingMessagesH, projectsH, teamEventsH, secureCLIH := wireHTTP(pgStores, cfg.Gateway.Token, cfg.Agents.Defaults.Workspace, msgBus, toolsReg, providerRegistry, permPE.IsOwner, gatewayAddr, mcpToolLister)
 	if providersH != nil {
 		providersH.SetAPIBaseFallback(cfg.Providers.APIBaseForType)
 	}
@@ -324,6 +324,9 @@ func runGateway() {
 	server.SetWakeHandler(wakeH)
 	if mcpH != nil {
 		server.SetMCPHandler(mcpH)
+	}
+	if projectsH != nil {
+		server.SetProjectHandler(projectsH)
 	}
 	if customToolsH != nil {
 		server.SetCustomToolsHandler(customToolsH)
@@ -934,7 +937,7 @@ func runGateway() {
 		channelMgr.SetContactCollector(contactCollector) // propagate to all channel handlers
 	}
 
-	go consumeInboundMessages(ctx, msgBus, agentRouter, cfg, sched, channelMgr, consumerTeamStore, quotaChecker, pgStores.Sessions, pgStores.Agents, contactCollector, postTurn)
+	go consumeInboundMessages(ctx, msgBus, agentRouter, cfg, sched, channelMgr, consumerTeamStore, quotaChecker, pgStores.Sessions, pgStores.Agents, contactCollector, postTurn, pgStores.Projects)
 
 	// Task recovery ticker: re-dispatches stale/pending team tasks on startup and periodically.
 	var taskTicker *tasks.TaskTicker

--- a/cmd/gateway_consumer.go
+++ b/cmd/gateway_consumer.go
@@ -25,7 +25,7 @@ import (
 // and routes them through the scheduler/agent loop, then publishes the response back.
 // Also handles subagent announcements: routes them through the parent agent's session
 // (matching TS subagent-announce.ts pattern) so the agent can reformulate for the user.
-func consumeInboundMessages(ctx context.Context, msgBus *bus.MessageBus, agents *agent.Router, cfg *config.Config, sched *scheduler.Scheduler, channelMgr *channels.Manager, teamStore store.TeamStore, quotaChecker *channels.QuotaChecker, sessStore store.SessionStore, agentStore store.AgentStore, contactCollector *store.ContactCollector, postTurn tools.PostTurnProcessor) {
+func consumeInboundMessages(ctx context.Context, msgBus *bus.MessageBus, agents *agent.Router, cfg *config.Config, sched *scheduler.Scheduler, channelMgr *channels.Manager, teamStore store.TeamStore, quotaChecker *channels.QuotaChecker, sessStore store.SessionStore, agentStore store.AgentStore, contactCollector *store.ContactCollector, postTurn tools.PostTurnProcessor, projectStore store.ProjectStore) {
 	slog.Info("inbound message consumer started")
 
 	// Inbound message deduplication (matching TS src/infra/dedupe.ts + inbound-dedupe.ts).
@@ -72,7 +72,7 @@ func consumeInboundMessages(ctx context.Context, msgBus *bus.MessageBus, agents 
 	debouncer := bus.NewInboundDebouncer(
 		time.Duration(debounceMs)*time.Millisecond,
 		func(msg bus.InboundMessage) {
-			processNormalMessage(ctx, msg, agents, cfg, sched, channelMgr, teamStore, quotaChecker, sessStore, agentStore, contactCollector, postTurn, msgBus)
+			processNormalMessage(ctx, msg, agents, cfg, sched, channelMgr, teamStore, quotaChecker, sessStore, agentStore, contactCollector, postTurn, msgBus, projectStore)
 		},
 	)
 	defer debouncer.Stop()

--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -37,6 +37,7 @@ func processNormalMessage(
 	contactCollector *store.ContactCollector,
 	postTurn tools.PostTurnProcessor,
 	msgBus *bus.MessageBus,
+	projectStore store.ProjectStore,
 ) {
 	// Determine target agent via bindings or explicit AgentID
 	agentID := msg.AgentID
@@ -44,7 +45,11 @@ func processNormalMessage(
 		agentID = resolveAgentRoute(cfg, msg.Channel, msg.ChatID, msg.PeerKind)
 	}
 
-	agentLoop, err := agents.Get(agentID)
+	// Resolve project for this chat (nil projectStore = backward compatible)
+	channelType := resolveChannelType(channelMgr, msg.Channel)
+	projectID, projectOverrides := resolveProjectOverrides(ctx, projectStore, channelType, msg.ChatID)
+
+	agentLoop, err := agents.GetForProject(agentID, projectID, projectOverrides)
 	if err != nil {
 		slog.Warn("inbound: agent not found", "agent", agentID, "channel", msg.Channel)
 		return

--- a/cmd/gateway_consumer_project.go
+++ b/cmd/gateway_consumer_project.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// resolveProjectOverrides looks up the project for a chat and returns its ID + MCP env overrides.
+// Returns empty values if no project is configured (backward compatible).
+func resolveProjectOverrides(ctx context.Context, projectStore store.ProjectStore, channelType, chatID string) (string, map[string]map[string]string) {
+	if projectStore == nil || channelType == "" || chatID == "" {
+		return "", nil
+	}
+	project, err := projectStore.GetProjectByChatID(ctx, channelType, chatID)
+	if err != nil {
+		slog.Warn("project.resolve_failed", "channelType", channelType, "chatID", chatID, "error", err)
+		return "", nil
+	}
+	if project == nil {
+		return "", nil
+	}
+	overrides, err := projectStore.GetMCPOverridesMap(ctx, project.ID)
+	if err != nil {
+		slog.Warn("project.overrides_failed", "project", project.Slug, "error", err)
+		return project.ID.String(), nil
+	}
+	return project.ID.String(), overrides
+}

--- a/cmd/gateway_consumer_project_test.go
+++ b/cmd/gateway_consumer_project_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// stubProjectStore implements store.ProjectStore for testing.
+type stubProjectStore struct {
+	store.ProjectStore // embed interface — panics on unimplemented methods
+
+	project   *store.Project
+	overrides map[string]map[string]string
+	chatErr   error
+	overErr   error
+}
+
+func (s *stubProjectStore) GetProjectByChatID(_ context.Context, _, _ string) (*store.Project, error) {
+	return s.project, s.chatErr
+}
+
+func (s *stubProjectStore) GetMCPOverridesMap(_ context.Context, _ uuid.UUID) (map[string]map[string]string, error) {
+	return s.overrides, s.overErr
+}
+
+func TestResolveProjectOverrides(t *testing.T) {
+	testProjectID := uuid.New()
+
+	tests := []struct {
+		name          string
+		store         store.ProjectStore
+		channelType   string
+		chatID        string
+		wantProjectID string
+		wantOverrides map[string]map[string]string
+	}{
+		{
+			name:          "nil store returns empty (backward compat)",
+			store:         nil,
+			channelType:   "telegram",
+			chatID:        "-100123",
+			wantProjectID: "",
+			wantOverrides: nil,
+		},
+		{
+			name:          "empty channelType returns empty",
+			store:         &stubProjectStore{},
+			channelType:   "",
+			chatID:        "-100123",
+			wantProjectID: "",
+			wantOverrides: nil,
+		},
+		{
+			name:          "empty chatID returns empty",
+			store:         &stubProjectStore{},
+			channelType:   "telegram",
+			chatID:        "",
+			wantProjectID: "",
+			wantOverrides: nil,
+		},
+		{
+			name: "no project found returns empty (not an error)",
+			store: &stubProjectStore{
+				project: nil,
+				chatErr: nil,
+			},
+			channelType:   "telegram",
+			chatID:        "-100999",
+			wantProjectID: "",
+			wantOverrides: nil,
+		},
+		{
+			name: "project found with overrides",
+			store: &stubProjectStore{
+				project: &store.Project{
+					BaseModel: store.BaseModel{ID: testProjectID},
+					Slug:      "xpos",
+				},
+				overrides: map[string]map[string]string{
+					"gitlab":    {"GITLAB_PROJECT_PATH": "duhd/xpos"},
+					"atlassian": {"JIRA_PROJECT_KEY": "XPOS"},
+				},
+			},
+			channelType:   "telegram",
+			chatID:        "-100123",
+			wantProjectID: testProjectID.String(),
+			wantOverrides: map[string]map[string]string{
+				"gitlab":    {"GITLAB_PROJECT_PATH": "duhd/xpos"},
+				"atlassian": {"JIRA_PROJECT_KEY": "XPOS"},
+			},
+		},
+		{
+			name: "project found but no overrides configured",
+			store: &stubProjectStore{
+				project: &store.Project{
+					BaseModel: store.BaseModel{ID: testProjectID},
+					Slug:      "empty-proj",
+				},
+				overrides: map[string]map[string]string{},
+			},
+			channelType:   "telegram",
+			chatID:        "-100456",
+			wantProjectID: testProjectID.String(),
+			wantOverrides: map[string]map[string]string{},
+		},
+		{
+			name: "DB error on project lookup — graceful degradation",
+			store: &stubProjectStore{
+				chatErr: errors.New("connection refused"),
+			},
+			channelType:   "telegram",
+			chatID:        "-100123",
+			wantProjectID: "",
+			wantOverrides: nil,
+		},
+		{
+			name: "project found but overrides query fails — returns projectID only",
+			store: &stubProjectStore{
+				project: &store.Project{
+					BaseModel: store.BaseModel{ID: testProjectID},
+					Slug:      "xpos",
+				},
+				overErr: errors.New("timeout"),
+			},
+			channelType:   "telegram",
+			chatID:        "-100123",
+			wantProjectID: testProjectID.String(),
+			wantOverrides: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			gotID, gotOverrides := resolveProjectOverrides(ctx, tt.store, tt.channelType, tt.chatID)
+
+			if gotID != tt.wantProjectID {
+				t.Errorf("projectID: got %q, want %q", gotID, tt.wantProjectID)
+			}
+			if tt.wantOverrides == nil {
+				if gotOverrides != nil {
+					t.Errorf("overrides: got %v, want nil", gotOverrides)
+				}
+				return
+			}
+			if len(gotOverrides) != len(tt.wantOverrides) {
+				t.Errorf("overrides len: got %d, want %d", len(gotOverrides), len(tt.wantOverrides))
+				return
+			}
+			for server, wantEnv := range tt.wantOverrides {
+				gotEnv, ok := gotOverrides[server]
+				if !ok {
+					t.Errorf("missing server %q in overrides", server)
+					continue
+				}
+				for k, wantV := range wantEnv {
+					if gotV := gotEnv[k]; gotV != wantV {
+						t.Errorf("overrides[%q][%q]: got %q, want %q", server, k, gotV, wantV)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/gateway_http_handlers.go
+++ b/cmd/gateway_http_handlers.go
@@ -9,8 +9,8 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/tools"
 )
 
-// wireHTTP creates HTTP handlers (agents + skills + traces + MCP + custom tools + channel instances + providers + delegations + builtin tools + pending messages).
-func wireHTTP(stores *store.Stores, token, defaultWorkspace string, msgBus *bus.MessageBus, toolsReg *tools.Registry, providerReg *providers.Registry, isOwner func(string) bool, gatewayAddr string, mcpToolLister httpapi.MCPToolLister) (*httpapi.AgentsHandler, *httpapi.SkillsHandler, *httpapi.TracesHandler, *httpapi.MCPHandler, *httpapi.CustomToolsHandler, *httpapi.ChannelInstancesHandler, *httpapi.ProvidersHandler, *httpapi.DelegationsHandler, *httpapi.BuiltinToolsHandler, *httpapi.PendingMessagesHandler, *httpapi.TeamEventsHandler, *httpapi.SecureCLIHandler) {
+// wireHTTP creates HTTP handlers (agents + skills + traces + MCP + custom tools + channel instances + providers + delegations + builtin tools + pending messages + projects + team events + secure CLI).
+func wireHTTP(stores *store.Stores, token, defaultWorkspace string, msgBus *bus.MessageBus, toolsReg *tools.Registry, providerReg *providers.Registry, isOwner func(string) bool, gatewayAddr string, mcpToolLister httpapi.MCPToolLister) (*httpapi.AgentsHandler, *httpapi.SkillsHandler, *httpapi.TracesHandler, *httpapi.MCPHandler, *httpapi.CustomToolsHandler, *httpapi.ChannelInstancesHandler, *httpapi.ProvidersHandler, *httpapi.DelegationsHandler, *httpapi.BuiltinToolsHandler, *httpapi.PendingMessagesHandler, *httpapi.ProjectHandler, *httpapi.TeamEventsHandler, *httpapi.SecureCLIHandler) {
 	var agentsH *httpapi.AgentsHandler
 	var skillsH *httpapi.SkillsHandler
 	var tracesH *httpapi.TracesHandler
@@ -21,6 +21,7 @@ func wireHTTP(stores *store.Stores, token, defaultWorkspace string, msgBus *bus.
 	var delegationsH *httpapi.DelegationsHandler
 	var builtinToolsH *httpapi.BuiltinToolsHandler
 	var pendingMessagesH *httpapi.PendingMessagesHandler
+	var projectsH *httpapi.ProjectHandler
 	var secureCLIH *httpapi.SecureCLIHandler
 
 	if stores != nil && stores.Agents != nil {
@@ -79,9 +80,13 @@ func wireHTTP(stores *store.Stores, token, defaultWorkspace string, msgBus *bus.
 		pendingMessagesH = httpapi.NewPendingMessagesHandler(stores.PendingMessages, stores.Agents, token, providerReg)
 	}
 
+	if stores != nil && stores.Projects != nil {
+		projectsH = httpapi.NewProjectHandler(stores.Projects, token)
+	}
+
 	if stores != nil && stores.SecureCLI != nil {
 		secureCLIH = httpapi.NewSecureCLIHandler(stores.SecureCLI, token, msgBus)
 	}
 
-	return agentsH, skillsH, tracesH, mcpH, customToolsH, channelInstancesH, providersH, delegationsH, builtinToolsH, pendingMessagesH, teamEventsH, secureCLIH
+	return agentsH, skillsH, tracesH, mcpH, customToolsH, channelInstancesH, providersH, delegationsH, builtinToolsH, pendingMessagesH, projectsH, teamEventsH, secureCLIH
 }

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -91,7 +91,7 @@ type ResolverDeps struct {
 // NewManagedResolver creates a ResolverFunc that builds Loops from DB agent data.
 // Agents are defined in Postgres, not config.json.
 func NewManagedResolver(deps ResolverDeps) ResolverFunc {
-	return func(agentKey string) (Agent, error) {
+	return func(agentKey string, opts ResolveOpts) (Agent, error) {
 		ctx := context.Background()
 
 		// Support lookup by UUID (e.g. from cron jobs that store agent_id as UUID)
@@ -247,7 +247,7 @@ func NewManagedResolver(deps ResolverDeps) ResolverFunc {
 			mcpOpts = append(mcpOpts, mcpbridge.WithPool(deps.MCPPool))
 		}
 		mcpMgr := mcpbridge.NewManager(toolsReg, mcpOpts...)
-			if err := mcpMgr.LoadForAgent(ctx, ag.ID, ""); err != nil {
+			if err := mcpMgr.LoadForAgent(ctx, ag.ID, "", opts.ProjectID, opts.ProjectOverrides); err != nil {
 				slog.Warn("failed to load MCP servers for agent", "agent", agentKey, "error", err)
 			} else if mcpMgr.IsSearchMode() {
 				// Search mode: too many tools — register mcp_tool_search meta-tool.

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -7,9 +7,18 @@ import (
 	"time"
 )
 
+// ResolveOpts carries per-request context for the resolver (e.g., project scoping).
+// When ProjectID is non-empty the resolver creates a Loop whose MCP connections
+// are scoped to that project, preventing cross-project contamination in shared
+// agents like sdlc-assistant.
+type ResolveOpts struct {
+	ProjectID        string
+	ProjectOverrides map[string]map[string]string
+}
+
 // ResolverFunc is called when an agent isn't found in the cache.
 // Used to lazy-create agents from DB.
-type ResolverFunc func(agentKey string) (Agent, error)
+type ResolverFunc func(agentKey string, opts ResolveOpts) (Agent, error)
 
 const defaultRouterTTL = 10 * time.Minute
 
@@ -83,7 +92,7 @@ func (r *Router) Get(agentID string) (Agent, error) {
 
 	// Try resolver (create from DB)
 	if resolver != nil {
-		ag, err := resolver(agentID)
+		ag, err := resolver(agentID, ResolveOpts{})
 		if err != nil {
 			return nil, err
 		}
@@ -99,6 +108,50 @@ func (r *Router) Get(agentID string) (Agent, error) {
 	}
 
 	return nil, fmt.Errorf("agent not found: %s", agentID)
+}
+
+// GetForProject returns an agent Loop scoped to a specific project.
+// Cache key: "agentID:projectID". If projectID is empty, falls back to Get(agentID).
+func (r *Router) GetForProject(agentID, projectID string, projectOverrides map[string]map[string]string) (Agent, error) {
+	if projectID == "" {
+		return r.Get(agentID)
+	}
+	cacheKey := agentID + ":" + projectID
+
+	r.mu.RLock()
+	entry, ok := r.agents[cacheKey]
+	resolver := r.resolver
+	r.mu.RUnlock()
+
+	if ok && (r.ttl == 0 || time.Since(entry.cachedAt) < r.ttl) {
+		return entry.agent, nil
+	}
+	if ok {
+		r.mu.Lock()
+		delete(r.agents, cacheKey)
+		r.mu.Unlock()
+	}
+	if resolver == nil {
+		return nil, fmt.Errorf("agent not found: %s", agentID)
+	}
+
+	ag, err := resolver(agentID, ResolveOpts{
+		ProjectID:        projectID,
+		ProjectOverrides: projectOverrides,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r.mu.Lock()
+	// Double-check: another goroutine might have created it
+	if existing, ok := r.agents[cacheKey]; ok {
+		r.mu.Unlock()
+		return existing.agent, nil
+	}
+	r.agents[cacheKey] = &agentEntry{agent: ag, cachedAt: time.Now()}
+	r.mu.Unlock()
+	return ag, nil
 }
 
 // Remove removes an agent from the router.

--- a/internal/agent/router_project_test.go
+++ b/internal/agent/router_project_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+)
+
+// mockProvider implements the Provider interface for testing.
+type mockProvider struct{}
+
+func (m *mockProvider) Chat(ctx context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+	return &providers.ChatResponse{}, nil
+}
+
+func (m *mockProvider) ChatStream(ctx context.Context, req providers.ChatRequest, onChunk func(providers.StreamChunk)) (*providers.ChatResponse, error) {
+	return &providers.ChatResponse{}, nil
+}
+
+func (m *mockProvider) DefaultModel() string { return "test-model" }
+func (m *mockProvider) Name() string          { return "test-provider" }
+
+// mockAgent implements the Agent interface for testing.
+type mockAgent struct {
+	id string
+}
+
+func (m *mockAgent) ID() string                                              { return m.id }
+func (m *mockAgent) Run(_ context.Context, _ RunRequest) (*RunResult, error) { return nil, nil }
+func (m *mockAgent) IsRunning() bool                                         { return false }
+func (m *mockAgent) Model() string                                           { return "test-model" }
+func (m *mockAgent) ProviderName() string                                    { return "test-provider" }
+func (m *mockAgent) Provider() providers.Provider                            { return &mockProvider{} }
+
+func TestGetForProject_EmptyProjectFallsBackToGet(t *testing.T) {
+	r := NewRouter()
+	r.SetResolver(func(agentKey string, opts ResolveOpts) (Agent, error) {
+		return &mockAgent{id: agentKey}, nil
+	})
+
+	ag, err := r.GetForProject("sdlc-assistant", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ag.ID() != "sdlc-assistant" {
+		t.Errorf("got agent ID %q, want 'sdlc-assistant'", ag.ID())
+	}
+}
+
+func TestGetForProject_DifferentProjectsSeparateCache(t *testing.T) {
+	callCount := 0
+
+	r := NewRouter()
+	r.SetResolver(func(agentKey string, opts ResolveOpts) (Agent, error) {
+		callCount++
+		return &mockAgent{id: agentKey + ":" + opts.ProjectID}, nil
+	})
+
+	ag1, err := r.GetForProject("sdlc-assistant", "uuid-xpos", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ag2, err := r.GetForProject("sdlc-assistant", "uuid-payment", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ag1.ID() == ag2.ID() {
+		t.Error("different projects should get different cached agents")
+	}
+	if callCount != 2 {
+		t.Errorf("resolver should be called twice (once per project), got %d", callCount)
+	}
+}
+
+func TestGetForProject_SameProjectUsesCache(t *testing.T) {
+	callCount := 0
+
+	r := NewRouter()
+	r.SetResolver(func(agentKey string, opts ResolveOpts) (Agent, error) {
+		callCount++
+		return &mockAgent{id: agentKey}, nil
+	})
+
+	_, _ = r.GetForProject("sdlc-assistant", "uuid-xpos", nil)
+	_, _ = r.GetForProject("sdlc-assistant", "uuid-xpos", nil)
+
+	if callCount != 1 {
+		t.Errorf("resolver should be called once (cached), got %d", callCount)
+	}
+}
+
+func TestGetForProject_NoProjectAndWithProject_SeparateCache(t *testing.T) {
+	callCount := 0
+
+	r := NewRouter()
+	r.SetResolver(func(agentKey string, opts ResolveOpts) (Agent, error) {
+		callCount++
+		suffix := ""
+		if opts.ProjectID != "" {
+			suffix = ":" + opts.ProjectID
+		}
+		return &mockAgent{id: agentKey + suffix}, nil
+	})
+
+	ag1, _ := r.GetForProject("sdlc-assistant", "", nil)
+	ag2, _ := r.GetForProject("sdlc-assistant", "uuid-xpos", nil)
+
+	if ag1.ID() == ag2.ID() {
+		t.Error("no-project and with-project should get different agents")
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 resolver calls, got %d", callCount)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -62,6 +62,7 @@ type Server struct {
 	mediaServeHandler       *httpapi.MediaServeHandler       // media serve endpoint
 	activityHandler         *httpapi.ActivityHandler         // activity audit log API
 	usageHandler            *httpapi.UsageHandler            // usage analytics API
+	projectHandler          *httpapi.ProjectHandler          // project CRUD + MCP overrides API
 	apiKeysHandler     *httpapi.APIKeysHandler      // API key management
 	apiKeyStore        store.APIKeyStore            // for API key auth lookup
 	docsHandler        *httpapi.DocsHandler         // OpenAPI spec + Swagger UI
@@ -206,6 +207,11 @@ func (s *Server) BuildMux() *http.ServeMux {
 	// MCP server management API
 	if s.mcpHandler != nil {
 		s.mcpHandler.RegisterRoutes(mux)
+	}
+
+	// Project CRUD + MCP overrides API
+	if s.projectHandler != nil {
+		s.projectHandler.RegisterRoutes(mux)
 	}
 
 	// Custom tool CRUD API
@@ -557,6 +563,9 @@ func (s *Server) SetActivityHandler(h *httpapi.ActivityHandler) { s.activityHand
 
 // SetUsageHandler sets the usage analytics handler.
 func (s *Server) SetUsageHandler(h *httpapi.UsageHandler) { s.usageHandler = h }
+
+// SetProjectHandler sets the project CRUD + MCP overrides handler.
+func (s *Server) SetProjectHandler(h *httpapi.ProjectHandler) { s.projectHandler = h }
 
 // SetDocsHandler sets the OpenAPI spec + Swagger UI handler.
 func (s *Server) SetDocsHandler(h *httpapi.DocsHandler) { s.docsHandler = h }

--- a/internal/http/projects.go
+++ b/internal/http/projects.go
@@ -1,0 +1,277 @@
+package http
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// ProjectHandler handles project CRUD and MCP override HTTP endpoints.
+type ProjectHandler struct {
+	store store.ProjectStore
+	token string
+}
+
+// NewProjectHandler creates a handler for project management endpoints.
+func NewProjectHandler(store store.ProjectStore, token string) *ProjectHandler {
+	return &ProjectHandler{store: store, token: token}
+}
+
+// RegisterRoutes registers all project routes on the given mux.
+func (h *ProjectHandler) RegisterRoutes(mux *http.ServeMux) {
+	// Project CRUD
+	mux.HandleFunc("GET /v1/projects", h.auth(h.handleListProjects))
+	mux.HandleFunc("POST /v1/projects", h.auth(h.handleCreateProject))
+	mux.HandleFunc("GET /v1/projects/by-chat", h.auth(h.handleGetByChat))
+	mux.HandleFunc("GET /v1/projects/{id}", h.auth(h.handleGetProject))
+	mux.HandleFunc("PUT /v1/projects/{id}", h.auth(h.handleUpdateProject))
+	mux.HandleFunc("DELETE /v1/projects/{id}", h.auth(h.handleDeleteProject))
+
+	// MCP overrides
+	mux.HandleFunc("GET /v1/projects/{id}/mcp", h.auth(h.handleListMCPOverrides))
+	mux.HandleFunc("PUT /v1/projects/{id}/mcp/{serverName}", h.auth(h.handleSetMCPOverride))
+	mux.HandleFunc("DELETE /v1/projects/{id}/mcp/{serverName}", h.auth(h.handleRemoveMCPOverride))
+}
+
+func (h *ProjectHandler) auth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if h.token != "" {
+			if extractBearerToken(r) != h.token {
+				locale := extractLocale(r)
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": i18n.T(locale, i18n.MsgUnauthorized)})
+				return
+			}
+		}
+		userID := extractUserID(r)
+		ctx := store.WithLocale(r.Context(), extractLocale(r))
+		if userID != "" {
+			ctx = store.WithUserID(ctx, userID)
+		}
+		r = r.WithContext(ctx)
+		next(w, r)
+	}
+}
+
+// --- Project CRUD ---
+
+func (h *ProjectHandler) handleListProjects(w http.ResponseWriter, r *http.Request) {
+	projects, err := h.store.ListProjects(r.Context())
+	if err != nil {
+		slog.Error("projects.list", "error", err)
+		locale := store.LocaleFromContext(r.Context())
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgFailedToList, "projects")})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"projects": projects})
+}
+
+func (h *ProjectHandler) handleCreateProject(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+
+	var payload struct {
+		Name        string     `json:"name"`
+		Slug        string     `json:"slug"`
+		ChannelType *string    `json:"channel_type"`
+		ChatID      *string    `json:"chat_id"`
+		TeamID      *uuid.UUID `json:"team_id"`
+		Description *string    `json:"description"`
+		Status      string     `json:"status"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&payload); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidJSON)})
+		return
+	}
+
+	if payload.Name == "" || payload.Slug == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "name and slug")})
+		return
+	}
+	if !isValidSlug(payload.Slug) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidSlug, "slug")})
+		return
+	}
+
+	if payload.Status == "" {
+		payload.Status = "active"
+	}
+
+	project := store.Project{
+		Name:        payload.Name,
+		Slug:        payload.Slug,
+		ChannelType: payload.ChannelType,
+		ChatID:      payload.ChatID,
+		TeamID:      payload.TeamID,
+		Description: payload.Description,
+		Status:      payload.Status,
+		CreatedBy:   store.UserIDFromContext(r.Context()),
+	}
+
+	if err := h.store.CreateProject(r.Context(), &project); err != nil {
+		slog.Error("projects.create", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, project)
+}
+
+func (h *ProjectHandler) handleGetProject(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "project")})
+		return
+	}
+
+	project, err := h.store.GetProject(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "project", id.String())})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, project)
+}
+
+func (h *ProjectHandler) handleGetByChat(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	channelType := r.URL.Query().Get("channel_type")
+	chatID := r.URL.Query().Get("chat_id")
+
+	if channelType == "" || chatID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "channel_type and chat_id")})
+		return
+	}
+
+	project, err := h.store.GetProjectByChatID(r.Context(), channelType, chatID)
+	if err != nil || project == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "project not found for this chat"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, project)
+}
+
+func (h *ProjectHandler) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "project")})
+		return
+	}
+
+	var updates map[string]any
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&updates); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidJSON)})
+		return
+	}
+
+	if slug, ok := updates["slug"]; ok {
+		if s, _ := slug.(string); !isValidSlug(s) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidSlug, "slug")})
+			return
+		}
+	}
+
+	if err := h.store.UpdateProject(r.Context(), id, updates); err != nil {
+		slog.Error("projects.update", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
+}
+
+func (h *ProjectHandler) handleDeleteProject(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "project")})
+		return
+	}
+
+	if err := h.store.DeleteProject(r.Context(), id); err != nil {
+		slog.Error("projects.delete", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- MCP Overrides ---
+
+func (h *ProjectHandler) handleListMCPOverrides(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "project")})
+		return
+	}
+
+	overrides, err := h.store.GetMCPOverrides(r.Context(), id)
+	if err != nil {
+		slog.Error("projects.list_mcp_overrides", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgFailedToList, "MCP overrides")})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"overrides": overrides})
+}
+
+func (h *ProjectHandler) handleSetMCPOverride(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "project")})
+		return
+	}
+
+	serverName := r.PathValue("serverName")
+	if serverName == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "serverName")})
+		return
+	}
+
+	var envOverrides map[string]string
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&envOverrides); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidJSON)})
+		return
+	}
+
+	if err := h.store.SetMCPOverride(r.Context(), id, serverName, envOverrides); err != nil {
+		slog.Error("projects.set_mcp_override", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
+}
+
+func (h *ProjectHandler) handleRemoveMCPOverride(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "project")})
+		return
+	}
+
+	serverName := r.PathValue("serverName")
+	if serverName == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "serverName")})
+		return
+	}
+
+	if err := h.store.RemoveMCPOverride(r.Context(), id, serverName); err != nil {
+		slog.Error("projects.remove_mcp_override", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -148,7 +148,9 @@ func (m *Manager) Start(ctx context.Context) error {
 
 // LoadForAgent connects MCP servers accessible by a specific agent+user.
 // Previously registered MCP tools for this manager are cleared and reloaded.
-func (m *Manager) LoadForAgent(ctx context.Context, agentID uuid.UUID, userID string) error {
+// projectID and projectOverrides enable per-project MCP process isolation:
+// each project gets its own pool entry with merged env vars.
+func (m *Manager) LoadForAgent(ctx context.Context, agentID uuid.UUID, userID string, projectID string, projectOverrides map[string]map[string]string) error {
 	if m.store == nil {
 		return nil
 	}
@@ -173,8 +175,13 @@ func (m *Manager) LoadForAgent(ctx context.Context, agentID uuid.UUID, userID st
 
 		if m.pool != nil {
 			// Pool mode: acquire shared connection, create per-agent BridgeTools
+			var serverOverrides map[string]string
+			if projectOverrides != nil {
+				serverOverrides = projectOverrides[srv.Name]
+			}
 			if err := m.connectViaPool(ctx, srv.Name, srv.Transport, srv.Command,
-				args, env, srv.URL, headers, srv.ToolPrefix, srv.TimeoutSec); err != nil {
+				args, env, srv.URL, headers, srv.ToolPrefix, srv.TimeoutSec,
+				projectID, serverOverrides); err != nil {
 				slog.Warn("mcp.server.connect_failed", "server", srv.Name, "error", err)
 				continue
 			}
@@ -189,8 +196,13 @@ func (m *Manager) LoadForAgent(ctx context.Context, agentID uuid.UUID, userID st
 		}
 
 		// Apply tool filtering from grants
+		// Use poolKey for pool-backed servers so filterTools finds the right entries
+		poolKey := srv.Name
+		if m.pool != nil && projectID != "" {
+			poolKey = srv.Name + ":" + projectID
+		}
 		if len(info.ToolAllow) > 0 || len(info.ToolDeny) > 0 {
-			m.filterTools(srv.Name, info.ToolAllow, info.ToolDeny)
+			m.filterTools(poolKey, info.ToolAllow, info.ToolDeny)
 		}
 	}
 

--- a/internal/mcp/manager_connect.go
+++ b/internal/mcp/manager_connect.go
@@ -121,10 +121,35 @@ func (m *Manager) registerBridgeTools(ss *serverState, mcpTools []mcpgo.Tool, se
 	return registeredNames
 }
 
+// mergeEnv merges base env with project overrides.
+// Project overrides take priority (add/replace only, never remove base keys).
+func mergeEnv(base, overrides map[string]string) map[string]string {
+	if len(overrides) == 0 {
+		return base
+	}
+	merged := make(map[string]string, len(base)+len(overrides))
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range overrides {
+		merged[k] = v
+	}
+	return merged
+}
+
 // connectViaPool acquires a shared connection from the pool and creates
 // per-agent BridgeTools pointing to the shared client/connected pointers.
-func (m *Manager) connectViaPool(ctx context.Context, name, transportType, command string, args []string, env map[string]string, url string, headers map[string]string, toolPrefix string, timeoutSec int) error {
-	entry, err := m.pool.Acquire(ctx, name, transportType, command, args, env, url, headers, timeoutSec)
+func (m *Manager) connectViaPool(ctx context.Context, name, transportType, command string,
+	args []string, env map[string]string, url string, headers map[string]string,
+	toolPrefix string, timeoutSec int, projectID string, projectEnvOverrides map[string]string) error {
+
+	mergedEnv := mergeEnv(env, projectEnvOverrides)
+	poolKey := name
+	if projectID != "" {
+		poolKey = name + ":" + projectID
+	}
+
+	entry, err := m.pool.Acquire(ctx, poolKey, name, transportType, command, args, mergedEnv, url, headers, timeoutSec)
 	if err != nil {
 		return err
 	}
@@ -134,24 +159,25 @@ func (m *Manager) connectViaPool(ctx context.Context, name, transportType, comma
 
 	// Track server state and per-agent tool names
 	m.mu.Lock()
-	m.servers[name] = entry.state
+	m.servers[poolKey] = entry.state
 	if m.poolServers == nil {
 		m.poolServers = make(map[string]struct{})
 	}
-	m.poolServers[name] = struct{}{}
+	m.poolServers[poolKey] = struct{}{}
 	if m.poolToolNames == nil {
 		m.poolToolNames = make(map[string][]string)
 	}
-	m.poolToolNames[name] = registeredNames
+	m.poolToolNames[poolKey] = registeredNames
 	m.mu.Unlock()
 
 	if len(registeredNames) > 0 {
-		tools.RegisterToolGroup("mcp:"+name, registeredNames)
+		tools.RegisterToolGroup("mcp:"+poolKey, registeredNames)
 		m.updateMCPGroup()
 	}
 
 	slog.Info("mcp.server.connected_via_pool",
 		"server", name,
+		"poolKey", poolKey,
 		"transport", transportType,
 		"tools", len(registeredNames),
 	)

--- a/internal/mcp/pool.go
+++ b/internal/mcp/pool.go
@@ -34,25 +34,27 @@ func NewPool() *Pool {
 // Acquire returns a shared connection for the named server.
 // If no connection exists, it connects using the provided config.
 // Increments the reference count.
-func (p *Pool) Acquire(ctx context.Context, name, transportType, command string, args []string, env map[string]string, url string, headers map[string]string, timeoutSec int) (*poolEntry, error) {
+// poolKey is the composite key (e.g. "name" or "name:projectID") used for
+// process isolation; name is the server name used for connectAndDiscover.
+func (p *Pool) Acquire(ctx context.Context, poolKey, name, transportType, command string, args []string, env map[string]string, url string, headers map[string]string, timeoutSec int) (*poolEntry, error) {
 	p.mu.Lock()
 
-	if entry, ok := p.servers[name]; ok && entry.state.connected.Load() {
+	if entry, ok := p.servers[poolKey]; ok && entry.state.connected.Load() {
 		entry.refCount++
 		p.mu.Unlock()
-		slog.Debug("mcp.pool.reuse", "server", name, "refCount", entry.refCount)
+		slog.Debug("mcp.pool.reuse", "server", name, "poolKey", poolKey, "refCount", entry.refCount)
 		return entry, nil
 	}
 
 	// If entry exists but disconnected, close old connection first
-	if old, ok := p.servers[name]; ok {
+	if old, ok := p.servers[poolKey]; ok {
 		if old.state.cancel != nil {
 			old.state.cancel()
 		}
 		if old.state.client != nil {
 			_ = old.state.client.Close()
 		}
-		delete(p.servers, name)
+		delete(p.servers, poolKey)
 	}
 
 	p.mu.Unlock()
@@ -76,7 +78,7 @@ func (p *Pool) Acquire(ctx context.Context, name, transportType, command string,
 
 	p.mu.Lock()
 	// Check if another goroutine connected while we were connecting
-	if existing, ok := p.servers[name]; ok && existing.state.connected.Load() {
+	if existing, ok := p.servers[poolKey]; ok && existing.state.connected.Load() {
 		// Use existing, close ours
 		p.mu.Unlock()
 		hcancel()
@@ -86,26 +88,26 @@ func (p *Pool) Acquire(ctx context.Context, name, transportType, command string,
 		p.mu.Unlock()
 		return existing, nil
 	}
-	p.servers[name] = entry
+	p.servers[poolKey] = entry
 	p.mu.Unlock()
 
-	slog.Info("mcp.pool.connected", "server", name, "tools", len(mcpTools))
+	slog.Info("mcp.pool.connected", "server", name, "poolKey", poolKey, "tools", len(mcpTools))
 	return entry, nil
 }
 
 // Release decrements the reference count for a server.
 // The connection is NOT closed when refCount reaches 0 — it stays
 // alive for future agents. Use Stop() to close all connections.
-func (p *Pool) Release(name string) {
+func (p *Pool) Release(poolKey string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if entry, ok := p.servers[name]; ok {
+	if entry, ok := p.servers[poolKey]; ok {
 		entry.refCount--
 		if entry.refCount < 0 {
 			entry.refCount = 0
 		}
-		slog.Debug("mcp.pool.release", "server", name, "refCount", entry.refCount)
+		slog.Debug("mcp.pool.release", "poolKey", poolKey, "refCount", entry.refCount)
 	}
 }
 

--- a/internal/store/pg/factory.go
+++ b/internal/store/pg/factory.go
@@ -43,6 +43,7 @@ func NewPGStores(cfg store.StoreConfig) (*store.Stores, error) {
 		Contacts:         NewPGContactStore(db),
 		Activity:         NewPGActivityStore(db),
 		Snapshots:        NewPGSnapshotStore(db),
+		Projects:         NewPGProjectStore(db),
 		SecureCLI:        NewPGSecureCLIStore(db, cfg.EncryptionKey),
 		APIKeys:           NewPGAPIKeyStore(db),
 		Heartbeats:        NewPGHeartbeatStore(db),

--- a/internal/store/pg/projects.go
+++ b/internal/store/pg/projects.go
@@ -1,0 +1,180 @@
+package pg
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/google/uuid"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+var secretKeyPattern = regexp.MustCompile(`(?i)(^|_)(TOKEN|SECRET|PASSWORD|API_KEY)($|_)`)
+
+// PGProjectStore implements store.ProjectStore backed by Postgres.
+type PGProjectStore struct {
+	db *sql.DB
+}
+
+func NewPGProjectStore(db *sql.DB) *PGProjectStore {
+	return &PGProjectStore{db: db}
+}
+
+// --- Project CRUD ---
+
+func (s *PGProjectStore) CreateProject(ctx context.Context, p *store.Project) error {
+	query := `INSERT INTO projects (name, slug, channel_type, chat_id, team_id, description, status, created_by)
+	           VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, created_at, updated_at`
+	return s.db.QueryRowContext(ctx, query,
+		p.Name, p.Slug, p.ChannelType, p.ChatID, nilUUID(p.TeamID),
+		p.Description, p.Status, p.CreatedBy,
+	).Scan(&p.ID, &p.CreatedAt, &p.UpdatedAt)
+}
+
+func (s *PGProjectStore) GetProject(ctx context.Context, id uuid.UUID) (*store.Project, error) {
+	query := `SELECT id, name, slug, channel_type, chat_id, team_id, description, status, created_by, created_at, updated_at
+	           FROM projects WHERE id = $1`
+	return s.scanProject(s.db.QueryRowContext(ctx, query, id))
+}
+
+func (s *PGProjectStore) GetProjectBySlug(ctx context.Context, slug string) (*store.Project, error) {
+	query := `SELECT id, name, slug, channel_type, chat_id, team_id, description, status, created_by, created_at, updated_at
+	           FROM projects WHERE slug = $1`
+	return s.scanProject(s.db.QueryRowContext(ctx, query, slug))
+}
+
+func (s *PGProjectStore) GetProjectByChatID(ctx context.Context, channelType, chatID string) (*store.Project, error) {
+	query := `SELECT id, name, slug, channel_type, chat_id, team_id, description, status, created_by, created_at, updated_at
+	           FROM projects WHERE channel_type = $1 AND chat_id = $2 AND status = 'active'`
+	p, err := s.scanProject(s.db.QueryRowContext(ctx, query, channelType, chatID))
+	if err == sql.ErrNoRows {
+		return nil, nil // no project — not an error
+	}
+	return p, err
+}
+
+func (s *PGProjectStore) scanProject(row *sql.Row) (*store.Project, error) {
+	p := &store.Project{}
+	err := row.Scan(
+		&p.ID, &p.Name, &p.Slug, &p.ChannelType, &p.ChatID, &p.TeamID,
+		&p.Description, &p.Status, &p.CreatedBy, &p.CreatedAt, &p.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (s *PGProjectStore) ListProjects(ctx context.Context) ([]store.Project, error) {
+	query := `SELECT id, name, slug, channel_type, chat_id, team_id, description, status, created_by, created_at, updated_at
+	           FROM projects ORDER BY name`
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make([]store.Project, 0)
+	for rows.Next() {
+		var p store.Project
+		if err := rows.Scan(
+			&p.ID, &p.Name, &p.Slug, &p.ChannelType, &p.ChatID, &p.TeamID,
+			&p.Description, &p.Status, &p.CreatedBy, &p.CreatedAt, &p.UpdatedAt,
+		); err != nil {
+			continue
+		}
+		result = append(result, p)
+	}
+	return result, rows.Err()
+}
+
+func (s *PGProjectStore) UpdateProject(ctx context.Context, id uuid.UUID, updates map[string]any) error {
+	return execMapUpdate(ctx, s.db, "projects", id, updates)
+}
+
+func (s *PGProjectStore) DeleteProject(ctx context.Context, id uuid.UUID) error {
+	_, err := s.db.ExecContext(ctx, "DELETE FROM projects WHERE id = $1", id)
+	return err
+}
+
+// --- MCP overrides ---
+
+// SetMCPOverride upserts env overrides for a project+server.
+// Rejects keys that look like secrets (TOKEN, SECRET, PASSWORD, API_KEY).
+func (s *PGProjectStore) SetMCPOverride(ctx context.Context, projectID uuid.UUID, serverName string, envOverrides map[string]string) error {
+	for key := range envOverrides {
+		if secretKeyPattern.MatchString(key) {
+			return fmt.Errorf("env key %q contains secret pattern (TOKEN/SECRET/PASSWORD/API_KEY) — use mcp_servers.env for secrets", key)
+		}
+	}
+	envJSON, err := json.Marshal(envOverrides)
+	if err != nil {
+		return err
+	}
+	query := `INSERT INTO project_mcp_overrides (project_id, server_name, env_overrides)
+	           VALUES ($1, $2, $3)
+	           ON CONFLICT (project_id, server_name) DO UPDATE SET env_overrides = $3, updated_at = NOW()`
+	_, err = s.db.ExecContext(ctx, query, projectID, serverName, envJSON)
+	return err
+}
+
+func (s *PGProjectStore) RemoveMCPOverride(ctx context.Context, projectID uuid.UUID, serverName string) error {
+	_, err := s.db.ExecContext(ctx,
+		"DELETE FROM project_mcp_overrides WHERE project_id = $1 AND server_name = $2",
+		projectID, serverName)
+	return err
+}
+
+func (s *PGProjectStore) GetMCPOverrides(ctx context.Context, projectID uuid.UUID) ([]store.ProjectMCPOverride, error) {
+	query := `SELECT id, project_id, server_name, env_overrides, enabled
+	           FROM project_mcp_overrides WHERE project_id = $1 ORDER BY server_name`
+	rows, err := s.db.QueryContext(ctx, query, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make([]store.ProjectMCPOverride, 0)
+	for rows.Next() {
+		var o store.ProjectMCPOverride
+		var envJSON []byte
+		if err := rows.Scan(&o.ID, &o.ProjectID, &o.ServerName, &envJSON, &o.Enabled); err != nil {
+			continue
+		}
+		o.EnvOverrides = make(map[string]string)
+		if len(envJSON) > 0 {
+			if err := json.Unmarshal(envJSON, &o.EnvOverrides); err != nil {
+				continue
+			}
+		}
+		result = append(result, o)
+	}
+	return result, rows.Err()
+}
+
+// GetMCPOverridesMap returns {serverName: {envKey: envVal}} for runtime env injection.
+func (s *PGProjectStore) GetMCPOverridesMap(ctx context.Context, projectID uuid.UUID) (map[string]map[string]string, error) {
+	query := `SELECT server_name, env_overrides FROM project_mcp_overrides
+	           WHERE project_id = $1 AND enabled = true`
+	rows, err := s.db.QueryContext(ctx, query, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make(map[string]map[string]string)
+	for rows.Next() {
+		var serverName string
+		var envJSON []byte
+		if err := rows.Scan(&serverName, &envJSON); err != nil {
+			return nil, err
+		}
+		env := make(map[string]string)
+		if err := json.Unmarshal(envJSON, &env); err != nil {
+			return nil, err
+		}
+		result[serverName] = env
+	}
+	return result, rows.Err()
+}

--- a/internal/store/pg/projects_test.go
+++ b/internal/store/pg/projects_test.go
@@ -1,0 +1,40 @@
+package pg
+
+import "testing"
+
+func TestSecretKeyPattern(t *testing.T) {
+	tests := []struct {
+		key      string
+		isSecret bool
+	}{
+		{"GITLAB_TOKEN", true},
+		{"gitlab_token", true},
+		{"GitLab_Token", true},
+		{"API_KEY", true},
+		{"api_key", true},
+		{"MY_SECRET", true},
+		{"DB_PASSWORD", true},
+		{"password", true},
+		{"AUTH_TOKEN_V2", true},
+		{"X_API_KEY_EXTRA", true},
+		{"SECRET_STUFF", true},
+
+		{"GITLAB_PROJECT_ID", false},
+		{"GITLAB_PROJECT_PATH", false},
+		{"JIRA_PROJECT_KEY", false},
+		{"CONFLUENCE_SPACE_KEY", false},
+		{"PROJECT_PATH", false},
+		{"BOARD_ID", false},
+		{"WORKSPACE_DIR", false},
+		{"TOKENIZER_TYPE", false}, // contains "TOKEN" substring but not at word boundary
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := secretKeyPattern.MatchString(tt.key)
+			if got != tt.isSecret {
+				t.Errorf("secretKeyPattern.MatchString(%q) = %v, want %v", tt.key, got, tt.isSecret)
+			}
+		})
+	}
+}

--- a/internal/store/project_store.go
+++ b/internal/store/project_store.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Project represents a workspace bound to a group chat.
+type Project struct {
+	BaseModel
+	Name        string     `json:"name"`
+	Slug        string     `json:"slug"`
+	ChannelType *string    `json:"channel_type,omitempty"`
+	ChatID      *string    `json:"chat_id,omitempty"`
+	TeamID      *uuid.UUID `json:"team_id,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	Status      string     `json:"status"`
+	CreatedBy   string     `json:"created_by"`
+}
+
+// ProjectMCPOverride holds per-project env overrides for an MCP server.
+type ProjectMCPOverride struct {
+	ID           uuid.UUID         `json:"id"`
+	ProjectID    uuid.UUID         `json:"project_id"`
+	ServerName   string            `json:"server_name"`
+	EnvOverrides map[string]string `json:"env_overrides"`
+	Enabled      bool              `json:"enabled"`
+}
+
+// ProjectStore manages project entities and their MCP overrides.
+type ProjectStore interface {
+	CreateProject(ctx context.Context, p *Project) error
+	GetProject(ctx context.Context, id uuid.UUID) (*Project, error)
+	GetProjectBySlug(ctx context.Context, slug string) (*Project, error)
+	GetProjectByChatID(ctx context.Context, channelType, chatID string) (*Project, error)
+	ListProjects(ctx context.Context) ([]Project, error)
+	UpdateProject(ctx context.Context, id uuid.UUID, updates map[string]any) error
+	DeleteProject(ctx context.Context, id uuid.UUID) error
+
+	// MCP overrides
+	SetMCPOverride(ctx context.Context, projectID uuid.UUID, serverName string, envOverrides map[string]string) error
+	RemoveMCPOverride(ctx context.Context, projectID uuid.UUID, serverName string) error
+	GetMCPOverrides(ctx context.Context, projectID uuid.UUID) ([]ProjectMCPOverride, error)
+	// GetMCPOverridesMap returns {serverName: {envKey: envVal}} for runtime injection.
+	GetMCPOverridesMap(ctx context.Context, projectID uuid.UUID) (map[string]map[string]string, error)
+}

--- a/internal/store/stores.go
+++ b/internal/store/stores.go
@@ -25,6 +25,7 @@ type Stores struct {
 	Contacts         ContactStore
 	Activity         ActivityStore
 	Snapshots        SnapshotStore
+	Projects         ProjectStore
 	SecureCLI        SecureCLIStore
 	APIKeys           APIKeyStore
 	Heartbeats        HeartbeatStore

--- a/migrations/000027_projects.down.sql
+++ b/migrations/000027_projects.down.sql
@@ -1,0 +1,6 @@
+-- 000020_projects.down.sql
+DROP TRIGGER IF EXISTS set_project_mcp_overrides_updated_at ON project_mcp_overrides;
+DROP TRIGGER IF EXISTS set_projects_updated_at ON projects;
+DROP FUNCTION IF EXISTS update_projects_updated_at();
+DROP TABLE IF EXISTS project_mcp_overrides;
+DROP TABLE IF EXISTS projects;

--- a/migrations/000027_projects.up.sql
+++ b/migrations/000027_projects.up.sql
@@ -1,0 +1,45 @@
+-- 000020_projects.up.sql
+-- Project entity for per-group MCP env overrides (Project-as-a-Channel)
+
+CREATE TABLE projects (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    name          VARCHAR(255) NOT NULL,
+    slug          VARCHAR(100) NOT NULL UNIQUE,
+    channel_type  VARCHAR(50),
+    chat_id       VARCHAR(255),
+    team_id       UUID REFERENCES agent_teams(id) ON DELETE SET NULL,
+    description   TEXT,
+    status        VARCHAR(20) NOT NULL DEFAULT 'active',
+    created_by    VARCHAR(255) NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(channel_type, chat_id)
+);
+
+CREATE TABLE project_mcp_overrides (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    project_id    UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    server_name   VARCHAR(255) NOT NULL,
+    env_overrides JSONB NOT NULL DEFAULT '{}',
+    enabled       BOOLEAN NOT NULL DEFAULT true,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(project_id, server_name)
+);
+
+-- Auto-update updated_at on row modification
+CREATE OR REPLACE FUNCTION update_projects_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_projects_updated_at
+    BEFORE UPDATE ON projects
+    FOR EACH ROW EXECUTE FUNCTION update_projects_updated_at();
+
+CREATE TRIGGER set_project_mcp_overrides_updated_at
+    BEFORE UPDATE ON project_mcp_overrides
+    FOR EACH ROW EXECUTE FUNCTION update_projects_updated_at();

--- a/ui/web/src/i18n/locales/en/projects.json
+++ b/ui/web/src/i18n/locales/en/projects.json
@@ -1,0 +1,79 @@
+{
+  "title": "Projects",
+  "description": "Manage project workspaces and their MCP server overrides",
+  "addProject": "New Project",
+  "searchPlaceholder": "Search projects...",
+  "emptyTitle": "No projects",
+  "emptyDescription": "Create your first project to get started.",
+  "noMatchTitle": "No matching projects",
+  "noMatchDescription": "Try a different search term.",
+  "columns": {
+    "name": "Name",
+    "slug": "Slug",
+    "channel": "Channel",
+    "status": "Status",
+    "overrides": "MCP Overrides",
+    "createdBy": "Created By",
+    "actions": "Actions"
+  },
+  "manageOverrides": "Manage MCP overrides",
+  "delete": {
+    "title": "Delete Project",
+    "description": "Are you sure you want to delete \"{{name}}\"? This will also remove all MCP overrides.",
+    "confirmLabel": "Delete"
+  },
+  "form": {
+    "createTitle": "New Project",
+    "editTitle": "Edit Project",
+    "name": "Name *",
+    "slug": "Slug *",
+    "slugHint": "Lowercase letters, numbers, and hyphens only",
+    "channelType": "Channel Type",
+    "channelTypePlaceholder": "Select channel type...",
+    "chatId": "Chat ID",
+    "chatIdPlaceholder": "e.g. -1001234567890",
+    "description": "Description",
+    "descriptionPlaceholder": "Brief description of this project",
+    "status": "Status",
+    "cancel": "Cancel",
+    "create": "Create",
+    "update": "Update",
+    "saving": "Saving...",
+    "errors": {
+      "nameRequired": "Name and slug are required",
+      "slugInvalid": "Slug must be lowercase letters, numbers, and hyphens only"
+    }
+  },
+  "overrides": {
+    "title": "MCP Overrides — {{name}}",
+    "description": "Per-project environment variable overrides for MCP servers. Secret keys (TOKEN, SECRET, PASSWORD, API_KEY) must be set in the global MCP server config.",
+    "serverName": "MCP Server *",
+    "serverNamePlaceholder": "e.g. gitlab, atlassian",
+    "envOverrides": "Environment Variables",
+    "envKeyPlaceholder": "Variable name",
+    "envValuePlaceholder": "Value",
+    "addVariable": "Add Variable",
+    "addOverride": "Add Override",
+    "save": "Save",
+    "saving": "Saving...",
+    "noOverrides": "No MCP overrides configured",
+    "noOverridesDescription": "Add per-project environment variables for MCP servers.",
+    "failedLoad": "Failed to load overrides",
+    "failedSave": "Failed to save override",
+    "failedDelete": "Failed to delete override",
+    "saved": "Override saved",
+    "deleted": "Override deleted"
+  },
+  "status": {
+    "active": "Active",
+    "archived": "Archived"
+  },
+  "toast": {
+    "created": "Project created",
+    "updated": "Project updated",
+    "deleted": "Project deleted",
+    "failedCreate": "Failed to create project",
+    "failedUpdate": "Failed to update project",
+    "failedDelete": "Failed to delete project"
+  }
+}

--- a/ui/web/src/i18n/locales/vi/projects.json
+++ b/ui/web/src/i18n/locales/vi/projects.json
@@ -1,0 +1,79 @@
+{
+  "title": "Dự án",
+  "description": "Quản lý workspace dự án và cấu hình MCP server riêng",
+  "addProject": "Dự án mới",
+  "searchPlaceholder": "Tìm dự án...",
+  "emptyTitle": "Chưa có dự án",
+  "emptyDescription": "Tạo dự án đầu tiên để bắt đầu.",
+  "noMatchTitle": "Không tìm thấy dự án",
+  "noMatchDescription": "Thử từ khóa khác.",
+  "columns": {
+    "name": "Tên",
+    "slug": "Slug",
+    "channel": "Kênh",
+    "status": "Trạng thái",
+    "overrides": "MCP Override",
+    "createdBy": "Người tạo",
+    "actions": "Thao tác"
+  },
+  "manageOverrides": "Quản lý MCP override",
+  "delete": {
+    "title": "Xóa dự án",
+    "description": "Bạn có chắc muốn xóa \"{{name}}\"? Tất cả MCP override cũng sẽ bị xóa.",
+    "confirmLabel": "Xóa"
+  },
+  "form": {
+    "createTitle": "Dự án mới",
+    "editTitle": "Sửa dự án",
+    "name": "Tên *",
+    "slug": "Slug *",
+    "slugHint": "Chỉ chữ thường, số và dấu gạch ngang",
+    "channelType": "Loại kênh",
+    "channelTypePlaceholder": "Chọn loại kênh...",
+    "chatId": "Chat ID",
+    "chatIdPlaceholder": "VD: -1001234567890",
+    "description": "Mô tả",
+    "descriptionPlaceholder": "Mô tả ngắn về dự án",
+    "status": "Trạng thái",
+    "cancel": "Hủy",
+    "create": "Tạo",
+    "update": "Cập nhật",
+    "saving": "Đang lưu...",
+    "errors": {
+      "nameRequired": "Tên và slug là bắt buộc",
+      "slugInvalid": "Slug chỉ được chứa chữ thường, số và dấu gạch ngang"
+    }
+  },
+  "overrides": {
+    "title": "MCP Override — {{name}}",
+    "description": "Biến môi trường riêng cho từng dự án. Các key bí mật (TOKEN, SECRET, PASSWORD, API_KEY) phải đặt trong cấu hình MCP server chung.",
+    "serverName": "MCP Server *",
+    "serverNamePlaceholder": "VD: gitlab, atlassian",
+    "envOverrides": "Biến môi trường",
+    "envKeyPlaceholder": "Tên biến",
+    "envValuePlaceholder": "Giá trị",
+    "addVariable": "Thêm biến",
+    "addOverride": "Thêm Override",
+    "save": "Lưu",
+    "saving": "Đang lưu...",
+    "noOverrides": "Chưa có MCP override",
+    "noOverridesDescription": "Thêm biến môi trường riêng cho MCP server.",
+    "failedLoad": "Không thể tải override",
+    "failedSave": "Không thể lưu override",
+    "failedDelete": "Không thể xóa override",
+    "saved": "Đã lưu override",
+    "deleted": "Đã xóa override"
+  },
+  "status": {
+    "active": "Hoạt động",
+    "archived": "Lưu trữ"
+  },
+  "toast": {
+    "created": "Đã tạo dự án",
+    "updated": "Đã cập nhật dự án",
+    "deleted": "Đã xóa dự án",
+    "failedCreate": "Không thể tạo dự án",
+    "failedUpdate": "Không thể cập nhật dự án",
+    "failedDelete": "Không thể xóa dự án"
+  }
+}

--- a/ui/web/src/i18n/locales/zh/projects.json
+++ b/ui/web/src/i18n/locales/zh/projects.json
@@ -1,0 +1,79 @@
+{
+  "title": "项目",
+  "description": "管理项目工作空间及其 MCP 服务器配置",
+  "addProject": "新建项目",
+  "searchPlaceholder": "搜索项目...",
+  "emptyTitle": "暂无项目",
+  "emptyDescription": "创建第一个项目以开始使用。",
+  "noMatchTitle": "未找到匹配项目",
+  "noMatchDescription": "请尝试其他搜索词。",
+  "columns": {
+    "name": "名称",
+    "slug": "Slug",
+    "channel": "渠道",
+    "status": "状态",
+    "overrides": "MCP 覆盖",
+    "createdBy": "创建者",
+    "actions": "操作"
+  },
+  "manageOverrides": "管理 MCP 覆盖",
+  "delete": {
+    "title": "删除项目",
+    "description": "确定要删除 \"{{name}}\" 吗？所有 MCP 覆盖也将被删除。",
+    "confirmLabel": "删除"
+  },
+  "form": {
+    "createTitle": "新建项目",
+    "editTitle": "编辑项目",
+    "name": "名称 *",
+    "slug": "Slug *",
+    "slugHint": "仅限小写字母、数字和连字符",
+    "channelType": "渠道类型",
+    "channelTypePlaceholder": "选择渠道类型...",
+    "chatId": "Chat ID",
+    "chatIdPlaceholder": "例如 -1001234567890",
+    "description": "描述",
+    "descriptionPlaceholder": "项目简要描述",
+    "status": "状态",
+    "cancel": "取消",
+    "create": "创建",
+    "update": "更新",
+    "saving": "保存中...",
+    "errors": {
+      "nameRequired": "名称和 Slug 为必填项",
+      "slugInvalid": "Slug 仅允许小写字母、数字和连字符"
+    }
+  },
+  "overrides": {
+    "title": "MCP 覆盖 — {{name}}",
+    "description": "每个项目的 MCP 服务器环境变量覆盖。敏感键（TOKEN、SECRET、PASSWORD、API_KEY）须在全局 MCP 服务器配置中设置。",
+    "serverName": "MCP 服务器 *",
+    "serverNamePlaceholder": "例如 gitlab、atlassian",
+    "envOverrides": "环境变量",
+    "envKeyPlaceholder": "变量名",
+    "envValuePlaceholder": "值",
+    "addVariable": "添加变量",
+    "addOverride": "添加覆盖",
+    "save": "保存",
+    "saving": "保存中...",
+    "noOverrides": "暂无 MCP 覆盖",
+    "noOverridesDescription": "为 MCP 服务器添加项目专属环境变量。",
+    "failedLoad": "加载覆盖失败",
+    "failedSave": "保存覆盖失败",
+    "failedDelete": "删除覆盖失败",
+    "saved": "覆盖已保存",
+    "deleted": "覆盖已删除"
+  },
+  "status": {
+    "active": "活跃",
+    "archived": "已归档"
+  },
+  "toast": {
+    "created": "项目已创建",
+    "updated": "项目已更新",
+    "deleted": "项目已删除",
+    "failedCreate": "创建项目失败",
+    "failedUpdate": "更新项目失败",
+    "failedDelete": "删除项目失败"
+  }
+}

--- a/ui/web/src/lib/query-keys.ts
+++ b/ui/web/src/lib/query-keys.ts
@@ -66,6 +66,11 @@ export const queryKeys = {
     all: ["teams"] as const,
     detail: (id: string) => ["teams", id] as const,
   },
+  projects: {
+    all: ["projects"] as const,
+    detail: (id: string) => ["projects", id] as const,
+    overrides: (id: string) => ["projects", id, "overrides"] as const,
+  },
   memory: {
     all: ["memory"] as const,
     list: (params: Record<string, unknown>) => ["memory", params] as const,

--- a/ui/web/src/pages/projects/hooks/use-projects.ts
+++ b/ui/web/src/pages/projects/hooks/use-projects.ts
@@ -1,0 +1,144 @@
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import i18next from "i18next";
+import { useHttp } from "@/hooks/use-ws";
+import { queryKeys } from "@/lib/query-keys";
+import { toast } from "@/stores/use-toast-store";
+
+export interface ProjectData {
+  id: string;
+  name: string;
+  slug: string;
+  channel_type?: string | null;
+  chat_id?: string | null;
+  team_id?: string | null;
+  description?: string | null;
+  status: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProjectInput {
+  name: string;
+  slug: string;
+  channel_type?: string | null;
+  chat_id?: string | null;
+  description?: string | null;
+  status?: string;
+}
+
+export interface ProjectMCPOverride {
+  id: string;
+  project_id: string;
+  server_name: string;
+  env_overrides: Record<string, string>;
+  enabled: boolean;
+}
+
+export function useProjects() {
+  const http = useHttp();
+  const queryClient = useQueryClient();
+
+  const { data: projects = [], isLoading: loading } = useQuery({
+    queryKey: queryKeys.projects.all,
+    queryFn: async () => {
+      const res = await http.get<{ projects: ProjectData[] }>("/v1/projects");
+      return res.projects ?? [];
+    },
+  });
+
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: queryKeys.projects.all }),
+    [queryClient],
+  );
+
+  const createProject = useCallback(
+    async (data: ProjectInput) => {
+      try {
+        const res = await http.post<ProjectData>("/v1/projects", data);
+        await invalidate();
+        toast.success(i18next.t("projects:toast.created"));
+        return res;
+      } catch (err) {
+        toast.error(i18next.t("projects:toast.failedCreate"), err instanceof Error ? err.message : "");
+        throw err;
+      }
+    },
+    [http, invalidate],
+  );
+
+  const updateProject = useCallback(
+    async (id: string, data: Partial<ProjectInput>) => {
+      try {
+        await http.put(`/v1/projects/${id}`, data);
+        await invalidate();
+        toast.success(i18next.t("projects:toast.updated"));
+      } catch (err) {
+        toast.error(i18next.t("projects:toast.failedUpdate"), err instanceof Error ? err.message : "");
+        throw err;
+      }
+    },
+    [http, invalidate],
+  );
+
+  const deleteProject = useCallback(
+    async (id: string) => {
+      try {
+        await http.delete(`/v1/projects/${id}`);
+        await invalidate();
+        toast.success(i18next.t("projects:toast.deleted"));
+      } catch (err) {
+        toast.error(i18next.t("projects:toast.failedDelete"), err instanceof Error ? err.message : "");
+        throw err;
+      }
+    },
+    [http, invalidate],
+  );
+
+  const listOverrides = useCallback(
+    async (projectId: string) => {
+      const res = await http.get<{ overrides: ProjectMCPOverride[] }>(`/v1/projects/${projectId}/mcp`);
+      return res.overrides ?? [];
+    },
+    [http],
+  );
+
+  const setOverride = useCallback(
+    async (projectId: string, serverName: string, envOverrides: Record<string, string>) => {
+      try {
+        await http.put(`/v1/projects/${projectId}/mcp/${serverName}`, envOverrides);
+        toast.success(i18next.t("projects:overrides.saved"));
+      } catch (err) {
+        toast.error(i18next.t("projects:overrides.failedSave"), err instanceof Error ? err.message : "");
+        throw err;
+      }
+    },
+    [http],
+  );
+
+  const removeOverride = useCallback(
+    async (projectId: string, serverName: string) => {
+      try {
+        await http.delete(`/v1/projects/${projectId}/mcp/${serverName}`);
+        toast.success(i18next.t("projects:overrides.deleted"));
+      } catch (err) {
+        toast.error(i18next.t("projects:overrides.failedDelete"), err instanceof Error ? err.message : "");
+        throw err;
+      }
+    },
+    [http],
+  );
+
+  return {
+    projects,
+    loading,
+    refresh: invalidate,
+    createProject,
+    updateProject,
+    deleteProject,
+    listOverrides,
+    setOverride,
+    removeOverride,
+  };
+}

--- a/ui/web/src/pages/projects/project-form-dialog.tsx
+++ b/ui/web/src/pages/projects/project-form-dialog.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { slugify, isValidSlug } from "@/lib/slug";
+import type { ProjectData, ProjectInput } from "./hooks/use-projects";
+
+const CHANNEL_TYPES = [
+  { value: "", label: "—" },
+  { value: "telegram", label: "Telegram" },
+  { value: "zalo_oa", label: "Zalo OA" },
+  { value: "discord", label: "Discord" },
+  { value: "slack", label: "Slack" },
+  { value: "feishu", label: "Feishu/Lark" },
+  { value: "whatsapp", label: "WhatsApp" },
+  { value: "google_chat", label: "Google Chat" },
+];
+
+const STATUS_OPTIONS = [
+  { value: "active", label: "Active" },
+  { value: "archived", label: "Archived" },
+];
+
+interface ProjectFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  project?: ProjectData | null;
+  onSubmit: (data: ProjectInput) => Promise<unknown>;
+}
+
+export function ProjectFormDialog({ open, onOpenChange, project, onSubmit }: ProjectFormDialogProps) {
+  const { t } = useTranslation("projects");
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [channelType, setChannelType] = useState("");
+  const [chatId, setChatId] = useState("");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState("active");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [autoSlug, setAutoSlug] = useState(true);
+
+  useEffect(() => {
+    if (open) {
+      setName(project?.name ?? "");
+      setSlug(project?.slug ?? "");
+      setChannelType(project?.channel_type ?? "");
+      setChatId(project?.chat_id ?? "");
+      setDescription(project?.description ?? "");
+      setStatus(project?.status ?? "active");
+      setError("");
+      setAutoSlug(!project);
+    }
+  }, [open, project]);
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (autoSlug) {
+      setSlug(slugify(value));
+    }
+  };
+
+  const handleSlugChange = (value: string) => {
+    setAutoSlug(false);
+    setSlug(slugify(value));
+  };
+
+  const handleSubmit = async () => {
+    if (!name.trim() || !slug.trim()) {
+      setError(t("form.errors.nameRequired"));
+      return;
+    }
+    if (!isValidSlug(slug)) {
+      setError(t("form.errors.slugInvalid"));
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+    try {
+      await onSubmit({
+        name: name.trim(),
+        slug: slug.trim(),
+        channel_type: channelType || null,
+        chat_id: chatId.trim() || null,
+        description: description.trim() || null,
+        status,
+      });
+      onOpenChange(false);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : t("form.saving"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !loading && onOpenChange(v)}>
+      <DialogContent className="max-h-[85vh] flex flex-col sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{project ? t("form.editTitle") : t("form.createTitle")}</DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2 px-0.5 -mx-0.5 overflow-y-auto min-h-0">
+          <div className="grid gap-1.5">
+            <Label htmlFor="proj-name">{t("form.name")}</Label>
+            <Input id="proj-name" value={name} onChange={(e) => handleNameChange(e.target.value)} placeholder="XPOS" className="text-base md:text-sm" />
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="proj-slug">{t("form.slug")}</Label>
+            <Input id="proj-slug" value={slug} onChange={(e) => handleSlugChange(e.target.value)} placeholder="xpos" className="font-mono text-base md:text-sm" />
+            <p className="text-xs text-muted-foreground">{t("form.slugHint")}</p>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label>{t("form.channelType")}</Label>
+            <Select value={channelType || "__none__"} onValueChange={(v) => setChannelType(v === "__none__" ? "" : v)}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CHANNEL_TYPES.map((ct) => (
+                  <SelectItem key={ct.value || "__none__"} value={ct.value || "__none__"}>{ct.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="proj-chatid">{t("form.chatId")}</Label>
+            <Input id="proj-chatid" value={chatId} onChange={(e) => setChatId(e.target.value)} placeholder={t("form.chatIdPlaceholder")} className="font-mono text-base md:text-sm" />
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="proj-desc">{t("form.description")}</Label>
+            <Textarea
+              id="proj-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t("form.descriptionPlaceholder")}
+              rows={2}
+              className="text-base md:text-sm"
+            />
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label>{t("form.status")}</Label>
+            <Select value={status} onValueChange={setStatus}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_OPTIONS.map((s) => (
+                  <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>{t("form.cancel")}</Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            {loading ? t("form.saving") : project ? t("form.update") : t("form.create")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/web/src/pages/projects/project-overrides-dialog.tsx
+++ b/ui/web/src/pages/projects/project-overrides-dialog.tsx
@@ -1,0 +1,196 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2, Plus, Trash2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { KeyValueEditor } from "@/components/shared/key-value-editor";
+import type { ProjectData, ProjectMCPOverride } from "./hooks/use-projects";
+
+interface ProjectOverridesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  project: ProjectData;
+  onLoadOverrides: (projectId: string) => Promise<ProjectMCPOverride[]>;
+  onSaveOverride: (projectId: string, serverName: string, envOverrides: Record<string, string>) => Promise<void>;
+  onRemoveOverride: (projectId: string, serverName: string) => Promise<void>;
+}
+
+export function ProjectOverridesDialog({
+  open,
+  onOpenChange,
+  project,
+  onLoadOverrides,
+  onSaveOverride,
+  onRemoveOverride,
+}: ProjectOverridesDialogProps) {
+  const { t } = useTranslation("projects");
+  const [overrides, setOverrides] = useState<ProjectMCPOverride[]>([]);
+  const [loadingList, setLoadingList] = useState(false);
+  const [error, setError] = useState("");
+
+  // New override form state
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newServerName, setNewServerName] = useState("");
+  const [newEnv, setNewEnv] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [deletingServer, setDeletingServer] = useState<string | null>(null);
+
+  const loadOverrides = useCallback(async () => {
+    setLoadingList(true);
+    setError("");
+    try {
+      const result = await onLoadOverrides(project.id);
+      setOverrides(result);
+    } catch {
+      setError(t("overrides.failedLoad"));
+    } finally {
+      setLoadingList(false);
+    }
+  }, [onLoadOverrides, project.id, t]);
+
+  useEffect(() => {
+    if (open) {
+      loadOverrides();
+      setShowAddForm(false);
+      setNewServerName("");
+      setNewEnv({});
+    }
+  }, [open, loadOverrides]);
+
+  const handleSave = async () => {
+    if (!newServerName.trim()) return;
+    setSaving(true);
+    try {
+      await onSaveOverride(project.id, newServerName.trim(), newEnv);
+      setShowAddForm(false);
+      setNewServerName("");
+      setNewEnv({});
+      await loadOverrides();
+    } catch {
+      // toast already shown by hook
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (serverName: string) => {
+    setDeletingServer(serverName);
+    try {
+      await onRemoveOverride(project.id, serverName);
+      await loadOverrides();
+    } catch {
+      // toast already shown by hook
+    } finally {
+      setDeletingServer(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] flex flex-col sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{t("overrides.title", { name: project.name })}</DialogTitle>
+          <p className="text-xs text-muted-foreground mt-1">{t("overrides.description")}</p>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto min-h-0 space-y-4 py-2">
+          {loadingList ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : error ? (
+            <p className="text-sm text-destructive text-center py-4">{error}</p>
+          ) : overrides.length === 0 && !showAddForm ? (
+            <div className="text-center py-8">
+              <p className="text-sm text-muted-foreground">{t("overrides.noOverrides")}</p>
+              <p className="text-xs text-muted-foreground mt-1">{t("overrides.noOverridesDescription")}</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {overrides.map((ov) => (
+                <div key={ov.server_name} className="rounded-md border p-3">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="font-mono text-sm font-medium">{ov.server_name}</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(ov.server_name)}
+                      disabled={deletingServer === ov.server_name}
+                      className="text-destructive hover:text-destructive h-7 w-7 p-0"
+                    >
+                      {deletingServer === ov.server_name ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </div>
+                  <div className="space-y-1">
+                    {Object.entries(ov.env_overrides).map(([key, value]) => (
+                      <div key={key} className="flex items-center gap-2 text-xs font-mono">
+                        <span className="text-muted-foreground">{key}</span>
+                        <span>=</span>
+                        <span className="truncate">{value}</span>
+                      </div>
+                    ))}
+                    {Object.keys(ov.env_overrides).length === 0 && (
+                      <span className="text-xs text-muted-foreground italic">No variables</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {showAddForm && (
+            <div className="rounded-md border p-3 space-y-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="override-server">{t("overrides.serverName")}</Label>
+                <Input
+                  id="override-server"
+                  value={newServerName}
+                  onChange={(e) => setNewServerName(e.target.value)}
+                  placeholder={t("overrides.serverNamePlaceholder")}
+                  className="font-mono text-base md:text-sm"
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>{t("overrides.envOverrides")}</Label>
+                <KeyValueEditor
+                  value={newEnv}
+                  onChange={setNewEnv}
+                  keyPlaceholder={t("overrides.envKeyPlaceholder")}
+                  valuePlaceholder={t("overrides.envValuePlaceholder")}
+                  addLabel={t("overrides.addVariable")}
+                />
+              </div>
+              <div className="flex gap-2 justify-end">
+                <Button variant="outline" size="sm" onClick={() => setShowAddForm(false)} disabled={saving}>
+                  {t("form.cancel")}
+                </Button>
+                <Button size="sm" onClick={handleSave} disabled={saving || !newServerName.trim()}>
+                  {saving ? t("overrides.saving") : t("overrides.save")}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {!showAddForm && (
+          <div className="pt-2 border-t">
+            <Button variant="outline" size="sm" onClick={() => setShowAddForm(true)} className="gap-1">
+              <Plus className="h-3.5 w-3.5" /> {t("overrides.addOverride")}
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/web/src/pages/projects/projects-page.tsx
+++ b/ui/web/src/pages/projects/projects-page.tsx
@@ -1,0 +1,216 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { FolderKanban, Plus, RefreshCw, Pencil, Trash2, Plug } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/shared/page-header";
+import { EmptyState } from "@/components/shared/empty-state";
+import { SearchInput } from "@/components/shared/search-input";
+import { Pagination } from "@/components/shared/pagination";
+import { TableSkeleton } from "@/components/shared/loading-skeleton";
+import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
+import { useProjects, type ProjectData, type ProjectInput } from "./hooks/use-projects";
+import { ProjectFormDialog } from "./project-form-dialog";
+import { ProjectOverridesDialog } from "./project-overrides-dialog";
+import { useMinLoading } from "@/hooks/use-min-loading";
+import { useDeferredLoading } from "@/hooks/use-deferred-loading";
+import { usePagination } from "@/hooks/use-pagination";
+
+export function ProjectsPage() {
+  const { t } = useTranslation("projects");
+  const { t: tc } = useTranslation("common");
+  const {
+    projects, loading, refresh,
+    createProject, updateProject, deleteProject,
+    listOverrides, setOverride, removeOverride,
+  } = useProjects();
+  const spinning = useMinLoading(loading);
+  const showSkeleton = useDeferredLoading(loading && projects.length === 0);
+  const [search, setSearch] = useState("");
+  const [formOpen, setFormOpen] = useState(false);
+  const [editProject, setEditProject] = useState<ProjectData | null>(null);
+  const [overridesProject, setOverridesProject] = useState<ProjectData | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<ProjectData | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  const filtered = projects.filter(
+    (p) =>
+      p.name.toLowerCase().includes(search.toLowerCase()) ||
+      p.slug.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const { pageItems, pagination, setPage, setPageSize, resetPage } = usePagination(filtered);
+
+  useEffect(() => { resetPage(); }, [search, resetPage]);
+
+  const handleCreate = async (data: ProjectInput) => {
+    await createProject(data);
+  };
+
+  const handleEdit = async (data: ProjectInput) => {
+    if (!editProject) return;
+    await updateProject(editProject.id, data);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteLoading(true);
+    try {
+      await deleteProject(deleteTarget.id);
+      setDeleteTarget(null);
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 sm:p-6">
+      <PageHeader
+        title={t("title")}
+        description={t("description")}
+        actions={
+          <div className="flex gap-2">
+            <Button size="sm" onClick={() => { setEditProject(null); setFormOpen(true); }} className="gap-1">
+              <Plus className="h-3.5 w-3.5" /> {t("addProject")}
+            </Button>
+            <Button variant="outline" size="sm" onClick={refresh} disabled={spinning} className="gap-1">
+              <RefreshCw className={"h-3.5 w-3.5" + (spinning ? " animate-spin" : "")} /> {tc("refresh")}
+            </Button>
+          </div>
+        }
+      />
+
+      <div className="mt-4">
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder={t("searchPlaceholder")}
+          className="max-w-sm"
+        />
+      </div>
+
+      <div className="mt-4">
+        {showSkeleton ? (
+          <TableSkeleton rows={5} />
+        ) : filtered.length === 0 ? (
+          <EmptyState
+            icon={FolderKanban}
+            title={search ? t("noMatchTitle") : t("emptyTitle")}
+            description={search ? t("noMatchDescription") : t("emptyDescription")}
+          />
+        ) : (
+          <div className="overflow-x-auto rounded-md border">
+            <table className="w-full min-w-[600px] text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="px-4 py-3 text-left font-medium">{t("columns.name")}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t("columns.channel")}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t("columns.status")}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t("columns.createdBy")}</th>
+                  <th className="px-4 py-3 text-right font-medium">{t("columns.actions")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pageItems.map((proj) => (
+                  <tr key={proj.id} className="border-b last:border-0 hover:bg-muted/30">
+                    <td className="px-4 py-3">
+                      <div>
+                        <span className="font-medium">{proj.name}</span>
+                        <span className="ml-1.5 font-mono text-xs text-muted-foreground">({proj.slug})</span>
+                      </div>
+                      {proj.description && (
+                        <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-xs">{proj.description}</p>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {proj.channel_type ? (
+                        <div>
+                          <Badge variant="outline">{proj.channel_type}</Badge>
+                          {proj.chat_id && (
+                            <span className="ml-1.5 font-mono text-[11px] text-muted-foreground">{proj.chat_id}</span>
+                          )}
+                        </div>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge variant={proj.status === "active" ? "default" : "secondary"}>
+                        {t(`status.${proj.status}` as const)}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">{proj.created_by || "—"}</td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setOverridesProject(proj)}
+                          title={t("manageOverrides")}
+                        >
+                          <Plug className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => { setEditProject(proj); setFormOpen(true); }}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setDeleteTarget(proj)}
+                          className="text-destructive hover:text-destructive"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <Pagination
+              page={pagination.page}
+              pageSize={pagination.pageSize}
+              total={pagination.total}
+              totalPages={pagination.totalPages}
+              onPageChange={setPage}
+              onPageSizeChange={setPageSize}
+            />
+          </div>
+        )}
+      </div>
+
+      <ProjectFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        project={editProject}
+        onSubmit={editProject ? handleEdit : handleCreate}
+      />
+
+      {overridesProject && (
+        <ProjectOverridesDialog
+          open={!!overridesProject}
+          onOpenChange={(open) => !open && setOverridesProject(null)}
+          project={overridesProject}
+          onLoadOverrides={listOverrides}
+          onSaveOverride={setOverride}
+          onRemoveOverride={removeOverride}
+        />
+      )}
+
+      <ConfirmDeleteDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        title={t("delete.title")}
+        description={t("delete.description", { name: deleteTarget?.name })}
+        confirmValue={deleteTarget?.name || ""}
+        confirmLabel={t("delete.confirmLabel")}
+        onConfirm={handleDelete}
+        loading={deleteLoading}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Enable **per-project MCP process isolation** where each project gets its own pool entry with merged env vars. Supports multi-tenant deployments where different projects need different MCP server configurations.

### Core pipeline changes

- **Router**: `ResolveOpts` struct + `GetForProject()` with project-scoped cache key
- **Resolver**: passes `projectID` + `projectOverrides` to MCP manager  
- **MCP Manager**: `LoadForAgent` accepts project params, passes to pool
- **MCP Pool**: composite `poolKey` (`name:projectID`) for process isolation, `mergeEnv()` for override merging
- **Consumer**: resolves project at message arrival → propagates through delegation

### New components

- **Project Store**: CRUD + MCP overrides (PostgreSQL)
- **HTTP API**: `/v1/projects` (CRUD), `/v1/projects/:id/overrides`
- **Consumer project resolver**: maps `(channel, chatID)` → project
- **Web Dashboard**: Projects page with form + MCP overrides dialogs
- **Migration 000027**: `projects` + `project_mcp_overrides` tables

## Architecture

```
Message arrives → resolveProjectOverrides(channel, chatID)
  → projectID + overrides propagated in RunRequest
  → Router.GetForProject(agentKey, projectID, overrides)
  → Resolver passes to mcpMgr.LoadForAgent(..., projectID, overrides)
  → MCP Pool uses poolKey = "serverName:projectID" (process isolation)
  → Pool.Acquire merges base env + project overrides
```

## Test plan

- [x] `go build ./cmd/` passes (Linux)
- [x] Unit tests: `gateway_consumer_project_test.go`, `router_project_test.go`, `projects_test.go`
- [ ] E2E: create project with MCP overrides, send message → verify isolated MCP process
- [ ] Verify pool reuse when same project sends multiple messages