### PR TITLE
fix(tools): session ownership check uses UUID instead of agent_key

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -39,9 +39,12 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (*RunResult, error) 
 		l.emit(event)
 	}
 
-	// Inject agent UUID into context for tool routing
+	// Inject agent UUID + key into context for tool routing
 	if l.agentUUID != uuid.Nil {
 		ctx = store.WithAgentID(ctx, l.agentUUID)
+	}
+	if l.id != "" {
+		ctx = store.WithAgentKey(ctx, l.id)
 	}
 	// Inject tenant into context for tool-level tenant scoping (spawn, MCP, etc.)
 	if l.tenantID != uuid.Nil {

--- a/internal/store/context.go
+++ b/internal/store/context.go
@@ -12,7 +12,8 @@ const (
 	// UserIDKey is the context key for the external user ID (TEXT, free-form).
 	UserIDKey contextKey = "goclaw_user_id"
 	// AgentIDKey is the context key for the agent UUID.
-	AgentIDKey contextKey = "goclaw_agent_id"
+	AgentIDKey  contextKey = "goclaw_agent_id"
+	AgentKeyKey contextKey = "goclaw_agent_key"
 	// AgentTypeKey is the context key for the agent type ("open" or "predefined").
 	AgentTypeKey contextKey = "goclaw_agent_type"
 	// SenderIDKey is the original individual sender's ID (not group-scoped).
@@ -74,6 +75,19 @@ func AgentIDFromContext(ctx context.Context) uuid.UUID {
 		return v
 	}
 	return uuid.Nil
+}
+
+// WithAgentKey returns a new context with the given agent key (string identifier).
+func WithAgentKey(ctx context.Context, key string) context.Context {
+	return context.WithValue(ctx, AgentKeyKey, key)
+}
+
+// AgentKeyFromContext extracts the agent key from context. Returns "" if not set.
+func AgentKeyFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(AgentKeyKey).(string); ok {
+		return v
+	}
+	return ""
 }
 
 // WithAgentType returns a new context with the given agent type.

--- a/internal/tools/sessions_send.go
+++ b/internal/tools/sessions_send.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
@@ -109,9 +110,14 @@ func (t *SessionsSendTool) Execute(ctx context.Context, args map[string]any) *Re
 // ============================================================
 
 func resolveAgentIDString(ctx context.Context) string {
+	// Prefer agent key (string identifier used in session keys: "agent:<key>:...")
+	if key := store.AgentKeyFromContext(ctx); key != "" {
+		return key
+	}
+	// Fallback to UUID string (backward compat)
 	id := store.AgentIDFromContext(ctx)
-	if id.String() == "00000000-0000-0000-0000-000000000000" {
-		return "" // no agent ID in context
+	if id == uuid.Nil {
+		return ""
 	}
 	return id.String()
 }


### PR DESCRIPTION
## Summary

`resolveAgentIDString()` returns the agent **UUID** from context, but session keys use the agent **key** (string): `agent:<key>:ws:direct:<id>`. The `HasPrefix` ownership check in `session_status`, `session_history`, and `session_send` always fails because UUID != key, returning:

> access denied: session belongs to a different agent

### Why it's masked in single-tenant

In single-user/gateway-token setups, the agent UUID in context is often `Nil` (no agent resolution step), so `resolveAgentIDString` returns `""` and the check is skipped (`agentID != "" &&`). The bug surfaces when agents have both a UUID and a key — which is all agents created via the API or WebUI in multi-tenant deployments.

### Fix

- Add `AgentKeyKey` to context (`store.WithAgentKey` / `AgentKeyFromContext`)
- Inject agent key (`l.id`) into context in `runLoop` alongside the UUID
- `resolveAgentIDString` prefers agent key, falls back to UUID for backward compat

### Files changed

- `internal/store/context.go` — new `AgentKeyKey` context key + accessors
- `internal/agent/loop.go` — inject `l.id` via `WithAgentKey`
- `internal/tools/sessions_send.go` — `resolveAgentIDString` prefers key over UUID

## Test plan

- [ ] Agent calls `session_status` on its own session — should succeed (was "access denied")
- [ ] Agent calls `session_history` — should succeed
- [ ] Agent calls `session_send` to its own session — should succeed
- [ ] Cross-agent access still denied (different key in session prefix)