### PR TITLE
fix(slack): resolve race condition in mention event delivery

### DIFF
--- a/internal/channels/slack/handlers_mention.go
+++ b/internal/channels/slack/handlers_mention.go
@@ -21,8 +21,11 @@ func (c *Channel) handleAppMention(ev *slackevents.AppMentionEvent) {
 		return
 	}
 
-	// Dedup: app_mention may arrive alongside a message event
-	dedupKey := ev.Channel + ":" + ev.TimeStamp
+	// Dedup: app_mention may arrive alongside a message event. Slack delivers both in 
+	// no guaranteed order. We use a :mention suffix so that app_mention is not blocked 
+	// by a generic message event that might have arrived first and triggered requireMention 
+	// gating. Duplicate triggers are safely coalesced by the downstream debouncer.
+	dedupKey := ev.Channel + ":" + ev.TimeStamp + ":mention"
 	if _, loaded := c.dedup.LoadOrStore(dedupKey, time.Now()); loaded {
 		return
 	}


### PR DESCRIPTION
## Issue
Slack delivers both a message event and an app_mention event for the same user @mention, but they arrive in an unpredictable order. Goclaw was previously using the exact same deduplication key (channelID:messageTS) for both events.

- The Problem: If the message event arrived first in a channel with requireMention: true, Goclaw would set the deduplication key and then return early (recording to history but not responding). When the app_mention event arrived milliseconds later, it would hit the deduplication check and be dropped as a duplicate, resulting in the bot silently ignoring legitimate mentions in approximately 50% of cases.

## Changes & Solution
- Segmented Deduplication: Modified `internal/channels/slack/handlers_mention.go` to use a :mention suffix for

This ensures that app_mention events are never blocked by their generic message counterparts. Duplicate triggers in channels without mention-gating are safely coalesced by Goclaw's internal 300ms debouncer into a single agent request, ensuring reliability without duplicate replies.