### PR TITLE
fix(ui): fix chat nav route and crypto.randomUUID in non-secure contexts

### DIFF
--- a/ui/web/src/components/layout/sidebar.tsx
+++ b/ui/web/src/components/layout/sidebar.tsx
@@ -73,7 +73,7 @@ export function Sidebar({ collapsed, onNavItemClick }: SidebarProps) {
       <nav className="flex-1 space-y-4 overflow-y-auto px-2 py-4">
         <SidebarGroup label={t("groups.core")} collapsed={collapsed}>
           <SidebarItem to={ROUTES.OVERVIEW} icon={LayoutDashboard} label={t("nav.overview")} collapsed={collapsed} />
-          <SidebarItem to={ROUTES.CHAT} icon={MessageSquare} label={t("nav.chat")} collapsed={collapsed} />
+          <SidebarItem to="/chat" icon={MessageSquare} label={t("nav.chat")} collapsed={collapsed} />
           <SidebarItem to={ROUTES.AGENTS} icon={Bot} label={t("nav.agents")} collapsed={collapsed} />
           <SidebarItem to={ROUTES.TEAMS} icon={Users} label={t("nav.agentTeams")} collapsed={collapsed} />
         </SidebarGroup>

--- a/ui/web/src/pages/chat/chat-page.tsx
+++ b/ui/web/src/pages/chat/chat-page.tsx
@@ -15,6 +15,7 @@ import { useChatMessages } from "./hooks/use-chat-messages";
 import { useChatSend } from "./hooks/use-chat-send";
 import { isOwnSession, parseSessionKey } from "@/lib/session-key";
 import { useVirtualKeyboard } from "@/hooks/use-virtual-keyboard";
+import { generateId } from "@/lib/utils";
 
 export function ChatPage() {
   const { t } = useTranslation("chat");
@@ -114,7 +115,7 @@ export function ChatPage() {
   const handleAgentChange = useCallback(
     (newAgentId: string) => {
       setAgentId(newAgentId);
-      navigate(`/chat/${encodeURIComponent(`agent:${newAgentId}:ws:direct:${crypto.randomUUID()}`)}`);
+      navigate(`/chat/${encodeURIComponent(`agent:${newAgentId}:ws:direct:${generateId()}`)}`);
     },
     [navigate],
   );

--- a/ui/web/src/pages/chat/hooks/use-chat-send.ts
+++ b/ui/web/src/pages/chat/hooks/use-chat-send.ts
@@ -34,7 +34,11 @@ export function useChatSend({
     async (message: string, sessionKey: string, files?: AttachedFile[]) => {
       const hasMessage = message.trim().length > 0;
       const hasFiles = files && files.length > 0;
-      if (!ws.isConnected || (!hasMessage && !hasFiles) || !sessionKey) return;
+      if (!ws.isConnected) {
+        setError("Not connected. Please wait for the connection to be established.");
+        return;
+      }
+      if ((!hasMessage && !hasFiles) || !sessionKey) return;
 
       const trimmed = message.trim();
       setError(null);

--- a/ui/web/src/pages/chat/hooks/use-chat-sessions.ts
+++ b/ui/web/src/pages/chat/hooks/use-chat-sessions.ts
@@ -7,6 +7,7 @@ import { useAuthStore } from "@/stores/use-auth-store";
 import { toast } from "@/stores/use-toast-store";
 import i18next from "i18next";
 import { userFriendlyError } from "@/lib/error-utils";
+import { generateId } from "@/lib/utils";
 
 /**
  * Manages the session list for the chat sidebar.
@@ -45,7 +46,7 @@ export function useChatSessions(agentId: string) {
   }, [loadSessions]);
 
   const buildNewSessionKey = useCallback(() => {
-    const convId = crypto.randomUUID();
+    const convId = generateId();
     return `agent:${agentId}:ws:direct:${convId}`;
   }, [agentId]);
 

--- a/ui/web/src/pages/skills/skill-upload-dialog.tsx
+++ b/ui/web/src/pages/skills/skill-upload-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { validateSkillZip } from "./lib/validate-skill-zip";
+import { generateId } from "@/lib/utils";
 
 type FileStatus = "validating" | "valid" | "invalid" | "uploading" | "success" | "error";
 
@@ -46,7 +47,7 @@ export function SkillUploadDialog({ open, onOpenChange, onUpload }: SkillUploadD
     if (fresh.length === 0) return;
 
     const pending: FileEntry[] = fresh.map((f) => ({
-      id: crypto.randomUUID(),
+      id: generateId(),
       file: f,
       status: "validating" as const,
     }));


### PR DESCRIPTION
## Summary

- **sidebar nav**: `ROUTES.CHAT` (`/chat/:sessionKey?`) was used as a navigation target, causing the browser to literally navigate to `/chat/:sessionKey?` instead of `/chat`. Fixed by using the hardcoded `"/chat"` string.
- **`crypto.randomUUID` crash**: `buildNewSessionKey()`, `handleAgentChange()`, and `skill-upload-dialog` called bare `crypto.randomUUID()` which is only available in secure contexts (HTTPS/localhost). On HTTP the call threw `TypeError: crypto.randomUUID is not a function`, silently aborting the send. Fixed by replacing all calls with `generateId()` from `@/lib/utils` which already had the correct fallback.
- **`use-chat-send` UX**: split the silent `!ws.isConnected || ...` guard into a separate branch that sets a visible error message so users see feedback when the WebSocket is not ready.

## Test Plan

- [x] Build passes: `pnpm build` ✓
- [x] Navigating to Chat from sidebar opens `/chat` (not `/chat/:sessionKey?`)
- [x] Typing a message and clicking Send on HTTP successfully calls `chat.send` (verified via server logs)
- [x] New chat session key generated correctly on HTTP deployment