### PR TITLE
fix(storage): hide tenant roots from master storage

### DIFF
--- a/internal/http/storage.go
+++ b/internal/http/storage.go
@@ -71,7 +71,7 @@ func (h *StorageHandler) tenantBaseDir(r *http.Request) string {
 // tenants (tenant isolation root — each tenant's data is scoped internally).
 var protectedDirs = []string{"skills", "skills-store", "media", "tenants"}
 
-func isProtectedPath(rel string) bool {
+func topLevelPath(rel string) string {
 	top := rel
 	if before, _, ok := strings.Cut(rel, "/"); ok {
 		top = before
@@ -80,12 +80,30 @@ func isProtectedPath(rel string) bool {
 	if i := strings.IndexByte(top, '/'); i >= 0 {
 		top = top[:i]
 	}
+	return top
+}
+
+func isProtectedPath(rel string) bool {
+	top := topLevelPath(rel)
 	for _, d := range protectedDirs {
 		if strings.EqualFold(top, d) {
 			return true
 		}
 	}
 	return false
+}
+
+// isHiddenPath reports paths that should not be surfaced in the Storage UI/API.
+// Master tenant keeps its legacy base dir for backward compatibility, but must
+// not expose the cross-tenant isolation root.
+func (h *StorageHandler) isHiddenPath(r *http.Request, rel string) bool {
+	if rel == "" {
+		return false
+	}
+	if store.TenantIDFromContext(r.Context()) != store.MasterTenantID {
+		return false
+	}
+	return strings.EqualFold(topLevelPath(rel), "tenants")
 }
 
 // handleList lists files and directories under ~/.goclaw/ with depth limiting.
@@ -111,6 +129,10 @@ func (h *StorageHandler) handleList(w http.ResponseWriter, r *http.Request) {
 	base := h.tenantBaseDir(r)
 	rootDir := base
 	if subPath != "" {
+		if h.isHiddenPath(r, subPath) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "path", subPath)})
+			return
+		}
 		rootDir = filepath.Join(base, filepath.Clean(subPath))
 		if !strings.HasPrefix(rootDir, base) {
 			slog.Warn("security.storage_escape", "resolved", rootDir, "root", base)
@@ -138,6 +160,13 @@ func (h *StorageHandler) handleList(w http.ResponseWriter, r *http.Request) {
 			return nil
 		}
 		rel, _ := filepath.Rel(base, path)
+
+		if h.isHiddenPath(r, rel) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
 
 		// Skip symlinks
 		if d.Type()&os.ModeSymlink != 0 {
@@ -250,6 +279,9 @@ func (h *StorageHandler) handleSize(w http.ResponseWriter, r *http.Request) {
 			return nil
 		}
 		rel, _ := filepath.Rel(sizeBase, path)
+		if h.isHiddenPath(r, rel) {
+			return nil
+		}
 		if skills.IsSystemArtifact(rel) {
 			return nil
 		}
@@ -288,6 +320,10 @@ func (h *StorageHandler) handleRead(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(relPath, "..") {
 		slog.Warn("security.storage_traversal", "path", relPath)
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+	if h.isHiddenPath(r, relPath) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgFileNotFound)})
 		return
 	}
 

--- a/internal/http/storage_test.go
+++ b/internal/http/storage_test.go
@@ -1,0 +1,116 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+func TestStorageListHidesTenantRootForMaster(t *testing.T) {
+	baseDir := t.TempDir()
+	writeStorageTestFile(t, filepath.Join(baseDir, "master.txt"), "master")
+	writeStorageTestFile(t, filepath.Join(baseDir, "tenants", "tenant-a", "secret.txt"), "tenant-secret")
+
+	handler := NewStorageHandler(baseDir)
+	req := httptest.NewRequest("GET", "/v1/storage/files", nil)
+	req = req.WithContext(store.WithTenantID(context.Background(), store.MasterTenantID))
+	w := httptest.NewRecorder()
+
+	handler.handleList(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp struct {
+		Files []struct {
+			Path string `json:"path"`
+			Name string `json:"name"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	for _, f := range resp.Files {
+		if f.Path == "tenants" || strings.HasPrefix(f.Path, "tenants/") {
+			t.Fatalf("master storage unexpectedly exposed tenant path %q", f.Path)
+		}
+	}
+}
+
+func TestStorageReadTenantRootReturnsNotFoundForMaster(t *testing.T) {
+	baseDir := t.TempDir()
+	writeStorageTestFile(t, filepath.Join(baseDir, "tenants", "tenant-a", "secret.txt"), "tenant-secret")
+
+	handler := NewStorageHandler(baseDir)
+	req := httptest.NewRequest("GET", "/v1/storage/files/tenants/tenant-a/secret.txt", nil)
+	req = req.WithContext(store.WithTenantID(context.Background(), store.MasterTenantID))
+	req.SetPathValue("path", "tenants/tenant-a/secret.txt")
+	w := httptest.NewRecorder()
+
+	handler.handleRead(w, req)
+	if w.Code != 404 {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestStorageSizeExcludesTenantRootForMaster(t *testing.T) {
+	baseDir := t.TempDir()
+	writeStorageTestFile(t, filepath.Join(baseDir, "master.txt"), "12345")
+	writeStorageTestFile(t, filepath.Join(baseDir, "tenants", "tenant-a", "secret.txt"), "1234567890")
+
+	handler := NewStorageHandler(baseDir)
+	req := httptest.NewRequest("GET", "/v1/storage/size", nil)
+	req = req.WithContext(store.WithTenantID(context.Background(), store.MasterTenantID))
+	w := httptest.NewRecorder()
+
+	handler.handleSize(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	body := w.Body.String()
+	lines := strings.Split(strings.TrimSpace(body), "\n")
+	if len(lines) == 0 {
+		t.Fatal("expected SSE response body")
+	}
+
+	last := lines[len(lines)-1]
+	if !strings.HasPrefix(last, "data: ") {
+		t.Fatalf("unexpected SSE line %q", last)
+	}
+
+	var payload struct {
+		Total int64 `json:"total"`
+		Files int   `json:"files"`
+		Done  bool  `json:"done"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(last, "data: ")), &payload); err != nil {
+		t.Fatalf("unmarshal SSE payload: %v", err)
+	}
+	if !payload.Done {
+		t.Fatalf("expected final SSE payload, got %#v", payload)
+	}
+	if payload.Total != 5 {
+		t.Fatalf("total = %d, want 5", payload.Total)
+	}
+	if payload.Files != 1 {
+		t.Fatalf("files = %d, want 1", payload.Files)
+	}
+}
+
+func writeStorageTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

This prevents the master Storage page from exposing the cross-tenant isolation root.

Before:
- The master storage listing surfaced the top-level `tenants/` directory and its contents.
- Master storage reads could target `tenants/...` paths directly.
- Master storage size calculations included files stored under tenant-specific directories.

After:
- The master storage API hides the `tenants/` root from listings.
- Direct reads into `tenants/...` return `404` from the storage API.
- Master storage size calculations exclude tenant-specific files.

## Changes

- added a storage-level hidden-path rule for the master tenant scope
- filtered hidden tenant paths out of storage list and size traversal
- rejected master storage reads into hidden tenant paths
- added regression tests for listing, reading, and size calculation against tenant roots

## Test plan

- `go test ./internal/http`
- Verified master storage listing does not return `tenants/`
- Verified master storage reads for `tenants/...` return `404`
