### PR TITLE
feat(memory): add Voyage AI embedding provider

### DIFF
--- a/cmd/gateway_agents.go
+++ b/cmd/gateway_agents.go
@@ -105,8 +105,12 @@ func buildEmbeddingProvider(
 	memCfg *config.MemoryConfig,
 	providerReg *providers.Registry,
 ) memory.EmbeddingProvider {
-	// Resolve model: embedding settings → memCfg override → default
-	model := "text-embedding-3-small"
+	// Resolve model: embedding settings → memCfg override → default (per-provider)
+	defaultModel := "text-embedding-3-small"
+	if dbp.ProviderType == store.ProviderVoyage {
+		defaultModel = "voyage-4"
+	}
+	model := defaultModel
 	if es != nil && es.Model != "" {
 		model = es.Model
 	}
@@ -121,6 +125,15 @@ func buildEmbeddingProvider(
 	}
 	if memCfg != nil && memCfg.EmbeddingAPIBase != "" {
 		apiBase = memCfg.EmbeddingAPIBase
+	}
+
+	// Voyage AI: dedicated embedding provider (not OpenAI-compatible chat provider).
+	if dbp.ProviderType == store.ProviderVoyage {
+		if dbp.APIKey == "" {
+			slog.Warn("voyage embedding provider missing API key", "name", dbp.Name)
+			return nil
+		}
+		return memory.NewVoyageEmbeddingProvider(dbp.Name, dbp.APIKey, apiBase, model)
 	}
 
 	// Gemini requires dimension truncation to match pgvector(1536) index.

--- a/internal/memory/voyage_embedding.go
+++ b/internal/memory/voyage_embedding.go
@@ -1,0 +1,105 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	voyageAPIBase    = "https://api.voyageai.com/v1"
+	voyageDefaultModel = "voyage-4"
+)
+
+// VoyageEmbeddingProvider uses the Voyage AI embedding API.
+// Voyage AI supports an optional input_type field ("query" or "document")
+// which can improve retrieval quality for asymmetric use cases.
+type VoyageEmbeddingProvider struct {
+	name      string
+	model     string
+	apiKey    string
+	apiBase   string
+	inputType string // "query", "document", or "" (omit from request)
+}
+
+// NewVoyageEmbeddingProvider creates a Voyage AI embedding provider.
+// apiBase defaults to https://api.voyageai.com/v1; model defaults to voyage-3.
+func NewVoyageEmbeddingProvider(name, apiKey, apiBase, model string) *VoyageEmbeddingProvider {
+	if apiBase == "" {
+		apiBase = voyageAPIBase
+	}
+	if model == "" {
+		model = voyageDefaultModel
+	}
+	return &VoyageEmbeddingProvider{
+		name:    name,
+		model:   model,
+		apiKey:  apiKey,
+		apiBase: apiBase,
+	}
+}
+
+// WithInputType sets the input_type parameter sent to the Voyage API.
+// Use "document" when indexing stored texts, "query" when embedding a search query.
+// Leave empty (default) to omit the field and let the API use its default.
+func (p *VoyageEmbeddingProvider) WithInputType(t string) *VoyageEmbeddingProvider {
+	p.inputType = t
+	return p
+}
+
+func (p *VoyageEmbeddingProvider) Name() string  { return p.name }
+func (p *VoyageEmbeddingProvider) Model() string { return p.model }
+
+func (p *VoyageEmbeddingProvider) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	reqBody := map[string]any{
+		"input": texts,
+		"model": p.model,
+	}
+	if p.inputType != "" {
+		reqBody["input_type"] = p.inputType
+	}
+
+	bodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.apiBase+"/embeddings", bytes.NewReader(bodyJSON))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embedding request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("voyage embedding API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Data []struct {
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	embeddings := make([][]float32, len(result.Data))
+	for i, d := range result.Data {
+		embeddings[i] = d.Embedding
+	}
+
+	return embeddings, nil
+}

--- a/internal/store/provider_store.go
+++ b/internal/store/provider_store.go
@@ -31,6 +31,7 @@ const (
 	ProviderOllama          = "ollama"       // local or self-hosted Ollama (no API key)
 	ProviderOllamaCloud     = "ollama_cloud" // Ollama Cloud (Bearer token required)
 	ProviderACP             = "acp"          // ACP (Agent Client Protocol) agent subprocess
+	ProviderVoyage          = "voyage"       // Voyage AI (embedding-only)
 )
 
 // ValidProviderTypes lists all accepted provider_type values.
@@ -57,6 +58,7 @@ var ValidProviderTypes = map[string]bool{
 	ProviderOllama:          true,
 	ProviderOllamaCloud:     true,
 	ProviderACP:             true,
+	ProviderVoyage:          true,
 }
 
 // LLMProviderData represents an LLM provider configuration.

--- a/ui/web/src/constants/providers.ts
+++ b/ui/web/src/constants/providers.ts
@@ -27,4 +27,5 @@ export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: "ollama_cloud", label: "Ollama Cloud", apiBase: "https://ollama.com/v1", placeholder: "" },
   { value: "claude_cli", label: "Claude CLI (Local)", apiBase: "", placeholder: "" },
   { value: "acp", label: "ACP Agent (Subprocess)", apiBase: "", placeholder: "claude" },
+  { value: "voyage", label: "Voyage AI (Embeddings)", apiBase: "https://api.voyageai.com/v1", placeholder: "" },
 ];


### PR DESCRIPTION
## Summary

- Add `VoyageEmbeddingProvider` in `internal/memory/voyage_embedding.go` — a dedicated Voyage AI implementation that calls `https://api.voyageai.com/v1/embeddings` directly, with support for the `input_type` param (`"query"` / `"document"`) for improved asymmetric retrieval quality
- Add `ProviderVoyage = "voyage"` constant and register it in `ValidProviderTypes` so users can create a Voyage provider via the API or UI
- Update `buildEmbeddingProvider` in `cmd/gateway_agents.go` to route the `voyage` provider type through `VoyageEmbeddingProvider` (Voyage is embedding-only; it has no chat API), with `voyage-4` as the default model
- Add Voyage AI to the UI provider type selector (`ui/web/src/constants/providers.ts`) with the API base pre-filled

## Motivation

Voyage AI produces state-of-the-art embeddings for retrieval, especially for code and domain-specific corpora. The existing `OpenAIEmbeddingProvider` cannot be used for Voyage because:
1. Voyage's `input_type` field (query vs document distinction) is not part of the OpenAI spec
2. Voyage has no chat endpoint — it should never be registered as a chat provider in the registry

This PR adds a thin, dedicated provider that satisfies the `EmbeddingProvider` interface and integrates cleanly with the existing embedding resolution flow.

## Test plan

- [ ] Add a provider with type `voyage` and a valid Voyage AI API key via the UI
- [ ] Set `embedding.provider` in system configs to the provider name
- [ ] Send a message that triggers memory storage — verify embeddings are generated with model `voyage-4`
- [ ] Confirm `input_type` can be omitted (default) or configured per deployment