### PR TITLE
feat: configurable tool loop detection thresholds per agent

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -500,7 +500,7 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 	}
 
 	// 4. Run LLM iteration loop
-	var loopDetector toolLoopState // detects repeated no-progress tool calls
+	loopDetector := newToolLoopState(l.toolLoopCfg) // detects repeated no-progress tool calls
 	var totalUsage providers.Usage
 	iteration := 0
 	totalToolCalls := 0

--- a/internal/agent/loop_types.go
+++ b/internal/agent/loop_types.go
@@ -115,6 +115,9 @@ type Loop struct {
 	// Thinking level for extended thinking support
 	thinkingLevel string
 
+	// Tool loop detection config (per-agent overrides, nil = use defaults)
+	toolLoopCfg *store.ToolLoopConfig
+
 	// Self-evolve: predefined agents can update SOUL.md through chat
 	selfEvolve bool
 
@@ -243,6 +246,9 @@ type LoopConfig struct {
 	// Thinking level: "off", "low", "medium", "high" (from agent other_config)
 	ThinkingLevel string
 
+	// Tool loop detection config (per-agent overrides, nil = use defaults)
+	ToolLoopCfg *store.ToolLoopConfig
+
 	// Self-evolve: predefined agents can update SOUL.md (style/tone) through chat
 	SelfEvolve bool
 
@@ -351,6 +357,7 @@ func NewLoop(cfg LoopConfig) *Loop {
 		builtinToolSettings:    cfg.BuiltinToolSettings,
 		disabledTools:          cfg.DisabledTools,
 		thinkingLevel:          cfg.ThinkingLevel,
+		toolLoopCfg:            cfg.ToolLoopCfg,
 		selfEvolve:             cfg.SelfEvolve,
 		skillEvolve:            cfg.SkillEvolve,
 		skillNudgeInterval:     cfg.SkillNudgeInterval,

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -379,6 +379,7 @@ func NewManagedResolver(deps ResolverDeps) ResolverFunc {
 			BuiltinToolSettings:    builtinSettings,
 			DisabledTools:          disabledTools,
 			ThinkingLevel:          ag.ParseThinkingLevel(),
+			ToolLoopCfg:            ag.ParseToolLoopConfig(),
 			SelfEvolve:             ag.ParseSelfEvolve(),
 			SkillEvolve:            ag.AgentType == store.AgentTypePredefined && ag.ParseSkillEvolve(),
 			SkillNudgeInterval:     ag.ParseSkillNudgeInterval(),

--- a/internal/agent/toolloop.go
+++ b/internal/agent/toolloop.go
@@ -6,22 +6,80 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
-// Tool loop detection thresholds (per-run, not per-session).
+// Default tool loop detection thresholds (per-run, not per-session).
+// These are used when no per-agent overrides are configured.
 const (
-	toolLoopHistorySize       = 30
-	toolLoopWarningThreshold  = 3 // inject warning into conversation
-	toolLoopCriticalThreshold = 5 // force stop the iteration loop
+	defaultToolLoopHistorySize       = 30
+	defaultToolLoopWarningThreshold  = 3 // inject warning into conversation
+	defaultToolLoopCriticalThreshold = 5 // force stop the iteration loop
 
 	// Read-only streak: consecutive non-mutating tool calls without any write/edit.
-	readOnlyStreakWarning  = 8
-	readOnlyStreakCritical = 12
+	defaultReadOnlyStreakWarning  = 8
+	defaultReadOnlyStreakCritical = 12
 
 	// Same-result: same tool returning identical results with different args.
-	sameResultWarning  = 4
-	sameResultCritical = 6
+	defaultSameResultWarning  = 4
+	defaultSameResultCritical = 6
 )
+
+// toolLoopThresholds holds the resolved thresholds for a single run.
+type toolLoopThresholds struct {
+	historySize       int
+	warningThreshold  int
+	criticalThreshold int
+	readOnlyWarning   int
+	readOnlyCritical  int
+	sameResultWarning  int
+	sameResultCritical int
+}
+
+// defaultToolLoopThresholds returns the hardcoded default thresholds.
+func defaultToolLoopThresholds() toolLoopThresholds {
+	return toolLoopThresholds{
+		historySize:        defaultToolLoopHistorySize,
+		warningThreshold:   defaultToolLoopWarningThreshold,
+		criticalThreshold:  defaultToolLoopCriticalThreshold,
+		readOnlyWarning:    defaultReadOnlyStreakWarning,
+		readOnlyCritical:   defaultReadOnlyStreakCritical,
+		sameResultWarning:  defaultSameResultWarning,
+		sameResultCritical: defaultSameResultCritical,
+	}
+}
+
+// mergeToolLoopConfig returns thresholds with per-agent overrides applied.
+// Non-zero values in cfg override the defaults.
+func mergeToolLoopConfig(cfg *store.ToolLoopConfig) toolLoopThresholds {
+	t := defaultToolLoopThresholds()
+	if cfg == nil {
+		return t
+	}
+	if cfg.HistorySize > 0 {
+		t.historySize = cfg.HistorySize
+	}
+	if cfg.WarningThreshold > 0 {
+		t.warningThreshold = cfg.WarningThreshold
+	}
+	if cfg.CriticalThreshold > 0 {
+		t.criticalThreshold = cfg.CriticalThreshold
+	}
+	if cfg.ReadOnlyWarning > 0 {
+		t.readOnlyWarning = cfg.ReadOnlyWarning
+	}
+	if cfg.ReadOnlyCritical > 0 {
+		t.readOnlyCritical = cfg.ReadOnlyCritical
+	}
+	if cfg.SameResultWarning > 0 {
+		t.sameResultWarning = cfg.SameResultWarning
+	}
+	if cfg.SameResultCritical > 0 {
+		t.sameResultCritical = cfg.SameResultCritical
+	}
+	return t
+}
 
 // mutatingTools are tools that indicate real progress (write/create/action).
 // exec is excluded: ambiguous (could be ls or rm). It neither resets nor
@@ -36,7 +94,15 @@ var mutatingTools = map[string]bool{
 
 // toolLoopState tracks recent tool calls within a single agent run
 // to detect infinite loops (same tool + same args + same result).
+// newToolLoopState creates a toolLoopState with resolved thresholds.
+func newToolLoopState(cfg *store.ToolLoopConfig) toolLoopState {
+	return toolLoopState{
+		cfg: mergeToolLoopConfig(cfg),
+	}
+}
+
 type toolLoopState struct {
+	cfg            toolLoopThresholds
 	history        []toolCallRecord
 	readOnlyStreak int // consecutive non-mutating, non-exec tool calls
 }
@@ -54,8 +120,8 @@ func (s *toolLoopState) record(toolName string, args map[string]any) string {
 		toolName: toolName,
 		argsHash: h,
 	})
-	if len(s.history) > toolLoopHistorySize {
-		s.history = s.history[len(s.history)-toolLoopHistorySize:]
+	if len(s.history) > s.cfg.historySize {
+		s.history = s.history[len(s.history)-s.cfg.historySize:]
 	}
 	return h
 }
@@ -76,7 +142,7 @@ func (s *toolLoopState) recordResult(argsHash, resultContent string) {
 // detect checks for repeated no-progress tool calls.
 // Returns level ("warning", "critical", or "") and a human-readable message.
 func (s *toolLoopState) detect(toolName string, argsHash string) (level, message string) {
-	if len(s.history) < toolLoopWarningThreshold {
+	if len(s.history) < s.cfg.warningThreshold {
 		return "", ""
 	}
 
@@ -101,13 +167,13 @@ func (s *toolLoopState) detect(toolName string, argsHash string) (level, message
 		}
 	}
 
-	if noProgressCount >= toolLoopCriticalThreshold {
+	if noProgressCount >= s.cfg.criticalThreshold {
 		return "critical", fmt.Sprintf(
 			"CRITICAL: %s has been called %d times with identical arguments and results. "+
 				"Stopping to prevent runaway loop.", toolName, noProgressCount)
 	}
 
-	if noProgressCount >= toolLoopWarningThreshold {
+	if noProgressCount >= s.cfg.warningThreshold {
 		return "warning", fmt.Sprintf(
 			"[System: WARNING — %s has been called %d times with the same arguments and identical results. "+
 				"This is not making progress. Try a completely different approach, use different tools, "+
@@ -133,12 +199,12 @@ func (s *toolLoopState) recordMutation(toolName string) {
 // detectReadOnlyStreak checks for long runs of read-only tool calls
 // without any write/edit action. Returns level and message.
 func (s *toolLoopState) detectReadOnlyStreak() (level, message string) {
-	if s.readOnlyStreak >= readOnlyStreakCritical {
+	if s.readOnlyStreak >= s.cfg.readOnlyCritical {
 		return "critical", fmt.Sprintf(
 			"CRITICAL: %d consecutive read-only tool calls without any write/edit action. "+
 				"Stopping to prevent runaway loop.", s.readOnlyStreak)
 	}
-	if s.readOnlyStreak >= readOnlyStreakWarning {
+	if s.readOnlyStreak >= s.cfg.readOnlyWarning {
 		return "warning", fmt.Sprintf(
 			"[System: WARNING — You have made %d consecutive read-only tool calls (list_files, read_file, find, etc.) "+
 				"without writing or editing any file. If you already have the information you need, use the edit or "+
@@ -161,12 +227,12 @@ func (s *toolLoopState) detectSameResult(toolName, resultHash string) (level, me
 			count++
 		}
 	}
-	if count >= sameResultCritical {
+	if count >= s.cfg.sameResultCritical {
 		return "critical", fmt.Sprintf(
 			"CRITICAL: %s returned identical results %d times (with different arguments). "+
 				"Stopping to prevent runaway loop.", toolName, count)
 	}
-	if count >= sameResultWarning {
+	if count >= s.cfg.sameResultWarning {
 		return "warning", fmt.Sprintf(
 			"[System: WARNING — %s has returned the same result %d times with different arguments. "+
 				"The information is already in your context. Stop re-reading and take action — "+

--- a/internal/agent/toolloop_test.go
+++ b/internal/agent/toolloop_test.go
@@ -1,9 +1,13 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
 
 func TestToolLoopDetection_NoLoop(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 
 	// 2 identical calls with same result → below threshold, no detection
 	for i := range 2 {
@@ -17,35 +21,35 @@ func TestToolLoopDetection_NoLoop(t *testing.T) {
 }
 
 func TestToolLoopDetection_Warning(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 
 	var lastLevel string
-	for range toolLoopWarningThreshold {
+	for range defaultToolLoopWarningThreshold {
 		h := s.record("list_files", map[string]any{"path": "."})
 		s.recordResult(h, "access denied")
 		lastLevel, _ = s.detect("list_files", h)
 	}
 	if lastLevel != "warning" {
-		t.Fatalf("expected warning after %d calls, got %q", toolLoopWarningThreshold, lastLevel)
+		t.Fatalf("expected warning after %d calls, got %q", defaultToolLoopWarningThreshold, lastLevel)
 	}
 }
 
 func TestToolLoopDetection_Critical(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 
 	var lastLevel string
-	for range toolLoopCriticalThreshold {
+	for range defaultToolLoopCriticalThreshold {
 		h := s.record("list_files", map[string]any{"path": "."})
 		s.recordResult(h, "access denied")
 		lastLevel, _ = s.detect("list_files", h)
 	}
 	if lastLevel != "critical" {
-		t.Fatalf("expected critical after %d calls, got %q", toolLoopCriticalThreshold, lastLevel)
+		t.Fatalf("expected critical after %d calls, got %q", defaultToolLoopCriticalThreshold, lastLevel)
 	}
 }
 
 func TestToolLoopDetection_DifferentArgs(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 
 	// Same tool but different args each time → no detection
 	for i := range 15 {
@@ -60,7 +64,7 @@ func TestToolLoopDetection_DifferentArgs(t *testing.T) {
 }
 
 func TestToolLoopDetection_DifferentResults(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 
 	// Same args but different results each time → progress, no detection
 	for i := range 15 {
@@ -74,7 +78,7 @@ func TestToolLoopDetection_DifferentResults(t *testing.T) {
 }
 
 func TestToolLoopDetection_MixedTools(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 
 	// Alternate between two tools with same result → each tool only hit ~half
 	// With 8 iterations, each tool is called 4 times → below critical (5)
@@ -105,29 +109,29 @@ func TestStableJSON(t *testing.T) {
 // --- Read-only streak detection ---
 
 func TestReadOnlyStreak_Warning(t *testing.T) {
-	var s toolLoopState
-	for range readOnlyStreakWarning {
+	s := newToolLoopState(nil)
+	for range defaultReadOnlyStreakWarning {
 		s.recordMutation("read_file")
 	}
 	level, _ := s.detectReadOnlyStreak()
 	if level != "warning" {
-		t.Fatalf("expected warning after %d read-only calls, got %q", readOnlyStreakWarning, level)
+		t.Fatalf("expected warning after %d read-only calls, got %q", defaultReadOnlyStreakWarning, level)
 	}
 }
 
 func TestReadOnlyStreak_Critical(t *testing.T) {
-	var s toolLoopState
-	for range readOnlyStreakCritical {
+	s := newToolLoopState(nil)
+	for range defaultReadOnlyStreakCritical {
 		s.recordMutation("list_files")
 	}
 	level, _ := s.detectReadOnlyStreak()
 	if level != "critical" {
-		t.Fatalf("expected critical after %d read-only calls, got %q", readOnlyStreakCritical, level)
+		t.Fatalf("expected critical after %d read-only calls, got %q", defaultReadOnlyStreakCritical, level)
 	}
 }
 
 func TestReadOnlyStreak_ResetByMutation(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 	// 7 read-only calls → below warning
 	for range 7 {
 		s.recordMutation("read_file")
@@ -148,7 +152,7 @@ func TestReadOnlyStreak_ResetByMutation(t *testing.T) {
 }
 
 func TestReadOnlyStreak_ExecNeutral(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 	// 5 reads → streak = 5
 	for range 5 {
 		s.recordMutation("read_file")
@@ -174,9 +178,9 @@ func TestReadOnlyStreak_ExecNeutral(t *testing.T) {
 // --- Same-result cross-args detection ---
 
 func TestSameResult_Warning(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 	sameResult := "directory listing output"
-	for i := range sameResultWarning {
+	for i := range defaultSameResultWarning {
 		args := map[string]any{"path": string(rune('a' + i))}
 		h := s.record("list_files", args)
 		s.recordResult(h, sameResult)
@@ -184,14 +188,14 @@ func TestSameResult_Warning(t *testing.T) {
 	rh := hashResult(sameResult)
 	level, _ := s.detectSameResult("list_files", rh)
 	if level != "warning" {
-		t.Fatalf("expected warning after %d same-result calls, got %q", sameResultWarning, level)
+		t.Fatalf("expected warning after %d same-result calls, got %q", defaultSameResultWarning, level)
 	}
 }
 
 func TestSameResult_Critical(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 	sameResult := "directory listing output"
-	for i := range sameResultCritical {
+	for i := range defaultSameResultCritical {
 		args := map[string]any{"path": string(rune('a' + i))}
 		h := s.record("list_files", args)
 		s.recordResult(h, sameResult)
@@ -199,12 +203,12 @@ func TestSameResult_Critical(t *testing.T) {
 	rh := hashResult(sameResult)
 	level, _ := s.detectSameResult("list_files", rh)
 	if level != "critical" {
-		t.Fatalf("expected critical after %d same-result calls, got %q", sameResultCritical, level)
+		t.Fatalf("expected critical after %d same-result calls, got %q", defaultSameResultCritical, level)
 	}
 }
 
 func TestSameResult_DifferentResults(t *testing.T) {
-	var s toolLoopState
+	s := newToolLoopState(nil)
 	// Same tool, same args pattern, but different results each time → no detection
 	for i := range 8 {
 		args := map[string]any{"path": string(rune('a' + i))}
@@ -230,5 +234,165 @@ func TestHashToolCall(t *testing.T) {
 	h3 := hashToolCall("read_file", map[string]any{"path": "."})
 	if h1 == h3 {
 		t.Fatal("different tools should have different hashes")
+	}
+}
+
+
+// --- Per-agent config override tests ---
+
+func TestMergeToolLoopConfig_Nil(t *testing.T) {
+	cfg := mergeToolLoopConfig(nil)
+	if cfg.warningThreshold != defaultToolLoopWarningThreshold {
+		t.Fatalf("expected default warning %d, got %d", defaultToolLoopWarningThreshold, cfg.warningThreshold)
+	}
+	if cfg.criticalThreshold != defaultToolLoopCriticalThreshold {
+		t.Fatalf("expected default critical %d, got %d", defaultToolLoopCriticalThreshold, cfg.criticalThreshold)
+	}
+	if cfg.historySize != defaultToolLoopHistorySize {
+		t.Fatalf("expected default history %d, got %d", defaultToolLoopHistorySize, cfg.historySize)
+	}
+}
+
+func TestMergeToolLoopConfig_PartialOverride(t *testing.T) {
+	cfg := mergeToolLoopConfig(&store.ToolLoopConfig{
+		WarningThreshold: 5,
+		ReadOnlyCritical: 20,
+	})
+	// Overridden
+	if cfg.warningThreshold != 5 {
+		t.Fatalf("expected overridden warning 5, got %d", cfg.warningThreshold)
+	}
+	if cfg.readOnlyCritical != 20 {
+		t.Fatalf("expected overridden readOnlyCritical 20, got %d", cfg.readOnlyCritical)
+	}
+	// Defaults preserved
+	if cfg.criticalThreshold != defaultToolLoopCriticalThreshold {
+		t.Fatalf("expected default critical %d, got %d", defaultToolLoopCriticalThreshold, cfg.criticalThreshold)
+	}
+	if cfg.readOnlyWarning != defaultReadOnlyStreakWarning {
+		t.Fatalf("expected default readOnlyWarning %d, got %d", defaultReadOnlyStreakWarning, cfg.readOnlyWarning)
+	}
+}
+
+func TestMergeToolLoopConfig_FullOverride(t *testing.T) {
+	cfg := mergeToolLoopConfig(&store.ToolLoopConfig{
+		HistorySize:        50,
+		WarningThreshold:   6,
+		CriticalThreshold:  10,
+		ReadOnlyWarning:    15,
+		ReadOnlyCritical:   25,
+		SameResultWarning:  8,
+		SameResultCritical: 12,
+	})
+	if cfg.historySize != 50 {
+		t.Fatalf("expected 50, got %d", cfg.historySize)
+	}
+	if cfg.warningThreshold != 6 {
+		t.Fatalf("expected 6, got %d", cfg.warningThreshold)
+	}
+	if cfg.criticalThreshold != 10 {
+		t.Fatalf("expected 10, got %d", cfg.criticalThreshold)
+	}
+	if cfg.readOnlyWarning != 15 {
+		t.Fatalf("expected 15, got %d", cfg.readOnlyWarning)
+	}
+	if cfg.readOnlyCritical != 25 {
+		t.Fatalf("expected 25, got %d", cfg.readOnlyCritical)
+	}
+	if cfg.sameResultWarning != 8 {
+		t.Fatalf("expected 8, got %d", cfg.sameResultWarning)
+	}
+	if cfg.sameResultCritical != 12 {
+		t.Fatalf("expected 12, got %d", cfg.sameResultCritical)
+	}
+}
+
+func TestToolLoopDetection_CustomThresholds(t *testing.T) {
+	// Custom: warning at 5, critical at 8
+	s := newToolLoopState(&store.ToolLoopConfig{
+		WarningThreshold:  5,
+		CriticalThreshold: 8,
+	})
+
+	// 4 calls → below custom warning (5)
+	for range 4 {
+		h := s.record("list_files", map[string]any{"path": "."})
+		s.recordResult(h, "access denied")
+		level, _ := s.detect("list_files", h)
+		if level != "" {
+			t.Fatalf("expected no detection at <5, got %q", level)
+		}
+	}
+
+	// 5th call → warning
+	h := s.record("list_files", map[string]any{"path": "."})
+	s.recordResult(h, "access denied")
+	level, _ := s.detect("list_files", h)
+	if level != "warning" {
+		t.Fatalf("expected warning at 5, got %q", level)
+	}
+
+	// Fill up to 8 → critical
+	for range 3 {
+		h = s.record("list_files", map[string]any{"path": "."})
+		s.recordResult(h, "access denied")
+	}
+	level, _ = s.detect("list_files", h)
+	if level != "critical" {
+		t.Fatalf("expected critical at 8, got %q", level)
+	}
+}
+
+func TestReadOnlyStreak_CustomThresholds(t *testing.T) {
+	s := newToolLoopState(&store.ToolLoopConfig{
+		ReadOnlyWarning:  12,
+		ReadOnlyCritical: 20,
+	})
+
+	// 11 reads → below custom warning (12)
+	for range 11 {
+		s.recordMutation("read_file")
+	}
+	level, _ := s.detectReadOnlyStreak()
+	if level != "" {
+		t.Fatalf("expected no detection at 11, got %q", level)
+	}
+
+	// 12th read → warning
+	s.recordMutation("read_file")
+	level, _ = s.detectReadOnlyStreak()
+	if level != "warning" {
+		t.Fatalf("expected warning at 12, got %q", level)
+	}
+}
+
+func TestParseToolLoopConfig(t *testing.T) {
+	// Test with valid config
+	ad := &store.AgentData{
+		OtherConfig: []byte(`{"tool_loop":{"warning_threshold":5,"critical_threshold":10}}`),
+	}
+	cfg := ad.ParseToolLoopConfig()
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.WarningThreshold != 5 {
+		t.Fatalf("expected warning 5, got %d", cfg.WarningThreshold)
+	}
+	if cfg.CriticalThreshold != 10 {
+		t.Fatalf("expected critical 10, got %d", cfg.CriticalThreshold)
+	}
+
+	// Test with empty other_config
+	ad2 := &store.AgentData{}
+	if ad2.ParseToolLoopConfig() != nil {
+		t.Fatal("expected nil for empty other_config")
+	}
+
+	// Test with other_config but no tool_loop key
+	ad3 := &store.AgentData{
+		OtherConfig: []byte(`{"thinking_level":"high"}`),
+	}
+	if ad3.ParseToolLoopConfig() != nil {
+		t.Fatal("expected nil when tool_loop key is absent")
 	}
 }

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -235,6 +235,33 @@ func (a *AgentData) ParseSkillNudgeInterval() int {
 	return *cfg.SkillNudgeInterval
 }
 
+// ToolLoopConfig holds per-agent overrides for tool loop detection thresholds.
+// Zero values mean "use default". Only non-zero values override the hardcoded defaults.
+type ToolLoopConfig struct {
+	HistorySize        int `json:"history_size,omitempty"`
+	WarningThreshold   int `json:"warning_threshold,omitempty"`
+	CriticalThreshold  int `json:"critical_threshold,omitempty"`
+	ReadOnlyWarning    int `json:"read_only_warning,omitempty"`
+	ReadOnlyCritical   int `json:"read_only_critical,omitempty"`
+	SameResultWarning  int `json:"same_result_warning,omitempty"`
+	SameResultCritical int `json:"same_result_critical,omitempty"`
+}
+
+// ParseToolLoopConfig extracts tool_loop from other_config JSONB.
+// Returns nil if not configured.
+func (a *AgentData) ParseToolLoopConfig() *ToolLoopConfig {
+	if len(a.OtherConfig) == 0 {
+		return nil
+	}
+	var cfg struct {
+		ToolLoop *ToolLoopConfig `json:"tool_loop"`
+	}
+	if json.Unmarshal(a.OtherConfig, &cfg) != nil {
+		return nil
+	}
+	return cfg.ToolLoop
+}
+
 // WorkspaceSharingConfig controls per-user workspace isolation.
 // When shared_dm/shared_group is true, users share the base workspace directory
 // instead of each getting an isolated subfolder.


### PR DESCRIPTION
## Summary

Add per-agent tool loop detection config via `other_config` JSONB field (`tool_loop` key).

Agents can now override the hardcoded loop detection thresholds without code changes:

| Field | Default | Description |
|-------|---------|-------------|
| `history_size` | 30 | Sliding window size for call history |
| `warning_threshold` | 3 | Same-args-same-result warning |
| `critical_threshold` | 5 | Same-args-same-result force stop |
| `read_only_warning` | 8 | Consecutive read-only calls warning |
| `read_only_critical` | 12 | Consecutive read-only calls force stop |
| `same_result_warning` | 4 | Different-args-same-result warning |
| `same_result_critical` | 6 | Different-args-same-result force stop |

## Configuration Example

```json
{
  "other_config": {
    "tool_loop": {
      "warning_threshold": 5,
      "critical_threshold": 8,
      "read_only_warning": 15,
      "read_only_critical": 25
    }
  }
}
```

Zero values = use defaults. Only non-zero values override.

## Changes (6 files, +309/-44)

| File | Change |
|------|--------|
| `store/agent_store.go` | `ToolLoopConfig` struct + `ParseToolLoopConfig()` |
| `agent/toolloop.go` | Replace `const` → configurable `toolLoopThresholds` + `mergeToolLoopConfig()` |
| `agent/loop_types.go` | Thread `ToolLoopCfg` through `LoopConfig` → `Loop` struct |
| `agent/resolver.go` | Wire `ParseToolLoopConfig()` into LoopConfig |
| `agent/loop.go` | `newToolLoopState(cfg)` instead of zero-value init |
| `agent/toolloop_test.go` | Update existing + 6 new tests for config overrides |

## Design Decisions

- **Zero DDL migration** — reuses existing `other_config` JSONB
- **Zero new API** — existing `agents.update` already handles `other_config`
- **Zero breaking changes** — unconfigured agents use identical defaults
- **Follows existing pattern** — same as `thinking_level`, `self_evolve`, etc.
- **All 21 tests passing**