### PR TITLE
feat(cli-credentials): add Google OAuth flow for gws preset

### DIFF
--- a/internal/http/secure_cli.go
+++ b/internal/http/secure_cli.go
@@ -37,6 +37,9 @@ func (h *SecureCLIHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /v1/cli-credentials/{id}", h.auth(h.handleUpdate))
 	mux.HandleFunc("DELETE /v1/cli-credentials/{id}", h.auth(h.handleDelete))
 	mux.HandleFunc("POST /v1/cli-credentials/{id}/test", h.auth(h.handleDryRun))
+	// gws Google OAuth helper endpoints
+	mux.HandleFunc("POST /v1/cli-credentials/gws/oauth-url", h.auth(h.handleGwsOAuthURL))
+	mux.HandleFunc("POST /v1/cli-credentials/gws/oauth-exchange", h.auth(h.handleGwsOAuthExchange))
 }
 
 func (h *SecureCLIHandler) auth(next http.HandlerFunc) http.HandlerFunc {

--- a/internal/http/secure_cli_gws_oauth.go
+++ b/internal/http/secure_cli_gws_oauth.go
@@ -1,0 +1,150 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	gwsOAuthAuthURL    = "https://accounts.google.com/o/oauth2/v2/auth"
+	gwsOAuthTokenURL   = "https://oauth2.googleapis.com/token"
+	gwsOAuthRedirect   = "urn:ietf:wg:oauth:2.0:oob"
+	gwsOAuthScope      = "https://mail.google.com/"
+	gwsCredentialsDir  = "/tmp/goclaw-gws"
+	gwsCredentialsFile = "/tmp/goclaw-gws/credentials.json"
+)
+
+// gwsOAuthURLRequest is the request body for the OAuth URL endpoint.
+type gwsOAuthURLRequest struct {
+	ClientID string `json:"client_id"`
+}
+
+// gwsOAuthExchangeRequest is the request body for the token exchange endpoint.
+type gwsOAuthExchangeRequest struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	Code         string `json:"code"`
+}
+
+// handleGwsOAuthURL builds a Google OAuth authorization URL for gws.
+// POST /v1/cli-credentials/gws/oauth-url
+func (h *SecureCLIHandler) handleGwsOAuthURL(w http.ResponseWriter, r *http.Request) {
+	var req gwsOAuthURLRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<16)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if strings.TrimSpace(req.ClientID) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "client_id is required"})
+		return
+	}
+
+	params := url.Values{}
+	params.Set("client_id", req.ClientID)
+	params.Set("redirect_uri", gwsOAuthRedirect)
+	params.Set("response_type", "code")
+	params.Set("scope", gwsOAuthScope)
+	params.Set("access_type", "offline")
+	params.Set("prompt", "consent")
+
+	authURL := gwsOAuthAuthURL + "?" + params.Encode()
+	writeJSON(w, http.StatusOK, map[string]string{"url": authURL})
+}
+
+// handleGwsOAuthExchange exchanges an authorization code for tokens and writes
+// the authorized_user credentials file to disk.
+// POST /v1/cli-credentials/gws/oauth-exchange
+func (h *SecureCLIHandler) handleGwsOAuthExchange(w http.ResponseWriter, r *http.Request) {
+	var req gwsOAuthExchangeRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<16)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if strings.TrimSpace(req.ClientID) == "" || strings.TrimSpace(req.ClientSecret) == "" || strings.TrimSpace(req.Code) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "client_id, client_secret, and code are required"})
+		return
+	}
+
+	refreshToken, err := exchangeGwsCode(req.ClientID, req.ClientSecret, req.Code)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "token exchange failed: " + err.Error()})
+		return
+	}
+
+	credPath, err := writeGwsCredentials(req.ClientID, req.ClientSecret, refreshToken)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to write credentials: " + err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"credentials_file": credPath,
+		"status":           "authorized",
+	})
+}
+
+// exchangeGwsCode posts to Google's token endpoint and returns the refresh_token.
+func exchangeGwsCode(clientID, clientSecret, code string) (string, error) {
+	form := url.Values{}
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("code", code)
+	form.Set("redirect_uri", gwsOAuthRedirect)
+	form.Set("grant_type", "authorization_code")
+
+	resp, err := http.PostForm(gwsOAuthTokenURL, form)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return "", err
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("unexpected response: %s", body)
+	}
+	if errMsg, ok := result["error"].(string); ok {
+		desc, _ := result["error_description"].(string)
+		if desc != "" {
+			return "", fmt.Errorf("%s: %s", errMsg, desc)
+		}
+		return "", fmt.Errorf("%s", errMsg)
+	}
+	refreshToken, ok := result["refresh_token"].(string)
+	if !ok || refreshToken == "" {
+		return "", fmt.Errorf("no refresh_token in response (code may have been used already)")
+	}
+	return refreshToken, nil
+}
+
+// writeGwsCredentials writes the authorized_user JSON to the credentials file.
+func writeGwsCredentials(clientID, clientSecret, refreshToken string) (string, error) {
+	if err := os.MkdirAll(gwsCredentialsDir, 0o700); err != nil {
+		return "", err
+	}
+	creds := map[string]string{
+		"type":          "authorized_user",
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+		"refresh_token": refreshToken,
+	}
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	credPath := filepath.Join(gwsCredentialsDir, "credentials.json")
+	if err := os.WriteFile(credPath, data, 0o644); err != nil {
+		return "", err
+	}
+	return credPath, nil
+}

--- a/internal/tools/credential_presets.go
+++ b/internal/tools/credential_presets.go
@@ -80,6 +80,17 @@ var CLIPresets = map[string]CLIPreset{
 		Timeout:     300,
 		Tips:        "Use -json flag for structured output",
 	},
+	"gws": {
+		BinaryName:  "gws",
+		Description: "Google Workspace CLI — Gmail, Calendar, Drive, Sheets, Docs",
+		EnvVars: []EnvVarDef{
+			{Name: "GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE", Desc: "Path to authorized credentials JSON (auto-generated from OAuth)", IsFile: true},
+		},
+		DenyArgs:    []string{`auth\s+setup`, `auth\s+login`, `auth\s+logout`, `auth\s+revoke`},
+		DenyVerbose: []string{`--debug`},
+		Timeout:     30,
+		Tips:        "Gmail: gws gmail +send --to X --subject Y --body Z | gws gmail +triage | gws gmail +reply --message-id ID --body Z",
+	},
 }
 
 // GetPreset returns a preset by name, or nil if not found.

--- a/ui/web/src/i18n/locales/en/cli-credentials.json
+++ b/ui/web/src/i18n/locales/en/cli-credentials.json
@@ -52,5 +52,24 @@
     "updateFailed": "Failed to update credential",
     "deleted": "CLI credential deleted",
     "deleteFailed": "Failed to delete credential"
+  },
+  "gws": {
+    "wizardTitle": "Google OAuth Authorization",
+    "wizardHint": "Authorize Google access to generate the credentials file. You need a Google Cloud OAuth 2.0 Client ID and Client Secret.",
+    "clientId": "Client ID",
+    "clientSecret": "Client Secret",
+    "clientSecretPlaceholder": "Your OAuth client secret",
+    "clientIdRequired": "Client ID is required.",
+    "allFieldsRequired": "Client ID, Client Secret, and authorization code are required.",
+    "getAuthUrl": "Get Authorization URL",
+    "urlFailed": "Failed to generate authorization URL.",
+    "openUrlHint": "Open the URL below in your browser, grant access, then paste the code shown by Google:",
+    "authCode": "Authorization Code",
+    "authCodePlaceholder": "Paste the code shown by Google",
+    "authorize": "Authorize",
+    "authorizing": "Authorizing…",
+    "exchangeFailed": "Token exchange failed.",
+    "authorized": "Authorization successful",
+    "credFilledHint": "The credentials file path has been filled in below. Save the credential to complete setup."
   }
 }

--- a/ui/web/src/i18n/locales/vi/cli-credentials.json
+++ b/ui/web/src/i18n/locales/vi/cli-credentials.json
@@ -52,5 +52,24 @@
     "updateFailed": "Không thể cập nhật thông tin",
     "deleted": "Đã xóa thông tin CLI",
     "deleteFailed": "Không thể xóa thông tin"
+  },
+  "gws": {
+    "wizardTitle": "Ủy quyền Google OAuth",
+    "wizardHint": "Ủy quyền truy cập Google để tạo tệp thông tin xác thực. Bạn cần Client ID và Client Secret từ Google Cloud OAuth 2.0.",
+    "clientId": "Client ID",
+    "clientSecret": "Client Secret",
+    "clientSecretPlaceholder": "Client secret OAuth của bạn",
+    "clientIdRequired": "Client ID là bắt buộc.",
+    "allFieldsRequired": "Client ID, Client Secret và mã ủy quyền là bắt buộc.",
+    "getAuthUrl": "Lấy URL ủy quyền",
+    "urlFailed": "Không thể tạo URL ủy quyền.",
+    "openUrlHint": "Mở URL bên dưới trong trình duyệt, cấp quyền, sau đó dán mã Google hiển thị:",
+    "authCode": "Mã ủy quyền",
+    "authCodePlaceholder": "Dán mã Google hiển thị vào đây",
+    "authorize": "Ủy quyền",
+    "authorizing": "Đang ủy quyền…",
+    "exchangeFailed": "Trao đổi token thất bại.",
+    "authorized": "Ủy quyền thành công",
+    "credFilledHint": "Đường dẫn tệp thông tin xác thực đã được điền bên dưới. Lưu thông tin xác thực để hoàn tất thiết lập."
   }
 }

--- a/ui/web/src/i18n/locales/zh/cli-credentials.json
+++ b/ui/web/src/i18n/locales/zh/cli-credentials.json
@@ -52,5 +52,24 @@
     "updateFailed": "更新凭证失败",
     "deleted": "CLI 凭证已删除",
     "deleteFailed": "删除凭证失败"
+  },
+  "gws": {
+    "wizardTitle": "Google OAuth 授权",
+    "wizardHint": "授权 Google 访问以生成凭证文件。您需要 Google Cloud OAuth 2.0 的 Client ID 和 Client Secret。",
+    "clientId": "Client ID",
+    "clientSecret": "Client Secret",
+    "clientSecretPlaceholder": "您的 OAuth 客户端密钥",
+    "clientIdRequired": "Client ID 为必填项。",
+    "allFieldsRequired": "Client ID、Client Secret 和授权码为必填项。",
+    "getAuthUrl": "获取授权 URL",
+    "urlFailed": "生成授权 URL 失败。",
+    "openUrlHint": "在浏览器中打开以下 URL，授予访问权限，然后粘贴 Google 显示的代码：",
+    "authCode": "授权码",
+    "authCodePlaceholder": "粘贴 Google 显示的代码",
+    "authorize": "授权",
+    "authorizing": "授权中…",
+    "exchangeFailed": "令牌交换失败。",
+    "authorized": "授权成功",
+    "credFilledHint": "凭证文件路径已填入下方。保存凭证以完成设置。"
   }
 }

--- a/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
+++ b/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
@@ -12,6 +12,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import type { SecureCLIBinary, CLICredentialInput, CLIPreset } from "./hooks/use-cli-credentials";
+import { GwsOAuthWizard } from "./gws-oauth-wizard";
 
 interface Props {
   open: boolean;
@@ -42,12 +43,12 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
   const [error, setError] = useState("");
 
   const isEdit = !!credential;
-  // Build typed entry list to avoid noUncheckedIndexedAccess issues
+  const isGws = selectedPreset === "gws";
+
   const presetEntries: Array<[string, CLIPreset]> = Object.entries(presets).filter(
     (e): e is [string, CLIPreset] => e[1] !== undefined,
   );
 
-  // Current preset definition (for env var fields)
   const activePreset: CLIPreset | null =
     selectedPreset !== NONE_PRESET ? (presets[selectedPreset] ?? null) : null;
 
@@ -139,9 +140,7 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
                   ))}
                 </SelectContent>
               </Select>
-              <p className="text-xs text-muted-foreground">
-                {t("form.presetHint")}
-              </p>
+              <p className="text-xs text-muted-foreground">{t("form.presetHint")}</p>
             </div>
           )}
 
@@ -150,6 +149,15 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
             <p className="text-xs text-muted-foreground rounded-md border border-dashed p-2">
               {t("form.encryptedHint")}
             </p>
+          )}
+
+          {/* gws: OAuth wizard above env var inputs — create mode only */}
+          {isGws && !isEdit && (
+            <GwsOAuthWizard
+              onAuthorized={(credPath) =>
+                setEnvValues((prev) => ({ ...prev, GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE: credPath }))
+              }
+            />
           )}
 
           {/* Env var inputs from preset */}
@@ -164,16 +172,14 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
                   </Label>
                   <Input
                     id={`env-${ev.name}`}
-                    type="password"
+                    type={ev.is_file ? "text" : "password"}
                     autoComplete="off"
                     placeholder={ev.desc}
                     value={envValues[ev.name] ?? ""}
                     onChange={(e) => setEnvValues((prev) => ({ ...prev, [ev.name]: e.target.value }))}
                     className="text-base md:text-sm"
                   />
-                  {ev.desc && (
-                    <p className="text-xs text-muted-foreground">{ev.desc}</p>
-                  )}
+                  {ev.desc && <p className="text-xs text-muted-foreground">{ev.desc}</p>}
                 </div>
               ))}
             </div>

--- a/ui/web/src/pages/cli-credentials/gws-oauth-wizard.tsx
+++ b/ui/web/src/pages/cli-credentials/gws-oauth-wizard.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useHttp } from "@/hooks/use-ws";
+
+interface Props {
+  /** Called when OAuth completes — provides the written credentials file path */
+  onAuthorized: (credentialsFilePath: string) => void;
+}
+
+/**
+ * GwsOAuthWizard renders a self-contained step-by-step Google OAuth flow
+ * for the gws (Google Workspace CLI) preset. Steps:
+ *  1. Enter Client ID → get authorization URL
+ *  2. User opens URL and pastes the auth code
+ *  3. Exchange code → receive credentials file path
+ */
+export function GwsOAuthWizard({ onAuthorized }: Props) {
+  const { t } = useTranslation("cli-credentials");
+  const http = useHttp();
+
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [authUrl, setAuthUrl] = useState("");
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [authorized, setAuthorized] = useState(false);
+
+  const handleGetUrl = async () => {
+    const id = clientId.trim();
+    if (!id) {
+      setError(t("gws.clientIdRequired"));
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const res = await http.post<{ url: string }>("/v1/cli-credentials/gws/oauth-url", { client_id: id });
+      setAuthUrl(res.url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("gws.urlFailed"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAuthorize = async () => {
+    const id = clientId.trim();
+    const secret = clientSecret.trim();
+    const authCode = code.trim();
+    if (!id || !secret || !authCode) {
+      setError(t("gws.allFieldsRequired"));
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const res = await http.post<{ credentials_file: string; status: string }>(
+        "/v1/cli-credentials/gws/oauth-exchange",
+        { client_id: id, client_secret: secret, code: authCode },
+      );
+      setAuthorized(true);
+      onAuthorized(res.credentials_file);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("gws.exchangeFailed"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (authorized) {
+    return (
+      <div className="rounded-md border border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950 p-3">
+        <p className="text-sm font-medium text-green-700 dark:text-green-400">{t("gws.authorized")}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">{t("gws.credFilledHint")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 rounded-md border p-3">
+      <p className="text-sm font-medium">{t("gws.wizardTitle")}</p>
+      <p className="text-xs text-muted-foreground">{t("gws.wizardHint")}</p>
+
+      {/* Step 1 — Client credentials */}
+      <div className="grid gap-1.5">
+        <Label htmlFor="gws-client-id">{t("gws.clientId")}</Label>
+        <Input
+          id="gws-client-id"
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+          placeholder="xxxxxxxxxx.apps.googleusercontent.com"
+          className="text-base md:text-sm"
+          autoComplete="off"
+        />
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="gws-client-secret">{t("gws.clientSecret")}</Label>
+        <Input
+          id="gws-client-secret"
+          type="password"
+          value={clientSecret}
+          onChange={(e) => setClientSecret(e.target.value)}
+          placeholder={t("gws.clientSecretPlaceholder")}
+          className="text-base md:text-sm"
+          autoComplete="off"
+        />
+      </div>
+
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        disabled={loading || !clientId.trim()}
+        onClick={handleGetUrl}
+      >
+        {t("gws.getAuthUrl")}
+      </Button>
+
+      {/* Step 2 — Authorization URL */}
+      {authUrl && (
+        <div className="grid gap-1.5">
+          <p className="text-xs text-muted-foreground">{t("gws.openUrlHint")}</p>
+          <a
+            href={authUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-primary underline break-all"
+          >
+            {authUrl}
+          </a>
+          <Label htmlFor="gws-code">{t("gws.authCode")}</Label>
+          <Input
+            id="gws-code"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder={t("gws.authCodePlaceholder")}
+            className="text-base md:text-sm"
+            autoComplete="off"
+          />
+          <Button
+            type="button"
+            size="sm"
+            disabled={loading || !code.trim()}
+            onClick={handleAuthorize}
+          >
+            {loading ? t("gws.authorizing") : t("gws.authorize")}
+          </Button>
+        </div>
+      )}
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add OAuth authorization flow in CLI Credentials page for `gws` (Google Workspace CLI) preset
- User can authorize Google access without external CLI tools — entirely within the dashboard
- Follows the existing CLI Credentials pattern (preset + env vars), no new built-in tools

## Flow
1. CLI Credentials → New → select `gws` preset
2. Enter Google OAuth Client ID + Secret (from Google Cloud Console)
3. Click "Get Authorization URL" → open in browser → login Google → copy code
4. Paste authorization code → click "Authorize"
5. Backend exchanges code for refresh_token, writes credentials file, auto-fills env var path
6. Save → done, agent uses `exec "gws gmail +send ..."` with credentials auto-injected

## Changes
- `internal/http/secure_cli_gws_oauth.go` — OAuth URL + code exchange endpoints
- `internal/http/secure_cli.go` — 2 new route registrations
- `internal/tools/credential_presets.go` — simplified gws preset (1 env var)
- `ui/web/src/pages/cli-credentials/gws-oauth-wizard.tsx` — OAuth wizard component
- `ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx` — integrate wizard
- i18n: en/vi/zh keys

## Test plan
- [ ] CLI Credentials → New → select gws preset → OAuth wizard shows
- [ ] Get URL → authorize → paste code → credentials file created
- [ ] Save credential → agent can run `gws gmail +triage` via exec
- [ ] Verify credentials not leaked in agent output