### PR TITLE
fix(mcp): add empty properties to object schemas for OpenAI compat

### DIFF
--- a/internal/mcp/bridge_tool.go
+++ b/internal/mcp/bridge_tool.go
@@ -125,6 +125,9 @@ func inputSchemaToMap(schema mcpgo.ToolInputSchema) map[string]any {
 	}
 	if len(schema.Properties) > 0 {
 		m["properties"] = schema.Properties
+	} else if m["type"] == "object" {
+		// OpenAI requires "properties" even when empty for object schemas.
+		m["properties"] = map[string]any{}
 	}
 	if len(schema.Required) > 0 {
 		m["required"] = schema.Required

--- a/internal/mcp/bridge_tool_test.go
+++ b/internal/mcp/bridge_tool_test.go
@@ -47,6 +47,19 @@ func TestInputSchemaToMap_EmptyType(t *testing.T) {
 	}
 }
 
+func TestInputSchemaToMap_ObjectNoProperties(t *testing.T) {
+	schema := mcpgo.ToolInputSchema{Type: "object"}
+	m := inputSchemaToMap(schema)
+
+	props, ok := m["properties"].(map[string]any)
+	if !ok || props == nil {
+		t.Fatal("expected empty properties map for object schema, got nil — OpenAI rejects object schemas without properties")
+	}
+	if len(props) != 0 {
+		t.Errorf("expected empty properties, got %v", props)
+	}
+}
+
 func TestExtractTextContent(t *testing.T) {
 	result := &mcpgo.CallToolResult{
 		Content: []mcpgo.Content{


### PR DESCRIPTION
## Summary
- MCP tools that accept no parameters return `{type: "object"}` without `properties` — valid per JSON Schema spec, but OpenAI API strictly requires `properties` on object schemas
- Requests fail with HTTP 400: `"object schema missing properties"` when any MCP tool has a no-param schema
- Add default empty `properties: {}` in `inputSchemaToMap()` when type is `object` and MCP server provides none

## Reproduction
1. Connect an MCP server with a tool that takes no parameters (e.g. `list_team`, `list_tasks`)
2. Use an OpenAI-compatible provider (Codex, GPT, etc.)
3. Send any message → HTTP 400 on first LLM call

## Test plan
- [x] Added `TestInputSchemaToMap_ObjectNoProperties` — verifies empty properties map is present
- [ ] Manual: MCP tool with no params works with OpenAI provider