### PR TITLE
fix(docker): change default host port to avoid Windows Hyper-V exclusion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,9 @@ services:
         ENABLE_PYTHON: "${ENABLE_PYTHON:-true}"
         ENABLE_FULL_SKILLS: "${ENABLE_FULL_SKILLS:-false}"
     ports:
-      - "${GOCLAW_PORT:-18790}:18790"
+      # Host port default 28790 — avoids Windows Hyper-V excluded port ranges.
+      # Override with GOCLAW_PORT env var if needed.
+      - "${GOCLAW_PORT:-28790}:18790"
     env_file:
       - path: .env
         required: false


### PR DESCRIPTION
## Summary
- Default host port 18790 falls in Windows Hyper-V excluded port range (18780-18879), causing `bind: access forbidden` on Docker startup
- Changed default to 28790 — outside typical Hyper-V reserved ranges
- Internal container port remains 18790 (no app changes needed)
- Users can still override via `GOCLAW_PORT` env var

## Context
Windows with Hyper-V (Docker Desktop, WSL2) randomly reserves TCP port ranges on each boot. Port 18790 frequently lands in these excluded ranges, breaking `docker compose up` for Windows users.

## Test plan
- [x] `docker compose up -d` succeeds on Windows with Hyper-V
- [ ] Verify existing `GOCLAW_PORT` override still works
- [ ] Verify Linux/macOS unaffected (no behavioral change)