### PR TITLE
fix(feishu): harden API client with defensive HTTP status checks

### DIFF
--- a/internal/channels/feishu/larkclient.go
+++ b/internal/channels/feishu/larkclient.go
@@ -68,6 +68,10 @@ func (c *LarkClient) getToken(ctx context.Context) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("lark token request failed with HTTP %d", resp.StatusCode)
+	}
+
 	var result struct {
 		Code              int    `json:"code"`
 		Msg               string `json:"msg"`
@@ -150,6 +154,10 @@ func (c *LarkClient) doJSONOnce(ctx context.Context, method, path string, body a
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("lark api %s %s: failed with HTTP %d", method, path, resp.StatusCode)
+	}
+
 	var result apiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("lark api decode: %w", err)
@@ -175,6 +183,10 @@ func (c *LarkClient) doDownload(ctx context.Context, path string) ([]byte, strin
 		return nil, "", fmt.Errorf("lark download %s: %w", path, err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("lark download %s: failed with HTTP %d", path, resp.StatusCode)
+	}
 
 	// Check for JSON error response
 	ct := resp.Header.Get("Content-Type")
@@ -243,6 +255,10 @@ func (c *LarkClient) doMultipart(ctx context.Context, path string, fields map[st
 		return nil, fmt.Errorf("lark upload %s: %w", path, err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("lark upload %s: failed with HTTP %d", path, resp.StatusCode)
+	}
 
 	var result apiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {


### PR DESCRIPTION
## Problem
Non-JSON error pages from Feishu (load balancer errors, outages) caused cryptic JSON parse failures.
## Solution
 Added 2xx status range validation before attempting to decode response bodies.