### PR TITLE
fix(routing): bindings override channel instance agent_id

### DIFF
--- a/cmd/gateway_consumer_handlers.go
+++ b/cmd/gateway_consumer_handlers.go
@@ -562,9 +562,9 @@ func handleResetCommand(
 		return false
 	}
 
-	agentID := msg.AgentID
+	agentID := resolveAgentRoute(cfg, msg.Channel, msg.ChatID, msg.PeerKind)
 	if agentID == "" {
-		agentID = resolveAgentRoute(cfg, msg.Channel, msg.ChatID, msg.PeerKind)
+		agentID = msg.AgentID
 	}
 	peerKind := msg.PeerKind
 	if peerKind == "" {
@@ -601,9 +601,9 @@ func handleStopCommand(
 		return false
 	}
 
-	agentID := msg.AgentID
+	agentID := resolveAgentRoute(cfg, msg.Channel, msg.ChatID, msg.PeerKind)
 	if agentID == "" {
-		agentID = resolveAgentRoute(cfg, msg.Channel, msg.ChatID, msg.PeerKind)
+		agentID = msg.AgentID
 	}
 	peerKind := msg.PeerKind
 	if peerKind == "" {

--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -46,10 +46,12 @@ func processNormalMessage(
 		ctx = store.WithTenantID(ctx, store.MasterTenantID)
 	}
 
-	// Determine target agent via bindings or explicit AgentID
-	agentID := msg.AgentID
+	// Determine target agent: bindings take priority over channel instance default.
+	// This allows one channel instance (e.g. single Slack bot) to route to
+	// different agents based on chat_id/peer_kind bindings.
+	agentID := resolveAgentRoute(cfg, msg.Channel, msg.ChatID, msg.PeerKind)
 	if agentID == "" {
-		agentID = resolveAgentRoute(cfg, msg.Channel, msg.ChatID, msg.PeerKind)
+		agentID = msg.AgentID
 	}
 
 	agentLoop, err := agents.Get(ctx, agentID)


### PR DESCRIPTION
Closes #232

## Summary
- Swap priority: `resolveAgentRoute()` (bindings) runs first, falls back to `msg.AgentID` (channel instance default) when no binding matches
- Allows one channel instance (e.g. single Slack bot) to route to different agents based on chat_id/peer_kind bindings
- Zero impact for users without bindings config