### PR TITLE
fix(cron): reset session before each run to prevent stale retry history

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -782,7 +782,7 @@ func runGateway() {
 	defer sched.Stop()
 
 	// Start cron service with job handler (routes through scheduler's cron lane)
-	pgStores.Cron.SetOnJob(makeCronJobHandler(sched, msgBus, cfg, channelMgr))
+	pgStores.Cron.SetOnJob(makeCronJobHandler(sched, msgBus, cfg, channelMgr, pgStores.Sessions))
 	pgStores.Cron.SetOnEvent(func(event store.CronEvent) {
 		server.BroadcastEvent(*protocol.NewEvent(protocol.EventCron, event))
 	})

--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -21,7 +21,7 @@ import (
 // Safe because cron jobs only fire after Start(), well after this is set.
 var cronHeartbeatWakeFn func(agentID string)
 
-func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg *config.Config, channelMgr *channels.Manager) func(job *store.CronJob) (*store.CronJobResult, error) {
+func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg *config.Config, channelMgr *channels.Manager, sessionStore store.SessionStore) func(job *store.CronJob) (*store.CronJobResult, error) {
 	return func(job *store.CronJob) (*store.CronJobResult, error) {
 		agentID := job.AgentID
 		if agentID == "" {
@@ -62,6 +62,11 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 
 		// Build context with tenant scope so agent loop events are scoped correctly.
 		cronCtx := store.WithTenantID(context.Background(), job.TenantID)
+
+		// Reset session before each cron run to prevent stale messages from
+		// previous failed attempts polluting history on retry (#379).
+		sessionStore.Reset(cronCtx, sessionKey)
+		sessionStore.Save(cronCtx, sessionKey)
 
 		// Schedule through cron lane — scheduler handles agent resolution and concurrency
 		outCh := sched.Schedule(cronCtx, scheduler.LaneCron, agent.RunRequest{


### PR DESCRIPTION
Closes #379

## Summary
- Root cause: `ExecuteWithRetry` re-calls cron handler without clearing session — stale messages from failed attempts pollute history on retry
- Fix: call `sessionStore.Reset()` + `Save()` before each cron run so agent starts with clean session
- Cron jobs are stateless by design, carrying history adds cost with no benefit