### PR TITLE
feat(channels): enforce MediaMaxBytes for outbound media uploads

### DIFF
--- a/internal/channels/discord/send_media.go
+++ b/internal/channels/discord/send_media.go
@@ -21,11 +21,20 @@ func (c *Channel) sendMediaMessage(channelID string, content string, mediaList [
 			continue
 		}
 
+		maxBytes := c.config.MediaMaxBytes
+		if maxBytes <= 0 {
+			maxBytes = defaultMediaMaxBytes
+		}
+
 		f, err := os.Open(filePath)
 		if err != nil {
 			return fmt.Errorf("open media file %s: %w", filePath, err)
 		}
 		defer f.Close()
+
+		if info, err := f.Stat(); err == nil && info.Size() > maxBytes {
+			return fmt.Errorf("outbound media too large: %d bytes (limit %d)", info.Size(), maxBytes)
+		}
 
 		ct := att.ContentType
 		if ct == "" {

--- a/internal/channels/telegram/send.go
+++ b/internal/channels/telegram/send.go
@@ -282,6 +282,20 @@ func (c *Channel) sendMediaMessage(ctx context.Context, chatID int64, msg bus.Ou
 			}
 		}
 
+		// Honor MediaMaxBytes for outbound sends.
+		// Prevents attempting to upload huge files that would fail via Telegram Bot API or local proxy.
+		maxBytes := c.config.MediaMaxBytes
+		if maxBytes == 0 {
+			if c.config.APIServer != "" {
+				maxBytes = localAPIDefaultMaxBytes
+			} else {
+				maxBytes = defaultMediaMaxBytes
+			}
+		}
+		if info, err := os.Stat(media.URL); err == nil && info.Size() > maxBytes {
+			return fmt.Errorf("outbound media too large: %d bytes (limit %d)", info.Size(), maxBytes)
+		}
+
 		// Send based on content type.
 		// Large images (>photoSizeThreshold) are sent as documents to avoid Telegram compression.
 		ct := strings.ToLower(media.ContentType)


### PR DESCRIPTION
## Problem: 
Previously, the `MediaMaxBytes` configuration setting in GoClaw only governed inbound media (downloads from users). Outbound sends (media generated by agents or tools) were not checking any size limits. This meant the bot would attempt to upload massive files (e.g., a 200MB video) through the Telegram or Discord API, leading to:

1. 413 Payload Too Large errors from platform APIs.
2. Generic network timeouts that would hang or block worker goroutines.
3. Wasted server bandwidth and resources on uploads that were guaranteed to fail.

## Solution: 
This PR unifies the MediaMaxBytes behavior so it now governs both directions:
1. Outbound Pre-flight Checks: Both Telegram (`sendMediaMessage`) and Discord (`send_media.go`) now verify the local file size of an attachment against the configured `MediaMaxBytes` before attempting the upload.
2. Descriptive Errors: If an outbound file exceeds the limit, the bot returns a clear error immediately instead of failing silently or Timing out during the network transmission.
