### PR TITLE
fix(pkg-helper): fix apk-packages persist file not writable in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,11 +97,18 @@ RUN set -eux; \
 RUN chmod +x /app/docker-entrypoint.sh && \
     chmod 755 /app/pkg-helper && chown root:root /app/pkg-helper
 
-# Create data directories (owned by goclaw user).
-# Binaries and entrypoint stay root-owned (readable by all).
-RUN mkdir -p /app/workspace /app/data /app/skills /app/tsnet-state /app/.goclaw \
-    && chown -R goclaw:goclaw /app/workspace /app/data /app/skills /app/tsnet-state /app/.goclaw \
-    && chown goclaw:goclaw /app/bundled-skills
+# Create data directories.
+# .runtime has split ownership: root owns the dir (so pkg-helper can write apk-packages),
+# while pip/npm subdirs are goclaw-owned (runtime installs by the app process).
+RUN mkdir -p /app/workspace /app/data/.runtime/pip /app/data/.runtime/npm-global/lib \
+        /app/data/.runtime/pip-cache /app/skills /app/tsnet-state /app/.goclaw \
+    && touch /app/data/.runtime/apk-packages \
+    && chown -R goclaw:goclaw /app/workspace /app/skills /app/tsnet-state /app/.goclaw \
+    && chown goclaw:goclaw /app/bundled-skills /app/data \
+    && chown root:goclaw /app/data/.runtime /app/data/.runtime/apk-packages \
+    && chmod 0750 /app/data/.runtime \
+    && chmod 0640 /app/data/.runtime/apk-packages \
+    && chown -R goclaw:goclaw /app/data/.runtime/pip /app/data/.runtime/npm-global /app/data/.runtime/pip-cache
 
 # Default environment
 ENV GOCLAW_CONFIG=/app/config.json \

--- a/cmd/pkg-helper/main.go
+++ b/cmd/pkg-helper/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
@@ -61,6 +62,9 @@ func main() {
 	if err := os.Chmod(socketPath, 0660); err != nil {
 		slog.Warn("pkg-helper: chmod socket failed", "error", err)
 	}
+
+	// Ensure persist directory is writable by root (self-healing for upgrades).
+	ensurePersistDir()
 
 	// Graceful shutdown on SIGTERM/SIGINT.
 	sigCh := make(chan os.Signal, 1)
@@ -222,4 +226,30 @@ func apkListFile() string {
 		runtimeDir = "/app/data/.runtime"
 	}
 	return runtimeDir + "/apk-packages"
+}
+
+// ensurePersistDir ensures the apk persist file's parent directory is writable by root.
+// On existing volumes the directory may be goclaw-owned (from older images); fix ownership
+// using CAP_CHOWN so pkg-helper can create/write the persist file.
+func ensurePersistDir() {
+	dir := filepath.Dir(apkListFile())
+	fi, err := os.Stat(dir)
+	if err != nil {
+		// Directory doesn't exist — entrypoint should have created it.
+		return
+	}
+	if !fi.IsDir() {
+		return
+	}
+
+	// Try to fix ownership to root:goclaw (gid 1000) if not already root-owned.
+	// CAP_CHOWN is available even when CAP_DAC_OVERRIDE is dropped.
+	if stat, ok := fi.Sys().(*syscall.Stat_t); ok && stat.Uid != 0 {
+		if err := os.Chown(dir, 0, 1000); err != nil {
+			slog.Warn("pkg-helper: cannot fix persist dir ownership", "dir", dir, "error", err)
+		} else {
+			os.Chmod(dir, 0750) //nolint:errcheck
+			slog.Info("pkg-helper: fixed persist dir ownership", "dir", dir)
+		}
+	}
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,14 +7,23 @@ RUNTIME_DIR="/app/data/.runtime"
 # Non-fatal: on first start with a fresh volume the directory may not be
 # writable yet (volume initialisation race on some Docker runtimes).
 # The app starts fine without .runtime; package installs will fail gracefully.
-mkdir -p "$RUNTIME_DIR/pip" "$RUNTIME_DIR/npm-global/lib" || true
+mkdir -p "$RUNTIME_DIR/pip" "$RUNTIME_DIR/npm-global/lib" "$RUNTIME_DIR/pip-cache" || true
+
+# Fix .runtime ownership for split root/goclaw access.
+# .runtime itself must be root-owned so pkg-helper (root) can write apk-packages.
+# Subdirs pip/, npm-global/, pip-cache/ must be goclaw-owned for runtime installs.
+# This also handles upgrades from older images where .runtime was fully goclaw-owned.
+if [ "$(id -u)" = "0" ] && [ -d "$RUNTIME_DIR" ]; then
+  chown root:goclaw "$RUNTIME_DIR" 2>/dev/null || true
+  chmod 0750 "$RUNTIME_DIR" 2>/dev/null || true
+  chown -R goclaw:goclaw "$RUNTIME_DIR/pip" "$RUNTIME_DIR/npm-global" "$RUNTIME_DIR/pip-cache" 2>/dev/null || true
+fi
 
 # Python: allow agent to pip install to writable target dir
 export PYTHONPATH="$RUNTIME_DIR/pip:${PYTHONPATH:-}"
 export PIP_TARGET="$RUNTIME_DIR/pip"
 export PIP_BREAK_SYSTEM_PACKAGES=1
 export PIP_CACHE_DIR="$RUNTIME_DIR/pip-cache"
-mkdir -p "$RUNTIME_DIR/pip-cache" || true
 
 # Node.js: allow agent to npm install -g to writable prefix
 # NODE_PATH includes both pre-installed system globals and runtime-installed globals.
@@ -23,11 +32,10 @@ export NODE_PATH="/usr/local/lib/node_modules:$RUNTIME_DIR/npm-global/lib/node_m
 export PATH="$RUNTIME_DIR/npm-global/bin:$RUNTIME_DIR/pip/bin:$PATH"
 
 # System packages: re-install on-demand packages persisted across recreates.
-# In Docker: entrypoint runs as root (then drops via su-exec).
-# Outside Docker: may run as non-root — skip privileged operations gracefully.
+# After chown above, root owns .runtime and can create this file.
 APK_LIST="$RUNTIME_DIR/apk-packages"
-touch "$APK_LIST" 2>/dev/null || true
 if [ "$(id -u)" = "0" ]; then
+  touch "$APK_LIST" 2>/dev/null || true
   chown root:goclaw "$APK_LIST" 2>/dev/null || true
   chmod 0640 "$APK_LIST" 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary

Runtime-installed system packages (e.g. `bash`, `pandoc`) are lost on container recreate because pkg-helper cannot write the persist file.

**Root cause:** `.runtime/` directory on the data volume is owned by `goclaw:goclaw`. pkg-helper runs as root but without `CAP_DAC_OVERRIDE` (dropped in docker-compose.yml), so `persistAdd()` fails with "permission denied". The entrypoint's `touch` also fails silently (`|| true`).

**Fix:** Set `.runtime/` ownership to `root:goclaw` (mode 0750) — root can write `apk-packages`, goclaw can still traverse for pip/npm subdirs. Three layers:

- **Dockerfile**: pre-create `.runtime` with split ownership (`root:goclaw` for dir, `goclaw:goclaw` for pip/npm subdirs)
- **docker-entrypoint.sh**: fix ownership on existing volumes (upgrade path, uses `CAP_CHOWN`)
- **pkg-helper**: `ensurePersistDir()` at startup as defense-in-depth

## Test plan

- [x] Fresh volume: deploy from scratch → install system package via UI → recreate container → package persists
- [x] Existing volume (upgrade): deploy over older image where `.runtime` is `goclaw:goclaw` → entrypoint fixes ownership → install works
- [x] pip/npm packages unaffected — subdirs remain `goclaw:goclaw`
- [ ] Verify pkg-helper logs show no "persist add failed" warnings

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)