### PR TITLE
fix(slack): enable thread-based session isolation for DMs (AI Panel support)

### DIFF
--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -57,6 +57,14 @@ func processNormalMessage(
 	}
 	sessionKey := sessions.BuildScopedSessionKey(agentID, msg.Channel, sessions.PeerKind(peerKind), msg.ChatID, cfg.Sessions.Scope, cfg.Sessions.DmScope, cfg.Sessions.MainKey)
 
+	// Thread-based isolation override (e.g. Slack threads or AI Panel)
+	if lk := msg.Metadata["local_key"]; lk != "" && strings.Contains(lk, ":thread:") {
+		parts := strings.Split(lk, ":thread:")
+		if len(parts) == 2 {
+			sessionKey = sessions.BuildScopedThreadSessionKey(agentID, msg.Channel, sessions.PeerKind(peerKind), msg.ChatID, parts[1])
+		}
+	}
+
 	// Forum topic: override session key to isolate per-topic history.
 	// TS ref: buildTelegramGroupPeerId() in src/telegram/bot/helpers.ts
 	if msg.Metadata["is_forum"] == "true" && peerKind == string(sessions.PeerGroup) {

--- a/internal/channels/slack/handlers.go
+++ b/internal/channels/slack/handlers.go
@@ -142,7 +142,7 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 	// Determine local_key and thread context
 	localKey := channelID
 	threadTS := ev.ThreadTimeStamp
-	if !isDM && threadTS != "" {
+	if threadTS != "" {
 		localKey = fmt.Sprintf("%s:thread:%s", channelID, threadTS)
 	}
 

--- a/internal/sessions/key.go
+++ b/internal/sessions/key.go
@@ -59,6 +59,14 @@ func BuildDMThreadSessionKey(agentID, channel, peerID string, threadID int) stri
 	return fmt.Sprintf("agent:%s:%s:direct:%s:thread:%d", agentID, channel, peerID, threadID)
 }
 
+// BuildScopedThreadSessionKey builds a session key that includes a thread/topic ID.
+// Supports string-based thread IDs (e.g. Slack timestamps).
+//
+//	agent:{agentId}:{channel}:{kind}:{chatID}:thread:{threadID}
+func BuildScopedThreadSessionKey(agentID, channel string, kind PeerKind, chatID, threadID string) string {
+	return fmt.Sprintf("agent:%s:%s:%s:%s:thread:%s", agentID, channel, kind, chatID, threadID)
+}
+
 // BuildSubagentSessionKey builds the session key for a subagent.
 //
 //	agent:{agentId}:subagent:{label}
@@ -194,6 +202,12 @@ func BuildWSSessionKey(agentID, conversationID string) string {
 func IsWSSession(key string) bool {
 	_, rest := ParseSessionKey(key)
 	return strings.HasPrefix(rest, "ws:") || strings.HasPrefix(rest, "ws-")
+}
+
+// IsThreadSession checks if a session key indicates a thread-scoped session.
+func IsThreadSession(key string) bool {
+	_, rest := ParseSessionKey(key)
+	return strings.Contains(rest, ":thread:")
 }
 
 // PeerKindFromGroup returns PeerGroup if isGroup is true, PeerDirect otherwise.


### PR DESCRIPTION
Fixes #435

This PR enables thread-based session isolation for Slack Direct Messages. 

### Changes:
- **`internal/channels/slack/handlers.go`**: Removed the `!isDM` restriction, allowing `thread_ts` to be propagated for DMs. This is essential for supporting Slack's native **AI Panel**, which uses threads to isolate conversations.
- **`internal/sessions/key.go`**: Added `BuildScopedThreadSessionKey` to support string-based thread IDs (Slack uses timestamps like `1710000000.000000`).
- **`cmd/gateway_consumer_normal.go`**: Updated the message consumer to detect thread-scoped `local_key` values and automatically override the session key to ensure isolation.

Verified with Slack AI Panel: clicking \"New Chat\" now correctly starts a fresh GoClaw session with clean history.