### PR TITLE
refactor(docker): rename network shared → goclaw-net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ COMPOSE = docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f
 UPGRADE = docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.upgrade.yml
 
 net:
-	docker network inspect shared >/dev/null 2>&1 || docker network create shared
+	docker network inspect goclaw-net >/dev/null 2>&1 || docker network create goclaw-net
 
 version-file:
 	@echo $(VERSION) > VERSION

--- a/docker-compose.selfservice.yml
+++ b/docker-compose.selfservice.yml
@@ -15,7 +15,7 @@ services:
       - "${GOCLAW_UI_PORT:-3000}:80"
     networks:
       - default
-      - shared
+      - goclaw-net
     depends_on:
       - goclaw
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
           pids: 200
     networks:
       - default
-      - shared
+      - goclaw-net
     restart: unless-stopped
 
 volumes:
@@ -67,6 +67,6 @@ volumes:
   goclaw-workspace:
 
 networks:
-  shared:
-    name: shared
+  goclaw-net:
+    name: goclaw-net
     driver: bridge


### PR DESCRIPTION
## Summary
- Rename Docker network from generic `shared` to project-scoped `goclaw-net` to avoid conflicts with other projects on the same host
- Updated `docker-compose.yml`, `docker-compose.selfservice.yml`, and `Makefile`
- Fix https://github.com/nextlevelbuilder/goclaw/issues/89

## Test plan
- [ ] Run `make net` — verify `goclaw-net` network is created
- [ ] Run `docker compose up` — verify services join `goclaw-net`
- [ ] Run `docker compose -f docker-compose.selfservice.yml up` — verify UI service joins `goclaw-net`