### PR TITLE
fix(agent): auto-recover from model context window overflow errors

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -769,6 +769,28 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 
 		if err != nil {
 			l.emitLLMSpanEnd(ctx, llmSpanID, llmSpanStart, nil, err)
+
+			// Handle context window overflow: perform emergency history pruning and retry the turn.
+			if providers.IsContextOverflowError(err) && iteration < maxIter && len(messages) > 2 {
+				slog.Warn("context overflow detected, pruning and retrying",
+					"agent", l.id, "iteration", iteration, "messages", len(messages))
+
+				// 1. Kick off long-term maintenance (asynchronous summary and session cleanup).
+				l.maybeSummarize(ctx, req.SessionKey)
+
+				// 2. Perform immediate in-memory pruning of current turn history to clear window space.
+				// Keep [0] (System Prompt) and prune roughly oldest 50% of the remaining history.
+				pivot := len(messages) / 2
+				if pivot < 2 {
+					pivot = 2 // ensure we keep at least the system prompt
+				}
+				messages = append(messages[:1], messages[pivot:]...)
+
+				// 3. Retry the same turn
+				iteration--
+				continue
+			}
+
 			return nil, fmt.Errorf("LLM call failed (iteration %d): %w", iteration, err)
 		}
 

--- a/internal/providers/retry.go
+++ b/internal/providers/retry.go
@@ -95,6 +95,21 @@ func IsRetryableError(err error) bool {
 	return false
 }
 
+// IsContextOverflowError checks if an error indicates a context window/length limit has been exceeded.
+// Recognizes common provider strings for context window exhaustion across multiple LLM backends.
+func IsContextOverflowError(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	// Match standard context window stop reason strings and provider-specific error variants.
+	return strings.Contains(lower, "context_window_exceeded") ||
+		strings.Contains(lower, "context_length_exceeded") ||
+		strings.Contains(lower, "context_overflow") ||
+		strings.Contains(lower, "too many tokens") ||
+		strings.Contains(lower, "maximum context length")
+}
+
 // RetryDo executes fn with retry logic using exponential backoff and jitter.
 func RetryDo[T any](ctx context.Context, cfg RetryConfig, fn func() (T, error)) (T, error) {
 	if cfg.Attempts <= 0 {


### PR DESCRIPTION
## The Issue
When an agent session grows too long especially during complex tasks with large file reads or extensive tool outputs the LLM provider (such as Anthropic or OpenAI-compatible backends) can return a fatal "context window exceeded" error (model_context_window_exceeded).

Currently, goclaw treats this as a hard failure. The agent loop crashes, and the user receives a cryptic error message. This effectively breaks the conversation, requiring the user to manually clear their history or start over, which results in a poor and frustrating user experience during long-running workflows.

## The Changes
This PR introduces an automatic self-healing mechanism to recover from context exhaustion without crashing the session:

1. Context Overflow Detection: Added a new helper, `isContextOverflowError`, and integrated it into the provider retry logic. It identifies specific error strings across multiple backends (Anthropic, OpenAI-compatible, etc.) that indicate the prompt has outgrown its memory limit.
2. Emergency In-Memory Pruning: When an overflow is detected during a run, the agent now performs an immediate "emergency prune" of its current in-memory history slice discarding the oldest 50% of the middle history while strictly preserving the critical System Prompt and the current User Message.
3. Iteration Auto-Retry: Instead of returning an error, the agent loop now decrements its iteration counter and retries the same turn immediately with the lightened context. This converts a session-ending crash into a successful (though slightly truncated) response.
4. Integrated Maintenance: The recovery process also triggers `maybeSummarize` in the background to ensure the session history is properly compacted and summarized for all future conversation turns.