### PR TITLE
Polish Memory selects and add a Midnight dark preset for eye comfort

### DIFF
--- a/ui/web/src/components/layout/topbar.tsx
+++ b/ui/web/src/components/layout/topbar.tsx
@@ -1,4 +1,21 @@
-import { Moon, Sun, PanelLeftClose, PanelLeftOpen, Menu, LogOut, Globe, Clock, Building2, ChevronDown, Check, User, KeyRound, Info, Settings2 } from "lucide-react";
+import {
+  Moon,
+  Sun,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Menu,
+  LogOut,
+  Globe,
+  Clock,
+  Building2,
+  ChevronDown,
+  Check,
+  User,
+  KeyRound,
+  Info,
+  Settings2,
+  Palette,
+} from "lucide-react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useUiStore } from "@/stores/use-ui-store";
@@ -7,7 +24,16 @@ import { useTenants } from "@/hooks/use-tenants";
 import { useIsMobile } from "@/hooks/use-media-query";
 import { useEmbeddingStatus } from "@/hooks/use-embedding-status";
 
-import { ROUTES, SUPPORTED_LANGUAGES, LANGUAGE_LABELS, TIMEZONE_OPTIONS, LOCAL_STORAGE_KEYS, type Language } from "@/lib/constants";
+import {
+  ROUTES,
+  SUPPORTED_LANGUAGES,
+  LANGUAGE_LABELS,
+  TIMEZONE_OPTIONS,
+  COLOR_PRESETS,
+  LOCAL_STORAGE_KEYS,
+  type ColorPreset,
+  type Language,
+} from "@/lib/constants";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Popover } from "radix-ui";
 import { useState } from "react";
@@ -23,6 +49,8 @@ export function Topbar() {
   const setLanguage = useUiStore((s) => s.setLanguage);
   const timezone = useUiStore((s) => s.timezone);
   const setTimezone = useUiStore((s) => s.setTimezone);
+  const colorPreset = useUiStore((s) => s.colorPreset);
+  const setColorPreset = useUiStore((s) => s.setColorPreset);
   const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
   const setMobileSidebarOpen = useUiStore((s) => s.setMobileSidebarOpen);
@@ -82,6 +110,26 @@ export function Topbar() {
           <SelectContent>
             {TIMEZONE_OPTIONS.map((tz) => (
               <SelectItem key={tz.value} value={tz.value}>{tz.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={colorPreset}
+          onValueChange={(v) => setColorPreset(v as ColorPreset)}
+        >
+          <SelectTrigger
+            title={t("colorPreset")}
+            className="h-auto w-auto gap-1 border-0 bg-transparent px-2 py-1.5 text-sm text-muted-foreground shadow-none hover:bg-accent hover:text-accent-foreground focus-visible:ring-0 dark:bg-transparent dark:hover:bg-accent **:data-radix-select-icon:hidden"
+          >
+            <Palette className="h-4 w-4 shrink-0" />
+            <span className="hidden sm:inline"><SelectValue /></span>
+          </SelectTrigger>
+          <SelectContent>
+            {COLOR_PRESETS.map((preset) => (
+              <SelectItem key={preset} value={preset}>
+                {t(`colorPresets.${preset}`)}
+              </SelectItem>
             ))}
           </SelectContent>
         </Select>

--- a/ui/web/src/components/providers/theme-provider.tsx
+++ b/ui/web/src/components/providers/theme-provider.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useUiStore, type Theme } from "@/stores/use-ui-store";
+import type { ColorPreset } from "@/lib/constants";
 
 function applyTheme(theme: Theme) {
   const root = document.documentElement;
@@ -13,12 +14,21 @@ function applyTheme(theme: Theme) {
   }
 }
 
+function applyColorPreset(preset: ColorPreset) {
+  document.documentElement.setAttribute("data-color-preset", preset);
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const theme = useUiStore((s) => s.theme);
+  const colorPreset = useUiStore((s) => s.colorPreset);
 
   useEffect(() => {
     applyTheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    applyColorPreset(colorPreset);
+  }, [colorPreset]);
 
   // Listen for system theme changes when in "system" mode
   useEffect(() => {

--- a/ui/web/src/i18n/locales/en/topbar.json
+++ b/ui/web/src/i18n/locales/en/topbar.json
@@ -4,6 +4,7 @@
   "openMenu": "Open menu",
   "systemSettings": "System Settings",
   "toggleTheme": "Toggle theme",
+  "colorPreset": "Color preset",
   "logout": "Logout",
   "logoutConfirm": "Are you sure you want to logout?",
   "language": "Language",
@@ -29,5 +30,9 @@
     "en": "English",
     "vi": "Tiếng Việt",
     "zh": "中文"
+  },
+  "colorPresets": {
+    "classic": "Classic",
+    "midnight": "Midnight"
   }
 }

--- a/ui/web/src/i18n/locales/vi/topbar.json
+++ b/ui/web/src/i18n/locales/vi/topbar.json
@@ -3,6 +3,7 @@
   "expandSidebar": "Mở rộng thanh bên",
   "language": "Ngôn ngữ",
   "timezone": "Múi giờ",
+  "colorPreset": "Màu giao diện",
   "languages": {
     "en": "English",
     "vi": "Tiếng Việt",
@@ -29,5 +30,9 @@
     "viewRelease": "Xem chi tiết →"
   },
   "systemSettings": "Cài đặt hệ thống",
-  "toggleTheme": "Chuyển đổi giao diện"
+  "toggleTheme": "Chuyển đổi giao diện",
+  "colorPresets": {
+    "classic": "Mặc định",
+    "midnight": "Đêm sâu"
+  }
 }

--- a/ui/web/src/i18n/locales/zh/topbar.json
+++ b/ui/web/src/i18n/locales/zh/topbar.json
@@ -3,6 +3,7 @@
   "expandSidebar": "展开侧边栏",
   "language": "语言",
   "timezone": "时区",
+  "colorPreset": "配色预设",
   "languages": {
     "en": "English",
     "vi": "Tiếng Việt",
@@ -29,5 +30,9 @@
     "viewRelease": "查看发行说明 →"
   },
   "systemSettings": "系统设置",
-  "toggleTheme": "切换主题"
+  "toggleTheme": "切换主题",
+  "colorPresets": {
+    "classic": "经典",
+    "midnight": "深夜"
+  }
 }

--- a/ui/web/src/index.css
+++ b/ui/web/src/index.css
@@ -85,6 +85,28 @@
   --chart-5: oklch(0.62 0.02 50);
 }
 
+[data-color-preset="midnight"].dark {
+  --background: oklch(0.08 0 0);
+  --foreground: oklch(0.94 0 0);
+  --card: oklch(0.14 0 0);
+  --card-foreground: oklch(0.94 0 0);
+  --popover: oklch(0.18 0 0);
+  --popover-foreground: oklch(0.94 0 0);
+  --secondary: oklch(0.20 0 0);
+  --secondary-foreground: oklch(0.94 0 0);
+  --muted: oklch(0.17 0 0);
+  --muted-foreground: oklch(0.72 0 0);
+  --accent: oklch(0.24 0 0);
+  --accent-foreground: oklch(0.94 0 0);
+  --border: oklch(0.26 0 0);
+  --input: oklch(0.24 0 0);
+  --sidebar: oklch(0.12 0 0);
+  --sidebar-foreground: oklch(0.94 0 0);
+  --sidebar-accent: oklch(0.24 0 0);
+  --sidebar-accent-foreground: oklch(0.94 0 0);
+  --sidebar-border: oklch(0.24 0 0);
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/ui/web/src/lib/constants.ts
+++ b/ui/web/src/lib/constants.ts
@@ -51,6 +51,7 @@ export const LOCAL_STORAGE_KEYS = {
   TENANT_HINT: "goclaw:tenant_hint",
   SETUP_SKIPPED: "goclaw:setup_skipped",
   THEME: "goclaw:theme",
+  COLOR_PRESET: "goclaw:color_preset",
   SIDEBAR_COLLAPSED: "goclaw:sidebarCollapsed",
   LANGUAGE: "goclaw:language",
   TIMEZONE: "goclaw:timezone",
@@ -64,6 +65,9 @@ export const LANGUAGE_LABELS: Record<Language, string> = {
   vi: "Tiếng Việt",
   zh: "中文",
 };
+
+export const COLOR_PRESETS = ["classic", "midnight"] as const;
+export type ColorPreset = (typeof COLOR_PRESETS)[number];
 
 /** "auto" = browser's local timezone. */
 export const TIMEZONE_OPTIONS = [

--- a/ui/web/src/pages/knowledge-graph/knowledge-graph-page.tsx
+++ b/ui/web/src/pages/knowledge-graph/knowledge-graph-page.tsx
@@ -3,11 +3,15 @@ import { useTranslation } from "react-i18next";
 import { Network } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/shared/empty-state";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAgents } from "@/pages/agents/hooks/use-agents";
 import { useEmbeddingStatus } from "@/hooks/use-embedding-status";
 import { useSessions } from "@/pages/sessions/hooks/use-sessions";
 import { parseSessionKey } from "@/lib/session-key";
 import { KGEntitiesTab } from "@/pages/memory/kg-entities-tab";
+
+const KG_AGENT_PLACEHOLDER_VALUE = "__select_agent__";
+const KG_SCOPE_PLACEHOLDER_VALUE = "__all_scope__";
 
 export function KnowledgeGraphPage() {
   const { t } = useTranslation("memory");
@@ -56,31 +60,42 @@ export function KnowledgeGraphPage() {
             )}
           </p>
         </div>
-        <select
-          id="kg-agent"
-          value={agentId}
-          onChange={(e) => { setAgentId(e.target.value); setUserIdFilter(""); }}
-          className="h-8 rounded-md border bg-background px-2 text-base md:text-sm"
+        <Select
+          value={agentId || KG_AGENT_PLACEHOLDER_VALUE}
+          onValueChange={(value) => {
+            setAgentId(value === KG_AGENT_PLACEHOLDER_VALUE ? "" : value);
+            setUserIdFilter("");
+          }}
         >
-          <option value="">{t("filters.selectAgent")}</option>
-          {agents.map((a) => (
-            <option key={a.id} value={a.id}>
-              {a.display_name || a.agent_key}
-            </option>
-          ))}
-        </select>
-        {agentId && (
-          <select
-            id="kg-scope"
-            value={userIdFilter}
-            onChange={(e) => setUserIdFilter(e.target.value)}
-            className="h-8 rounded-md border bg-background px-2 text-base md:text-sm max-w-[240px]"
-          >
-            <option value="">{t("filters.allScope")}</option>
-            {scopeOptions.map((o) => (
-              <option key={o.value} value={o.value}>{o.label}</option>
+          <SelectTrigger id="kg-agent" className="h-8 min-w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent align="start">
+            <SelectItem value={KG_AGENT_PLACEHOLDER_VALUE}>{t("filters.selectAgent")}</SelectItem>
+            {agents.map((a) => (
+              <SelectItem key={a.id} value={a.id}>
+                {a.display_name || a.agent_key}
+              </SelectItem>
             ))}
-          </select>
+          </SelectContent>
+        </Select>
+        {agentId && (
+          <Select
+            value={userIdFilter || KG_SCOPE_PLACEHOLDER_VALUE}
+            onValueChange={(value) => setUserIdFilter(value === KG_SCOPE_PLACEHOLDER_VALUE ? "" : value)}
+          >
+            <SelectTrigger id="kg-scope" className="h-8 min-w-[220px] max-w-[280px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start">
+              <SelectItem value={KG_SCOPE_PLACEHOLDER_VALUE}>{t("filters.allScope")}</SelectItem>
+              {scopeOptions.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         )}
       </div>
 
@@ -92,18 +107,25 @@ export function KnowledgeGraphPage() {
             title={t("kg.selectAgentTitle")}
             description={t("kg.selectAgentDescription")}
             action={
-              <select
-                value={agentId}
-                onChange={(e) => { setAgentId(e.target.value); setUserIdFilter(""); }}
-                className="mt-2 h-9 rounded-md border bg-background px-3 text-base md:text-sm"
+              <Select
+                value={agentId || KG_AGENT_PLACEHOLDER_VALUE}
+                onValueChange={(value) => {
+                  setAgentId(value === KG_AGENT_PLACEHOLDER_VALUE ? "" : value);
+                  setUserIdFilter("");
+                }}
               >
-                <option value="">{t("filters.selectAgent")}</option>
-                {agents.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.display_name || a.agent_key}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger className="mt-2 h-9 min-w-[220px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="start">
+                  <SelectItem value={KG_AGENT_PLACEHOLDER_VALUE}>{t("filters.selectAgent")}</SelectItem>
+                  {agents.map((a) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      {a.display_name || a.agent_key}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             }
           />
         ) : (

--- a/ui/web/src/pages/memory/memory-create-dialog.tsx
+++ b/ui/web/src/pages/memory/memory-create-dialog.tsx
@@ -12,6 +12,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useAgents } from "@/pages/agents/hooks/use-agents";
 import { useMemoryDocuments } from "./hooks/use-memory";
 import type { AgentData } from "@/types/agent";
@@ -25,6 +32,9 @@ interface MemoryCreateDialogProps {
   /** Known user/group IDs from existing docs */
   knownUserIds?: string[];
 }
+
+const AGENT_PLACEHOLDER_VALUE = "__select_agent__";
+const SCOPE_PLACEHOLDER_VALUE = "__select_scope__";
 
 export function MemoryCreateDialog({ open, onOpenChange, agentId: parentAgentId, knownUserIds = [] }: MemoryCreateDialogProps) {
   const { t } = useTranslation("memory");
@@ -105,19 +115,22 @@ export function MemoryCreateDialog({ open, onOpenChange, agentId: parentAgentId,
           {/* Agent selector */}
           <div className="grid gap-1.5">
             <Label htmlFor="mc-agent">{t("createDialog.agentId")}</Label>
-            <select
-              id="mc-agent"
-              value={selectedAgentId || parentAgentId || ""}
-              onChange={(e) => setSelectedAgentId(e.target.value)}
-              className="h-9 rounded-md border bg-background px-3 text-base md:text-sm"
+            <Select
+              value={selectedAgentId || parentAgentId || AGENT_PLACEHOLDER_VALUE}
+              onValueChange={(value) => setSelectedAgentId(value === AGENT_PLACEHOLDER_VALUE ? "" : value)}
             >
-              <option value="">{t("createDialog.agentIdPlaceholder")}</option>
-              {agents.map((a) => (
-                <option key={a.id} value={a.id}>
-                  {a.display_name || a.agent_key}
-                </option>
-              ))}
-            </select>
+              <SelectTrigger id="mc-agent" className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="start">
+                <SelectItem value={AGENT_PLACEHOLDER_VALUE}>{t("createDialog.agentIdPlaceholder")}</SelectItem>
+                {agents.map((a) => (
+                  <SelectItem key={a.id} value={a.id}>
+                    {a.display_name || a.agent_key}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             {selectedAgent?.workspace && (
               <p className="font-mono text-[10px] text-muted-foreground">{selectedAgent.workspace}</p>
             )}
@@ -155,18 +168,22 @@ export function MemoryCreateDialog({ open, onOpenChange, agentId: parentAgentId,
               </Button>
             </div>
             {scopeMode === "existing" && knownUserIds.length > 0 && (
-              <select
-                value={selectedUserId}
-                onChange={(e) => setSelectedUserId(e.target.value)}
-                className="h-9 rounded-md border bg-background px-3 text-base md:text-sm"
+              <Select
+                value={selectedUserId || SCOPE_PLACEHOLDER_VALUE}
+                onValueChange={(value) => setSelectedUserId(value === SCOPE_PLACEHOLDER_VALUE ? "" : value)}
               >
-                <option value="">{t("createDialog.selectGroupUser")}</option>
-                {knownUserIds.map((uid) => (
-                  <option key={uid} value={uid}>
-                    {formatScopeLabel(uid)}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger className="h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="start">
+                  <SelectItem value={SCOPE_PLACEHOLDER_VALUE}>{t("createDialog.selectGroupUser")}</SelectItem>
+                  {knownUserIds.map((uid) => (
+                    <SelectItem key={uid} value={uid}>
+                      {formatScopeLabel(uid)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             )}
             {scopeMode === "custom" && (
               <Input

--- a/ui/web/src/pages/memory/memory-page.tsx
+++ b/ui/web/src/pages/memory/memory-page.tsx
@@ -4,6 +4,13 @@ import { Brain, Plus, RefreshCw, Search, Database, Trash2, RotateCw } from "luci
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { TableSkeleton } from "@/components/shared/loading-skeleton";
@@ -19,6 +26,9 @@ import { useMinLoading } from "@/hooks/use-min-loading";
 import { useDeferredLoading } from "@/hooks/use-deferred-loading";
 import { useEmbeddingStatus } from "@/hooks/use-embedding-status";
 import type { MemoryDocument } from "@/types/memory";
+
+const ALL_AGENTS_VALUE = "__all_agents__";
+const ALL_SCOPE_VALUE = "__all_scope__";
 
 export function MemoryPage() {
   const { t } = useTranslation("memory");
@@ -142,35 +152,48 @@ export function MemoryPage() {
       <div className="mt-4 flex flex-wrap items-end gap-3">
         <div className="grid gap-1.5">
           <Label htmlFor="mem-agent" className="text-xs">{t("filters.agent")}</Label>
-          <select
-            id="mem-agent"
-            value={agentId}
-            onChange={(e) => { setAgentId(e.target.value); setUserIdFilter(""); setPage(1); }}
-            className="h-9 rounded-md border bg-background px-3 text-base md:text-sm"
+          <Select
+            value={agentId || ALL_AGENTS_VALUE}
+            onValueChange={(value) => {
+              setAgentId(value === ALL_AGENTS_VALUE ? "" : value);
+              setUserIdFilter("");
+              setPage(1);
+            }}
           >
-            <option value="">{t("filters.allAgents")}</option>
-            {agents.map((a) => (
-              <option key={a.id} value={a.id}>
-                {a.display_name || a.agent_key}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger id="mem-agent" className="h-9 min-w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start">
+              <SelectItem value={ALL_AGENTS_VALUE}>{t("filters.allAgents")}</SelectItem>
+              {agents.map((a) => (
+                <SelectItem key={a.id} value={a.id}>
+                  {a.display_name || a.agent_key}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div className="grid gap-1.5">
           <Label htmlFor="mem-scope" className="text-xs">{t("filters.scope")}</Label>
-          <select
-            id="mem-scope"
-            value={userIdFilter}
-            onChange={(e) => { setUserIdFilter(e.target.value); setPage(1); }}
-            className="h-9 rounded-md border bg-background px-3 text-base md:text-sm min-w-[180px]"
+          <Select
+            value={userIdFilter || ALL_SCOPE_VALUE}
+            onValueChange={(value) => {
+              setUserIdFilter(value === ALL_SCOPE_VALUE ? "" : value);
+              setPage(1);
+            }}
           >
-            <option value="">{t("filters.allScope")}</option>
-            {userIds.map((uid) => (
-              <option key={uid} value={uid}>
-                {formatScopeLabel(uid, resolveContact)}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger id="mem-scope" className="h-9 min-w-[220px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start">
+              <SelectItem value={ALL_SCOPE_VALUE}>{t("filters.allScope")}</SelectItem>
+              {userIds.map((uid) => (
+                <SelectItem key={uid} value={uid}>
+                  {formatScopeLabel(uid, resolveContact)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         {agentId && (
           <Button

--- a/ui/web/src/stores/use-ui-store.ts
+++ b/ui/web/src/stores/use-ui-store.ts
@@ -1,17 +1,24 @@
 import { create } from "zustand";
 import i18n from "@/i18n";
-import { LOCAL_STORAGE_KEYS, type Language } from "@/lib/constants";
+import {
+  COLOR_PRESETS,
+  LOCAL_STORAGE_KEYS,
+  type ColorPreset,
+  type Language,
+} from "@/lib/constants";
 
 export type Theme = "light" | "dark" | "system";
 
 interface UiState {
   theme: Theme;
+  colorPreset: ColorPreset;
   language: Language;
   timezone: string; // IANA timezone or "auto"
   sidebarCollapsed: boolean;
   mobileSidebarOpen: boolean;
 
   setTheme: (theme: Theme) => void;
+  setColorPreset: (preset: ColorPreset) => void;
   setLanguage: (language: Language) => void;
   setTimezone: (tz: string) => void;
   toggleSidebar: () => void;
@@ -19,8 +26,16 @@ interface UiState {
   setMobileSidebarOpen: (open: boolean) => void;
 }
 
+const savedColorPreset = localStorage.getItem(LOCAL_STORAGE_KEYS.COLOR_PRESET);
+const initialColorPreset: ColorPreset = COLOR_PRESETS.includes(
+  savedColorPreset as ColorPreset,
+)
+  ? (savedColorPreset as ColorPreset)
+  : "classic";
+
 export const useUiStore = create<UiState>((set) => ({
   theme: (localStorage.getItem(LOCAL_STORAGE_KEYS.THEME) as Theme) ?? "dark",
+  colorPreset: initialColorPreset,
   language: (i18n.language as Language) ?? "en",
   timezone: localStorage.getItem(LOCAL_STORAGE_KEYS.TIMEZONE) ?? "auto",
   sidebarCollapsed:
@@ -30,6 +45,11 @@ export const useUiStore = create<UiState>((set) => ({
   setTheme: (theme) => {
     localStorage.setItem(LOCAL_STORAGE_KEYS.THEME, theme);
     set({ theme });
+  },
+
+  setColorPreset: (preset) => {
+    localStorage.setItem(LOCAL_STORAGE_KEYS.COLOR_PRESET, preset);
+    set({ colorPreset: preset });
   },
 
   setLanguage: (language) => {


### PR DESCRIPTION
## Summary
- Replaced native `<select>` controls in Memory page and Memory create dialog with the shared Select component for consistent spacing and styling.
- Added a color preset selector in the top header.
- Added a new `Midnight` preset that only adjusts dark-mode background/surface tokens to neutral black tones.
- Kept light mode unchanged and preserved important semantic colors.

## Why
In prolonged night-time use, the current dark palette can feel visually fatiguing because:
- Dark surfaces still carry warm/brown chroma, which appears brighter than neutral blacks.
- Bright layers on top of warm dark surfaces can increase perceived glare and make contrast feel harsh.
- During long sessions (especially scanning dense forms/tables), this can increase visual adaptation load and lead to eye strain.

This change introduces a `Midnight` preset that only neutralizes dark-mode background/surface tones for better night comfort.

To respect the original design direction, light theme remains unchanged, and key semantic/brand colors in dark mode are intentionally preserved.

## Validation
- `pnpm -C ui/web build`