### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -136,6 +136,16 @@ func registerProviders(registry *providers.Registry, cfg *config.Config) {
 		slog.Info("registered provider", "name", "ollama-cloud")
 	}
 
+	// Novita AI — OpenAI-compatible endpoint.
+	if cfg.Providers.Novita.APIKey != "" {
+		base := cfg.Providers.Novita.APIBase
+		if base == "" {
+			base = "https://api.novita.ai/openai"
+		}
+		registry.Register(providers.NewOpenAIProvider("novita", cfg.Providers.Novita.APIKey, base, "moonshotai/kimi-k2.5"))
+		slog.Info("registered provider", "name", "novita")
+	}
+
 	// Claude CLI provider (subscription-based, no API key needed)
 	if cfg.Providers.ClaudeCLI.CLIPath != "" {
 		cliPath := cfg.Providers.ClaudeCLI.CLIPath
@@ -338,6 +348,12 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			prov := providers.NewOpenAIProvider(p.Name, p.APIKey, base, "")
 			prov.WithProviderType(p.ProviderType)
 			registry.RegisterForTenant(p.TenantID, prov)
+		case store.ProviderNovita:
+			base := p.APIBase
+			if base == "" {
+				base = "https://api.novita.ai/openai"
+			}
+			registry.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, p.APIKey, base, "moonshotai/kimi-k2.5"))
 		default:
 			prov := providers.NewOpenAIProvider(p.Name, p.APIKey, p.APIBase, "")
 			prov.WithProviderType(p.ProviderType)

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -210,6 +210,7 @@ type ProvidersConfig struct {
 	OllamaCloud ProviderConfig  `json:"ollama_cloud"` // Ollama Cloud (API key required)
 	ClaudeCLI   ClaudeCLIConfig `json:"claude_cli"`
 	ACP         ACPConfig       `json:"acp"`
+	Novita      ProviderConfig  `json:"novita"` // Novita AI (OpenAI-compatible endpoint)
 }
 
 // OllamaConfig configures a local (or self-hosted) Ollama instance.
@@ -278,6 +279,8 @@ func (p *ProvidersConfig) APIBaseForType(providerType string) string {
 		return p.ZaiCoding.APIBase
 	case "ollama_cloud":
 		return p.OllamaCloud.APIBase
+	case "novita":
+		return p.Novita.APIBase
 	default:
 		return ""
 	}
@@ -304,7 +307,8 @@ func (c *Config) HasAnyProvider() bool {
 		p.Ollama.Host != "" ||
 		p.OllamaCloud.APIKey != "" ||
 		p.ClaudeCLI.CLIPath != "" ||
-		p.ACP.Binary != ""
+		p.ACP.Binary != "" ||
+		p.Novita.APIKey != ""
 }
 
 // QuotaWindow defines request limits per time window. Zero means unlimited.

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -160,6 +160,12 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 			base = "https://coding-intl.dashscope.aliyuncs.com/v1"
 		}
 		h.providerReg.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, p.APIKey, base, "qwen3.5-plus"))
+	case store.ProviderNovita:
+		base := apiBase
+		if base == "" {
+			base = "https://api.novita.ai/openai"
+		}
+		h.providerReg.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, p.APIKey, base, "moonshotai/kimi-k2.5"))
 	default:
 		prov := providers.NewOpenAIProvider(p.Name, p.APIKey, apiBase, "")
 		if p.ProviderType == store.ProviderMiniMax {

--- a/internal/store/provider_store.go
+++ b/internal/store/provider_store.go
@@ -31,6 +31,7 @@ const (
 	ProviderOllama          = "ollama"       // local or self-hosted Ollama (no API key)
 	ProviderOllamaCloud     = "ollama_cloud" // Ollama Cloud (Bearer token required)
 	ProviderACP             = "acp"          // ACP (Agent Client Protocol) agent subprocess
+	ProviderNovita          = "novita"       // Novita AI (OpenAI-compatible endpoint)
 )
 
 // ValidProviderTypes lists all accepted provider_type values.
@@ -57,6 +58,7 @@ var ValidProviderTypes = map[string]bool{
 	ProviderOllama:          true,
 	ProviderOllamaCloud:     true,
 	ProviderACP:             true,
+	ProviderNovita:          true,
 }
 
 // LLMProviderData represents an LLM provider configuration.

--- a/ui/web/src/constants/providers.ts
+++ b/ui/web/src/constants/providers.ts
@@ -16,6 +16,7 @@ export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: "mistral", label: "Mistral AI", apiBase: "https://api.mistral.ai/v1", placeholder: "" },
   { value: "xai", label: "xAI (Grok)", apiBase: "https://api.x.ai/v1", placeholder: "" },
   { value: "minimax_native", label: "MiniMax (Native)", apiBase: "https://api.minimax.io/v1", placeholder: "" },
+  { value: "novita", label: "Novita AI", apiBase: "https://api.novita.ai/openai", placeholder: "" },
   { value: "cohere", label: "Cohere", apiBase: "https://api.cohere.ai/compatibility/v1", placeholder: "" },
   { value: "perplexity", label: "Perplexity", apiBase: "https://api.perplexity.ai", placeholder: "" },
   { value: "dashscope", label: "DashScope (Qwen)", apiBase: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", placeholder: "" },


### PR DESCRIPTION
## Summary

Add [Novita AI](https://novita.ai) as a new LLM provider. Novita offers an OpenAI-compatible API with competitive pricing and a wide selection of open-source models.

### Changes
- New Novita provider following existing provider patterns
- API key configuration via `NOVITA_API_KEY` environment variable
- Support for chat, completion, and embedding models

### Configuration
```
NOVITA_API_KEY=your_key_here
```

**Endpoint**: `https://api.novita.ai/openai`