### PR TITLE
feat(providers): enable native Azure OpenAI and Azure AI Foundry support

### DIFF
--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -412,7 +412,12 @@ func (p *OpenAIProvider) doRequest(ctx context.Context, body any) (io.ReadCloser
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	// Azure OpenAI/Foundry support for now atleast
+	if strings.Contains(strings.ToLower(p.apiBase), "azure.com") {
+		httpReq.Header.Set("api-key", p.apiKey)
+	} else {
+		httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
 
 	resp, err := p.client.Do(httpReq)
 	if err != nil {


### PR DESCRIPTION
## Problem: 
GoClaw’s generic `OpenAIProvider` currently relies on standard `Authorization: Bearer` headers for all OpenAI-compatible endpoints. However, Azure OpenAI and Azure AI Foundry require an `api-key` header instead of the standard bearer token. This prevented users from natively using Azure-hosted models as generic providers without an external proxy to handle header translation.

## Solution: 
This PR adds a minimal detection logic to the `OpenAIProvider` 