### PR TITLE
fix(memory): qualify tenant clause for joined admin queries

### DIFF
--- a/internal/store/pg/helpers.go
+++ b/internal/store/pg/helpers.go
@@ -212,10 +212,10 @@ func tableHasUpdatedAt(table string) bool {
 
 // --- Tenant filter helpers ---
 
-// tenantClauseN returns an " AND tenant_id = $N" clause and the tenant UUID as the arg.
+// tenantClauseForN returns an " AND <tenantColumn> = $N" clause and the tenant UUID as the arg.
 // Returns ("", nil, nil) for cross-tenant callers (skip filter).
 // Returns error if tenant is missing from context (fail-closed).
-func tenantClauseN(ctx context.Context, paramN int) (clause string, args []any, err error) {
+func tenantClauseForN(ctx context.Context, paramN int, tenantColumn string) (clause string, args []any, err error) {
 	if store.IsCrossTenant(ctx) {
 		return "", nil, nil
 	}
@@ -223,7 +223,14 @@ func tenantClauseN(ctx context.Context, paramN int) (clause string, args []any, 
 	if tid == uuid.Nil {
 		return "", nil, fmt.Errorf("tenant_id required")
 	}
-	return fmt.Sprintf(" AND tenant_id = $%d", paramN), []any{tid}, nil
+	return fmt.Sprintf(" AND %s = $%d", tenantColumn, paramN), []any{tid}, nil
+}
+
+// tenantClauseN returns an " AND tenant_id = $N" clause and the tenant UUID as the arg.
+// Returns ("", nil, nil) for cross-tenant callers (skip filter).
+// Returns error if tenant is missing from context (fail-closed).
+func tenantClauseN(ctx context.Context, paramN int) (clause string, args []any, err error) {
+	return tenantClauseForN(ctx, paramN, "tenant_id")
 }
 
 // tenantIDForInsert returns the tenant UUID for INSERT operations.

--- a/internal/store/pg/memory_admin.go
+++ b/internal/store/pg/memory_admin.go
@@ -95,7 +95,7 @@ func (s *PGMemoryStore) GetDocumentDetail(ctx context.Context, agentID, userID, 
 	var q string
 	var args []any
 	if userID == "" {
-		tc, tcArgs, err := tenantClauseN(ctx, 3)
+		tc, tcArgs, err := tenantClauseForN(ctx, 3, "d.tenant_id")
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +108,7 @@ func (s *PGMemoryStore) GetDocumentDetail(ctx context.Context, agentID, userID, 
 			 GROUP BY d.id`
 		args = append([]any{aid, path}, tcArgs...)
 	} else {
-		tc, tcArgs, err := tenantClauseN(ctx, 4)
+		tc, tcArgs, err := tenantClauseForN(ctx, 4, "d.tenant_id")
 		if err != nil {
 			return nil, err
 		}
@@ -148,7 +148,7 @@ func (s *PGMemoryStore) ListChunks(ctx context.Context, agentID, userID, path st
 	var q string
 	var args []any
 	if userID == "" {
-		tc, tcArgs, err := tenantClauseN(ctx, 3)
+		tc, tcArgs, err := tenantClauseForN(ctx, 3, "d.tenant_id")
 		if err != nil {
 			return nil, err
 		}
@@ -161,7 +161,7 @@ func (s *PGMemoryStore) ListChunks(ctx context.Context, agentID, userID, path st
 			 ORDER BY c.start_line`
 		args = append([]any{aid, path}, tcArgs...)
 	} else {
-		tc, tcArgs, err := tenantClauseN(ctx, 4)
+		tc, tcArgs, err := tenantClauseForN(ctx, 4, "d.tenant_id")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Fix tenant filtering for memory admin queries that join `memory_documents` and `memory_chunks`.

Before:
- `tenantClauseN` always emitted an unqualified `tenant_id` predicate.
- Joined memory admin queries could append that predicate to SQL where both joined tables expose `tenant_id`, which made the filter ambiguous.

After:
- Joined memory admin queries qualify the tenant predicate as `d.tenant_id`.
- Store code can now opt into a qualified tenant filter via `tenantClauseForN` while keeping existing single-table callers unchanged.

## Changes

- Add `tenantClauseForN(ctx, paramN, tenantColumn)` in `internal/store/pg/helpers.go`.
- Keep `tenantClauseN` as the default wrapper for single-table queries.
- Update memory admin document detail and chunk listing queries to use `tenantClauseForN(..., "d.tenant_id")`.

## Test plan

- `go test ./internal/store/...`