### PR TITLE
fix(telegram): clear draft after materializing DM stream

### DIFF
--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -111,11 +111,11 @@ type StreamingChannel interface {
 	// firstStream: true for the first stream in a run (may become reasoning lane —
 	// must use message transport so it persists as a real message). false for
 	// subsequent streams (answer lane — may use draft transport for stealth preview).
-	CreateStream(ctx context.Context, chatID string, runID string, firstStream bool) (ChannelStream, error)
+	CreateStream(ctx context.Context, chatID string, firstStream bool) (ChannelStream, error)
 	// FinalizeStream is called after the stream has been stopped to hand off
 	// the stream's messageID (if any) back to the channel's placeholder map
 	// so that Send() can edit it with the final formatted response.
-	FinalizeStream(ctx context.Context, chatID string, runID string, stream ChannelStream)
+	FinalizeStream(ctx context.Context, chatID string, stream ChannelStream)
 	// ReasoningStreamEnabled returns whether reasoning should be shown as a
 	// separate message. Default: true. Channels that don't support lanes can
 	// return false to skip reasoning routing.

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -111,11 +111,11 @@ type StreamingChannel interface {
 	// firstStream: true for the first stream in a run (may become reasoning lane —
 	// must use message transport so it persists as a real message). false for
 	// subsequent streams (answer lane — may use draft transport for stealth preview).
-	CreateStream(ctx context.Context, chatID string, firstStream bool) (ChannelStream, error)
+	CreateStream(ctx context.Context, chatID string, runID string, firstStream bool) (ChannelStream, error)
 	// FinalizeStream is called after the stream has been stopped to hand off
 	// the stream's messageID (if any) back to the channel's placeholder map
 	// so that Send() can edit it with the final formatted response.
-	FinalizeStream(ctx context.Context, chatID string, stream ChannelStream)
+	FinalizeStream(ctx context.Context, chatID string, runID string, stream ChannelStream)
 	// ReasoningStreamEnabled returns whether reasoning should be shown as a
 	// separate message. Default: true. Channels that don't support lanes can
 	// return false to skip reasoning routing.

--- a/internal/channels/telegram/channel.go
+++ b/internal/channels/telegram/channel.go
@@ -46,6 +46,7 @@ type Channel struct {
 	pollDone         chan struct{}       // closed when polling goroutine exits
 	handlerWg        sync.WaitGroup     // tracks in-flight handler goroutines for graceful shutdown
 	handlerSem       chan struct{}       // bounded semaphore for concurrent handler goroutines
+	pendingDraftID   sync.Map           // localKey string → int (draftID)
 }
 
 type thinkingCancel struct {

--- a/internal/channels/telegram/send.go
+++ b/internal/channels/telegram/send.go
@@ -161,6 +161,24 @@ func (c *Channel) Send(ctx context.Context, msg bus.OutboundMessage) error {
 		}
 	}
 
+	// Captured draft cleanup: if this message follows a DM stream that used the
+	// draft transport, we must clear the stale draft as soon as this bubble is sent.
+	if pID, ok := c.pendingDraftID.LoadAndDelete(localKey); ok {
+		draftID := pID.(int)
+		defer func() {
+			go func() {
+				params := &telego.SendMessageDraftParams{
+					ChatID:          chatID,
+					DraftID:         draftID,
+					Text:            "",
+					MessageThreadID: resolveThreadIDForSend(threadID),
+				}
+				// Best-effort fired with Background ctx — cosmetic failure is ignored.
+				_ = c.bot.SendMessageDraft(context.Background(), params)
+			}()
+		}()
+	}
+
 	// Placeholder update (e.g. LLM retry notification): edit the placeholder
 	// but keep it alive for the final response. Don't stop typing or cleanup.
 	if msg.Metadata["placeholder_update"] == "true" {

--- a/internal/channels/telegram/stream.go
+++ b/internal/channels/telegram/stream.go
@@ -331,6 +331,11 @@ func (c *Channel) FinalizeStream(ctx context.Context, chatID string, stream chan
 		slog.Warn("stream: initial send landed but ID unknown. Suppressing fallback message to avoid duplicate.", "chat_id", chatID)
 	}
 
+	// Capture draft ID for clearing after the final Send()
+	if ds, ok := stream.(*DraftStream); ok && ds.UsedDraftTransport() {
+		c.pendingDraftID.Store(chatID, ds.draftID)
+	}
+
 	// Stop thinking animation
 	if stop, ok := c.stopThinking.Load(chatID); ok {
 		if cf, ok := stop.(*thinkingCancel); ok {


### PR DESCRIPTION
## Summary
In Telegram DMs using `draft_transport`, the preview draft sometimes stays in the input area even after the "real" message is delivered, which briefly shows a duplicate reply.

This PR ensures that as soon as the real message is delivered in `Send()`, we explicitly call `sendMessageDraft` with an empty string to clear the stale draft.
## Changes: 
- Capture the `draftID` when a stream ends and clear it in the background after the final message is sent.
- Robustness: The cleanup is asynchronous and "best-effort," so it won't block the actual message delivery if the Telegram API is slow.