### PR TITLE
perf(agent): optimize prefix cache efficiency and harden inbound security

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -268,7 +268,7 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 
 	// buildMessages resolves context files once and also detects BOOTSTRAP.md presence
 	// (hadBootstrap) — no extra DB roundtrip needed for bootstrap detection.
-	messages, hadBootstrap := l.buildMessages(ctx, history, summary, req.Message, req.ExtraSystemPrompt, req.SessionKey, req.Channel, req.ChannelType, req.PeerKind, req.UserID, req.HistoryLimit, req.SkillFilter, req.LightContext)
+	messages, hadBootstrap := l.buildMessages(ctx, history, summary, req.Message, req.SystemEvents, req.ExtraSystemPrompt, req.SessionKey, req.Channel, req.ChannelType, req.PeerKind, req.UserID, req.HistoryLimit, req.SkillFilter, req.LightContext)
 
 	// 1b. Determine image routing strategy.
 	// If read_image tool has a dedicated vision provider, images are NOT attached inline

--- a/internal/agent/loop_history.go
+++ b/internal/agent/loop_history.go
@@ -66,7 +66,7 @@ func (l *Loop) buildMCPToolDescs(toolNames []string) map[string]string {
 // buildMessages constructs the full message list for an LLM request.
 // Returns the messages and whether BOOTSTRAP.md was present in context files
 // (used by the caller for auto-cleanup without an extra DB roundtrip).
-func (l *Loop) buildMessages(ctx context.Context, history []providers.Message, summary, userMessage, extraSystemPrompt, sessionKey, channel, channelType, peerKind, userID string, historyLimit int, skillFilter []string, lightContext bool) ([]providers.Message, bool) {
+func (l *Loop) buildMessages(ctx context.Context, history []providers.Message, summary, userMessage string, systemEvents []string, extraSystemPrompt, sessionKey, channel, channelType, peerKind, userID string, historyLimit int, skillFilter []string, lightContext bool) ([]providers.Message, bool) {
 	var messages []providers.Message
 
 	// Build full system prompt using the new builder (matching TS buildAgentSystemPrompt)
@@ -235,7 +235,27 @@ func (l *Loop) buildMessages(ctx context.Context, history []providers.Message, s
 		l.sessions.Save(ctx, sessionKey)
 	}
 
-	// Current user message
+	// Current user message — Sanitize to prevent spoofing and prepend system events.
+	// We move gateway system events (model switch, node status) from the system prompt 
+	// to the user message timeline to protect the high-context prefix cache.
+	userMessage = SanitizeInboundSystemTags(userMessage)
+	if len(systemEvents) > 0 {
+		var sb strings.Builder
+		now := time.Now().Format("15:04:05")
+		for _, event := range systemEvents {
+			sb.WriteString("System: [")
+			sb.WriteString(now)
+			sb.WriteString("] ")
+			sb.WriteString(event)
+			sb.WriteByte('\n')
+		}
+		if userMessage != "" {
+			sb.WriteByte('\n')
+			sb.WriteString(userMessage)
+		}
+		userMessage = sb.String()
+	}
+
 	messages = append(messages, providers.Message{
 		Role:    "user",
 		Content: userMessage,

--- a/internal/agent/loop_types.go
+++ b/internal/agent/loop_types.go
@@ -409,6 +409,10 @@ type RunRequest struct {
 	TeamTaskID    string // team task ID (if delegation has an associated task)
 	ParentAgentID string // parent agent key that initiated the delegation
 
+	// Gateway system events (model switches, node status, etc.)
+	// These are prepended to the user message in buildMessages to avoid KV cache busts in the system prompt.
+	SystemEvents []string
+
 	// Workspace scope propagation (set by delegation, read by workspace tools)
 	WorkspaceChannel string
 	WorkspaceChatID  string

--- a/internal/agent/sanitize.go
+++ b/internal/agent/sanitize.go
@@ -407,3 +407,49 @@ func IsSilentReply(text string) bool {
 func isWordChar(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
 }
+
+// --- Inbound Sanitization (Security) ---
+
+// SanitizeInboundSystemTags prevents LLM spoofing by rewriting user-supplied
+// "System:" prefixes to "System (untrusted):" before they reach the prompt.
+// Smart version: skips lines within triple-backtick (```) code blocks to avoid 
+// false positives during technical discussions.
+func SanitizeInboundSystemTags(content string) string {
+	if content == "" {
+		return content
+	}
+	// Case-insensitive check for prefix anywhere in content (fast check)
+	lower := strings.ToLower(content)
+	if !strings.Contains(lower, "system:") {
+		return content
+	}
+
+	lines := strings.Split(content, "\n")
+	changed := false
+	inCodeBlock := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Toggle code block state
+		if strings.HasPrefix(trimmed, "```") {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+
+		// Skip sanitization if inside a code block or if line doesn't start with "system:" (case insensitive)
+		if inCodeBlock || !strings.HasPrefix(strings.ToLower(trimmed), "system:") {
+			continue
+		}
+
+		// Replace it, preserving the rest of the line's own punctuation or whitespace.
+		// Use the first 7 chars of 'trimmed' for case-insensitive match (guaranteed at least 7 due to prefix check).
+		lines[i] = strings.Replace(line, trimmed[:7], "System (untrusted):", 1)
+		changed = true
+	}
+
+	if !changed {
+		return content
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/agent/systemprompt.go
+++ b/internal/agent/systemprompt.go
@@ -254,18 +254,18 @@ func BuildSystemPrompt(cfg SystemPromptConfig) string {
 		lines = append(lines, buildGroupChatReplyHint()...)
 	}
 
-	// 10. Extra system prompt (wrapped in tags for context isolation)
+	// 10. # Project Context — remaining context files (persona files already injected early)
+	if len(otherFiles) > 0 {
+		lines = append(lines, buildProjectContextSection(otherFiles, cfg.AgentType)...)
+	}
+
+	// 11. Extra system prompt (wrapped in tags for context isolation)
 	if cfg.ExtraPrompt != "" {
 		header := "## Additional Context"
 		if isMinimal {
 			header = "## Subagent Context"
 		}
 		lines = append(lines, header, "", "<extra_context>", cfg.ExtraPrompt, "</extra_context>", "")
-	}
-
-	// 11. # Project Context — remaining context files (persona files already injected early)
-	if len(otherFiles) > 0 {
-		lines = append(lines, buildProjectContextSection(otherFiles, cfg.AgentType)...)
 	}
 
 	// 13. ## Sub-Agent Spawning — skipped for team agents and bootstrap


### PR DESCRIPTION
## Issue
The current system prompt structure causes frequent KV cache busts because dynamic context (such as subagent instructions and heartbeat checklists) is injected before the large, stable project context files. This results in significantly higher latency and token costs on providers that support prefix caching (like Anthropic and OpenAI). Additionally, there is a security risk where user-supplied messages can spoof system markers in the prompt.

## Changes & Solution
1. Prefix Cache Alignment: Reordered the system prompt in `internal/agent/systemprompt.go`to place the stable # Project Context sections before the dynamic extraSystemPrompt. This ensures the high-context prefix stays cached across turns.
2. Timeline-Based Events: Moved gateway system events (model switches, node status) from the system prompt into the conversation timeline. They are now prepended to the user's message with a System: [HH:MM:SS] marker in `internal/agent/loop_history.go`.
3. Inbound Sanitization: Implemented a markdown-aware `SanitizeInboundSystemTags` utility in `internal/agent/sanitize.go`. It rewrites user-supplied System: prefixes at the start of any line to System (untrusted):, but intelligently skips any text inside triple-backtick (```) code blocks to avoid false positives.