### PR TITLE
fix(agent): set TenantID on streaming events in runLoop emitRun

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -36,6 +36,7 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 		event.UserID = req.UserID
 		event.Channel = req.Channel
 		event.ChatID = req.ChatID
+		event.TenantID = l.tenantID
 		l.emit(event)
 	}
 


### PR DESCRIPTION
## Summary

- `runLoop`'s `emitRun` wrapper in `loop.go` is missing `event.TenantID`, causing all streaming events (`chunk`, `thinking`, `tool.call`) to be emitted with `TenantID=Nil`
- The event filter (`event_filter.go:43-44`) blocks unscoped events for non-admin clients: tenant-bound API key users receive **no streaming** — only `run.started` and `run.completed` get through (emitted from `Run()` in `loop_run.go` which already sets `TenantID`)
- Fix: add `event.TenantID = l.tenantID` to match `loop_run.go`'s emitRun

## Impact

Any multi-tenant deployment where users connect via tenant-bound API keys sees no live streaming. The agent runs successfully and the final response appears, but chunk/thinking/tool events are silently dropped by the event filter.

## Test plan

- [ ] Connect via tenant-bound API key (not gateway token)
- [ ] Send a message — verify chunk, thinking, tool.call events stream in real-time
- [ ] Verify admin/gateway token users are unaffected (crossTenant bypasses the filter)