### PR TITLE
fix(ui): session detail missing tool calls, memory dialog errors

### DIFF
--- a/ui/web/src/i18n/locales/en/memory.json
+++ b/ui/web/src/i18n/locales/en/memory.json
@@ -185,6 +185,7 @@
     "docIndexFailed": "Failed to index document",
     "allIndexed": "All documents indexed",
     "allIndexFailed": "Failed to index all",
-    "searchFailed": "Search failed"
+    "searchFailed": "Search failed",
+    "docLoadFailed": "Failed to load document"
   }
 }

--- a/ui/web/src/i18n/locales/vi/memory.json
+++ b/ui/web/src/i18n/locales/vi/memory.json
@@ -185,6 +185,7 @@
     "docIndexFailed": "Không thể lập chỉ mục tài liệu",
     "allIndexed": "Đã lập chỉ mục tất cả tài liệu",
     "allIndexFailed": "Không thể lập chỉ mục tất cả",
-    "searchFailed": "Tìm kiếm thất bại"
+    "searchFailed": "Tìm kiếm thất bại",
+    "docLoadFailed": "Không thể tải tài liệu"
   }
 }

--- a/ui/web/src/i18n/locales/zh/memory.json
+++ b/ui/web/src/i18n/locales/zh/memory.json
@@ -185,6 +185,7 @@
     "docIndexFailed": "索引文档失败",
     "allIndexed": "所有文档已索引",
     "allIndexFailed": "索引所有文档失败",
-    "searchFailed": "搜索失败"
+    "searchFailed": "搜索失败",
+    "docLoadFailed": "加载文档失败"
   }
 }

--- a/ui/web/src/pages/memory/kg-entity-detail-dialog.tsx
+++ b/ui/web/src/pages/memory/kg-entity-detail-dialog.tsx
@@ -52,7 +52,7 @@ export function KGEntityDetailDialog({ open, onOpenChange, agentId, entity, getE
 
   return (
     <Dialog open={open} onOpenChange={(v) => !traversing && onOpenChange(v)}>
-      <DialogContent className="max-w-3xl max-h-[85vh] flex flex-col">
+      <DialogContent aria-describedby={undefined} className="max-w-3xl max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <span>{entity?.name}</span>

--- a/ui/web/src/pages/memory/kg-extract-dialog.tsx
+++ b/ui/web/src/pages/memory/kg-extract-dialog.tsx
@@ -38,7 +38,7 @@ export function KGExtractDialog({ open, onOpenChange, onExtract }: KGExtractDial
 
   return (
     <Dialog open={open} onOpenChange={(v) => !loading && onOpenChange(v)}>
-      <DialogContent className="max-w-2xl max-h-[85vh] flex flex-col">
+      <DialogContent aria-describedby={undefined} className="max-w-2xl max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>{t("kg.extractDialog.title")}</DialogTitle>
         </DialogHeader>

--- a/ui/web/src/pages/memory/memory-create-dialog.tsx
+++ b/ui/web/src/pages/memory/memory-create-dialog.tsx
@@ -96,7 +96,7 @@ export function MemoryCreateDialog({ open, onOpenChange, agentId: parentAgentId,
 
   return (
     <Dialog open={open} onOpenChange={(v) => !loading && onOpenChange(v)}>
-      <DialogContent className="max-w-3xl max-h-[85vh] flex flex-col">
+      <DialogContent aria-describedby={undefined} className="max-w-3xl max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>{t("createDialog.title")}</DialogTitle>
         </DialogHeader>

--- a/ui/web/src/pages/memory/memory-document-dialog.tsx
+++ b/ui/web/src/pages/memory/memory-document-dialog.tsx
@@ -48,7 +48,7 @@ export function MemoryDocumentDialog({ open, onOpenChange, agentId, document }: 
       setDetail(res);
       setContent(res.content);
     } catch {
-      toast.error(i18next.t("memory:toast.failedCreate"));
+      toast.error(i18next.t("memory:toast.docLoadFailed"));
     } finally {
       setLoadingDetail(false);
     }
@@ -98,7 +98,7 @@ export function MemoryDocumentDialog({ open, onOpenChange, agentId, document }: 
       toast.success(i18next.t("memory:documentDialog.title"), document.path);
       onOpenChange(false);
     } catch (err) {
-      toast.error(i18next.t("memory:toast.failedCreate"), err instanceof Error ? err.message : "");
+      toast.error(i18next.t("memory:toast.docUpdateFailed"), err instanceof Error ? err.message : "");
     } finally {
       setSaving(false);
     }
@@ -108,7 +108,7 @@ export function MemoryDocumentDialog({ open, onOpenChange, agentId, document }: 
 
   return (
     <Dialog open={open} onOpenChange={(v) => !saving && onOpenChange(v)}>
-      <DialogContent className="max-w-4xl max-h-[85vh] flex flex-col">
+      <DialogContent aria-describedby={undefined} className="max-w-4xl max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <span className="font-mono text-sm">{document?.path}</span>

--- a/ui/web/src/pages/memory/memory-search-dialog.tsx
+++ b/ui/web/src/pages/memory/memory-search-dialog.tsx
@@ -37,7 +37,7 @@ export function MemorySearchDialog({ open, onOpenChange, agentId }: MemorySearch
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[85vh] flex flex-col">
+      <DialogContent aria-describedby={undefined} className="max-w-2xl max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>{t("searchDialog.title")}</DialogTitle>
         </DialogHeader>

--- a/ui/web/src/pages/sessions/session-detail-page.tsx
+++ b/ui/web/src/pages/sessions/session-detail-page.tsx
@@ -25,9 +25,13 @@ function isSystemMessage(msg: ChatMessage): boolean {
 function isDisplayable(msg: ChatMessage): boolean {
   // Hide tool role messages (shown inline with assistant)
   if (msg.role === "tool") return false;
-  // Hide messages with empty/whitespace content
-  if (!msg.content?.trim()) return false;
-  return true;
+  // Show if there is text content
+  if (msg.content?.trim()) return true;
+  // Assistant messages with tool calls or thinking should still be displayed
+  if (msg.role === "assistant") {
+    return !!(msg.toolDetails?.length || msg.tool_calls?.length || msg.thinking?.trim());
+  }
+  return false;
 }
 
 interface SessionDetailPageProps {


### PR DESCRIPTION
## Summary
- **Session detail**: `isDisplayable()` filtered out assistant messages that have `tool_calls` or `thinking` but no text content — tool call cards and thinking blocks were invisible in session history (live chat unaffected)
- **Memory document dialog**: load/save errors showed wrong toast message "Failed to create document" (`toast.failedCreate`) instead of correct keys (`toast.docLoadFailed` / `toast.docUpdateFailed`). Added missing `docLoadFailed` i18n key to en/vi/zh
- **Memory dialogs**: all 5 dialogs missing `aria-describedby={undefined}` on `DialogContent`, causing Radix UI console warnings

## Test plan
- [ ] Open a session that has tool calls → verify tool call cards and thinking blocks are now visible in session detail
- [ ] Open memory page → click a document → verify no "Failed to create document" toast on load
- [ ] Edit + save a memory document → verify error toast says "Failed to update" not "Failed to create" on failure
- [ ] Open browser console on memory page → verify no Radix `aria-describedby` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)