### PR TITLE
fix(http): propagate cross-tenant context in auth middleware

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -289,14 +289,17 @@ func requireAuth(minRole permissions.Role, next http.HandlerFunc) http.HandlerFu
 		}
 		if auth.CrossTenant && auth.TenantID != uuid.Nil {
 			// Cross-tenant admin with tenant scope: filter data by chosen tenant
+			ctx = store.WithCrossTenant(ctx)
 			ctx = store.WithTenantID(ctx, auth.TenantID)
 			slog.Debug("security.http_auth_resolved",
 				"path", r.URL.Path,
 				"role", string(auth.Role),
+				"cross_tenant", true,
 				"tenant_scope", auth.TenantID.String(),
 			)
 		} else if auth.CrossTenant {
-			// Auto-scope to MasterTenantID so all operations use a concrete tenant.
+			// Cross-tenant admin without scope: default to MasterTenantID.
+			ctx = store.WithCrossTenant(ctx)
 			ctx = store.WithTenantID(ctx, store.MasterTenantID)
 			slog.Debug("security.http_auth_resolved",
 				"path", r.URL.Path,
@@ -367,6 +370,7 @@ func requireAuthBearer(minRole permissions.Role, bearer string, w http.ResponseW
 		ctx = store.WithUserID(ctx, userID)
 	}
 	if auth.CrossTenant {
+		ctx = store.WithCrossTenant(ctx)
 		ctx = store.WithTenantID(ctx, store.MasterTenantID)
 	} else if auth.TenantID != uuid.Nil {
 		ctx = store.WithTenantID(ctx, auth.TenantID)


### PR DESCRIPTION
## Summary

- HTTP auth middleware (`requireAuth`, `requireAuthBearer`) detects cross-tenant admin status but never propagates it to the request context via `store.WithCrossTenant(ctx)`
- All HTTP tenant management endpoints (`/v1/tenants/*`) return 403 "insufficient role" even with valid gateway token + owner user ID
- WebSocket path works correctly because `Client.IsCrossTenant()` is independent

## Root Cause

`auth.CrossTenant` is correctly set to `true` in `resolveAuth()` for owner users, but `requireAuth` only calls `store.WithTenantID()` — never `store.WithCrossTenant()`. The `TenantsHandler.handleList()` checks `store.IsCrossTenant(ctx)` which returns false.

## Fix

Add `ctx = store.WithCrossTenant(ctx)` in both `requireAuth` and `requireAuthBearer` when `auth.CrossTenant` is true (3 locations).

## Test plan

- [x] `curl -H "Authorization: Bearer $TOKEN" -H "X-GoClaw-User-Id: $OWNER_ID" /v1/tenants` returns 200 (was 403)
- [x] `POST /v1/tenants` with owner credentials creates tenant successfully (was 403)
- [x] Tenant CRUD idempotent — re-plan shows 0 changes after apply
- [x] Tenant-scoped resources (providers, agents) deploy correctly within created tenants
- [x] Existing HTTP auth tests pass (`go test ./internal/http/...`)
- [x] Non-owner users still get 403 on tenant endpoints
- [x] WS tenant operations unaffected

## Verified with GCPlane

Tested end-to-end with [gcplane](https://github.com/dataplanelabs/gcplane) multi-tenant manifests:
- Created 2 tenants (acme-corp, startup-io) via `POST /v1/tenants`
- Deployed 2 providers + 4 agents to acme-corp tenant scope
- Deployed 1 provider + 2 agents to startup-io tenant scope
- Tenant isolation confirmed — each tenant only sees its own resources