### PR TITLE
feat(http): add REST API endpoints for team management

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -308,7 +308,7 @@ func runGateway() {
 	if mcpMgr != nil {
 		mcpToolLister = mcpMgr
 	}
-	agentsH, skillsH, tracesH, mcpH, channelInstancesH, providersH, builtinToolsH, pendingMessagesH, teamEventsH, secureCLIH, mcpUserCredsH := wireHTTP(pgStores, cfg.Gateway.Token, cfg.Agents.Defaults.Workspace, dataDir, bundledSkillsDir, msgBus, toolsReg, providerRegistry, permPE.IsOwner, gatewayAddr, mcpToolLister)
+	agentsH, skillsH, tracesH, mcpH, channelInstancesH, providersH, builtinToolsH, pendingMessagesH, teamsH, teamEventsH, secureCLIH, mcpUserCredsH := wireHTTP(pgStores, cfg.Gateway.Token, cfg.Agents.Defaults.Workspace, dataDir, bundledSkillsDir, msgBus, toolsReg, providerRegistry, permPE.IsOwner, gatewayAddr, mcpToolLister)
 	if providersH != nil {
 		providersH.SetAPIBaseFallback(cfg.Providers.APIBaseForType)
 	}
@@ -341,6 +341,9 @@ func runGateway() {
 	}
 	if providersH != nil {
 		server.SetProvidersHandler(providersH)
+	}
+	if teamsH != nil {
+		server.SetTeamsHandler(teamsH)
 	}
 	if teamEventsH != nil {
 		server.SetTeamEventsHandler(teamEventsH)

--- a/cmd/gateway_http_handlers.go
+++ b/cmd/gateway_http_handlers.go
@@ -10,7 +10,7 @@ import (
 )
 
 // wireHTTP creates HTTP handlers (agents + skills + traces + MCP + channel instances + providers + builtin tools + pending messages).
-func wireHTTP(stores *store.Stores, token, defaultWorkspace, dataDir, bundledSkillsDir string, msgBus *bus.MessageBus, toolsReg *tools.Registry, providerReg *providers.Registry, isOwner func(string) bool, gatewayAddr string, mcpToolLister httpapi.MCPToolLister) (*httpapi.AgentsHandler, *httpapi.SkillsHandler, *httpapi.TracesHandler, *httpapi.MCPHandler, *httpapi.ChannelInstancesHandler, *httpapi.ProvidersHandler, *httpapi.BuiltinToolsHandler, *httpapi.PendingMessagesHandler, *httpapi.TeamEventsHandler, *httpapi.SecureCLIHandler, *httpapi.MCPUserCredentialsHandler) {
+func wireHTTP(stores *store.Stores, token, defaultWorkspace, dataDir, bundledSkillsDir string, msgBus *bus.MessageBus, toolsReg *tools.Registry, providerReg *providers.Registry, isOwner func(string) bool, gatewayAddr string, mcpToolLister httpapi.MCPToolLister) (*httpapi.AgentsHandler, *httpapi.SkillsHandler, *httpapi.TracesHandler, *httpapi.MCPHandler, *httpapi.ChannelInstancesHandler, *httpapi.ProvidersHandler, *httpapi.BuiltinToolsHandler, *httpapi.PendingMessagesHandler, *httpapi.TeamsHandler, *httpapi.TeamEventsHandler, *httpapi.SecureCLIHandler, *httpapi.MCPUserCredentialsHandler) {
 	var agentsH *httpapi.AgentsHandler
 	var skillsH *httpapi.SkillsHandler
 	var tracesH *httpapi.TracesHandler
@@ -62,7 +62,12 @@ func wireHTTP(stores *store.Stores, token, defaultWorkspace, dataDir, bundledSki
 		}
 	}
 
+	var teamsH *httpapi.TeamsHandler
 	var teamEventsH *httpapi.TeamEventsHandler
+
+	if stores != nil && stores.Teams != nil && stores.Agents != nil {
+		teamsH = httpapi.NewTeamsHandler(stores.Teams, stores.Agents, stores.AgentLinks, token, msgBus)
+	}
 
 	if stores != nil && stores.Teams != nil {
 		teamEventsH = httpapi.NewTeamEventsHandler(stores.Teams, token)
@@ -80,5 +85,5 @@ func wireHTTP(stores *store.Stores, token, defaultWorkspace, dataDir, bundledSki
 		secureCLIH = httpapi.NewSecureCLIHandler(stores.SecureCLI, token, msgBus)
 	}
 
-	return agentsH, skillsH, tracesH, mcpH, channelInstancesH, providersH, builtinToolsH, pendingMessagesH, teamEventsH, secureCLIH, mcpUserCredsH
+	return agentsH, skillsH, tracesH, mcpH, channelInstancesH, providersH, builtinToolsH, pendingMessagesH, teamsH, teamEventsH, secureCLIH, mcpUserCredsH
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -45,6 +45,7 @@ type Server struct {
 	mcpHandler         *httpapi.MCPHandler         // MCP server management API
 	channelInstancesHandler *httpapi.ChannelInstancesHandler // channel instance CRUD API
 	providersHandler        *httpapi.ProvidersHandler        // provider CRUD API
+	teamsHandler            *httpapi.TeamsHandler             // team CRUD + member management API
 	teamEventsHandler       *httpapi.TeamEventsHandler       // team event history API
 	teamAttachmentsHandler  *httpapi.TeamAttachmentsHandler  // team attachment download API
 	builtinToolsHandler     *httpapi.BuiltinToolsHandler     // builtin tool management API
@@ -227,6 +228,11 @@ func (s *Server) BuildMux() *http.ServeMux {
 		s.providersHandler.RegisterRoutes(mux)
 	}
 
+
+	// Team CRUD + member management API
+	if s.teamsHandler != nil {
+		s.teamsHandler.RegisterRoutes(mux)
+	}
 
 	// Team event history API
 	if s.teamEventsHandler != nil {
@@ -495,6 +501,9 @@ func (s *Server) SetChannelInstancesHandler(h *httpapi.ChannelInstancesHandler) 
 
 // SetProvidersHandler sets the provider CRUD handler.
 func (s *Server) SetProvidersHandler(h *httpapi.ProvidersHandler) { s.providersHandler = h }
+
+// SetTeamsHandler sets the team CRUD + member management handler.
+func (s *Server) SetTeamsHandler(h *httpapi.TeamsHandler) { s.teamsHandler = h }
 
 // SetTeamEventsHandler sets the team event history handler.
 func (s *Server) SetTeamEventsHandler(h *httpapi.TeamEventsHandler) { s.teamEventsHandler = h }

--- a/internal/http/teams.go
+++ b/internal/http/teams.go
@@ -1,0 +1,426 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/permissions"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+// TeamsHandler handles team CRUD and member management HTTP endpoints.
+type TeamsHandler struct {
+	teams  store.TeamStore
+	agents store.AgentStore
+	links  store.AgentLinkStore
+	token  string
+	msgBus *bus.MessageBus
+}
+
+// NewTeamsHandler creates a handler for team management endpoints.
+func NewTeamsHandler(teams store.TeamStore, agents store.AgentStore, links store.AgentLinkStore, token string, msgBus *bus.MessageBus) *TeamsHandler {
+	return &TeamsHandler{teams: teams, agents: agents, links: links, token: token, msgBus: msgBus}
+}
+
+// RegisterRoutes registers all team management routes on the given mux.
+func (h *TeamsHandler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/teams", h.authMiddleware(h.handleList))
+	mux.HandleFunc("POST /v1/teams", h.authMiddleware(h.handleCreate))
+	mux.HandleFunc("GET /v1/teams/{id}", h.authMiddleware(h.handleGet))
+	mux.HandleFunc("POST /v1/teams/{id}/members", h.authMiddleware(h.handleAddMember))
+	mux.HandleFunc("DELETE /v1/teams/{id}/members/{agentId}", h.authMiddleware(h.handleRemoveMember))
+}
+
+func (h *TeamsHandler) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return requireAuth(h.token, "", next)
+}
+
+// emitCacheInvalidate broadcasts a cache invalidation event for team data.
+func (h *TeamsHandler) emitCacheInvalidate() {
+	if h.msgBus == nil {
+		return
+	}
+	h.msgBus.Broadcast(bus.Event{
+		Name:    protocol.EventCacheInvalidate,
+		Payload: bus.CacheInvalidatePayload{Kind: bus.CacheKindTeam},
+	})
+}
+
+// resolveAgent resolves an agent by UUID or agent_key.
+func (h *TeamsHandler) resolveAgent(ctx context.Context, keyOrID string) (*store.AgentData, error) {
+	if id, err := uuid.Parse(keyOrID); err == nil {
+		return h.agents.GetByID(ctx, id)
+	}
+	return h.agents.GetByKey(ctx, keyOrID)
+}
+
+// --- List ---
+
+func (h *TeamsHandler) handleList(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	userID := store.UserIDFromContext(r.Context())
+	auth := resolveAuth(r, h.token)
+
+	var teams []store.TeamData
+	var err error
+	if permissions.HasMinRole(auth.Role, permissions.RoleAdmin) {
+		teams, err = h.teams.ListTeams(r.Context())
+	} else {
+		if userID == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgUserIDHeader)})
+			return
+		}
+		teams, err = h.teams.ListUserTeams(r.Context(), userID)
+	}
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"teams": teams, "count": len(teams)})
+}
+
+// --- Create ---
+
+type teamCreateRequest struct {
+	Name        string          `json:"name"`
+	Lead        string          `json:"lead"`    // agent key or UUID
+	Members     []string        `json:"members"` // agent keys or UUIDs
+	Description string          `json:"description"`
+	Settings    json.RawMessage `json:"settings"`
+}
+
+func (h *TeamsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	locale := store.LocaleFromContext(ctx)
+	userID := store.UserIDFromContext(ctx)
+	if userID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgUserIDHeader)})
+		return
+	}
+
+	var req teamCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidRequest, err.Error())})
+		return
+	}
+
+	if req.Name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "name")})
+		return
+	}
+	if req.Lead == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "lead")})
+		return
+	}
+
+	// Resolve lead agent
+	leadAgent, err := h.resolveAgent(ctx, req.Lead)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "lead agent: " + err.Error()})
+		return
+	}
+
+	// Enforce single-team leadership
+	if existingTeam, _ := h.teams.GetTeamForAgent(ctx, leadAgent.ID); existingTeam != nil && existingTeam.LeadAgentID == leadAgent.ID {
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"error": fmt.Sprintf("agent %q already leads team %q", req.Lead, existingTeam.Name),
+		})
+		return
+	}
+
+	// Resolve member agents
+	var memberAgents []*store.AgentData
+	for _, memberKey := range req.Members {
+		ag, err := h.resolveAgent(ctx, memberKey)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "member agent " + memberKey + ": " + err.Error()})
+			return
+		}
+		memberAgents = append(memberAgents, ag)
+	}
+
+	// Create team
+	team := &store.TeamData{
+		Name:        req.Name,
+		LeadAgentID: leadAgent.ID,
+		Description: req.Description,
+		Status:      store.TeamStatusActive,
+		Settings:    req.Settings,
+		CreatedBy:   userID,
+	}
+	if err := h.teams.CreateTeam(ctx, team); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgFailedToCreate, "team", err.Error())})
+		return
+	}
+
+	// Add lead as member with lead role
+	if err := h.teams.AddMember(ctx, team.ID, leadAgent.ID, store.TeamRoleLead); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgFailedToCreate, "team lead membership", err.Error())})
+		return
+	}
+
+	// Add members
+	for _, ag := range memberAgents {
+		if ag.ID == leadAgent.ID {
+			continue
+		}
+		_ = h.teams.AddMember(ctx, team.ID, ag.ID, store.TeamRoleMember)
+	}
+
+	// Auto-create outbound agent_links from lead to each member
+	if h.links != nil {
+		for _, member := range memberAgents {
+			if member.ID == leadAgent.ID {
+				continue
+			}
+			link := &store.AgentLinkData{
+				SourceAgentID: leadAgent.ID,
+				TargetAgentID: member.ID,
+				Direction:     store.LinkDirectionOutbound,
+				TeamID:        &team.ID,
+				Description:   "auto-created by team",
+				MaxConcurrent: 3,
+				Status:        store.LinkStatusActive,
+				CreatedBy:     userID,
+			}
+			_ = h.links.CreateLink(ctx, link)
+		}
+	}
+
+	h.emitCacheInvalidate()
+	emitAudit(h.msgBus, r, "team.created", "team", team.ID.String())
+
+	// Emit team.created event
+	if h.msgBus != nil {
+		h.msgBus.Broadcast(bus.Event{
+			Name: protocol.EventTeamCreated,
+			Payload: protocol.TeamCreatedPayload{
+				TeamID:          team.ID.String(),
+				TeamName:        team.Name,
+				LeadAgentKey:    leadAgent.AgentKey,
+				LeadDisplayName: leadAgent.DisplayName,
+				MemberCount:     len(memberAgents) + 1,
+			},
+		})
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{"team": team})
+}
+
+// --- Get ---
+
+func (h *TeamsHandler) handleGet(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	locale := store.LocaleFromContext(ctx)
+
+	teamID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "team")})
+		return
+	}
+
+	team, err := h.teams.GetTeam(ctx, teamID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "team", teamID.String())})
+		return
+	}
+
+	// Non-admin callers must have team access
+	auth := resolveAuth(r, h.token)
+	if !permissions.HasMinRole(auth.Role, permissions.RoleAdmin) {
+		callerID := store.UserIDFromContext(ctx)
+		if ok, err := h.teams.HasTeamAccess(ctx, teamID, callerID); err != nil || !ok {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "team", teamID.String())})
+			return
+		}
+	}
+
+	members, err := h.teams.ListMembers(ctx, teamID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"team": team, "members": members})
+}
+
+// --- Add Member ---
+
+type addMemberRequest struct {
+	Agent string `json:"agent"` // agent key or UUID
+	Role  string `json:"role"`  // "member" (default) or "reviewer"
+}
+
+func (h *TeamsHandler) handleAddMember(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	locale := store.LocaleFromContext(ctx)
+	userID := store.UserIDFromContext(ctx)
+
+	teamID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "team")})
+		return
+	}
+
+	var req addMemberRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidRequest, err.Error())})
+		return
+	}
+	if req.Agent == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "agent")})
+		return
+	}
+
+	// Validate team exists
+	team, err := h.teams.GetTeam(ctx, teamID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "team", teamID.String())})
+		return
+	}
+
+	// Resolve agent
+	ag, err := h.resolveAgent(ctx, req.Agent)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "agent: " + err.Error()})
+		return
+	}
+
+	// Prevent adding lead again
+	if ag.ID == team.LeadAgentID {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgAgentIsTeamLead)})
+		return
+	}
+
+	// Validate and default role
+	role := req.Role
+	switch role {
+	case store.TeamRoleMember, store.TeamRoleReviewer:
+		// valid
+	case "":
+		role = store.TeamRoleMember
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "role must be member or reviewer"})
+		return
+	}
+
+	if err := h.teams.AddMember(ctx, teamID, ag.ID, role); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgFailedToCreate, "member", err.Error())})
+		return
+	}
+
+	// Auto-create link from lead to new member
+	if h.links != nil {
+		leadAgent, err := h.agents.GetByID(ctx, team.LeadAgentID)
+		if err == nil {
+			link := &store.AgentLinkData{
+				SourceAgentID: leadAgent.ID,
+				TargetAgentID: ag.ID,
+				Direction:     store.LinkDirectionOutbound,
+				TeamID:        &teamID,
+				Description:   "auto-created by team",
+				MaxConcurrent: 3,
+				Status:        store.LinkStatusActive,
+				CreatedBy:     userID,
+			}
+			_ = h.links.CreateLink(ctx, link)
+		}
+	}
+
+	h.emitCacheInvalidate()
+	emitAudit(h.msgBus, r, "team.member_added", "team", teamID.String())
+
+	// Emit event
+	if h.msgBus != nil {
+		h.msgBus.Broadcast(bus.Event{
+			Name: protocol.EventTeamMemberAdded,
+			Payload: protocol.TeamMemberAddedPayload{
+				TeamID:      teamID.String(),
+				TeamName:    team.Name,
+				AgentID:     ag.ID.String(),
+				AgentKey:    ag.AgentKey,
+				DisplayName: ag.DisplayName,
+				Role:        role,
+			},
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "added"})
+}
+
+// --- Remove Member ---
+
+func (h *TeamsHandler) handleRemoveMember(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	locale := store.LocaleFromContext(ctx)
+
+	teamID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "team")})
+		return
+	}
+
+	// Resolve agent: accept UUID or agent_key in path
+	var agentID uuid.UUID
+	if id, err := uuid.Parse(r.PathValue("agentId")); err == nil {
+		agentID = id
+	} else {
+		ag, agErr := h.agents.GetByKey(ctx, r.PathValue("agentId"))
+		if agErr != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "agent")})
+			return
+		}
+		agentID = ag.ID
+	}
+
+	// Validate team exists and prevent removing the lead
+	team, err := h.teams.GetTeam(ctx, teamID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "team", teamID.String())})
+		return
+	}
+	if agentID == team.LeadAgentID {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgCannotRemoveTeamLead)})
+		return
+	}
+
+	// Fetch agent info before removal for event
+	removedAgent, _ := h.agents.GetByID(ctx, agentID)
+
+	if err := h.teams.RemoveMember(ctx, teamID, agentID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgFailedToDelete, "member", err.Error())})
+		return
+	}
+
+	// Clean up team-specific links
+	if h.links != nil {
+		_ = h.links.DeleteTeamLinksForAgent(ctx, teamID, agentID)
+	}
+
+	h.emitCacheInvalidate()
+	emitAudit(h.msgBus, r, "team.member_removed", "team", teamID.String())
+
+	// Emit event
+	if h.msgBus != nil && removedAgent != nil {
+		h.msgBus.Broadcast(bus.Event{
+			Name: protocol.EventTeamMemberRemoved,
+			Payload: protocol.TeamMemberRemovedPayload{
+				TeamID:      teamID.String(),
+				TeamName:    team.Name,
+				AgentID:     removedAgent.ID.String(),
+				AgentKey:    removedAgent.AgentKey,
+				DisplayName: removedAgent.DisplayName,
+			},
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "removed"})
+}

--- a/internal/http/teams_test.go
+++ b/internal/http/teams_test.go
@@ -1,0 +1,922 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+var errNotFound = errors.New("not found")
+
+// ─── Mock stores ─────────────────────────────────────────
+
+// mockTeamStore implements store.TeamStore with in-memory maps.
+type mockTeamStore struct {
+	mu      sync.Mutex
+	teams   map[uuid.UUID]*store.TeamData
+	members map[uuid.UUID][]store.TeamMemberData // teamID → members
+	grants  map[uuid.UUID][]string               // teamID → userIDs with access
+}
+
+func newMockTeamStore() *mockTeamStore {
+	return &mockTeamStore{
+		teams:   make(map[uuid.UUID]*store.TeamData),
+		members: make(map[uuid.UUID][]store.TeamMemberData),
+		grants:  make(map[uuid.UUID][]string),
+	}
+}
+
+func (m *mockTeamStore) CreateTeam(_ context.Context, team *store.TeamData) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if team.ID == uuid.Nil {
+		team.ID = uuid.New()
+	}
+	team.CreatedAt = time.Now()
+	team.UpdatedAt = time.Now()
+	m.teams[team.ID] = team
+	return nil
+}
+
+func (m *mockTeamStore) GetTeam(_ context.Context, teamID uuid.UUID) (*store.TeamData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if t, ok := m.teams[teamID]; ok {
+		return t, nil
+	}
+	return nil, errNotFound
+}
+
+func (m *mockTeamStore) ListTeams(_ context.Context) ([]store.TeamData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []store.TeamData
+	for _, t := range m.teams {
+		result = append(result, *t)
+	}
+	return result, nil
+}
+
+func (m *mockTeamStore) AddMember(_ context.Context, teamID, agentID uuid.UUID, role string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.members[teamID] = append(m.members[teamID], store.TeamMemberData{
+		TeamID:   teamID,
+		AgentID:  agentID,
+		Role:     role,
+		JoinedAt: time.Now(),
+	})
+	return nil
+}
+
+func (m *mockTeamStore) RemoveMember(_ context.Context, teamID, agentID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	members := m.members[teamID]
+	for i, mem := range members {
+		if mem.AgentID == agentID {
+			m.members[teamID] = append(members[:i], members[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (m *mockTeamStore) ListMembers(_ context.Context, teamID uuid.UUID) ([]store.TeamMemberData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.members[teamID], nil
+}
+
+func (m *mockTeamStore) GetTeamForAgent(_ context.Context, agentID uuid.UUID) (*store.TeamData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, t := range m.teams {
+		if t.LeadAgentID == agentID {
+			return t, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockTeamStore) HasTeamAccess(_ context.Context, teamID uuid.UUID, userID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, u := range m.grants[teamID] {
+		if u == userID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *mockTeamStore) ListUserTeams(_ context.Context, userID string) ([]store.TeamData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []store.TeamData
+	for teamID, users := range m.grants {
+		for _, u := range users {
+			if u == userID {
+				if t, ok := m.teams[teamID]; ok {
+					result = append(result, *t)
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+// Stub out remaining TeamStore methods (unused by HTTP handler).
+func (m *mockTeamStore) UpdateTeam(context.Context, uuid.UUID, map[string]any) error { return nil }
+func (m *mockTeamStore) DeleteTeam(context.Context, uuid.UUID) error                 { return nil }
+func (m *mockTeamStore) ListIdleMembers(context.Context, uuid.UUID) ([]store.TeamMemberData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) KnownUserIDs(context.Context, uuid.UUID, int) ([]string, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) ListTaskScopes(context.Context, uuid.UUID) ([]store.ScopeEntry, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) CreateTask(context.Context, *store.TeamTaskData) error { return nil }
+func (m *mockTeamStore) UpdateTask(context.Context, uuid.UUID, map[string]any) error {
+	return nil
+}
+func (m *mockTeamStore) ListTasks(context.Context, uuid.UUID, string, string, string, string, string, int, int) ([]store.TeamTaskData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) GetTask(context.Context, uuid.UUID) (*store.TeamTaskData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) GetTasksByIDs(context.Context, []uuid.UUID) ([]store.TeamTaskData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) SearchTasks(context.Context, uuid.UUID, string, int, string) ([]store.TeamTaskData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) DeleteTask(context.Context, uuid.UUID, uuid.UUID) error { return nil }
+func (m *mockTeamStore) DeleteTasks(context.Context, []uuid.UUID, uuid.UUID) ([]uuid.UUID, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) ClaimTask(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (m *mockTeamStore) AssignTask(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (m *mockTeamStore) CompleteTask(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+func (m *mockTeamStore) CancelTask(context.Context, uuid.UUID, uuid.UUID, string) error { return nil }
+func (m *mockTeamStore) FailTask(context.Context, uuid.UUID, uuid.UUID, string) error   { return nil }
+func (m *mockTeamStore) FailPendingTask(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+func (m *mockTeamStore) ReviewTask(context.Context, uuid.UUID, uuid.UUID) error { return nil }
+func (m *mockTeamStore) ApproveTask(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+func (m *mockTeamStore) RejectTask(context.Context, uuid.UUID, uuid.UUID, string) error { return nil }
+func (m *mockTeamStore) AddTaskComment(context.Context, *store.TeamTaskCommentData) error {
+	return nil
+}
+func (m *mockTeamStore) ListTaskComments(context.Context, uuid.UUID) ([]store.TeamTaskCommentData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) ListRecentTaskComments(context.Context, uuid.UUID, int) ([]store.TeamTaskCommentData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) RecordTaskEvent(context.Context, *store.TeamTaskEventData) error { return nil }
+func (m *mockTeamStore) ListTaskEvents(context.Context, uuid.UUID) ([]store.TeamTaskEventData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) ListTeamEvents(context.Context, uuid.UUID, int, int) ([]store.TeamTaskEventData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) AttachFileToTask(context.Context, *store.TeamTaskAttachmentData) error {
+	return nil
+}
+func (m *mockTeamStore) GetAttachment(context.Context, uuid.UUID) (*store.TeamTaskAttachmentData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) ListTaskAttachments(context.Context, uuid.UUID) ([]store.TeamTaskAttachmentData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) DetachFileFromTask(context.Context, uuid.UUID, string) error { return nil }
+func (m *mockTeamStore) SetTaskFollowup(context.Context, uuid.UUID, uuid.UUID, time.Time, int, string, string, string) error {
+	return nil
+}
+func (m *mockTeamStore) ClearTaskFollowup(context.Context, uuid.UUID) error { return nil }
+func (m *mockTeamStore) ListAllFollowupDueTasks(context.Context) ([]store.TeamTaskData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) IncrementFollowupCount(context.Context, uuid.UUID, *time.Time) error {
+	return nil
+}
+func (m *mockTeamStore) ClearFollowupByScope(context.Context, string, string) (int, error) {
+	return 0, nil
+}
+func (m *mockTeamStore) SetFollowupForActiveTasks(context.Context, uuid.UUID, string, string, time.Time, int, string) (int, error) {
+	return 0, nil
+}
+func (m *mockTeamStore) HasActiveMemberTasks(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (m *mockTeamStore) UpdateTaskProgress(context.Context, uuid.UUID, uuid.UUID, int, string) error {
+	return nil
+}
+func (m *mockTeamStore) RenewTaskLock(context.Context, uuid.UUID, uuid.UUID) error { return nil }
+func (m *mockTeamStore) RecoverAllStaleTasks(context.Context) ([]store.RecoveredTaskInfo, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) ForceRecoverAllTasks(context.Context) ([]store.RecoveredTaskInfo, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) ListRecoverableTasks(context.Context, uuid.UUID) ([]store.TeamTaskData, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) MarkAllStaleTasks(_ context.Context, _ time.Time) ([]store.RecoveredTaskInfo, error) {
+	return nil, nil
+}
+func (m *mockTeamStore) ResetTaskStatus(context.Context, uuid.UUID, uuid.UUID) error { return nil }
+func (m *mockTeamStore) GrantTeamAccess(context.Context, uuid.UUID, string, string, string) error {
+	return nil
+}
+func (m *mockTeamStore) RevokeTeamAccess(context.Context, uuid.UUID, string) error { return nil }
+func (m *mockTeamStore) ListTeamGrants(context.Context, uuid.UUID) ([]store.TeamUserGrant, error) {
+	return nil, nil
+}
+
+// agentStoreStub provides no-op implementations for every AgentStore method.
+type agentStoreStub struct{}
+
+func (agentStoreStub) Create(context.Context, *store.AgentData) error                                          { return nil }
+func (agentStoreStub) GetByKey(context.Context, string) (*store.AgentData, error)                               { return nil, errNotFound }
+func (agentStoreStub) GetByID(context.Context, uuid.UUID) (*store.AgentData, error)                             { return nil, errNotFound }
+func (agentStoreStub) GetByKeys(context.Context, []string) ([]store.AgentData, error)                           { return nil, nil }
+func (agentStoreStub) GetByIDs(context.Context, []uuid.UUID) ([]store.AgentData, error)                         { return nil, nil }
+func (agentStoreStub) Update(context.Context, uuid.UUID, map[string]any) error                                  { return nil }
+func (agentStoreStub) Delete(context.Context, uuid.UUID) error                                                  { return nil }
+func (agentStoreStub) List(context.Context, string) ([]store.AgentData, error)                                  { return nil, nil }
+func (agentStoreStub) GetDefault(context.Context) (*store.AgentData, error)                                     { return nil, nil }
+func (agentStoreStub) ShareAgent(context.Context, uuid.UUID, string, string, string) error                      { return nil }
+func (agentStoreStub) RevokeShare(context.Context, uuid.UUID, string) error                                     { return nil }
+func (agentStoreStub) ListShares(context.Context, uuid.UUID) ([]store.AgentShareData, error)                    { return nil, nil }
+func (agentStoreStub) CanAccess(context.Context, uuid.UUID, string) (bool, string, error)                       { return false, "", nil }
+func (agentStoreStub) ListAccessible(context.Context, string) ([]store.AgentData, error)                        { return nil, nil }
+func (agentStoreStub) GetAgentContextFiles(context.Context, uuid.UUID) ([]store.AgentContextFileData, error)    { return nil, nil }
+func (agentStoreStub) SetAgentContextFile(context.Context, uuid.UUID, string, string) error                     { return nil }
+func (agentStoreStub) GetUserContextFiles(context.Context, uuid.UUID, string) ([]store.UserContextFileData, error) { return nil, nil }
+func (agentStoreStub) SetUserContextFile(context.Context, uuid.UUID, string, string, string) error              { return nil }
+func (agentStoreStub) DeleteUserContextFile(context.Context, uuid.UUID, string, string) error                   { return nil }
+func (agentStoreStub) GetUserOverride(context.Context, uuid.UUID, string) (*store.UserAgentOverrideData, error) { return nil, nil }
+func (agentStoreStub) SetUserOverride(context.Context, *store.UserAgentOverrideData) error                      { return nil }
+func (agentStoreStub) GetOrCreateUserProfile(context.Context, uuid.UUID, string, string, string) (bool, string, error) { return false, "", nil }
+func (agentStoreStub) EnsureUserProfile(context.Context, uuid.UUID, string) error                               { return nil }
+func (agentStoreStub) ListUserInstances(context.Context, uuid.UUID) ([]store.UserInstanceData, error)           { return nil, nil }
+func (agentStoreStub) UpdateUserProfileMetadata(context.Context, uuid.UUID, string, map[string]string) error    { return nil }
+
+// mockAgentStore overrides GetByID and GetByKey with in-memory maps.
+type mockAgentStore struct {
+	agentStoreStub
+	mu     sync.Mutex
+	agents map[uuid.UUID]*store.AgentData
+	byKey  map[string]*store.AgentData
+}
+
+func newMockAgentStore() *mockAgentStore {
+	return &mockAgentStore{
+		agents: make(map[uuid.UUID]*store.AgentData),
+		byKey:  make(map[string]*store.AgentData),
+	}
+}
+
+func (m *mockAgentStore) addAgent(ag *store.AgentData) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.agents[ag.ID] = ag
+	m.byKey[ag.AgentKey] = ag
+}
+
+func (m *mockAgentStore) GetByID(_ context.Context, id uuid.UUID) (*store.AgentData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if a, ok := m.agents[id]; ok {
+		return a, nil
+	}
+	return nil, errNotFound
+}
+
+func (m *mockAgentStore) GetByKey(_ context.Context, key string) (*store.AgentData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if a, ok := m.byKey[key]; ok {
+		return a, nil
+	}
+	return nil, errNotFound
+}
+
+// mockLinkStore implements the AgentLinkStore methods used by TeamsHandler.
+type mockLinkStore struct {
+	mu    sync.Mutex
+	links []store.AgentLinkData
+}
+
+func newMockLinkStore() *mockLinkStore { return &mockLinkStore{} }
+
+func (m *mockLinkStore) CreateLink(_ context.Context, link *store.AgentLinkData) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	link.ID = uuid.New()
+	m.links = append(m.links, *link)
+	return nil
+}
+
+func (m *mockLinkStore) DeleteTeamLinksForAgent(_ context.Context, teamID, agentID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var kept []store.AgentLinkData
+	for _, l := range m.links {
+		if l.TeamID != nil && *l.TeamID == teamID && (l.SourceAgentID == agentID || l.TargetAgentID == agentID) {
+			continue
+		}
+		kept = append(kept, l)
+	}
+	m.links = kept
+	return nil
+}
+
+// Stub remaining AgentLinkStore methods.
+func (m *mockLinkStore) DeleteLink(context.Context, uuid.UUID) error                 { return nil }
+func (m *mockLinkStore) UpdateLink(context.Context, uuid.UUID, map[string]any) error { return nil }
+func (m *mockLinkStore) GetLink(context.Context, uuid.UUID) (*store.AgentLinkData, error) {
+	return nil, nil
+}
+func (m *mockLinkStore) ListLinksFrom(context.Context, uuid.UUID) ([]store.AgentLinkData, error) {
+	return nil, nil
+}
+func (m *mockLinkStore) ListLinksTo(context.Context, uuid.UUID) ([]store.AgentLinkData, error) {
+	return nil, nil
+}
+func (m *mockLinkStore) CanDelegate(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (m *mockLinkStore) GetLinkBetween(context.Context, uuid.UUID, uuid.UUID) (*store.AgentLinkData, error) {
+	return nil, nil
+}
+func (m *mockLinkStore) DelegateTargets(context.Context, uuid.UUID) ([]store.AgentLinkData, error) {
+	return nil, nil
+}
+func (m *mockLinkStore) SearchDelegateTargets(context.Context, uuid.UUID, string, int) ([]store.AgentLinkData, error) {
+	return nil, nil
+}
+func (m *mockLinkStore) SearchDelegateTargetsByEmbedding(context.Context, uuid.UUID, []float32, int) ([]store.AgentLinkData, error) {
+	return nil, nil
+}
+
+// ─── Test helpers ────────────────────────────────────────
+
+var (
+	leadID     = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	memberID   = uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	reviewerID = uuid.MustParse("00000000-0000-0000-0000-000000000003")
+)
+
+func seedAgents(as *mockAgentStore) {
+	as.addAgent(&store.AgentData{
+		BaseModel:   store.BaseModel{ID: leadID},
+		AgentKey:    "lead-agent",
+		DisplayName: "Lead Agent",
+		AgentType:   store.AgentTypeOpen,
+	})
+	as.addAgent(&store.AgentData{
+		BaseModel:   store.BaseModel{ID: memberID},
+		AgentKey:    "member-agent",
+		DisplayName: "Member Agent",
+		AgentType:   store.AgentTypeOpen,
+	})
+	as.addAgent(&store.AgentData{
+		BaseModel:   store.BaseModel{ID: reviewerID},
+		AgentKey:    "reviewer-agent",
+		DisplayName: "Reviewer Agent",
+		AgentType:   store.AgentTypeOpen,
+	})
+}
+
+func newTestTeamsHandler() (*TeamsHandler, *mockTeamStore, *mockAgentStore, *mockLinkStore) {
+	ts := newMockTeamStore()
+	as := newMockAgentStore()
+	ls := newMockLinkStore()
+	seedAgents(as)
+	h := NewTeamsHandler(ts, as, ls, "test-token", nil)
+	return h, ts, as, ls
+}
+
+func newTeamsRequest(method, path string, body any) *http.Request {
+	var buf bytes.Buffer
+	if body != nil {
+		json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("X-GoClaw-User-Id", "admin-user")
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func decodeJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v (body: %s)", err, w.Body.String())
+	}
+	return result
+}
+
+// ─── Tests ───────────────────────────────────────────────
+
+func TestTeamsCreate(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, ls := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := newTeamsRequest("POST", "/v1/teams", teamCreateRequest{
+		Name:    "Translation Team",
+		Lead:    "lead-agent",
+		Members: []string{"member-agent", "reviewer-agent"},
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	result := decodeJSON(t, w)
+	teamData, ok := result["team"].(map[string]any)
+	if !ok {
+		t.Fatal("response missing 'team' field")
+	}
+	if teamData["name"] != "Translation Team" {
+		t.Errorf("team name = %v, want 'Translation Team'", teamData["name"])
+	}
+
+	// Verify team was stored
+	ts.mu.Lock()
+	if len(ts.teams) != 1 {
+		t.Errorf("teams count = %d, want 1", len(ts.teams))
+	}
+	ts.mu.Unlock()
+
+	// Verify members added (lead + 2 members = 3)
+	var teamID uuid.UUID
+	ts.mu.Lock()
+	for id := range ts.teams {
+		teamID = id
+	}
+	memberCount := len(ts.members[teamID])
+	ts.mu.Unlock()
+	if memberCount != 3 {
+		t.Errorf("member count = %d, want 3", memberCount)
+	}
+
+	// Verify links created (lead → member, lead → reviewer = 2)
+	ls.mu.Lock()
+	linkCount := len(ls.links)
+	ls.mu.Unlock()
+	if linkCount != 2 {
+		t.Errorf("link count = %d, want 2", linkCount)
+	}
+}
+
+func TestTeamsCreate_MissingName(t *testing.T) {
+	setupTestCache(t, nil)
+	h, _, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := newTeamsRequest("POST", "/v1/teams", teamCreateRequest{
+		Lead: "lead-agent",
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestTeamsCreate_MissingLead(t *testing.T) {
+	setupTestCache(t, nil)
+	h, _, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := newTeamsRequest("POST", "/v1/teams", teamCreateRequest{
+		Name: "My Team",
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestTeamsCreate_UnknownAgent(t *testing.T) {
+	setupTestCache(t, nil)
+	h, _, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := newTeamsRequest("POST", "/v1/teams", teamCreateRequest{
+		Name: "My Team",
+		Lead: "nonexistent-agent",
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestTeamsCreate_DuplicateLeadership(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	// Create first team
+	ts.mu.Lock()
+	existingID := uuid.New()
+	ts.teams[existingID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: existingID},
+		Name:        "Existing Team",
+		LeadAgentID: leadID,
+		Status:      store.TeamStatusActive,
+	}
+	ts.mu.Unlock()
+
+	// Try to create second team with same lead
+	req := newTeamsRequest("POST", "/v1/teams", teamCreateRequest{
+		Name: "Second Team",
+		Lead: "lead-agent",
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusConflict, w.Body.String())
+	}
+}
+
+func TestTeamsCreate_NoAuth(t *testing.T) {
+	setupTestCache(t, nil)
+	h, _, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("POST", "/v1/teams", bytes.NewBufferString(`{"name":"Team","lead":"lead-agent"}`))
+	req.Header.Set("Content-Type", "application/json")
+	// no Authorization header
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestTeamsList(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	// Seed a team
+	teamID := uuid.New()
+	ts.mu.Lock()
+	ts.teams[teamID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: teamID},
+		Name:        "Test Team",
+		LeadAgentID: leadID,
+		Status:      store.TeamStatusActive,
+	}
+	ts.mu.Unlock()
+
+	req := newTeamsRequest("GET", "/v1/teams", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	result := decodeJSON(t, w)
+	count, _ := result["count"].(float64)
+	if count != 1 {
+		t.Errorf("count = %v, want 1", count)
+	}
+}
+
+func TestTeamsGet(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	teamID := uuid.New()
+	ts.mu.Lock()
+	ts.teams[teamID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: teamID},
+		Name:        "Test Team",
+		LeadAgentID: leadID,
+		Status:      store.TeamStatusActive,
+	}
+	ts.members[teamID] = []store.TeamMemberData{
+		{TeamID: teamID, AgentID: leadID, Role: store.TeamRoleLead},
+		{TeamID: teamID, AgentID: memberID, Role: store.TeamRoleMember},
+	}
+	ts.mu.Unlock()
+
+	req := newTeamsRequest("GET", "/v1/teams/"+teamID.String(), nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	result := decodeJSON(t, w)
+	members, ok := result["members"].([]any)
+	if !ok {
+		t.Fatal("response missing 'members' field")
+	}
+	if len(members) != 2 {
+		t.Errorf("members count = %d, want 2", len(members))
+	}
+}
+
+func TestTeamsGet_NotFound(t *testing.T) {
+	setupTestCache(t, nil)
+	h, _, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := newTeamsRequest("GET", "/v1/teams/"+uuid.New().String(), nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestTeamsGet_InvalidID(t *testing.T) {
+	setupTestCache(t, nil)
+	h, _, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := newTeamsRequest("GET", "/v1/teams/not-a-uuid", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestTeamsAddMember(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, ls := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	teamID := uuid.New()
+	ts.mu.Lock()
+	ts.teams[teamID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: teamID},
+		Name:        "Test Team",
+		LeadAgentID: leadID,
+		Status:      store.TeamStatusActive,
+	}
+	ts.members[teamID] = []store.TeamMemberData{
+		{TeamID: teamID, AgentID: leadID, Role: store.TeamRoleLead},
+	}
+	ts.mu.Unlock()
+
+	req := newTeamsRequest("POST", "/v1/teams/"+teamID.String()+"/members", addMemberRequest{
+		Agent: "member-agent",
+		Role:  "member",
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	// Verify member was added
+	ts.mu.Lock()
+	memberCount := len(ts.members[teamID])
+	ts.mu.Unlock()
+	if memberCount != 2 {
+		t.Errorf("member count = %d, want 2", memberCount)
+	}
+
+	// Verify link was created
+	ls.mu.Lock()
+	linkCount := len(ls.links)
+	ls.mu.Unlock()
+	if linkCount != 1 {
+		t.Errorf("link count = %d, want 1", linkCount)
+	}
+}
+
+func TestTeamsAddMember_PreventAddingLead(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	teamID := uuid.New()
+	ts.mu.Lock()
+	ts.teams[teamID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: teamID},
+		Name:        "Test Team",
+		LeadAgentID: leadID,
+	}
+	ts.mu.Unlock()
+
+	req := newTeamsRequest("POST", "/v1/teams/"+teamID.String()+"/members", addMemberRequest{
+		Agent: "lead-agent",
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestTeamsAddMember_InvalidRole(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	teamID := uuid.New()
+	ts.mu.Lock()
+	ts.teams[teamID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: teamID},
+		Name:        "Test Team",
+		LeadAgentID: leadID,
+	}
+	ts.mu.Unlock()
+
+	req := newTeamsRequest("POST", "/v1/teams/"+teamID.String()+"/members", addMemberRequest{
+		Agent: "member-agent",
+		Role:  "admin",
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestTeamsAddMember_ReviewerRole(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	teamID := uuid.New()
+	ts.mu.Lock()
+	ts.teams[teamID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: teamID},
+		Name:        "Test Team",
+		LeadAgentID: leadID,
+	}
+	ts.mu.Unlock()
+
+	req := newTeamsRequest("POST", "/v1/teams/"+teamID.String()+"/members", addMemberRequest{
+		Agent: "reviewer-agent",
+		Role:  "reviewer",
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	ts.mu.Lock()
+	members := ts.members[teamID]
+	ts.mu.Unlock()
+	if len(members) != 1 || members[0].Role != store.TeamRoleReviewer {
+		t.Errorf("expected reviewer role, got %v", members)
+	}
+}
+
+func TestTeamsRemoveMember(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	teamID := uuid.New()
+	ts.mu.Lock()
+	ts.teams[teamID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: teamID},
+		Name:        "Test Team",
+		LeadAgentID: leadID,
+	}
+	ts.members[teamID] = []store.TeamMemberData{
+		{TeamID: teamID, AgentID: leadID, Role: store.TeamRoleLead},
+		{TeamID: teamID, AgentID: memberID, Role: store.TeamRoleMember},
+	}
+	ts.mu.Unlock()
+
+	req := newTeamsRequest("DELETE", "/v1/teams/"+teamID.String()+"/members/"+memberID.String(), nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	ts.mu.Lock()
+	memberCount := len(ts.members[teamID])
+	ts.mu.Unlock()
+	if memberCount != 1 {
+		t.Errorf("member count = %d, want 1 (only lead)", memberCount)
+	}
+}
+
+func TestTeamsRemoveMember_ByAgentKey(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	teamID := uuid.New()
+	ts.mu.Lock()
+	ts.teams[teamID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: teamID},
+		Name:        "Test Team",
+		LeadAgentID: leadID,
+	}
+	ts.members[teamID] = []store.TeamMemberData{
+		{TeamID: teamID, AgentID: leadID, Role: store.TeamRoleLead},
+		{TeamID: teamID, AgentID: memberID, Role: store.TeamRoleMember},
+	}
+	ts.mu.Unlock()
+
+	// Use agent key instead of UUID
+	req := newTeamsRequest("DELETE", "/v1/teams/"+teamID.String()+"/members/member-agent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+func TestTeamsRemoveMember_CannotRemoveLead(t *testing.T) {
+	setupTestCache(t, nil)
+	h, ts, _, _ := newTestTeamsHandler()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	teamID := uuid.New()
+	ts.mu.Lock()
+	ts.teams[teamID] = &store.TeamData{
+		BaseModel:   store.BaseModel{ID: teamID},
+		Name:        "Test Team",
+		LeadAgentID: leadID,
+	}
+	ts.mu.Unlock()
+
+	req := newTeamsRequest("DELETE", "/v1/teams/"+teamID.String()+"/members/"+leadID.String(), nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}


### PR DESCRIPTION
  Summary

  - Add 5 HTTP REST endpoints for teams, previously only accessible via WebSocket RPC:
    - POST /v1/teams — create team with lead + members
    - GET /v1/teams — list teams (admin: all, non-admin: accessible only)
    - GET /v1/teams/{id} — get team details + members
    - POST /v1/teams/{id}/members — add member (agent key or UUID)
    - DELETE /v1/teams/{id}/members/{agentId} — remove member (agent key or UUID)
  - Logic mirrors existing WS RPC handlers: single-team leadership enforcement, auto agent_links, cache invalidation, audit + pub/sub events, RBAC

  Test plan

  - 17 unit tests covering all endpoints (create, list, get, add/remove member)
  - Validation: missing fields, unknown agents, duplicate leadership, invalid roles, bad UUIDs
  - Auth: unauthorized requests rejected
  - Edge cases: remove by agent_key, can't remove lead, reviewer role
  - Manual: curl against running gateway to verify end-to-end