### PR TITLE
feat(http): enhance secure CLI environment variable handling

### DIFF
--- a/internal/http/secure_cli.go
+++ b/internal/http/secure_cli.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -43,6 +44,28 @@ func (h *SecureCLIHandler) auth(next http.HandlerFunc) http.HandlerFunc {
 	return requireAuth(permissions.RoleAdmin, next)
 }
 
+// secureCLIAttachEnvKeysForAPI sets env_keys from decrypted env JSON and clears EncryptedEnv for JSON responses.
+func secureCLIAttachEnvKeysForAPI(b *store.SecureCLIBinary) {
+	if len(b.EncryptedEnv) == 0 {
+		b.EnvKeys = nil
+		b.EncryptedEnv = nil
+		return
+	}
+	var m map[string]string
+	if err := json.Unmarshal(b.EncryptedEnv, &m); err != nil {
+		b.EnvKeys = nil
+		b.EncryptedEnv = nil
+		return
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	b.EnvKeys = keys
+	b.EncryptedEnv = nil
+}
+
 func (h *SecureCLIHandler) emitCacheInvalidate(key string) {
 	if h.msgBus == nil {
 		return
@@ -61,9 +84,8 @@ func (h *SecureCLIHandler) handleList(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgFailedToList, "CLI credentials")})
 		return
 	}
-	// Mask encrypted env — never send raw credentials to UI
 	for i := range result {
-		result[i].EncryptedEnv = nil
+		secureCLIAttachEnvKeysForAPI(&result[i])
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"items": result})
 }
@@ -178,7 +200,7 @@ func (h *SecureCLIHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b.EncryptedEnv = nil // don't expose credentials
+	secureCLIAttachEnvKeysForAPI(b)
 	writeJSON(w, http.StatusOK, b)
 }
 
@@ -199,7 +221,7 @@ func (h *SecureCLIHandler) handleUpdate(w http.ResponseWriter, r *http.Request) 
 	// Allowlist of updatable fields to prevent column injection
 	allowed := map[string]bool{
 		"binary_name": true, "binary_path": true, "description": true,
-		"env": true, "deny_args": true, "deny_verbose": true,
+		"env": true, "env_remove": true, "deny_args": true, "deny_verbose": true,
 		"timeout_seconds": true, "tips": true, "agent_id": true, "enabled": true,
 	}
 	for k := range updates {
@@ -208,13 +230,57 @@ func (h *SecureCLIHandler) handleUpdate(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// If env is updated, serialize as JSON string for the store encrypt path
-	if envVal, ok := updates["env"]; ok {
-		if envMap, isMap := envVal.(map[string]any); isMap {
-			envJSON, _ := json.Marshal(envMap)
-			updates["encrypted_env"] = string(envJSON)
-			delete(updates, "env")
+	// If env is updated: merge non-empty env values; env_remove deletes keys first (so a key can be re-added in the same request).
+	_, hasEnv := updates["env"]
+	_, hasRemove := updates["env_remove"]
+	if hasEnv || hasRemove {
+		existing, err := h.store.Get(r.Context(), id)
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "credential", id.String())})
+			return
 		}
+		merged := make(map[string]string)
+		if len(existing.EncryptedEnv) > 0 {
+			_ = json.Unmarshal(existing.EncryptedEnv, &merged)
+		}
+		if raw, ok := updates["env_remove"]; ok {
+			if arr, ok := raw.([]any); ok {
+				for _, x := range arr {
+					if s, ok := x.(string); ok {
+						s = strings.TrimSpace(s)
+						if s != "" {
+							delete(merged, s)
+						}
+					}
+				}
+			}
+		}
+		if envVal, ok := updates["env"]; ok {
+			if envMap, isMap := envVal.(map[string]any); isMap {
+				for k, v := range envMap {
+					key := strings.TrimSpace(k)
+					if key == "" {
+						continue
+					}
+					str, ok := v.(string)
+					if !ok {
+						continue
+					}
+					str = strings.TrimSpace(str)
+					if str != "" {
+						merged[key] = str
+					}
+				}
+			}
+		}
+		envJSON, err := json.Marshal(merged)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid env"})
+			return
+		}
+		updates["encrypted_env"] = string(envJSON)
+		delete(updates, "env")
+		delete(updates, "env_remove")
 	}
 
 	if err := h.store.Update(r.Context(), id, updates); err != nil {

--- a/internal/store/secure_cli_store.go
+++ b/internal/store/secure_cli_store.go
@@ -22,6 +22,8 @@ type SecureCLIBinary struct {
 	AgentID        *uuid.UUID      `json:"agent_id,omitempty"`
 	Enabled        bool            `json:"enabled"`
 	CreatedBy      string          `json:"created_by"`
+	// EnvKeys lists env var names present in encrypted storage (no values). Populated only for API responses.
+	EnvKeys []string `json:"env_keys,omitempty"`
 }
 
 // SecureCLIStore manages secure CLI binary credential configurations.

--- a/ui/web/src/components/shared/key-value-editor.tsx
+++ b/ui/web/src/components/shared/key-value-editor.tsx
@@ -14,6 +14,10 @@ interface KeyValueEditorProps {
   keyPlaceholder?: string;
   valuePlaceholder?: string;
   addLabel?: string;
+  /** When set with `existingKeys`, value inputs for those keys use this placeholder instead of `valuePlaceholder`. */
+  valuePlaceholderExisting?: string;
+  /** Keys (trimmed) treated as already stored — e.g. `env_keys` when editing a credential. */
+  existingKeys?: ReadonlySet<string> | readonly string[];
   /** Return true for keys whose values should be masked (type="password"). */
   maskValue?: (key: string) => boolean;
 }
@@ -33,14 +37,23 @@ function toObject(entries: KeyValuePair[]): Record<string, string> {
   return result;
 }
 
+function toExistingKeySet(keys: ReadonlySet<string> | readonly string[] | undefined): Set<string> | undefined {
+  if (!keys) return undefined;
+  if (keys instanceof Set) return keys;
+  return new Set(keys);
+}
+
 export function KeyValueEditor({
   value,
   onChange,
   keyPlaceholder = "Key",
   valuePlaceholder = "Value",
   addLabel = "Add",
+  valuePlaceholderExisting,
+  existingKeys,
   maskValue,
 }: KeyValueEditorProps) {
+  const existingKeySet = toExistingKeySet(existingKeys);
   const [entries, setEntries] = useState<KeyValuePair[]>(() => toEntries(value));
   const internalChange = useRef(false);
 
@@ -75,6 +88,14 @@ export function KeyValueEditor({
     emitChange(result);
   };
 
+  const valuePhForEntry = (entryKey: string) => {
+    const k = entryKey.trim();
+    if (valuePlaceholderExisting && existingKeySet && k && existingKeySet.has(k)) {
+      return valuePlaceholderExisting;
+    }
+    return valuePlaceholder;
+  };
+
   return (
     <div className="space-y-2">
       {entries.map((entry, idx) => (
@@ -83,14 +104,14 @@ export function KeyValueEditor({
             value={entry.key}
             onChange={(e) => updateEntry(idx, { key: e.target.value })}
             placeholder={keyPlaceholder}
-            className="flex-1 font-mono text-sm"
+            className="flex-1 font-mono text-base md:text-sm"
           />
           <Input
             type={maskValue?.(entry.key) ? "password" : "text"}
             value={entry.value}
             onChange={(e) => updateEntry(idx, { value: e.target.value })}
-            placeholder={valuePlaceholder}
-            className="flex-1 font-mono text-sm"
+            placeholder={valuePhForEntry(entry.key)}
+            className="flex-1 font-mono text-base md:text-sm"
           />
           <Button
             variant="ghost"

--- a/ui/web/src/i18n/locales/en/cli-credentials.json
+++ b/ui/web/src/i18n/locales/en/cli-credentials.json
@@ -22,6 +22,7 @@
     "noPreset": "No preset (manual)",
     "presetHint": "Selecting a preset auto-fills fields and shows required env vars.",
     "encryptedHint": "Credentials are encrypted and cannot be displayed. Leave environment variables empty to keep existing values, or re-enter to update.",
+    "addEnvVar": "Add variable",
     "envVars": "Environment Variables",
     "binaryName": "Binary Name",
     "binaryPath": "Binary Path",
@@ -33,6 +34,7 @@
     "agentIdHint": "optional — leave blank for global",
     "commaSeparated": "comma-separated",
     "binaryNameRequired": "Binary name is required.",
+    "envRequired": "At least one environment variable is required.",
     "failedToSave": "Failed to save."
   },
   "placeholders": {
@@ -42,7 +44,10 @@
     "denyArgs": "--admin, --force",
     "denyVerbose": "-v, --verbose",
     "tips": "Usage tips for the agent",
-    "agentId": "agent-id"
+    "agentId": "agent-id",
+    "envKey": "VAR_NAME",
+    "envValue": "value",
+    "envValueUnchanged": "Leave blank to keep"
   },
   "toast": {
     "created": "CLI credential created",

--- a/ui/web/src/i18n/locales/vi/cli-credentials.json
+++ b/ui/web/src/i18n/locales/vi/cli-credentials.json
@@ -22,6 +22,7 @@
     "noPreset": "Không dùng mẫu (nhập tay)",
     "presetHint": "Chọn mẫu sẽ tự động điền các trường và hiển thị biến môi trường cần thiết.",
     "encryptedHint": "Thông tin xác thực đã được mã hóa và không thể hiển thị. Để trống biến môi trường để giữ giá trị hiện tại, hoặc nhập lại để cập nhật.",
+    "addEnvVar": "Thêm biến",
     "envVars": "Biến môi trường",
     "binaryName": "Tên Binary",
     "binaryPath": "Đường dẫn Binary",
@@ -33,6 +34,7 @@
     "agentIdHint": "tùy chọn — để trống cho toàn cục",
     "commaSeparated": "phân cách bằng dấu phẩy",
     "binaryNameRequired": "Tên binary là bắt buộc.",
+    "envRequired": "Cần ít nhất một biến môi trường.",
     "failedToSave": "Không thể lưu."
   },
   "placeholders": {
@@ -42,7 +44,10 @@
     "denyArgs": "--admin, --force",
     "denyVerbose": "-v, --verbose",
     "tips": "Mẹo sử dụng cho agent",
-    "agentId": "agent-id"
+    "agentId": "agent-id",
+    "envKey": "TÊN_BIẾN",
+    "envValue": "giá trị",
+    "envValueUnchanged": "Để trống để giữ nguyên"
   },
   "toast": {
     "created": "Đã tạo thông tin CLI",

--- a/ui/web/src/i18n/locales/zh/cli-credentials.json
+++ b/ui/web/src/i18n/locales/zh/cli-credentials.json
@@ -22,6 +22,7 @@
     "noPreset": "不使用预设（手动）",
     "presetHint": "选择预设会自动填充字段并显示所需的环境变量。",
     "encryptedHint": "凭证已加密，无法显示。留空环境变量以保留现有值，或重新输入以更新。",
+    "addEnvVar": "添加变量",
     "envVars": "环境变量",
     "binaryName": "二进制名称",
     "binaryPath": "二进制路径",
@@ -33,6 +34,7 @@
     "agentIdHint": "可选 — 留空表示全局",
     "commaSeparated": "逗号分隔",
     "binaryNameRequired": "二进制名称为必填项。",
+    "envRequired": "至少需要设置一个环境变量。",
     "failedToSave": "保存失败。"
   },
   "placeholders": {
@@ -42,7 +44,10 @@
     "denyArgs": "--admin, --force",
     "denyVerbose": "-v, --verbose",
     "tips": "给代理的使用提示",
-    "agentId": "agent-id"
+    "agentId": "agent-id",
+    "envKey": "变量名",
+    "envValue": "值",
+    "envValueUnchanged": "留空则保持不变"
   },
   "toast": {
     "created": "CLI 凭证已创建",

--- a/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
+++ b/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
@@ -11,7 +11,12 @@ import { Switch } from "@/components/ui/switch";
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
+import { KeyValueEditor } from "@/components/shared/key-value-editor";
 import type { SecureCLIBinary, CLICredentialInput, CLIPreset } from "./hooks/use-cli-credentials";
+
+/** Env var keys whose values should be masked (type="password"). */
+const SENSITIVE_ENV_RE = /^.*(key|secret|token|password|credential).*$/i;
+const isSensitiveEnvKey = (key: string) => SENSITIVE_ENV_RE.test(key.trim());
 
 interface Props {
   open: boolean;
@@ -22,6 +27,17 @@ interface Props {
 }
 
 const NONE_PRESET = "__none__";
+
+function nonEmptyEnvPayload(envValues: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(envValues)) {
+    const kt = k.trim();
+    if (!kt) continue;
+    const vt = v.trim();
+    if (vt) out[kt] = vt;
+  }
+  return out;
+}
 
 export function CliCredentialFormDialog({ open, onOpenChange, credential, presets, onSubmit }: Props) {
   const { t } = useTranslation("cli-credentials");
@@ -50,6 +66,8 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
   // Current preset definition (for env var fields)
   const activePreset: CLIPreset | null =
     selectedPreset !== NONE_PRESET ? (presets[selectedPreset] ?? null) : null;
+  const showPresetEnvFields = activePreset !== null && activePreset.env_vars.length > 0;
+  const showCustomEnvEditor = !showPresetEnvFields;
 
   useEffect(() => {
     if (!open) return;
@@ -63,13 +81,21 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
     setTips(credential?.tips ?? "");
     setAgentId(credential?.agent_id ?? "");
     setEnabled(credential?.enabled ?? true);
-    setEnvValues({});
+    const ek = credential?.env_keys;
+    if (ek && ek.length > 0) {
+      setEnvValues(Object.fromEntries(ek.map((k) => [k, ""])));
+    } else {
+      setEnvValues({});
+    }
     setError("");
   }, [open, credential]);
 
   const applyPreset = (key: string) => {
     setSelectedPreset(key);
-    if (key === NONE_PRESET) return;
+    if (key === NONE_PRESET) {
+      setEnvValues({});
+      return;
+    }
     const p = presets[key];
     if (!p) return;
     setBinaryName(p.binary_name);
@@ -89,6 +115,11 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
       setError(t("form.binaryNameRequired"));
       return;
     }
+    const envPayload = nonEmptyEnvPayload(envValues);
+    if (!isEdit && Object.keys(envPayload).length === 0) {
+      setError(t("form.envRequired"));
+      return;
+    }
     setLoading(true);
     setError("");
     try {
@@ -104,7 +135,24 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
         enabled,
       };
       if (selectedPreset !== NONE_PRESET) payload.preset = selectedPreset;
-      if (Object.keys(envValues).length > 0) payload.env = envValues;
+      if (isEdit && credential) {
+        if (Object.keys(envPayload).length > 0) {
+          payload.env = envPayload;
+        }
+        const initialKeys = new Set(credential.env_keys ?? []);
+        const currentKeys = new Set(
+          Object.keys(envValues)
+            .map((k) => k.trim())
+            .filter(Boolean),
+        );
+        const removed = [...initialKeys].filter((k) => !currentKeys.has(k));
+        const removeFiltered = removed.filter((k) => !(k in envPayload));
+        if (removeFiltered.length > 0) {
+          payload.env_remove = removeFiltered;
+        }
+      } else {
+        payload.env = envPayload;
+      }
       await onSubmit(payload);
       onOpenChange(false);
     } catch (err) {
@@ -152,8 +200,8 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
             </p>
           )}
 
-          {/* Env var inputs from preset */}
-          {activePreset && activePreset.env_vars.length > 0 && (
+          {/* Env vars: preset-defined fields, or free-form key/value for manual / edit */}
+          {showPresetEnvFields && activePreset && (
             <div className="grid gap-3 rounded-md border p-3">
               <p className="text-sm font-medium">{t("form.envVars")}</p>
               {activePreset.env_vars.map((ev) => (
@@ -176,6 +224,21 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
                   )}
                 </div>
               ))}
+            </div>
+          )}
+          {showCustomEnvEditor && (
+            <div className="grid gap-2 rounded-md border p-3">
+              <p className="text-sm font-medium">{t("form.envVars")}</p>
+              <KeyValueEditor
+                value={envValues}
+                onChange={setEnvValues}
+                keyPlaceholder={t("placeholders.envKey")}
+                valuePlaceholder={t("placeholders.envValue")}
+                valuePlaceholderExisting={isEdit ? t("placeholders.envValueUnchanged") : undefined}
+                existingKeys={isEdit ? credential?.env_keys : undefined}
+                addLabel={t("form.addEnvVar")}
+                maskValue={isSensitiveEnvKey}
+              />
             </div>
           )}
 

--- a/ui/web/src/types/cli-credential.ts
+++ b/ui/web/src/types/cli-credential.ts
@@ -12,6 +12,8 @@ export interface SecureCLIBinary {
   created_by: string;
   created_at: string;
   updated_at: string;
+  /** Names of env vars in encrypted storage (values are never returned). */
+  env_keys?: string[];
 }
 
 export interface CLIPresetEnvVar {
@@ -43,4 +45,6 @@ export interface CLICredentialInput {
   agent_id?: string;
   enabled?: boolean;
   env?: Record<string, string>;
+  /** Keys to remove from stored env (edit only). Processed before env merge on the server. */
+  env_remove?: string[];
 }


### PR DESCRIPTION
Improves secure CLI credential management so admins can define, update, and remove injected environment variables from the web UI — without exposing secret values to the client.

**Backend:**
Expose only env_keys (sorted names) on list/get; never return env values.
Support partial updates: merge non-empty `env`; `env_remove` deletes keys (applied before merge so a key can be removed and set in one request).

**Frontend:**
Manual/custom credentials: key/value editor when not using a preset.
Edit: pre-fill stored keys with empty values; distinct placeholders for existing vs new vars; row delete → `env_remove`.