### PR TITLE
fix(slack): enable thread-based session isolation for DMs

### DIFF
--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -65,6 +65,14 @@ func processNormalMessage(
 	}
 	sessionKey := sessions.BuildScopedSessionKey(agentID, msg.Channel, sessions.PeerKind(peerKind), msg.ChatID)
 
+	// Thread-based isolation override (e.g. Slack DM threads, AI Panel)
+	if lk := msg.Metadata["local_key"]; lk != "" && strings.Contains(lk, ":thread:") {
+		parts := strings.SplitN(lk, ":thread:", 2)
+		if len(parts) == 2 {
+			sessionKey = sessions.BuildScopedThreadSessionKey(agentID, msg.Channel, sessions.PeerKind(peerKind), msg.ChatID, parts[1])
+		}
+	}
+
 	// Forum topic: override session key to isolate per-topic history.
 	// TS ref: buildTelegramGroupPeerId() in src/telegram/bot/helpers.ts
 	if msg.Metadata["is_forum"] == "true" && peerKind == string(sessions.PeerGroup) {

--- a/internal/channels/slack/handlers.go
+++ b/internal/channels/slack/handlers.go
@@ -166,7 +166,7 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 
 	// Determine local_key and thread context
 	localKey := channelID
-	if !isDM && threadTS != "" {
+	if threadTS != "" {
 		localKey = fmt.Sprintf("%s:thread:%s", channelID, threadTS)
 	}
 

--- a/internal/sessions/key.go
+++ b/internal/sessions/key.go
@@ -59,6 +59,14 @@ func BuildDMThreadSessionKey(agentID, channel, peerID string, threadID int) stri
 	return fmt.Sprintf("agent:%s:%s:direct:%s:thread:%d", agentID, channel, peerID, threadID)
 }
 
+// BuildScopedThreadSessionKey builds a session key that includes a thread/topic ID.
+// Supports string-based thread IDs (e.g. Slack timestamps).
+//
+//	agent:{agentId}:{channel}:{kind}:{chatID}:thread:{threadID}
+func BuildScopedThreadSessionKey(agentID, channel string, kind PeerKind, chatID, threadID string) string {
+	return fmt.Sprintf("agent:%s:%s:%s:%s:thread:%s", agentID, channel, kind, chatID, threadID)
+}
+
 // BuildSubagentSessionKey builds the session key for a subagent.
 //
 //	agent:{agentId}:subagent:{label}


### PR DESCRIPTION
## Summary
- Remove `!isDM` restriction in Slack handler so `thread_ts` propagates for DMs
- Add `BuildScopedThreadSessionKey` for string-based thread IDs (Slack timestamps)
- Update message consumer to detect thread-scoped `local_key` and override session key

Enables Slack AI Panel "New Chat" to correctly start fresh GoClaw sessions.

Based on #436 by @Erudition with review fixes applied:
- `strings.Split` → `strings.SplitN` for robust thread key parsing
- Removed unused `IsThreadSession` function (YAGNI)

Co-authored-by: Erudition <erudition@users.noreply.github.com>
Closes #435

## Test plan
- [ ] Verify non-threaded Slack DMs still work (no regression)
- [ ] Verify Slack AI Panel "New Chat" creates isolated sessions
- [ ] Verify group thread isolation is unchanged
- [ ] Verify Telegram DM thread isolation is unchanged