### PR TITLE
fix: address 5 bugs from issue #294 — stale context, cron reliability…

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -761,7 +761,7 @@ func runGateway() {
 	defer sched.Stop()
 
 	// Start cron service with job handler (routes through scheduler's cron lane)
-	pgStores.Cron.SetOnJob(makeCronJobHandler(sched, msgBus, cfg, channelMgr))
+	pgStores.Cron.SetOnJob(makeCronJobHandler(sched, msgBus, cfg, channelMgr, pgStores.Sessions))
 	pgStores.Cron.SetOnEvent(func(event store.CronEvent) {
 		server.BroadcastEvent(*protocol.NewEvent(protocol.EventCron, event))
 	})

--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/agent"
@@ -21,7 +22,7 @@ import (
 // Safe because cron jobs only fire after Start(), well after this is set.
 var cronHeartbeatWakeFn func(agentID string)
 
-func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg *config.Config, channelMgr *channels.Manager) func(job *store.CronJob) (*store.CronJobResult, error) {
+func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg *config.Config, channelMgr *channels.Manager, sessionMgr store.SessionStore) func(job *store.CronJob) (*store.CronJobResult, error) {
 	return func(job *store.CronJob) (*store.CronJobResult, error) {
 		agentID := job.AgentID
 		if agentID == "" {
@@ -31,6 +32,11 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 		}
 
 		sessionKey := sessions.BuildCronSessionKey(agentID, job.ID)
+
+		// Reset session before each cron run to prevent tool errors from previous
+		// runs from polluting the context and blocking future executions (#294).
+		sessionMgr.Reset(context.Background(), sessionKey)
+
 		channel := job.Payload.Channel
 		if channel == "" {
 			channel = "cron"
@@ -99,6 +105,9 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 			}
 			appendMediaToOutbound(&outMsg, result.Media)
 			msgBus.PublishOutbound(outMsg)
+		} else if job.Payload.Deliver {
+			slog.Warn("cron: delivery configured but channel/chatID missing — output discarded",
+				"job_id", job.ID, "job_name", job.Name, "channel", job.Payload.Channel, "to", job.Payload.To)
 		}
 
 		cronResult := &store.CronJobResult{

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1329,6 +1329,16 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 			pendingMsgs = append(pendingMsgs, forSession...)
 		}
 
+		// Periodic checkpoint: flush pending messages to session after each tool
+		// iteration to prevent data loss on container crash (#294).
+		if len(pendingMsgs) > 0 {
+			for _, msg := range pendingMsgs {
+				l.sessions.AddMessage(ctx, req.SessionKey, msg)
+			}
+			l.sessions.Save(ctx, req.SessionKey)
+			pendingMsgs = pendingMsgs[:0] // reset buffer, already persisted
+		}
+
 	}
 
 	// 4. Full sanitization pipeline (matching TS extractAssistantText + sanitizeUserFacingText)

--- a/internal/bootstrap/seed_store_test.go
+++ b/internal/bootstrap/seed_store_test.go
@@ -102,6 +102,9 @@ func (s *seedStubStore) UpdateUserProfileMetadata(_ context.Context, _ uuid.UUID
 func (s *seedStubStore) EnsureUserProfile(_ context.Context, _ uuid.UUID, _ string) error {
 	return nil
 }
+func (s *seedStubStore) PropagateContextFile(_ context.Context, _ uuid.UUID, _ string) (int, error) {
+	return 0, nil
+}
 
 // ---- Tests ----
 

--- a/internal/gateway/methods/agents_create_owner_test.go
+++ b/internal/gateway/methods/agents_create_owner_test.go
@@ -95,6 +95,9 @@ func (s *createCaptureStore) UpdateUserProfileMetadata(_ context.Context, _ uuid
 func (s *createCaptureStore) EnsureUserProfile(_ context.Context, _ uuid.UUID, _ string) error {
 	return nil
 }
+func (s *createCaptureStore) PropagateContextFile(_ context.Context, _ uuid.UUID, _ string) (int, error) {
+	return 0, nil
+}
 
 // ---- helpers ----
 

--- a/internal/gateway/methods/agents_files.go
+++ b/internal/gateway/methods/agents_files.go
@@ -3,6 +3,7 @@ package methods
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -215,9 +216,10 @@ func (m *AgentsMethods) handleFilesGet(ctx context.Context, client *gateway.Clie
 func (m *AgentsMethods) handleFilesSet(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
 	locale := store.LocaleFromContext(ctx)
 	var params struct {
-		AgentID string `json:"agentId"`
-		Name    string `json:"name"`
-		Content string `json:"content"`
+		AgentID   string `json:"agentId"`
+		Name      string `json:"name"`
+		Content   string `json:"content"`
+		Propagate bool   `json:"propagate"` // push change to all existing user instances
 	}
 	if req.Params != nil {
 		json.Unmarshal(req.Params, &params)
@@ -248,6 +250,17 @@ func (m *AgentsMethods) handleFilesSet(ctx context.Context, client *gateway.Clie
 			return
 		}
 
+		// Propagate to all existing user instances if requested (#294)
+		var propagated int
+		if params.Propagate {
+			n, err := m.agentStore.PropagateContextFile(ctx, ag.ID, params.Name)
+			if err != nil {
+				slog.Warn("agents.files.set: propagation failed", "agent", params.AgentID, "file", params.Name, "error", err)
+			} else {
+				propagated = n
+			}
+		}
+
 		// Invalidate both caches so the new content is served immediately
 		// without waiting for the ContextFileInterceptor's 5-minute TTL to expire.
 		m.agents.InvalidateAgent(params.AgentID)
@@ -263,6 +276,7 @@ func (m *AgentsMethods) handleFilesSet(ctx context.Context, client *gateway.Clie
 				"size":    len(params.Content),
 				"content": params.Content,
 			},
+			"propagated": propagated,
 		}))
 		return
 	}

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -334,6 +334,9 @@ type AgentStore interface {
 	GetAgentContextFiles(ctx context.Context, agentID uuid.UUID) ([]AgentContextFileData, error)
 	SetAgentContextFile(ctx context.Context, agentID uuid.UUID, fileName, content string) error
 
+	// Propagate agent-level file to all existing user instances
+	PropagateContextFile(ctx context.Context, agentID uuid.UUID, fileName string) (int, error)
+
 	// Per-user context files + overrides
 	GetUserContextFiles(ctx context.Context, agentID uuid.UUID, userID string) ([]UserContextFileData, error)
 	SetUserContextFile(ctx context.Context, agentID uuid.UUID, userID, fileName, content string) error

--- a/internal/store/pg/agents_context.go
+++ b/internal/store/pg/agents_context.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -48,6 +49,41 @@ func (s *PGAgentStore) SetAgentContextFile(ctx context.Context, agentID uuid.UUI
 		store.GenNewID(), agentID, fileName, content, time.Now(), tenantIDForInsert(ctx),
 	)
 	return err
+}
+
+// PropagateContextFile copies an agent-level context file to ALL existing user instances.
+// Only updates users who already have that file (seeded users). Returns count of updated rows.
+func (s *PGAgentStore) PropagateContextFile(ctx context.Context, agentID uuid.UUID, fileName string) (int, error) {
+	// Get the agent-level content
+	tClauseSelect, tArgsSelect, err := tenantClauseN(ctx, 3)
+	if err != nil {
+		return 0, err
+	}
+
+	var content string
+	err = s.db.QueryRowContext(ctx,
+		"SELECT content FROM agent_context_files WHERE agent_id = $1 AND file_name = $2"+tClauseSelect,
+		append([]any{agentID, fileName}, tArgsSelect...)...,
+	).Scan(&content)
+	if err != nil {
+		return 0, fmt.Errorf("agent file %s not found: %w", fileName, err)
+	}
+
+	// Update all existing user copies of this file
+	tClauseUpdate, tArgsUpdate, err := tenantClauseN(ctx, 5)
+	if err != nil {
+		return 0, err
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE user_context_files SET content = $1, updated_at = $2
+		 WHERE agent_id = $3 AND file_name = $4`+tClauseUpdate,
+		append([]any{content, time.Now(), agentID, fileName}, tArgsUpdate...)...,
+	)
+	if err != nil {
+		return 0, err
+	}
+	affected, _ := res.RowsAffected()
+	return int(affected), nil
 }
 
 // --- Per-user Context Files ---

--- a/internal/tools/context_file_interceptor_test.go
+++ b/internal/tools/context_file_interceptor_test.go
@@ -84,6 +84,9 @@ func (s *stubAgentStore) UpdateUserProfileMetadata(_ context.Context, _ uuid.UUI
 func (s *stubAgentStore) EnsureUserProfile(_ context.Context, _ uuid.UUID, _ string) error {
 	return nil
 }
+func (s *stubAgentStore) PropagateContextFile(_ context.Context, _ uuid.UUID, _ string) (int, error) {
+	return 0, nil
+}
 
 // ---- Tests ----
 


### PR DESCRIPTION
…, data safety

Fixes #294

1. Stale user_context_files after agent file update (#294.1, #294.2)
   - Added PropagateContextFile() to AgentStore — copies agent-level file to all existing user instances in one UPDATE
   - Added `propagate` param to agents.files.set WS handler
   - Response includes `propagated` count

2. Cron session reuse — tool errors block future runs (#294.3)
   - Reset cron session before each run via sessionMgr.Reset()
   - Each run starts clean, no stale error context

3. Write-behind cache risk — crash loses messages (#294.4)
   - Added periodic checkpoint flush after each tool iteration
   - Messages persisted to session after every tool call round
   - Worst case on crash: only current tool call lost, not entire run

4. Silent cron delivery failures (#294.5)
   - Added slog.Warn when deliver=true but channel/chatID missing

5. paired_devices cache gap (#294.6) — no fix needed
   - IsPaired() queries DB directly, no stale cache possible