### PR TITLE
feat(telegram): add security warning for open-pairing mode

### DIFF
--- a/cmd/channels_cmd.go
+++ b/cmd/channels_cmd.go
@@ -63,6 +63,14 @@ func channelsListCmd() *cobra.Command {
 				fmt.Fprintf(tw, "%s\t%v\t%s\n", e.Name, e.Enabled, creds)
 			}
 			tw.Flush()
+
+			// Security alert: warn on "Open Pairing" configuration (matching openclaw #48813)
+			if cfg.Channels.Telegram.Enabled && (cfg.Channels.Telegram.DMPolicy == "" || cfg.Channels.Telegram.DMPolicy == "pairing") && len(cfg.Channels.Telegram.AllowFrom) == 0 {
+				fmt.Println("\n⚠️  Telegram DM access warning")
+				fmt.Println("   Your bot is using the default DM policy (pairing) with no allowlist.")
+				fmt.Println("   Any Telegram user who discovers the bot can send pairing requests.")
+				fmt.Println("   For security, consider adding your user id to 'allow_from' in config.json.")
+			}
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")

--- a/internal/channels/telegram/channel.go
+++ b/internal/channels/telegram/channel.go
@@ -27,25 +27,25 @@ type Channel struct {
 	config           config.TelegramConfig
 	httpClient       *http.Client
 	transport        *http.Transport
-	ipv4Once         sync.Once          // guards enableIPv4Only to prevent data race
+	ipv4Once         sync.Once // guards enableIPv4Only to prevent data race
 	pairingService   store.PairingStore
-	agentStore      store.AgentStore              // for agent key lookup (nil if not configured)
-	configPermStore store.ConfigPermissionStore   // for group file writer management (nil if not configured)
-	teamStore       store.TeamStore               // for /tasks, /task_detail commands (nil if not configured)
-	placeholders     sync.Map         // localKey string → messageID int
-	stopThinking     sync.Map         // localKey string → *thinkingCancel
-	typingCtrls      sync.Map         // localKey string → *typing.Controller
-	reactions        sync.Map         // localKey string → *StatusReactionController
-	pairingReplySent sync.Map         // userID string → time.Time (debounce pairing replies)
-	threadIDs        sync.Map         // localKey string → messageThreadID int (for forum topic routing)
-	approvedGroups   sync.Map         // chatIDStr string → true (cached group pairing approval)
+	agentStore       store.AgentStore            // for agent key lookup (nil if not configured)
+	configPermStore  store.ConfigPermissionStore // for group file writer management (nil if not configured)
+	teamStore        store.TeamStore             // for /tasks, /task_detail commands (nil if not configured)
+	placeholders     sync.Map                    // localKey string → messageID int
+	stopThinking     sync.Map                    // localKey string → *thinkingCancel
+	typingCtrls      sync.Map                    // localKey string → *typing.Controller
+	reactions        sync.Map                    // localKey string → *StatusReactionController
+	pairingReplySent sync.Map                    // userID string → time.Time (debounce pairing replies)
+	threadIDs        sync.Map                    // localKey string → messageThreadID int (for forum topic routing)
+	approvedGroups   sync.Map                    // chatIDStr string → true (cached group pairing approval)
 	groupHistory     *channels.PendingHistory
 	historyLimit     int
 	requireMention   bool
 	pollCancel       context.CancelFunc // cancels the long polling context
-	pollDone         chan struct{}       // closed when polling goroutine exits
+	pollDone         chan struct{}      // closed when polling goroutine exits
 	handlerWg        sync.WaitGroup     // tracks in-flight handler goroutines for graceful shutdown
-	handlerSem       chan struct{}       // bounded semaphore for concurrent handler goroutines
+	handlerSem       chan struct{}      // bounded semaphore for concurrent handler goroutines
 }
 
 type thinkingCancel struct {
@@ -113,7 +113,7 @@ func New(cfg config.TelegramConfig, msgBus *bus.MessageBus, pairingSvc store.Pai
 		historyLimit = channels.DefaultGroupHistoryLimit
 	}
 
-	return &Channel{
+	c := &Channel{
 		BaseChannel:     base,
 		bot:             bot,
 		config:          cfg,
@@ -126,7 +126,14 @@ func New(cfg config.TelegramConfig, msgBus *bus.MessageBus, pairingSvc store.Pai
 		groupHistory:    channels.MakeHistory(channels.TypeTelegram, pendingStore, base.TenantID()),
 		historyLimit:    historyLimit,
 		requireMention:  requireMention,
-	}, nil
+	}
+
+	// Security alert: warn on "Open Pairing" configuration (matching openclaw #48813)
+	if (cfg.DMPolicy == "" || cfg.DMPolicy == "pairing") && len(cfg.AllowFrom) == 0 {
+		slog.Warn("telegram: security risk — bot is in 'pairing' mode with no allowed users. Unsolicited pairing requests are possible.", "bot", bot.Username())
+	}
+
+	return c, nil
 }
 
 // Start begins long polling for Telegram updates.

--- a/ui/web/src/pages/channels/channel-schemas.ts
+++ b/ui/web/src/pages/channels/channel-schemas.ts
@@ -72,7 +72,7 @@ export const configSchema: Record<string, FieldDef[]> = {
   telegram: [
     { key: "api_server", label: "API Server URL", type: "text", placeholder: "http://127.0.0.1:8081", help: "Custom Telegram Bot API server for large file uploads (up to 2GB). Leave empty for default." },
     { key: "proxy", label: "HTTP Proxy", type: "text", placeholder: "http://proxy:8080", help: "Route bot traffic through an HTTP proxy" },
-    { key: "dm_policy", label: "DM Policy", type: "select", options: dmPolicyOptions, defaultValue: "pairing" },
+    { key: "dm_policy", label: "DM Policy", type: "select", options: dmPolicyOptions, defaultValue: "pairing", help: "WARNING: 'Pairing' with an empty allowlist (Allowed Users) exposes your bot to unsolicited requests from anyone who finds it." },
     { key: "group_policy", label: "Group Policy", type: "select", options: groupPolicyOptions, defaultValue: "pairing" },
     { key: "require_mention", label: "Require @mention in groups", type: "boolean", defaultValue: true },
     { key: "history_limit", label: "Group History Limit", type: "number", defaultValue: 50, help: "Max pending group messages for context (0 = disabled)" },


### PR DESCRIPTION
## The Problem
Currently, the Telegram channel in goclaw defaults to `dmPolicy: "pairing"`. If a user completes the setup without explicitly configuring an `allow_from` list (which is common for new users), the bot enters an "Open Pairing" state.

In this state, any Telegram user who discovers the bot handle can send a pairing request. Many users are unaware that an empty allowlist in pairing mode results in an open bot, rather than a private one. This creates a security risk for bots handling sensitive data or system commands.

## The Solution
This PR ports the security awareness improvements from openclaw to goclaw. It implements a 3-tier warning system to ensure users are clearly informed of the risks across all interaction surfaces.