### PR TITLE
fix(providers): register Ollama provider in-memory and fix double /v1

### DIFF
--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -275,12 +275,13 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			continue
 		}
 		// Local Ollama requires no API key — handle before the key guard (same pattern as ClaudeCLI).
+		// DB/UI stores api_base as full URL (e.g. "http://localhost:11434/v1"), use directly.
 		if p.ProviderType == store.ProviderOllama {
-			host := p.APIBase
-			if host == "" {
-				host = "http://localhost:11434"
+			base := p.APIBase
+			if base == "" {
+				base = "http://localhost:11434/v1"
 			}
-			registry.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, "ollama", host+"/v1", "llama3.3"))
+			registry.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, "ollama", base, "llama3.3"))
 			slog.Info("registered provider from DB", "name", p.Name)
 			continue
 		}

--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -51,6 +51,24 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 		return
 	}
 
+	// Local Ollama has no API key — fetch models via OpenAI-compat endpoint directly.
+	if p.ProviderType == store.ProviderOllama {
+		base := strings.TrimRight(h.resolveAPIBase(p), "/")
+		if base == "" {
+			base = "http://localhost:11434/v1"
+		}
+		ollamaCtx, ollamaCancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer ollamaCancel()
+		models, err := fetchOpenAIModels(ollamaCtx, base, "ollama")
+		if err != nil {
+			slog.Warn("providers.models", "provider", p.Name, "error", err)
+			writeJSON(w, http.StatusOK, map[string]any{"models": []ModelInfo{}})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"models": models})
+		return
+	}
+
 	if p.APIKey == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "API key")})
 		return

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -116,6 +116,16 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 	if p.ProviderType == store.ProviderACP {
 		return
 	}
+	// Local Ollama requires no API key — register immediately.
+	// DB/UI stores api_base as full URL (e.g. "http://localhost:11434/v1"), use directly.
+	if p.ProviderType == store.ProviderOllama {
+		base := p.APIBase
+		if base == "" {
+			base = "http://localhost:11434/v1"
+		}
+		h.providerReg.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, "ollama", base, "llama3.3"))
+		return
+	}
 	// Claude CLI doesn't need an API key — register immediately
 	if p.ProviderType == store.ProviderClaudeCLI {
 		cliPath := p.APIBase // reuse APIBase field for CLI path


### PR DESCRIPTION
## Summary
- Add `ProviderOllama` case to `registerInMemory()` so Ollama providers created via UI are immediately usable without gateway restart
- Fix double `/v1` in `registerProvidersFromDB()` — UI sends full URL (`http://localhost:11434/v1`) but backend appended another `/v1`
- Add `ProviderOllama` case to `handleListProviderModels()` before the API key guard so model listing works for keyless Ollama

## Test plan
- [ ] Create Ollama provider via UI with default API base → verify succeeds without restart
- [ ] List models for Ollama provider → returns installed models
- [ ] Existing providers (OpenAI, Anthropic, etc.) unaffected — no logic changes for other types