### PR TITLE
feat(login): add theme toggle to login page

### DIFF
--- a/ui/web/src/pages/login/login-layout.tsx
+++ b/ui/web/src/pages/login/login-layout.tsx
@@ -1,11 +1,32 @@
+import { Moon, Sun } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useUiStore } from "@/stores/use-ui-store";
+
 interface LoginLayoutProps {
   children: React.ReactNode;
   subtitle?: string;
 }
 
 export function LoginLayout({ children, subtitle }: LoginLayoutProps) {
+  const { t } = useTranslation("topbar");
+  const theme = useUiStore((s) => s.theme);
+  const setTheme = useUiStore((s) => s.setTheme);
+  const isDark =
+    theme === "dark" ||
+    (theme === "system" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-background px-4">
+    <div className="relative flex min-h-dvh items-center justify-center bg-background px-4">
+      <button
+        type="button"
+        onClick={() => setTheme(isDark ? "light" : "dark")}
+        className="absolute top-4 right-4 cursor-pointer rounded-md border bg-card p-2 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+        title={t("toggleTheme")}
+        aria-label={t("toggleTheme")}
+      >
+        {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      </button>
       <div className="w-full max-w-sm space-y-6 rounded-lg border bg-card p-6 shadow-sm sm:p-8">
         <div className="text-center">
           <h1 className="text-2xl font-semibold tracking-tight">GoClaw</h1>


### PR DESCRIPTION
## Summary
- add a light/dark toggle to the unauthenticated login screen
- reuse the existing UI theme store instead of introducing a second theme mechanism
- keep the change isolated to the login layout

## Verification
- `pnpm build`
- browser check on `/login`: clean first visit starts dark, toggle switches page to light and persists `goclaw:theme=light`
- `pnpm lint` currently fails because the repo does not have `eslint` installed (`sh: eslint: command not found`)

Closes #353
