### PR TITLE
feat(xai): add grok catalog update and GA models

### DIFF
--- a/cmd/onboard_managed.go
+++ b/cmd/onboard_managed.go
@@ -28,6 +28,7 @@ func testPostgresConnection(dsn string) error {
 // UI discoverability. Users can later enable and configure them via the dashboard.
 var defaultPlaceholderProviders = []store.LLMProviderData{
 	{Name: "openrouter", DisplayName: "OpenRouter", ProviderType: store.ProviderOpenRouter, APIBase: "https://openrouter.ai/api/v1", Enabled: false},
+	{Name: "xai", DisplayName: "xAI (Grok)", ProviderType: store.ProviderXAI, APIBase: "https://api.x.ai/v1", Enabled: false},
 	{Name: "synthetic", DisplayName: "Synthetic", ProviderType: store.ProviderOpenAICompat, APIBase: "https://api.synthetic.new/openai/v1", Enabled: false},
 	{Name: "alicloud-api", DisplayName: "AliCloud API", ProviderType: store.ProviderDashScope, APIBase: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", Enabled: false},
 	{Name: "alicloud-sub", DisplayName: "AliCloud Sub", ProviderType: store.ProviderBailian, APIBase: "https://coding-intl.dashscope.aliyuncs.com/v1", Enabled: false},

--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -74,6 +74,8 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 		models = minimaxModels()
 	case "suno":
 		models = sunoModels()
+	case "xai":
+		models = xaiModels()
 	default:
 		// All other types use OpenAI-compatible /models endpoint
 		apiBase := strings.TrimRight(h.resolveAPIBase(p), "/")
@@ -237,6 +239,26 @@ func sunoModels() []ModelInfo {
 		{ID: "v4.5", Name: "Suno V4.5"},
 		{ID: "v4", Name: "Suno V4"},
 		{ID: "v3.5", Name: "Suno V3.5"},
+	}
+}
+
+// xaiModels returns a hardcoded list of xAI Grok models.
+func xaiModels() []ModelInfo {
+	return []ModelInfo{
+		// Grok 4.20 GA
+		{ID: "grok-4.20-reasoning", Name: "Grok 4.20 Reasoning"},
+		{ID: "grok-4.20-non-reasoning", Name: "Grok 4.20"},
+		{ID: "grok-4.20", Name: "Grok 4.20 (Auto)"},
+		// Grok 3
+		{ID: "grok-3-reasoning", Name: "Grok 3 Reasoning"},
+		{ID: "grok-3-non-reasoning", Name: "Grok 3"},
+		{ID: "grok-3", Name: "Grok 3 (Auto)"},
+		{ID: "grok-3-mini", Name: "Grok 3 Mini"},
+		// Grok 2
+		{ID: "grok-2-reasoning", Name: "Grok 2 Reasoning"},
+		{ID: "grok-2-non-reasoning", Name: "Grok 2"},
+		{ID: "grok-2", Name: "Grok 2 (Auto)"},
+		{ID: "grok-2-1212", Name: "Grok 2 (12-12)"},
 	}
 }
 


### PR DESCRIPTION
## The Problem
xAI recently released Grok 4.20 GA, but these models (grok-4.20-reasoning and grok-4.20-non-reasoning) were not easily discoverable in the goclaw dashboard. Additionally, xAI (Grok) was missing from the default placeholder providers seeded during the onboarding process, making it harder for new users to find and configure.

##  The Solution
This PR updates the xAI integration to ensure it is first-class and up-to-date. It adds a dedicated model catalog to the backend and ensures xAI appears as a standard option immediately after a fresh install.