### PR TITLE
fix(ui): align stat card heights when sparkline data is missing

### DIFF
--- a/ui/web/src/pages/overview/stat-card.tsx
+++ b/ui/web/src/pages/overview/stat-card.tsx
@@ -47,8 +47,8 @@ export function StatCard({
           {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
         </div>
       </div>
-      {sparkData && sparkData.length > 1 && (
-        <div className="mt-3 h-[40px]">
+      <div className="mt-3 h-[40px]">
+        {sparkData && sparkData.length > 1 && (
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={sparkData} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
               <defs>
@@ -68,8 +68,8 @@ export function StatCard({
               />
             </AreaChart>
           </ResponsiveContainer>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Stat cards on the overview dashboard have inconsistent heights — cards with sparkline charts are taller than cards without data.

## Fix

Always reserve the sparkline container (`h-[40px]`) regardless of whether chart data exists. The chart only renders inside when `sparkData.length > 1`, but the space is consistent across all cards.

## Before / After

**Before:** Cards with sparkline data are ~40px taller than cards without, causing jagged row alignment.

**After:** All cards have the same height. Empty sparkline area is invisible but reserves space.

## Files Changed

| File | Change |
|------|--------|
| `ui/web/src/pages/overview/stat-card.tsx` | Move sparkline container div outside the conditional |