### PR TITLE
chore(docker): make host ports customizable via environment variables

### DIFF
--- a/docker-compose.otel.yml
+++ b/docker-compose.otel.yml
@@ -9,9 +9,9 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:1.68.0
     ports:
-      - "16686:16686"   # Jaeger UI
-      - "4317:4317"     # OTLP gRPC
-      - "4318:4318"     # OTLP HTTP
+      - "${JAEGER_UI_PORT:-16686}:16686"   # Jaeger UI
+      - "${OTLP_GRPC_PORT:-4317}:4317"     # OTLP gRPC
+      - "${OTLP_HTTP_PORT:-4318}:4318"     # OTLP HTTP
     environment:
       - COLLECTOR_OTLP_ENABLED=true
     restart: unless-stopped

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -8,7 +8,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis-data:/data
     command: redis-server --appendonly yes


### PR DESCRIPTION
## 🎯 Changes
This pull request modifies the Docker Compose configurations to allow host ports to be configurable via environment variables instead of being hardcoded.

- Introduced `${JAEGER_UI_PORT:-16686}`, `${OTLP_GRPC_PORT:-4317}`, and `${OTLP_HTTP_PORT:-4318}` for observability services.
- Introduced `${REDIS_PORT:-6379}` for the Redis service.

## 💡 Motivation
Hardcoded port mappings can often lead to port conflicts on host machines, especially in environments running multiple stack instances or standard local services. This standardizes the compose overlays to match the current pattern, making deployments much more flexible and adaptable avoiding conflicts out-of-the-box.

## ✅ Checklist
- [x] Tested locally with default environment variables.
- [x] Verified backward compatibility with previous defaults.
