### PR TITLE
fix(security): harden secrets, MCP bridge auth, and file permissions

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -14,7 +14,7 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-goclaw}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-goclaw}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env (run ./prepare-env.sh)}
       POSTGRES_DB: ${POSTGRES_DB:-goclaw}
     volumes:
       - postgres-data:/var/lib/postgresql
@@ -30,7 +30,7 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      - GOCLAW_POSTGRES_DSN=postgres://${POSTGRES_USER:-goclaw}:${POSTGRES_PASSWORD:-goclaw}@postgres:5432/${POSTGRES_DB:-goclaw}?sslmode=disable
+      - GOCLAW_POSTGRES_DSN=postgres://${POSTGRES_USER:-goclaw}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-goclaw}?sslmode=disable
     volumes:
       - goclaw-skills:/app/skills
       - goclaw-workspace:/app/.goclaw

--- a/docker-compose.upgrade.yml
+++ b/docker-compose.upgrade.yml
@@ -24,7 +24,7 @@ services:
       - path: .env
         required: false
     environment:
-      - GOCLAW_POSTGRES_DSN=postgres://${POSTGRES_USER:-goclaw}:${POSTGRES_PASSWORD:-goclaw}@postgres:5432/${POSTGRES_DB:-goclaw}?sslmode=disable
+      - GOCLAW_POSTGRES_DSN=postgres://${POSTGRES_USER:-goclaw}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-goclaw}?sslmode=disable
       - GOCLAW_CONFIG=/app/data/config.json
       - GOCLAW_MIGRATIONS_DIR=/app/migrations
       - GOCLAW_ENCRYPTION_KEY=${GOCLAW_ENCRYPTION_KEY:-}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -311,17 +311,22 @@ func (s *Server) BuildMux() *http.ServeMux {
 
 	// MCP bridge: expose GoClaw tools to Claude CLI via streamable-http.
 	// Only listens on localhost (CLI runs on the same machine).
-	// Protected by gateway token when configured.
-	// Agent context (X-Agent-ID, X-User-ID) is injected from request headers.
+	// Protected by gateway token; disabled when no token is configured to
+	// prevent unauthenticated tool invocations if port is exposed.
 	if s.tools != nil {
-		bridgeHandler := mcpbridge.NewBridgeServer(s.tools, "1.0.0", s.msgBus)
-		var handler http.Handler = bridgeContextMiddleware(s.cfg.Gateway.Token, bridgeHandler)
 		if s.cfg.Gateway.Token != "" {
-			handler = tokenAuthMiddleware(s.cfg.Gateway.Token, handler)
+			bridgeHandler := mcpbridge.NewBridgeServer(s.tools, "1.0.0", s.msgBus)
+			handler := tokenAuthMiddleware(s.cfg.Gateway.Token,
+				bridgeContextMiddleware(s.cfg.Gateway.Token, bridgeHandler))
+			mux.Handle("/mcp/bridge", handler)
 		} else {
-			slog.Warn("security.mcp_bridge: no gateway token configured, MCP bridge tools are unauthenticated")
+			slog.Warn("security.mcp_bridge_disabled: no gateway token configured, MCP bridge is disabled")
+			mux.HandleFunc("/mcp/bridge", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				w.Write([]byte(`{"error":"mcp bridge disabled: set GOCLAW_GATEWAY_TOKEN to enable"}`))
+			})
 		}
-		mux.Handle("/mcp/bridge", handler)
 	}
 
 	s.mux = mux
@@ -405,6 +410,10 @@ func (s *Server) Start(ctx context.Context) error {
 	s.httpServer = &http.Server{
 		Addr:    addr,
 		Handler: mux,
+	}
+
+	if len(s.cfg.Gateway.AllowedOrigins) == 0 {
+		slog.Warn("security.cors_open: no allowed_origins configured, all WebSocket origins accepted — set gateway.allowed_origins in config for production")
 	}
 
 	slog.Info("gateway starting", "addr", addr)

--- a/prepare-env.sh
+++ b/prepare-env.sh
@@ -81,6 +81,22 @@ else
   echo "  [exists]    GOCLAW_GATEWAY_TOKEN"
 fi
 
+# 4. Auto-generate POSTGRES_PASSWORD if missing (required by docker-compose.postgres.yml)
+current_pg="$(get_env_val POSTGRES_PASSWORD)"
+if [ -z "$current_pg" ]; then
+  new_pg="$(gen_hex 16)"
+  set_env_val "POSTGRES_PASSWORD" "$new_pg"
+  echo "  [generated] POSTGRES_PASSWORD"
+else
+  echo "  [exists]    POSTGRES_PASSWORD"
+fi
+
+# 5. Restrict .env file permissions (secrets should not be world-readable)
+if [[ "$OSTYPE" != "msys" && "$OSTYPE" != "cygwin" && "$OSTYPE" != "win32" ]]; then
+  chmod 600 "$ENV_FILE"
+  echo "  [hardened]  .env permissions set to 600"
+fi
+
 echo ""
 echo "=== Done ==="
 echo ""


### PR DESCRIPTION
## Summary

Addresses actionable findings from security audit (#306):

- **H1: Default Postgres password** — `POSTGRES_PASSWORD` now uses `:?` (fail-fast) instead of `:-goclaw` in all compose files. `prepare-env.sh` auto-generates it so existing workflows aren't broken.
- **H3: MCP bridge unauthenticated** — Bridge returns 403 when no gateway token configured instead of serving tools without auth.
- **C1: `.env` file permissions** — `prepare-env.sh` now sets `chmod 600` on `.env` after generation (skipped on Windows).
- **H2: CORS allow-all** — Added startup warning when no `allowed_origins` configured (warn-only, not fail-closed, to avoid breaking existing setups).

## Findings intentionally skipped

| Finding | Reason |
|---------|--------|
| M1 (tokens in memory) | Security theater — all processes hold secrets in memory at runtime; already encrypted at-rest |
| M2 (no DB TLS) | Only in docker-compose (same network); remote users set sslmode themselves |
| M3 (DSN length logged) | A number reveals nothing actionable |
| L1 (protocol version) | Not a software version, useless for fingerprinting |
| L2 (guard default warn) | Design choice for single-user deployments; users can set "block" |
| L3 (proxy headers) | Edge case best handled at reverse proxy layer |

## Test plan

- [ ] Run `./prepare-env.sh` — verify `POSTGRES_PASSWORD` is generated and `.env` has 600 perms
- [ ] `docker compose -f docker-compose.yml -f docker-compose.postgres.yml up` without `.env` — verify fail-fast error for missing `POSTGRES_PASSWORD`
- [ ] Start gateway without `GOCLAW_GATEWAY_TOKEN` — verify `/mcp/bridge` returns 403
- [ ] Start gateway without `allowed_origins` — verify startup log shows CORS warning
- [ ] `go build ./internal/gateway/...` and `go vet ./internal/gateway/...` pass