### PR TITLE
feat(tools): add Google Workspace (gws) built-in tool

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -195,6 +195,12 @@ func runGateway() {
 	toolsReg.Register(tools.NewCronTool(pgStores.Cron))
 	slog.Info("cron tool registered")
 
+	// Google Workspace CLI tool
+	if pgStores.BuiltinTools != nil {
+		toolsReg.Register(tools.NewGWSTool(pgStores.BuiltinTools))
+		slog.Info("gws tool registered")
+	}
+
 	// Heartbeat tool (agent-facing)
 	heartbeatTool := tools.NewHeartbeatTool(pgStores.Heartbeats, pgStores.ConfigPermissions)
 	heartbeatTool.SetAgentStore(pgStores.Agents)

--- a/cmd/gateway_builtin_tools.go
+++ b/cmd/gateway_builtin_tools.go
@@ -86,6 +86,12 @@ func builtinToolSeedData() []store.BuiltinToolDef {
 		// messaging
 		{Name: "message", DisplayName: "Message", Description: "Send a proactive message to a user on a connected channel (Telegram, Discord, etc.)", Category: "messaging", Enabled: true},
 
+		// google-workspace
+		{Name: "gws", DisplayName: "Google Workspace", Description: "Interact with Google Workspace (Gmail, Calendar, Drive) via the gws CLI", Category: "google-workspace", Enabled: true,
+			Settings: json.RawMessage(`{"client_id":"","client_secret":"","refresh_token":""}`),
+			Metadata: json.RawMessage(`{"config_hint":"Built-in Tools → Google Workspace → Settings"}`),
+		},
+
 		// scheduling
 		{Name: "cron", DisplayName: "Cron Scheduler", Description: "Schedule or manage recurring tasks using cron expressions, at-times, or intervals", Category: "scheduling", Enabled: true,
 			Metadata: json.RawMessage(`{"config_hint":"Config → Cron"}`),

--- a/internal/http/builtin_tools.go
+++ b/internal/http/builtin_tools.go
@@ -33,6 +33,8 @@ func (h *BuiltinToolsHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /v1/tools/builtin/{name}", h.auth(h.handleUpdate))
 	mux.HandleFunc("PUT /v1/tools/builtin/{name}/tenant-config", h.auth(h.handleSetTenantConfig))
 	mux.HandleFunc("DELETE /v1/tools/builtin/{name}/tenant-config", h.auth(h.handleDeleteTenantConfig))
+	mux.HandleFunc("POST /v1/tools/builtin/gws/oauth-url", h.auth(h.handleGWSAuthURL))
+	mux.HandleFunc("POST /v1/tools/builtin/gws/oauth-exchange", h.auth(h.handleGWSExchange))
 }
 
 func (h *BuiltinToolsHandler) auth(next http.HandlerFunc) http.HandlerFunc {

--- a/internal/http/builtin_tools_gws_oauth.go
+++ b/internal/http/builtin_tools_gws_oauth.go
@@ -1,0 +1,134 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	gwsOAuthRedirectURI = "urn:ietf:wg:oauth:2.0:oob"
+	gwsOAuthAuthURL     = "https://accounts.google.com/o/oauth2/v2/auth"
+	gwsOAuthTokenURL    = "https://oauth2.googleapis.com/token"
+	gwsOAuthScope       = "https://mail.google.com/"
+)
+
+// handleGWSAuthURL generates a Google OAuth2 authorization URL for GWS.
+// Request body: { "client_id": "xxx", "client_secret": "yyy" }
+// Returns:      { "url": "https://accounts.google.com/..." }
+func (h *BuiltinToolsHandler) handleGWSAuthURL(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.ClientID == "" || body.ClientSecret == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "client_id and client_secret are required"})
+		return
+	}
+
+	params := url.Values{}
+	params.Set("client_id", body.ClientID)
+	params.Set("redirect_uri", gwsOAuthRedirectURI)
+	params.Set("response_type", "code")
+	params.Set("scope", gwsOAuthScope)
+	params.Set("access_type", "offline")
+	params.Set("prompt", "consent")
+
+	authURL := gwsOAuthAuthURL + "?" + params.Encode()
+	writeJSON(w, http.StatusOK, map[string]string{"url": authURL})
+}
+
+// handleGWSExchange exchanges a Google authorization code for a refresh token
+// and saves it to the GWS builtin tool settings.
+// Request body: { "client_id": "xxx", "client_secret": "yyy", "code": "4/0Axx..." }
+// Returns:      { "status": "authorized", "refresh_token_preview": "1//0xxx..." }
+func (h *BuiltinToolsHandler) handleGWSExchange(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+		Code         string `json:"code"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.ClientID == "" || body.ClientSecret == "" || body.Code == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "client_id, client_secret, and code are required"})
+		return
+	}
+
+	refreshToken, err := exchangeGWSCode(body.ClientID, body.ClientSecret, body.Code)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("token exchange failed: %s", err.Error())})
+		return
+	}
+
+	// Save refresh_token into builtin_tools settings for "gws"
+	newSettings := map[string]any{
+		"client_id":     body.ClientID,
+		"client_secret": body.ClientSecret,
+		"refresh_token": refreshToken,
+	}
+	if err := h.store.Update(r.Context(), "gws", map[string]any{"settings": newSettings}); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save settings"})
+		return
+	}
+
+	// Return only a preview of the refresh token for safety
+	preview := refreshToken
+	if len(preview) > 10 {
+		preview = preview[:10] + "..."
+	}
+	writeJSON(w, http.StatusOK, map[string]string{
+		"status":               "authorized",
+		"refresh_token_preview": preview,
+	})
+}
+
+// exchangeGWSCode posts to Google OAuth2 token endpoint and returns the refresh_token.
+func exchangeGWSCode(clientID, clientSecret, code string) (string, error) {
+	params := url.Values{}
+	params.Set("code", code)
+	params.Set("client_id", clientID)
+	params.Set("client_secret", clientSecret)
+	params.Set("redirect_uri", gwsOAuthRedirectURI)
+	params.Set("grant_type", "authorization_code")
+
+	resp, err := http.Post(gwsOAuthTokenURL, "application/x-www-form-urlencoded", strings.NewReader(params.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+
+	var tokenResp struct {
+		RefreshToken string `json:"refresh_token"`
+		Error        string `json:"error"`
+		ErrorDesc    string `json:"error_description"`
+	}
+	if err := json.Unmarshal(raw, &tokenResp); err != nil {
+		return "", fmt.Errorf("parse response: %w", err)
+	}
+	if tokenResp.Error != "" {
+		desc := tokenResp.ErrorDesc
+		if desc == "" {
+			desc = tokenResp.Error
+		}
+		return "", fmt.Errorf("%s", desc)
+	}
+	if tokenResp.RefreshToken == "" {
+		return "", fmt.Errorf("no refresh_token in response")
+	}
+	return tokenResp.RefreshToken, nil
+}

--- a/internal/tools/credential_presets.go
+++ b/internal/tools/credential_presets.go
@@ -80,6 +80,18 @@ var CLIPresets = map[string]CLIPreset{
 		Timeout:     300,
 		Tips:        "Use -json flag for structured output",
 	},
+	"gws": {
+		BinaryName:  "gws",
+		Description: "Google Workspace CLI — Gmail, Calendar, Drive, Sheets, Docs",
+		EnvVars: []EnvVarDef{
+			{Name: "GOOGLE_WORKSPACE_CLI_TOKEN", Desc: "OAuth token (from gws auth export)", Optional: true},
+			{Name: "GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE", Desc: "Path to credentials JSON file", IsFile: true, Optional: true},
+		},
+		DenyArgs:    []string{`auth\s+setup`, `auth\s+login`, `auth\s+logout`, `auth\s+revoke`},
+		DenyVerbose: []string{`--debug`},
+		Timeout:     30,
+		Tips:        "Gmail: gws gmail +send --to X --subject Y --body Z | gws gmail +search --query Q | gws gmail +triage | gws gmail +reply --message-id ID --body Z",
+	},
 }
 
 // GetPreset returns a preset by name, or nil if not found.

--- a/internal/tools/gws.go
+++ b/internal/tools/gws.go
@@ -1,0 +1,188 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// GWSTool wraps the gws CLI binary and exposes Google Workspace (Gmail) operations
+// as structured tool calls. Credentials are fetched at runtime from builtin_tools.settings.
+type GWSTool struct {
+	bts store.BuiltinToolStore
+}
+
+func NewGWSTool(bts store.BuiltinToolStore) *GWSTool {
+	return &GWSTool{bts: bts}
+}
+
+func (t *GWSTool) Name() string { return "gws" }
+
+func (t *GWSTool) Description() string {
+	return "Interact with Google Workspace services (Gmail). Actions: gmail_send, gmail_search, gmail_triage, gmail_reply, gmail_read."
+}
+
+func (t *GWSTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"action": map[string]any{
+				"type":        "string",
+				"enum":        []string{"gmail_send", "gmail_search", "gmail_triage", "gmail_reply", "gmail_read"},
+				"description": "Gmail operation to perform",
+			},
+			"to":         map[string]any{"type": "string", "description": "Recipient email (gmail_send)"},
+			"subject":    map[string]any{"type": "string", "description": "Email subject (gmail_send)"},
+			"body":       map[string]any{"type": "string", "description": "Email body or reply text (gmail_send, gmail_reply)"},
+			"query":      map[string]any{"type": "string", "description": "Search query (gmail_search)"},
+			"message_id": map[string]any{"type": "string", "description": "Message ID (gmail_reply, gmail_read)"},
+		},
+		"required": []string{"action"},
+	}
+}
+
+func (t *GWSTool) Execute(ctx context.Context, args map[string]any) *Result {
+	action, _ := args["action"].(string)
+	if action == "" {
+		return ErrorResult("gws: action is required. Valid: gmail_send, gmail_search, gmail_triage, gmail_reply, gmail_read")
+	}
+	if len(action) >= 4 && action[:4] == "auth" {
+		return ErrorResult("gws: auth actions are not permitted via this tool")
+	}
+
+	cliArgs, err := buildGWSArgs(action, args)
+	if err != nil {
+		return ErrorResult("gws: " + err.Error())
+	}
+
+	binaryPath, err := exec.LookPath("gws")
+	if err != nil {
+		return ErrorResult("gws CLI not installed. Install via Packages page: @googleworkspace/cli")
+	}
+
+	envMap, err := loadGWSCredentials(ctx, t.bts)
+	if err != nil {
+		return ErrorResult(err.Error())
+	}
+	for _, v := range envMap {
+		if v != "" {
+			AddCredentialScrubValues(v)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath, cliArgs...)
+	cmd.Env = buildCredentialedEnv(envMap)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	execErr := cmd.Run()
+	output := stdout.String()
+	if stderr.Len() > 0 {
+		if output != "" {
+			output += "\n"
+		}
+		output += "STDERR:\n" + stderr.String()
+	}
+
+	if execErr != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return ErrorResult("gws: command timed out after 30s")
+		}
+		exitCode := -1
+		if exitErr, ok := execErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		}
+		return &Result{
+			ForLLM:  fmt.Sprintf("gws: command failed (exit %d)\n%s", exitCode, ScrubCredentials(output)),
+			ForUser: fmt.Sprintf("gws command failed with exit code %d", exitCode),
+			IsError: true,
+		}
+	}
+	if output == "" {
+		output = "(command completed with no output)"
+	}
+	return SilentResult(ScrubCredentials(output))
+}
+
+func buildGWSArgs(action string, args map[string]any) ([]string, error) {
+	str := func(k string) string { v, _ := args[k].(string); return v }
+	switch action {
+	case "gmail_send":
+		to, subject, body := str("to"), str("subject"), str("body")
+		if to == "" || subject == "" || body == "" {
+			return nil, fmt.Errorf("gmail_send requires: to, subject, body")
+		}
+		return []string{"gmail", "+send", "--to", to, "--subject", subject, "--body", body}, nil
+	case "gmail_search":
+		q := str("query")
+		if q == "" {
+			return nil, fmt.Errorf("gmail_search requires: query")
+		}
+		params := fmt.Sprintf(`{"q":"%s","maxResults":10}`, q)
+		return []string{"gmail", "users", "messages", "list", "--params", params, "--format", "json"}, nil
+	case "gmail_triage":
+		return []string{"gmail", "+triage"}, nil
+	case "gmail_reply":
+		id, body := str("message_id"), str("body")
+		if id == "" || body == "" {
+			return nil, fmt.Errorf("gmail_reply requires: message_id, body")
+		}
+		return []string{"gmail", "+reply", "--message-id", id, "--body", body}, nil
+	case "gmail_read":
+		id := str("message_id")
+		if id == "" {
+			return nil, fmt.Errorf("gmail_read requires: message_id")
+		}
+		return []string{"gmail", "+read", "--message-id", id}, nil
+	default:
+		return nil, fmt.Errorf("unknown action %q", action)
+	}
+}
+
+type gwsSettings struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+func loadGWSCredentials(ctx context.Context, bts store.BuiltinToolStore) (map[string]string, error) {
+	raw, err := bts.GetSettings(ctx, "gws")
+	if err != nil || raw == nil {
+		return nil, fmt.Errorf("Google Workspace not configured. Go to Built-in Tools → gws → Settings")
+	}
+	var s gwsSettings
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("invalid gws settings: %v", err)
+	}
+	if s.ClientID == "" || s.ClientSecret == "" || s.RefreshToken == "" {
+		return nil, fmt.Errorf("Google Workspace not configured. Authorize via Built-in Tools → gws → Settings")
+	}
+
+	credsJSON, _ := json.Marshal(map[string]any{
+		"type":          "authorized_user",
+		"client_id":     s.ClientID,
+		"client_secret": s.ClientSecret,
+		"refresh_token": s.RefreshToken,
+	})
+
+	tmpDir := filepath.Join(os.TempDir(), "goclaw-gws")
+	_ = os.MkdirAll(tmpDir, 0755)
+	credsPath := filepath.Join(tmpDir, "credentials.json")
+	if err := os.WriteFile(credsPath, credsJSON, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write credentials: %v", err)
+	}
+
+	return map[string]string{"GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE": credsPath}, nil
+}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -22,6 +22,7 @@ var toolGroups = map[string][]string{
 	"ui":         {"browser"},
 	"automation": {"cron"},
 	"messaging":  {"message", "create_forum_topic", "list_group_members"},
+	"google":     {"gws"},
 	"team": {"team_tasks"},
 	// Composite group: all goclaw native tools (excludes MCP/custom plugins).
 	"goclaw": {
@@ -34,6 +35,7 @@ var toolGroups = map[string][]string{
 		"create_image", "create_video",
 		"skill_search", "mcp_tool_search", "tts",
 		"team_tasks",
+		"gws",
 	},
 }
 

--- a/ui/web/src/i18n/locales/en/tools.json
+++ b/ui/web/src/i18n/locales/en/tools.json
@@ -96,6 +96,7 @@
       "browser": "Browser",
       "sessions": "Sessions",
       "messaging": "Messaging",
+      "google-workspace": "Google Workspace",
       "scheduling": "Scheduling",
       "subagents": "Agents",
       "skills": "Skills",

--- a/ui/web/src/i18n/locales/vi/tools.json
+++ b/ui/web/src/i18n/locales/vi/tools.json
@@ -96,6 +96,7 @@
       "browser": "Trình duyệt",
       "sessions": "Session",
       "messaging": "Nhắn tin",
+      "google-workspace": "Google Workspace",
       "scheduling": "Lập lịch",
       "subagents": "Agent",
       "skills": "Skill",

--- a/ui/web/src/i18n/locales/zh/tools.json
+++ b/ui/web/src/i18n/locales/zh/tools.json
@@ -7,6 +7,7 @@
       "media": "媒体",
       "memory": "内存",
       "messaging": "消息",
+      "google-workspace": "Google Workspace",
       "runtime": "运行时",
       "scheduling": "调度",
       "sessions": "Session",

--- a/ui/web/src/pages/builtin-tools/builtin-tool-settings-dialog.tsx
+++ b/ui/web/src/pages/builtin-tools/builtin-tool-settings-dialog.tsx
@@ -16,9 +16,11 @@ import { MEDIA_TOOLS } from "./media-provider-params-schema";
 import { MediaProviderChainForm } from "./media-provider-chain-form";
 import { KGSettingsForm } from "./kg-settings-form";
 import { WebFetchExtractorChainForm } from "./web-fetch-extractor-chain-form";
+import { GWSSettingsForm } from "./gws-settings-form";
 
 const KG_TOOL = "knowledge_graph_search";
 const WEB_FETCH_TOOL = "web_fetch";
+const GWS_TOOL = "gws";
 
 interface Props {
   tool: BuiltinToolData | null;
@@ -31,12 +33,19 @@ export function BuiltinToolSettingsDialog({ tool, open, onOpenChange, onSave }: 
   const isMedia = tool ? MEDIA_TOOLS.has(tool.name) : false;
   const isKG = tool?.name === KG_TOOL;
   const isWebFetch = tool?.name === WEB_FETCH_TOOL;
+  const isGWS = tool?.name === GWS_TOOL;
   const wide = isMedia || isKG || isWebFetch;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className={wide ? "sm:max-w-2xl" : "sm:max-w-md"}>
-        {isWebFetch && tool ? (
+        {isGWS && tool ? (
+          <GWSSettingsForm
+            initialSettings={tool.settings ?? {}}
+            onSave={(settings) => onSave(tool.name, settings).then(() => onOpenChange(false))}
+            onCancel={() => onOpenChange(false)}
+          />
+        ) : isWebFetch && tool ? (
           <WebFetchExtractorChainForm
             initialSettings={tool.settings ?? {}}
             onSave={(settings) => onSave(tool.name, settings).then(() => onOpenChange(false))}

--- a/ui/web/src/pages/builtin-tools/builtin-tools-page.tsx
+++ b/ui/web/src/pages/builtin-tools/builtin-tools-page.tsx
@@ -25,7 +25,7 @@ import { useTenants } from "@/hooks/use-tenants";
 
 const CATEGORY_ORDER = [
   "filesystem", "runtime", "web", "memory", "media", "browser",
-  "sessions", "messaging", "scheduling", "subagents", "skills", "delegation", "teams",
+  "sessions", "messaging", "google-workspace", "scheduling", "subagents", "skills", "delegation", "teams",
 ];
 
 function hasEditableSettings(tool: BuiltinToolData): boolean {

--- a/ui/web/src/pages/builtin-tools/gws-oauth-wizard.tsx
+++ b/ui/web/src/pages/builtin-tools/gws-oauth-wizard.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Loader2, ExternalLink } from "lucide-react";
+import { useHttp } from "@/hooks/use-ws";
+
+interface Props {
+  clientId: string;
+  clientSecret: string;
+  /** Called with the refresh_token_preview after successful exchange */
+  onAuthorized: (previewToken: string) => void;
+}
+
+/**
+ * Two-step Google OAuth wizard embedded inside the GWS settings dialog.
+ * Step 1: generate auth URL  →  Step 2: paste code and exchange for refresh token.
+ */
+export function GWSOAuthWizard({ clientId, clientSecret, onAuthorized }: Props) {
+  const http = useHttp();
+  const [authURL, setAuthURL] = useState("");
+  const [authCode, setAuthCode] = useState("");
+  const [gettingURL, setGettingURL] = useState(false);
+  const [exchanging, setExchanging] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const hasCredentials = clientId.trim() !== "" && clientSecret.trim() !== "";
+
+  const handleGetAuthURL = async () => {
+    setError("");
+    setSuccess("");
+    setAuthURL("");
+    if (!hasCredentials) {
+      setError("Client ID and Client Secret are required.");
+      return;
+    }
+    setGettingURL(true);
+    try {
+      const res = await http.post<{ url: string }>("/v1/tools/builtin/gws/oauth-url", {
+        client_id: clientId.trim(),
+        client_secret: clientSecret.trim(),
+      });
+      setAuthURL(res.url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate URL");
+    } finally {
+      setGettingURL(false);
+    }
+  };
+
+  const handleExchange = async () => {
+    setError("");
+    setSuccess("");
+    if (!authCode.trim()) {
+      setError("Paste the authorization code first.");
+      return;
+    }
+    setExchanging(true);
+    try {
+      const res = await http.post<{ status: string; refresh_token_preview: string }>(
+        "/v1/tools/builtin/gws/oauth-exchange",
+        {
+          client_id: clientId.trim(),
+          client_secret: clientSecret.trim(),
+          code: authCode.trim(),
+        },
+      );
+      setSuccess(`Authorized. Refresh token saved (preview: ${res.refresh_token_preview})`);
+      setAuthCode("");
+      setAuthURL("");
+      onAuthorized(res.refresh_token_preview);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Exchange failed");
+    } finally {
+      setExchanging(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Step 1 */}
+      <div className="rounded-md border p-3 space-y-3">
+        <p className="text-xs font-medium">Step 1 — Get Authorization URL</p>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={handleGetAuthURL}
+          disabled={gettingURL || !hasCredentials}
+        >
+          {gettingURL && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
+          Get Authorization URL
+        </Button>
+        {authURL && (
+          <div className="space-y-1">
+            <p className="text-xs text-muted-foreground">
+              Open this URL, sign in with Google, and copy the authorization code:
+            </p>
+            <a
+              href={authURL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline break-all"
+            >
+              Open Google Authorization <ExternalLink className="h-3 w-3 shrink-0" />
+            </a>
+          </div>
+        )}
+      </div>
+
+      {/* Step 2 */}
+      <div className="rounded-md border p-3 space-y-3">
+        <p className="text-xs font-medium">Step 2 — Paste Authorization Code</p>
+        <Input
+          id="gws-auth-code"
+          type="text"
+          placeholder="4/0Axx..."
+          value={authCode}
+          onChange={(e) => setAuthCode(e.target.value)}
+        />
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          onClick={handleExchange}
+          disabled={exchanging || !authCode.trim() || !hasCredentials}
+        >
+          {exchanging && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
+          Authorize
+        </Button>
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      {success && <p className="text-xs text-green-600">{success}</p>}
+    </div>
+  );
+}

--- a/ui/web/src/pages/builtin-tools/gws-settings-form.tsx
+++ b/ui/web/src/pages/builtin-tools/gws-settings-form.tsx
@@ -1,0 +1,143 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Loader2, ChevronDown, ChevronUp } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { GWSOAuthWizard } from "./gws-oauth-wizard";
+
+interface GWSSettings {
+  client_id: string;
+  client_secret: string;
+  refresh_token: string;
+}
+
+const defaultSettings: GWSSettings = {
+  client_id: "",
+  client_secret: "",
+  refresh_token: "",
+};
+
+interface Props {
+  initialSettings: Record<string, unknown>;
+  onSave: (settings: Record<string, unknown>) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function GWSSettingsForm({ initialSettings, onSave, onCancel }: Props) {
+  const { t } = useTranslation("tools");
+  const [settings, setSettings] = useState<GWSSettings>(defaultSettings);
+  const [saving, setSaving] = useState(false);
+  const [showManual, setShowManual] = useState(false);
+
+  useEffect(() => {
+    setSettings({
+      ...defaultSettings,
+      ...initialSettings,
+      client_id: String(initialSettings.client_id ?? ""),
+      client_secret: String(initialSettings.client_secret ?? ""),
+      refresh_token: String(initialSettings.refresh_token ?? ""),
+    });
+  }, [initialSettings]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave(settings as unknown as Record<string, unknown>);
+    } catch {
+      // toast shown by hook
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Called by GWSOAuthWizard after successful token exchange.
+  // Backend already saved the full refresh_token — just close dialog, don't overwrite with preview.
+  const handleAuthorized = (_previewToken: string) => {
+    onCancel(); // close dialog — settings already saved by backend
+  };
+
+  const isValid =
+    settings.client_id.trim() !== "" &&
+    settings.client_secret.trim() !== "" &&
+    settings.refresh_token.trim() !== "";
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Google Workspace Settings</DialogTitle>
+        <DialogDescription>
+          Authorize Google access using your OAuth Client credentials.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4 py-2">
+        <div className="grid gap-1.5">
+          <Label htmlFor="gws-client-id" className="text-sm">Client ID *</Label>
+          <Input
+            id="gws-client-id"
+            type="text"
+            placeholder="xxxxx.apps.googleusercontent.com"
+            value={settings.client_id}
+            onChange={(e) => setSettings((s) => ({ ...s, client_id: e.target.value }))}
+          />
+        </div>
+
+        <div className="grid gap-1.5">
+          <Label htmlFor="gws-client-secret" className="text-sm">Client Secret *</Label>
+          <Input
+            id="gws-client-secret"
+            type="password"
+            placeholder="GOCSPX-..."
+            value={settings.client_secret}
+            onChange={(e) => setSettings((s) => ({ ...s, client_secret: e.target.value }))}
+          />
+        </div>
+
+        <GWSOAuthWizard
+          clientId={settings.client_id}
+          clientSecret={settings.client_secret}
+          onAuthorized={handleAuthorized}
+        />
+
+        {/* Advanced: manual refresh token fallback */}
+        <div>
+          <button
+            type="button"
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => setShowManual((v) => !v)}
+          >
+            {showManual ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            Advanced: paste Refresh Token manually
+          </button>
+          {showManual && (
+            <div className="mt-2 grid gap-1.5">
+              <Label htmlFor="gws-refresh-token" className="text-sm">Refresh Token</Label>
+              <Input
+                id="gws-refresh-token"
+                type="password"
+                placeholder="1//0xxx..."
+                value={settings.refresh_token}
+                onChange={(e) => setSettings((s) => ({ ...s, refresh_token: e.target.value }))}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel}>{t("builtin.kgSettings.cancel")}</Button>
+        <Button onClick={handleSave} disabled={saving || !isValid}>
+          {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+          {saving ? t("builtin.kgSettings.saving") : t("builtin.kgSettings.save")}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `gws` as a dedicated built-in tool for Gmail operations (send, search, triage, reply, read)
- OAuth authorization flow in Settings UI: enter Client ID/Secret → get auth URL → paste code → auto-save tokens
- Wraps `@googleworkspace/cli` binary (install via Packages page)
- Credentials stored encrypted in DB, scrubbed from output

## Changes
- `internal/tools/gws.go` — Tool implementation (5 Gmail actions, credential loading)
- `internal/http/builtin_tools_gws_oauth.go` — OAuth URL generation + code exchange endpoints
- `ui/web/src/pages/builtin-tools/gws-settings-form.tsx` — Settings form with OAuth wizard
- `ui/web/src/pages/builtin-tools/gws-oauth-wizard.tsx` — Step-by-step OAuth UI
- Seed entry, policy groups, i18n labels, preset

## Setup
1. Install `@googleworkspace/cli` via Packages page
2. Built-in Tools → gws → Settings → enter Google OAuth Client ID + Secret
3. Click "Get Authorization URL" → open in browser → login → paste code → Authorize
4. Agent can now use `gws` tool for Gmail operations

## Test plan
- [ ] Verify gws tool appears on Built-in Tools page
- [ ] Test OAuth flow: Get URL → authorize → token saved
- [ ] Test gmail_send via agent chat
- [ ] Test gmail_search, gmail_triage, gmail_read
- [ ] Verify credentials not leaked in agent output