### PR TITLE
patricksign/fix context leak, error scan, publish inboud block when b.inbound <- …

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -187,6 +187,10 @@ func checkDBChannels(db *sql.DB) {
 		label := fmt.Sprintf("%s/%s", channelType, name)
 		fmt.Printf("    %-24s %s\n", label+":", status)
 	}
+	if err := rows.Err(); err != nil {
+		fmt.Printf("    (error reading channels: %s)\n", err)
+		return
+	}
 	if !found {
 		fmt.Println("    (none configured in database)")
 	}
@@ -217,6 +221,10 @@ func checkDBProviders(db *sql.DB) {
 			status += " (no API key)"
 		}
 		fmt.Printf("    %-16s %s\n", displayName+":", status)
+	}
+	if err := rows.Err(); err != nil {
+		fmt.Printf("    (error reading providers: %s)\n", err)
+		return
 	}
 	if !found {
 		fmt.Println("    (none configured in database)")

--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -145,7 +146,9 @@ func processNormalMessage(
 	// Fire-and-forget: don't block message processing.
 	if teamStore != nil && msg.Channel != tools.ChannelSystem && msg.Channel != tools.ChannelTeammate && msg.Channel != tools.ChannelDashboard {
 		go func(ch, cid string) {
-			if n, err := teamStore.ClearFollowupByScope(ctx, ch, cid); err != nil {
+			bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if n, err := teamStore.ClearFollowupByScope(bgCtx, ch, cid); err != nil {
 				slog.Warn("auto-clear followup failed", "channel", ch, "chat_id", cid, "error", err)
 			} else if n > 0 {
 				slog.Info("auto-clear followup: cleared", "channel", ch, "chat_id", cid, "count", n)

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -328,7 +328,10 @@ func (c *BaseChannel) HandleMessage(senderID, chatID, content string, media []st
 		AgentID:  c.agentID,
 	}
 
-	c.bus.PublishInbound(msg)
+	if !c.bus.TryPublishInbound(msg) {
+		slog.Warn("bus.inbound full, message dropped",
+			"channel", c.name, "sender_id", senderID, "chat_id", chatID)
+	}
 }
 
 // GroupMember represents a member of a group chat.

--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -258,7 +258,7 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 	}
 
 	// Publish directly to bus (to preserve MediaFile MIME types)
-	c.Bus().PublishInbound(bus.InboundMessage{
+	if !c.Bus().TryPublishInbound(bus.InboundMessage{
 		Channel:  c.Name(),
 		SenderID: senderID,
 		ChatID:   channelID,
@@ -268,7 +268,10 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 		UserID:   senderID,
 		AgentID:  targetAgentID,
 		Metadata: metadata,
-	})
+	}) {
+		slog.Warn("bus.inbound full, message dropped",
+			"channel", "discord", "sender_id", senderID, "chat_id", channelID)
+	}
 
 	// Clear pending history after sending to agent.
 	if peerKind == "group" {

--- a/internal/channels/feishu/bot.go
+++ b/internal/channels/feishu/bot.go
@@ -247,7 +247,7 @@ func (c *Channel) handleMessageEvent(ctx context.Context, event *MessageEvent) {
 	userID := mc.SenderID
 
 	// 13. Publish to bus directly (to preserve MediaFile MIME types)
-	c.Bus().PublishInbound(bus.InboundMessage{
+	if !c.Bus().TryPublishInbound(bus.InboundMessage{
 		Channel:      c.Name(),
 		SenderID:     mc.SenderID,
 		ChatID:       chatID,
@@ -258,7 +258,10 @@ func (c *Channel) handleMessageEvent(ctx context.Context, event *MessageEvent) {
 		AgentID:      targetAgentID,
 		HistoryLimit: c.historyLimit,
 		Metadata:     metadata,
-	})
+	}) {
+		slog.Warn("bus.inbound full, message dropped",
+			"channel", "feishu", "sender_id", mc.SenderID, "chat_id", chatID)
+	}
 
 	// Clear pending history after sending to agent.
 	if mc.ChatType == "group" {

--- a/internal/channels/quota.go
+++ b/internal/channels/quota.go
@@ -258,6 +258,9 @@ func (qc *QuotaChecker) Usage(ctx context.Context) QuotaUsageResult {
 			Week:   QuotaUsage{Used: week, Limit: window.Week},
 		})
 	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("quota.usage: error iterating user counts", "error", err)
+	}
 
 	QueryTodaySummary(ctx, qc.db, &result)
 	return result

--- a/internal/channels/slack/utils.go
+++ b/internal/channels/slack/utils.go
@@ -35,7 +35,7 @@ func (c *Channel) HandleMessage(senderID, chatID, content string, mediaPaths []s
 		cc.EnsureContact(context.Background(), c.Type(), c.Name(), userID, userID, metadata["username"], "", peerKind)
 	}
 
-	c.Bus().PublishInbound(bus.InboundMessage{
+	if !c.Bus().TryPublishInbound(bus.InboundMessage{
 		Channel:  c.Name(),
 		SenderID: senderID,
 		ChatID:   chatID,
@@ -45,7 +45,10 @@ func (c *Channel) HandleMessage(senderID, chatID, content string, mediaPaths []s
 		UserID:   userID,
 		Metadata: metadata,
 		AgentID:  c.AgentID(),
-	})
+	}) {
+		slog.Warn("bus.inbound full, message dropped",
+			"channel", "slack", "sender_id", senderID, "chat_id", chatID)
+	}
 }
 
 // BlockReplyEnabled returns the per-channel block_reply override.

--- a/internal/channels/telegram/commands.go
+++ b/internal/channels/telegram/commands.go
@@ -116,7 +116,7 @@ func (c *Channel) handleBotCommand(ctx context.Context, message *telego.Message,
 		if isGroup {
 			peerKind = "group"
 		}
-		c.Bus().PublishInbound(bus.InboundMessage{
+		if !c.Bus().TryPublishInbound(bus.InboundMessage{
 			Channel:  c.Name(),
 			SenderID: senderID,
 			ChatID:   chatIDStr,
@@ -130,7 +130,10 @@ func (c *Channel) handleBotCommand(ctx context.Context, message *telego.Message,
 				"is_forum":          fmt.Sprintf("%t", isForum),
 				"message_thread_id": fmt.Sprintf("%d", messageThreadID),
 			},
-		})
+		}) {
+			slog.Warn("bus.inbound full, message dropped",
+				"channel", "telegram", "command", "reset", "sender_id", senderID, "chat_id", chatIDStr)
+		}
 		msg := tu.Message(chatIDObj, "Conversation history has been reset.")
 		setThread(msg)
 		c.bot.SendMessage(ctx, msg)
@@ -141,7 +144,7 @@ func (c *Channel) handleBotCommand(ctx context.Context, message *telego.Message,
 		if isGroup {
 			peerKind = "group"
 		}
-		c.Bus().PublishInbound(bus.InboundMessage{
+		if !c.Bus().TryPublishInbound(bus.InboundMessage{
 			Channel:  c.Name(),
 			SenderID: senderID,
 			ChatID:   chatIDStr,
@@ -155,7 +158,10 @@ func (c *Channel) handleBotCommand(ctx context.Context, message *telego.Message,
 				"is_forum":          fmt.Sprintf("%t", isForum),
 				"message_thread_id": fmt.Sprintf("%d", messageThreadID),
 			},
-		})
+		}) {
+			slog.Warn("bus.inbound full, message dropped",
+				"channel", "telegram", "command", "stop", "sender_id", senderID, "chat_id", chatIDStr)
+		}
 		// Feedback is sent by the consumer after cancel result is known.
 		return true
 
@@ -164,7 +170,7 @@ func (c *Channel) handleBotCommand(ctx context.Context, message *telego.Message,
 		if isGroup {
 			peerKind = "group"
 		}
-		c.Bus().PublishInbound(bus.InboundMessage{
+		if !c.Bus().TryPublishInbound(bus.InboundMessage{
 			Channel:  c.Name(),
 			SenderID: senderID,
 			ChatID:   chatIDStr,
@@ -178,7 +184,10 @@ func (c *Channel) handleBotCommand(ctx context.Context, message *telego.Message,
 				"is_forum":          fmt.Sprintf("%t", isForum),
 				"message_thread_id": fmt.Sprintf("%d", messageThreadID),
 			},
-		})
+		}) {
+			slog.Warn("bus.inbound full, message dropped",
+				"channel", "telegram", "command", "stopall", "sender_id", senderID, "chat_id", chatIDStr)
+		}
 		// Feedback is sent by the consumer after cancel result is known.
 		return true
 

--- a/internal/channels/telegram/handlers.go
+++ b/internal/channels/telegram/handlers.go
@@ -513,7 +513,7 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 		cc.EnsureContact(ctx, c.Type(), c.Name(), senderID, userID, user.FirstName, user.Username, peerKind)
 	}
 
-	c.Bus().PublishInbound(bus.InboundMessage{
+	if !c.Bus().TryPublishInbound(bus.InboundMessage{
 		Channel:      c.Name(),
 		SenderID:     senderID,
 		ChatID:       chatIDStr,
@@ -525,7 +525,10 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 		HistoryLimit: c.historyLimit,
 		ToolAllow:    topicCfg.tools,
 		Metadata:     metadata,
-	})
+	}) {
+		slog.Warn("bus.inbound full, message dropped",
+			"channel", "telegram", "sender_id", senderID, "chat_id", chatIDStr)
+	}
 
 	// Clear pending history after sending to agent.
 	if isGroup {

--- a/internal/store/pg/agents_context.go
+++ b/internal/store/pg/agents_context.go
@@ -32,6 +32,9 @@ func (s *PGAgentStore) GetAgentContextFiles(ctx context.Context, agentID uuid.UU
 		}
 		result = append(result, d)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -62,6 +65,9 @@ func (s *PGAgentStore) GetUserContextFiles(ctx context.Context, agentID uuid.UUI
 			continue
 		}
 		result = append(result, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -157,6 +163,9 @@ func (s *PGAgentStore) ListUserInstances(ctx context.Context, agentID uuid.UUID)
 			json.Unmarshal(metaJSON, &d.Metadata)
 		}
 		result = append(result, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/internal/store/pg/cron_crud.go
+++ b/internal/store/pg/cron_crud.go
@@ -135,6 +135,9 @@ func (s *PGCronStore) ListJobs(includeDisabled bool, agentID, userID string) []s
 		}
 		result = append(result, *job)
 	}
+	if err := rows.Err(); err != nil {
+		return nil
+	}
 	return result
 }
 

--- a/internal/store/pg/mcp_servers_access.go
+++ b/internal/store/pg/mcp_servers_access.go
@@ -60,6 +60,9 @@ func (s *PGMCPServerStore) ListAgentGrants(ctx context.Context, agentID uuid.UUI
 		}
 		result = append(result, g)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -83,6 +86,9 @@ func (s *PGMCPServerStore) ListServerGrants(ctx context.Context, serverID uuid.U
 		}
 		result = append(result, g)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -104,6 +110,9 @@ func (s *PGMCPServerStore) CountAgentGrantsByServer(ctx context.Context) (map[uu
 			continue
 		}
 		result[serverID] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -198,6 +207,9 @@ func (s *PGMCPServerStore) ListAccessible(ctx context.Context, agentID uuid.UUID
 		}
 		result = append(result, info)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -247,6 +259,9 @@ func (s *PGMCPServerStore) ListPendingRequests(ctx context.Context) ([]store.MCP
 		r.ReviewedBy = derefStr(reviewedBy)
 		r.ReviewNote = derefStr(reviewNote)
 		result = append(result, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/internal/store/pg/memory_admin.go
+++ b/internal/store/pg/memory_admin.go
@@ -37,6 +37,9 @@ func (s *PGMemoryStore) ListAllDocumentsGlobal(ctx context.Context) ([]store.Doc
 		}
 		result = append(result, info)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -70,6 +73,9 @@ func (s *PGMemoryStore) ListAllDocuments(ctx context.Context, agentID string) ([
 			info.UserID = *uid
 		}
 		result = append(result, info)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -158,6 +164,9 @@ func (s *PGMemoryStore) ListChunks(ctx context.Context, agentID, userID, path st
 			continue
 		}
 		result = append(result, ci)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/internal/store/pg/memory_docs.go
+++ b/internal/store/pg/memory_docs.go
@@ -141,6 +141,9 @@ func (s *PGMemoryStore) ListDocuments(ctx context.Context, agentID, userID strin
 		}
 		result = append(result, info)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -342,6 +345,10 @@ func (s *PGMemoryStore) BackfillEmbeddings(ctx context.Context) (int, error) {
 				continue
 			}
 			chunks = append(chunks, c)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return total, fmt.Errorf("iterate chunks without embeddings: %w", err)
 		}
 		rows.Close()
 

--- a/internal/store/pg/providers.go
+++ b/internal/store/pg/providers.go
@@ -105,6 +105,9 @@ func (s *PGProviderStore) ListProviders(ctx context.Context) ([]store.LLMProvide
 		p.APIKey = s.decryptKey(apiKey, p.Name)
 		result = append(result, p)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 

--- a/internal/store/pg/skills_admin.go
+++ b/internal/store/pg/skills_admin.go
@@ -92,6 +92,9 @@ func (s *PGSkillStore) ListSystemSkillDirs() map[string]string {
 		}
 		dirs[slug] = path
 	}
+	if err := rows.Err(); err != nil {
+		return nil
+	}
 	return dirs
 }
 


### PR DESCRIPTION
### Summary

**1. Missing rows.Err() Checks**

  Problem: After for rows.Next() loops in 10+ PostgreSQL store files, rows.Err() was never checked. If the database connection drops or a query times out
  mid-iteration, the loop exits silently with partial results — callers receive incomplete data without any error signal.

  Fix: Added rows.Err() check after every for rows.Next() loop (18 checks across 9 files). Each check matches the function's return signature.

**2. Goroutine Context Leak**

  Problem: In gateway_consumer_normal.go, a fire-and-forget goroutine calling ClearFollowupByScope captured the parent request-scoped ctx. Once the request
  handler returned and cancelled that context, the DB call inside the goroutine failed silently.

  Fix: Replaced the request-scoped ctx with context.WithTimeout(context.Background(), 5*time.Second) so the goroutine has its own independent lifecycle.

**3. Blocking PublishInbound Deadlock**

  **Problem**: Channel handlers (Telegram, Slack, Feishu, Discord) called PublishInbound, which performs a blocking channel send. When the inbound buffer (cap 500)
  was full, all handler goroutines blocked indefinitely — cascading into a full system freeze.

  **Fix**: Replaced 8 PublishInbound calls in 6 channel handler files with TryPublishInbound (non-blocking select/default). Dropped messages are logged via slog.Warn
  for observability.

---

### Test Plan

- Build & static analysis: go build ./... and go vet ./... — no errors
  - Race detector: go test -race ./... — all 26 test packages pass, zero races detected
  - Integration tests: go test -race ./tests/integration/ — no regressions
  - rows.Err() coverage:
    - Simulate DB connection drop mid-scan → store functions return error instead of partial results
    - cmd/doctor.go prints error instead of showing incomplete lists
  - Goroutine context leak:
    - Trigger ClearFollowupByScope via chat → verify followup is cleared in DB
    - No context cancellation errors in logs
  - PublishInbound deadlock:
    - High-volume messages through Telegram/Slack/Discord simultaneously
    - Channel handlers stay responsive when agent processing is slow
    - slog.Warn("bus.inbound full, message dropped") appears when buffer saturates
    - Internal consumers still use blocking PublishInbound — no internal message loss
  - End-to-end regression: Normal message flow per channel works with no drops under normal load