### PR TITLE
perf(agent): improve accuracy of context pruning by including Thinking and ToolCall overhead

### DIFF
--- a/internal/agent/pruning.go
+++ b/internal/agent/pruning.go
@@ -244,9 +244,19 @@ func findAssistantCutoff(msgs []providers.Message, keepLast int) int {
 	return -1
 }
 
-// estimateMessageChars returns the character count of a message's content.
+// estimateMessageChars returns the character count of a message's content sections.
+// Includes Thinking content and ToolCalls to ensure pruning is accurate for
+// reasoning models and tool-heavy agents.
 func estimateMessageChars(m providers.Message) int {
-	return utf8.RuneCountInString(m.Content)
+	chars := utf8.RuneCountInString(m.Content)
+	if m.Thinking != "" {
+		chars += utf8.RuneCountInString(m.Thinking)
+	}
+	for _, tc := range m.ToolCalls {
+		// Include tool name plus a small overhead buffer for JSON arguments
+		chars += utf8.RuneCountInString(tc.Name) + 100
+	}
+	return chars
 }
 
 // takeHead returns the first n runes of s.


### PR DESCRIPTION
## The Issue
The agent's message pruner previously only counted the `Content` field. For models that provide extensive reasoning in a separate `Thinking` field (e.g., DeepSeek, Claude), or for agents that make frequent tool calls, this led to a significant Under-Estimation of the total context usage. In some cases, a 4000-token thought block was being treated as "0 characters," which delayed pruning until the conversation was already far beyond the provider's token limit, causing the session to crash.

## The Changes
This PR upgrades the `estimateMessageChars` function to be more comprehensive:
1. Thinking-Aware: It now includes the character count of the `Thinking` field (reasoning section) in the overall message size.
2. Tool-Aware: It adds the character count of any `ToolCall` names plus a fixed buffer of 100 characters per call to approximate the overhead of JSON arguments.
3. Improved Pruning Reliability: By accurately calculating the total "token weight" of each message, the `pruneContextMessages` logic will now correctly trigger "Soft Trimming" and "Hard Clearing" steps at the expected thresholds.els and tool-heavy agents