### PR TITLE
fix(ui): isolate contact search cache key

### DIFF
--- a/ui/web/src/lib/query-keys.ts
+++ b/ui/web/src/lib/query-keys.ts
@@ -35,6 +35,7 @@ export const queryKeys = {
   contacts: {
     all: ["contacts"] as const,
     list: (params: Record<string, unknown>) => ["contacts", params] as const,
+    search: (params: Record<string, unknown>) => ["contacts", "search", params] as const,
     resolve: (ids: string) => ["contacts", "resolve", ids] as const,
   },
   skills: {

--- a/ui/web/src/pages/agents/hooks/use-contact-search.ts
+++ b/ui/web/src/pages/agents/hooks/use-contact-search.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useHttp } from "@/hooks/use-ws";
 import { queryKeys } from "@/lib/query-keys";
@@ -13,18 +13,18 @@ export function useContactSearch(search: string) {
   const [debouncedSearch, setDebouncedSearch] = useState("");
 
   // Simple debounce via timeout
-  useMemo(() => {
+  useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(search), 150);
     return () => clearTimeout(timer);
   }, [search]);
 
   const { data, isLoading } = useQuery({
-    queryKey: queryKeys.contacts.list({ search: debouncedSearch, limit: 20 }),
+    queryKey: queryKeys.contacts.search({ search: debouncedSearch, limit: 20 }),
     queryFn: async () => {
       const params: Record<string, string> = { limit: "20" };
       if (debouncedSearch) params.search = debouncedSearch;
       const res = await http.get<{ contacts: ChannelContact[] }>("/v1/contacts", params);
-      return Array.isArray(res.contacts) ? res.contacts : [];
+      return res.contacts ?? [];
     },
     enabled: debouncedSearch.length >= 2,
     staleTime: 30_000,


### PR DESCRIPTION
## Summary

Fix the agents contact search hook so it no longer shares a React Query cache entry with other contacts queries that cache a different response shape.

Before:
- `useContactSearch` reused `queryKeys.contacts.list(...)` even though it cached a `ChannelContact[]`, while other callers of `useContacts` cached `{ contacts, total }` under the same key family.
- A reliable repro path was on the agent detail flow: open `Advanced` -> `Workspace Sharing`, search for a contact there, then switch to `Permissions` or `Instances` and search for the same term again. The second hook could read the cached object shape instead of an array and show an empty result list or hit runtime errors depending on local guards.
- The debounce timer in `useContactSearch` was wired through `useMemo`, so old timers were not cleaned up as an effect cleanup.

After:
- `useContactSearch` uses its own `contacts.search` cache key, so its cached array stays isolated from `useContacts` callers.
- The hook can return `data ?? []` directly because it now owns its cache contract.
- The debounce timer runs in `useEffect`, so pending timers are cleaned up correctly between keystrokes and on unmount.

## Changes

- add `queryKeys.contacts.search(...)` for the agents contact search hook
- switch `useContactSearch` to the dedicated query key and simplify contact array handling
- replace the debounce `useMemo` with `useEffect`

## Test plan

- Reproduce the old bug on `Agent detail -> Config -> Workspace Sharing`: type a contact search term so `useContacts({ search, limit: 20 })` seeds the contacts cache.
- Without reloading, switch to `Agent detail -> Permissions` or `Agent detail -> Instances` and search for the same term again; verify the contact search now renders the expected contact list instead of reusing the wrong cached shape.
- Verify contact search still works in `Agent detail -> Files` when inserting a contact snippet into a context file.
