### PR TITLE
fix(agent): professionalize outbound delivery by stripping internal routing tags

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1348,14 +1348,14 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 
 	}
 
-	// 4. Full sanitization pipeline (matching TS extractAssistantText + sanitizeUserFacingText)
+	// 5. Full sanitization pipeline (matching TS extractAssistantText + sanitizeUserFacingText)
 	finalContent = SanitizeAssistantContent(finalContent)
 
 	// 4b. Config leak detection — disabled: too many false positives
 	// (e.g. agent explaining public architecture mentioning SOUL.md etc.)
 	// finalContent = StripConfigLeak(finalContent, l.agentType)
 
-	// 5. Handle NO_REPLY: save to session for context but mark as silent.
+	// 6. Handle NO_REPLY: save to session for context but mark as silent.
 	// Matching TS: NO_REPLY is saved (via resolveSilentReplyFallbackText) but
 	// filtered at the payload level before delivery.
 	isSilent := IsSilentReply(finalContent)
@@ -1373,7 +1373,7 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 		finalContent += "\n\n---\n_" + i18n.T(locale, i18n.MsgSkillNudgePostscript) + "_"
 	}
 
-	// 6. Fallback for empty content
+	// 7. Fallback for empty content
 	if finalContent == "" {
 		if len(asyncToolCalls) > 0 {
 			finalContent = "..."
@@ -1493,7 +1493,7 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 		}
 	}
 
-	// 7. Metadata Stripping: Clean internal [[...]] tags for user-facing content
+	// 8. Metadata Stripping: Clean internal [[...]] tags for user-facing content
 	// (Session version is already saved in assistantMsg above)
 	finalContent = StripMessageDirectives(finalContent)
 	if isSilent {
@@ -1502,7 +1502,7 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 		finalContent = ""
 	}
 
-	// 8. Maybe summarize
+	// 9. Maybe summarize
 	l.maybeSummarize(ctx, req.SessionKey)
 
 	return &RunResult{

--- a/internal/agent/sanitize.go
+++ b/internal/agent/sanitize.go
@@ -410,14 +410,22 @@ func isWordChar(r rune) bool {
 
 // --- Message Directives ([[name:value]]) ---
 
-// messageDirectivePattern matches internal routing tags like [[reply_to:123]]
-// or [[voice]] that should be stripped before delivering to a user.
-var messageDirectivePattern = regexp.MustCompile(`(?s)\[\[.*?\]\]`)
+// messageDirectivePattern matches structured routing tags: [[word]] or [[word:value]].
+// Single-line only (no (?s) dotall). Does NOT match arbitrary [[...]] content.
+var messageDirectivePattern = regexp.MustCompile(`\[\[\w+(?::[^\]\n]+)?\]\]`)
 
-// StripMessageDirectives removes internal [[...]] tags from user-facing text.
+// StripMessageDirectives removes internal [[...]] routing tags from user-facing text,
+// preserving [[tts...]] tags needed by the TTS auto-apply pipeline.
 func StripMessageDirectives(content string) string {
 	if !strings.Contains(content, "[[") {
 		return content
 	}
-	return strings.TrimSpace(messageDirectivePattern.ReplaceAllString(content, ""))
+	result := messageDirectivePattern.ReplaceAllStringFunc(content, func(match string) string {
+		inner := match[2 : len(match)-2] // strip [[ and ]]
+		if strings.HasPrefix(inner, "tts") {
+			return match // preserve for TTS AutoTagged mode
+		}
+		return ""
+	})
+	return strings.TrimSpace(result)
 }

--- a/internal/agent/sanitize_directives_test.go
+++ b/internal/agent/sanitize_directives_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import "testing"
+
+func TestStripMessageDirectives(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no tags", "Hello world", "Hello world"},
+		{"single tag prefix", "[[reply_to:123]] Hello", "Hello"},
+		{"single keyword tag", "[[voice]] Hello", "Hello"},
+		{"multiple tags", "[[reply_to:1]] Hello [[silent]]", "Hello"},
+		{"tag only", "[[reply_to:abc]]", ""},
+		{"tag mid-sentence", "Say [[voice]] something", "Say  something"},
+
+		// TTS tags must be preserved for TTS AutoTagged pipeline
+		{"preserve tts bare", "[[tts]] Hello", "[[tts]] Hello"},
+		{"preserve tts with param", "[[tts:en]] Hello", "[[tts:en]] Hello"},
+		{"preserve tts:text block", "[[tts:text]] Hello [[/tts:text]]", "[[tts:text]] Hello [[/tts:text]]"},
+		{"strip non-tts but keep tts", "[[reply_to:1]] [[tts]] Hello", "[[tts]] Hello"},
+
+		// Should NOT match non-directive patterns
+		{"no match without word chars", "text [[ ]] more", "text [[ ]] more"},
+		{"no match multiline", "text [[\nfoo\n]] more", "text [[\nfoo\n]] more"},
+
+		// Early exit: no [[ at all
+		{"fast path no brackets", "just plain text", "just plain text"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripMessageDirectives(tt.in)
+			if got != tt.want {
+				t.Errorf("StripMessageDirectives(%q)\n got  %q\n want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The Issue
The assistant occasionally emits internal directives in square brackets (e.g., [[reply_to:id]]) to coordinate threading or specific channel features. Because these were being passed directly to the RunResult, users on mobile/desktop chat apps were seeing these internal "routing tags" at the start of messages.

## The Changes
- Late-Stage Sanitization: Introduced `StripMessageDirectives` in the agent loop.
- Differential Output: The assistantMsg (Session Store) keeps the tags for model context, while the RunResult (Outbound Delivery) is stripped clean.

Oh and your numbering was wrong for the final agent loop steps  :D so I fixed it