### PR TITLE
fix(setup): generate unique agent key to prevent duplicate conflict

### DIFF
--- a/ui/web/src/pages/setup/step-agent.tsx
+++ b/ui/web/src/pages/setup/step-agent.tsx
@@ -26,7 +26,7 @@ interface StepAgentProps {
 
 export function StepAgent({ provider, model, onComplete, onBack, existingAgent }: StepAgentProps) {
   const { t } = useTranslation("setup");
-  const { createAgent, updateAgent, deleteAgent, resummonAgent } = useAgents();
+  const { agents, createAgent, updateAgent, deleteAgent, resummonAgent } = useAgents();
   const agentPresets = useAgentPresets();
 
   const isEditing = !!existingAgent;
@@ -61,9 +61,13 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
   }, [existingAgent, selectedPresetIdx, agentPresets]);
 
   const agentKey = useMemo(() => {
-    const slug = slugify(displayName);
-    return slug || "fox-spirit";
-  }, [displayName]);
+    const base = slugify(displayName) || "fox-spirit";
+    const existingKeys = new Set(agents.map((a) => a.agent_key));
+    if (!existingKeys.has(base)) return base;
+    let i = 2;
+    while (existingKeys.has(`${base}-${i}`)) i++;
+    return `${base}-${i}`;
+  }, [displayName, agents]);
 
   const selectedEmoji = useMemo(() => {
     if (selectedPresetIdx !== null && agentPresets[selectedPresetIdx]) {


### PR DESCRIPTION
## Summary
- When re-entering `/setup` after a previous agent was created (e.g. provider reset), selecting the same preset produced an identical slug (e.g. `me-me` from `🔮 Mễ Mễ`) and failed with 409 "agent already exists"
- Now checks existing agent keys and appends a numeric suffix (`-2`, `-3`, …) when the base key is already taken
- DB already enforces `UNIQUE(tenant_id, agent_key) WHERE deleted_at IS NULL` — this fix prevents the frontend from hitting that constraint

## Test plan
- [x] Go to `/setup` step 3 (agent creation) with an existing agent (e.g. `me-me`)
- [x] Select same preset again — verify key auto-generates as `me-me-2`
- [x] Create agent — verify no 409 error
- [x] Create another with same preset — verify key becomes `me-me-3`