### PR TITLE
fix(agent): scope runtime paths to the active tenant

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -26,8 +26,8 @@ import (
 	zalopersonal "github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/gateway"
-	"github.com/nextlevelbuilder/goclaw/internal/heartbeat"
 	"github.com/nextlevelbuilder/goclaw/internal/gateway/methods"
+	"github.com/nextlevelbuilder/goclaw/internal/heartbeat"
 	httpapi "github.com/nextlevelbuilder/goclaw/internal/http"
 	mcpbridge "github.com/nextlevelbuilder/goclaw/internal/mcp"
 	"github.com/nextlevelbuilder/goclaw/internal/media"
@@ -148,7 +148,7 @@ func runGateway() {
 	loadBootstrapFiles(pgStores, workspace, agentCfg)
 
 	// Subagent system
-	subagentMgr := setupSubagents(providerRegistry, cfg, msgBus, toolsReg, workspace, sandboxMgr)
+	subagentMgr := setupSubagents(providerRegistry, cfg, msgBus, toolsReg, workspace, dataDir, sandboxMgr)
 	if subagentMgr != nil {
 		// Wire announce queue for batched subagent result delivery (matching TS debounce pattern)
 		announceQueue := tools.NewAnnounceQueue(1000, 20,

--- a/cmd/gateway_agents.go
+++ b/cmd/gateway_agents.go
@@ -155,7 +155,7 @@ func buildEmbeddingProvider(
 	return nil
 }
 
-func setupSubagents(providerReg *providers.Registry, cfg *config.Config, msgBus *bus.MessageBus, toolsReg *tools.Registry, workspace string, sandboxMgr sandbox.Manager) *tools.SubagentManager {
+func setupSubagents(providerReg *providers.Registry, cfg *config.Config, msgBus *bus.MessageBus, toolsReg *tools.Registry, workspace, dataDir string, sandboxMgr sandbox.Manager) *tools.SubagentManager {
 	names := providerReg.List(context.Background())
 	if len(names) == 0 {
 		return nil
@@ -198,12 +198,12 @@ func setupSubagents(providerReg *providers.Registry, cfg *config.Config, msgBus 
 	toolsFactory := func() *tools.Registry {
 		reg := toolsReg.Clone()
 		if sandboxMgr != nil {
-			reg.Register(tools.NewSandboxedReadFileTool(workspace, agentCfg.RestrictToWorkspace, sandboxMgr))
+			reg.Register(newSubagentReadTool(reg, workspace, dataDir, agentCfg.RestrictToWorkspace, sandboxMgr))
 			reg.Register(tools.NewSandboxedWriteFileTool(workspace, agentCfg.RestrictToWorkspace, sandboxMgr))
 			reg.Register(tools.NewSandboxedListFilesTool(workspace, agentCfg.RestrictToWorkspace, sandboxMgr))
 			reg.Register(tools.NewSandboxedExecTool(workspace, agentCfg.RestrictToWorkspace, sandboxMgr))
 		} else {
-			reg.Register(tools.NewReadFileTool(workspace, agentCfg.RestrictToWorkspace))
+			reg.Register(newSubagentReadTool(reg, workspace, dataDir, agentCfg.RestrictToWorkspace, nil))
 			reg.Register(tools.NewWriteFileTool(workspace, agentCfg.RestrictToWorkspace))
 			reg.Register(tools.NewListFilesTool(workspace, agentCfg.RestrictToWorkspace))
 			reg.Register(tools.NewExecTool(workspace, agentCfg.RestrictToWorkspace))
@@ -212,6 +212,22 @@ func setupSubagents(providerReg *providers.Registry, cfg *config.Config, msgBus 
 	}
 
 	return tools.NewSubagentManager(provider, providerReg, agentCfg.Model, msgBus, toolsFactory, subCfg)
+}
+
+func newSubagentReadTool(reg *tools.Registry, workspace, dataDir string, restrict bool, sandboxMgr sandbox.Manager) *tools.ReadFileTool {
+	var readTool *tools.ReadFileTool
+	if sandboxMgr != nil {
+		readTool = tools.NewSandboxedReadFileTool(workspace, restrict, sandboxMgr)
+	} else {
+		readTool = tools.NewReadFileTool(workspace, restrict)
+	}
+	if existing, ok := reg.Get("read_file"); ok {
+		if parentReadTool, ok := existing.(*tools.ReadFileTool); ok {
+			readTool.CopyConfigFrom(parentReadTool)
+		}
+	}
+	readTool.SetDataDir(dataDir)
+	return readTool
 }
 
 // setupTTS creates the TTS manager from config and registers providers.

--- a/cmd/gateway_agents_test.go
+++ b/cmd/gateway_agents_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
+)
+
+func TestNewSubagentReadToolInheritsParentAllowPaths(t *testing.T) {
+	workspace := t.TempDir()
+	dataDir := t.TempDir()
+	relPath := filepath.Join("cli-workspaces", "subagent", "note.txt")
+	absPath := filepath.Join(dataDir, relPath)
+
+	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", absPath, err)
+	}
+	if err := os.WriteFile(absPath, []byte("subagent-version"), 0644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", absPath, err)
+	}
+
+	reg := tools.NewRegistry()
+	parentReadTool := tools.NewReadFileTool(workspace, true)
+	parentReadTool.AllowPaths(filepath.Join(dataDir, "cli-workspaces"))
+	reg.Register(parentReadTool)
+
+	childReadTool := newSubagentReadTool(reg, workspace, dataDir, true, nil)
+	got := childReadTool.Execute(context.Background(), map[string]any{"path": relPath})
+	if got.IsError {
+		t.Fatalf("read_file returned error: %s", got.ForLLM)
+	}
+	if got.ForLLM != "subagent-version" {
+		t.Fatalf("read_file = %q, want subagent-version", got.ForLLM)
+	}
+}

--- a/cmd/gateway_cron_test.go
+++ b/cmd/gateway_cron_test.go
@@ -1,0 +1,255 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/agent"
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/scheduler"
+	"github.com/nextlevelbuilder/goclaw/internal/sessions"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+func TestMakeCronJobHandler_SchedulesExpectedRunRequest(t *testing.T) {
+	msgBus := bus.New()
+	sess := &recordingSessionStore{}
+	tenantID := uuid.MustParse("0193a5b0-7000-7000-8000-000000000111")
+
+	var (
+		mu         sync.Mutex
+		gotCtxTID  uuid.UUID
+		gotRequest agent.RunRequest
+	)
+	sched := scheduler.NewScheduler(nil, scheduler.DefaultQueueConfig(), func(ctx context.Context, req agent.RunRequest) (*agent.RunResult, error) {
+		mu.Lock()
+		gotCtxTID = store.TenantIDFromContext(ctx)
+		gotRequest = req
+		mu.Unlock()
+		return &agent.RunResult{
+			Content: "cron-done",
+			Usage: &providers.Usage{
+				PromptTokens:     12,
+				CompletionTokens: 34,
+			},
+		}, nil
+	})
+
+	handler := makeCronJobHandler(sched, msgBus, &config.Config{}, nil, sess)
+	job := &store.CronJob{
+		ID:       "job-123",
+		TenantID: tenantID,
+		Name:     "Nightly summary",
+		UserID:   "user-123",
+		Payload: store.CronPayload{
+			Message: "summarize today's changes",
+		},
+	}
+
+	result, err := handler(job)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if result.Content != "cron-done" {
+		t.Fatalf("result.Content = %q, want cron-done", result.Content)
+	}
+	if result.InputTokens != 12 || result.OutputTokens != 34 {
+		t.Fatalf("result tokens = (%d,%d), want (12,34)", result.InputTokens, result.OutputTokens)
+	}
+
+	wantSessionKey := sessions.BuildCronSessionKey("default", job.ID)
+	if got := sess.resetCalls(); len(got) != 1 || got[0] != wantSessionKey {
+		t.Fatalf("reset calls = %#v, want [%q]", got, wantSessionKey)
+	}
+	if got := sess.saveCalls(); len(got) != 1 || got[0] != wantSessionKey {
+		t.Fatalf("save calls = %#v, want [%q]", got, wantSessionKey)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if gotCtxTID != tenantID {
+		t.Fatalf("tenant in scheduler ctx = %s, want %s", gotCtxTID, tenantID)
+	}
+	if gotRequest.SessionKey != wantSessionKey {
+		t.Fatalf("SessionKey = %q, want %q", gotRequest.SessionKey, wantSessionKey)
+	}
+	if gotRequest.Channel != "cron" {
+		t.Fatalf("Channel = %q, want cron", gotRequest.Channel)
+	}
+	if gotRequest.ChannelType != "" {
+		t.Fatalf("ChannelType = %q, want empty", gotRequest.ChannelType)
+	}
+	if gotRequest.UserID != job.UserID {
+		t.Fatalf("UserID = %q, want %q", gotRequest.UserID, job.UserID)
+	}
+	if gotRequest.RunID != "cron:"+job.ID {
+		t.Fatalf("RunID = %q, want %q", gotRequest.RunID, "cron:"+job.ID)
+	}
+	if gotRequest.TraceName != "Cron [Nightly summary] - default" {
+		t.Fatalf("TraceName = %q", gotRequest.TraceName)
+	}
+	if len(gotRequest.TraceTags) != 1 || gotRequest.TraceTags[0] != "cron" {
+		t.Fatalf("TraceTags = %#v, want [cron]", gotRequest.TraceTags)
+	}
+	if !strings.Contains(gotRequest.ExtraSystemPrompt, `scheduled job "Nightly summary"`) {
+		t.Fatalf("ExtraSystemPrompt missing job name: %q", gotRequest.ExtraSystemPrompt)
+	}
+	if !strings.Contains(gotRequest.ExtraSystemPrompt, "Delivery is not configured") {
+		t.Fatalf("ExtraSystemPrompt should mention delivery not configured: %q", gotRequest.ExtraSystemPrompt)
+	}
+}
+
+func TestMakeCronJobHandler_DeliversOutboundGroupMessage(t *testing.T) {
+	msgBus := bus.New()
+	channelMgr := channels.NewManager(msgBus)
+	channelMgr.RegisterChannel("alerts", &testChannel{
+		BaseChannel: channels.NewBaseChannel("alerts", msgBus, nil),
+		channelType: channels.TypeTelegram,
+	})
+
+	var gotRequest agent.RunRequest
+	sched := scheduler.NewScheduler(nil, scheduler.DefaultQueueConfig(), func(ctx context.Context, req agent.RunRequest) (*agent.RunResult, error) {
+		gotRequest = req
+		return &agent.RunResult{Content: "group-report"}, nil
+	})
+
+	handler := makeCronJobHandler(sched, msgBus, &config.Config{}, channelMgr, &recordingSessionStore{})
+	job := &store.CronJob{
+		ID:       "job-group",
+		TenantID: store.MasterTenantID,
+		Name:     "Group report",
+		AgentID:  "agent-x",
+		UserID:   "group:telegram:-100",
+		Payload: store.CronPayload{
+			Message: "post group report",
+			Deliver: true,
+			Channel: "alerts",
+			To:      "-100",
+		},
+	}
+
+	if _, err := handler(job); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if gotRequest.Channel != "alerts" {
+		t.Fatalf("Channel = %q, want alerts", gotRequest.Channel)
+	}
+	if gotRequest.ChannelType != channels.TypeTelegram {
+		t.Fatalf("ChannelType = %q, want %q", gotRequest.ChannelType, channels.TypeTelegram)
+	}
+	if gotRequest.PeerKind != "group" {
+		t.Fatalf("PeerKind = %q, want group", gotRequest.PeerKind)
+	}
+	if gotRequest.ChatID != "-100" {
+		t.Fatalf("ChatID = %q, want -100", gotRequest.ChatID)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	out, ok := msgBus.SubscribeOutbound(ctx)
+	if !ok {
+		t.Fatal("expected outbound message")
+	}
+	if out.Channel != "alerts" || out.ChatID != "-100" || out.Content != "group-report" {
+		t.Fatalf("outbound = %#v", out)
+	}
+	if out.Metadata["group_id"] != "-100" {
+		t.Fatalf("outbound metadata = %#v, want group_id=-100", out.Metadata)
+	}
+}
+
+type testChannel struct {
+	*channels.BaseChannel
+	channelType string
+}
+
+func (c *testChannel) Type() string                                    { return c.channelType }
+func (c *testChannel) Start(context.Context) error                     { return nil }
+func (c *testChannel) Stop(context.Context) error                      { return nil }
+func (c *testChannel) Send(context.Context, bus.OutboundMessage) error { return nil }
+func (c *testChannel) IsAllowed(string) bool                           { return true }
+
+type recordingSessionStore struct {
+	mu    sync.Mutex
+	reset []string
+	save  []string
+}
+
+func (s *recordingSessionStore) GetOrCreate(context.Context, string) *store.SessionData {
+	return &store.SessionData{}
+}
+func (s *recordingSessionStore) Get(context.Context, string) *store.SessionData {
+	return &store.SessionData{}
+}
+func (s *recordingSessionStore) AddMessage(context.Context, string, providers.Message)   {}
+func (s *recordingSessionStore) GetHistory(context.Context, string) []providers.Message  { return nil }
+func (s *recordingSessionStore) GetSummary(context.Context, string) string               { return "" }
+func (s *recordingSessionStore) SetSummary(context.Context, string, string)              {}
+func (s *recordingSessionStore) GetLabel(context.Context, string) string                 { return "" }
+func (s *recordingSessionStore) SetLabel(context.Context, string, string)                {}
+func (s *recordingSessionStore) SetAgentInfo(context.Context, string, uuid.UUID, string) {}
+func (s *recordingSessionStore) TruncateHistory(context.Context, string, int)            {}
+func (s *recordingSessionStore) SetHistory(context.Context, string, []providers.Message) {}
+func (s *recordingSessionStore) Reset(_ context.Context, key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reset = append(s.reset, key)
+}
+func (s *recordingSessionStore) Delete(context.Context, string) error { return nil }
+func (s *recordingSessionStore) Save(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.save = append(s.save, key)
+	return nil
+}
+func (s *recordingSessionStore) UpdateMetadata(context.Context, string, string, string, string) {}
+func (s *recordingSessionStore) AccumulateTokens(context.Context, string, int64, int64)         {}
+func (s *recordingSessionStore) IncrementCompaction(context.Context, string)                    {}
+func (s *recordingSessionStore) GetCompactionCount(context.Context, string) int                 { return 0 }
+func (s *recordingSessionStore) GetMemoryFlushCompactionCount(context.Context, string) int      { return 0 }
+func (s *recordingSessionStore) SetMemoryFlushDone(context.Context, string)                     {}
+func (s *recordingSessionStore) GetSessionMetadata(context.Context, string) map[string]string {
+	return nil
+}
+func (s *recordingSessionStore) SetSessionMetadata(context.Context, string, map[string]string) {}
+func (s *recordingSessionStore) SetSpawnInfo(context.Context, string, string, int)             {}
+func (s *recordingSessionStore) SetContextWindow(context.Context, string, int)                 {}
+func (s *recordingSessionStore) GetContextWindow(context.Context, string) int                  { return 0 }
+func (s *recordingSessionStore) SetLastPromptTokens(context.Context, string, int, int)         {}
+func (s *recordingSessionStore) GetLastPromptTokens(context.Context, string) (int, int)        { return 0, 0 }
+func (s *recordingSessionStore) List(context.Context, string) []store.SessionInfo              { return nil }
+func (s *recordingSessionStore) ListPaged(context.Context, store.SessionListOpts) store.SessionListResult {
+	return store.SessionListResult{}
+}
+func (s *recordingSessionStore) ListPagedRich(context.Context, store.SessionListOpts) store.SessionListRichResult {
+	return store.SessionListRichResult{}
+}
+func (s *recordingSessionStore) LastUsedChannel(context.Context, string) (string, string) {
+	return "", ""
+}
+
+func (s *recordingSessionStore) resetCalls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.reset...)
+}
+
+func (s *recordingSessionStore) saveCalls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.save...)
+}
+
+var _ store.SessionStore = (*recordingSessionStore)(nil)
+var _ channels.Channel = (*testChannel)(nil)

--- a/cmd/gateway_setup.go
+++ b/cmd/gateway_setup.go
@@ -246,6 +246,7 @@ func setupToolRegistry(
 	}
 	if rf, ok := toolsReg.Get("read_file"); ok {
 		if t, ok := rf.(*tools.ReadFileTool); ok {
+			t.SetDataDir(dataDir)
 			t.DenyPaths(readFileDenyPaths...)
 		}
 	}
@@ -586,4 +587,3 @@ func setupSkillsSystem(
 
 	return skillsLoader, skillSearchTool, globalSkillsDir, bundledSkillsDir, builtinSkillsDir
 }
-

--- a/internal/agent/cron_readfile_test.go
+++ b/internal/agent/cron_readfile_test.go
@@ -1,0 +1,207 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/sessions"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
+)
+
+func TestCronRunReadFilePrefersWorkspaceAndDataDirOverProcessRoot(t *testing.T) {
+	tests := []struct {
+		name         string
+		workspaceVal string
+		dataDirVal   string
+		want         string
+	}{
+		{
+			name:         "cron run prefers workspace file first",
+			workspaceVal: "workspace-version",
+			dataDirVal:   "data-version",
+			want:         "workspace-version",
+		},
+		{
+			name:         "cron run falls back to data dir before process root",
+			workspaceVal: "",
+			dataDirVal:   "data-version",
+			want:         "data-version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cwd := t.TempDir()
+			oldWD, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("Getwd: %v", err)
+			}
+			if err := os.Chdir(cwd); err != nil {
+				t.Fatalf("Chdir: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+			workspaceRoot := t.TempDir()
+			dataDir := t.TempDir()
+			userID := "cron-user"
+			relPath := filepath.Join("cli-workspaces", "job-1", "note.txt")
+			effectiveWorkspace := filepath.Join(workspaceRoot, userID)
+
+			writeAgentTestFile(t, filepath.Join(cwd, relPath), "process-root-version")
+			if tt.workspaceVal != "" {
+				writeAgentTestFile(t, filepath.Join(effectiveWorkspace, relPath), tt.workspaceVal)
+			}
+			if tt.dataDirVal != "" {
+				writeAgentTestFile(t, filepath.Join(dataDir, relPath), tt.dataDirVal)
+			}
+
+			loop := &Loop{
+				id:        "agent-cron",
+				tenantID:  store.MasterTenantID,
+				agentType: store.AgentTypeOpen,
+				workspace: workspaceRoot,
+				dataDir:   dataDir,
+				sessions:  noopSessionStore{},
+			}
+
+			req := RunRequest{
+				SessionKey: sessions.BuildCronSessionKey("agent-cron", "job-1"),
+				RunID:      "cron:job-1",
+				Channel:    "cron",
+				UserID:     userID,
+				Message:    "Read the cron note",
+			}
+
+			ctxSetup, err := loop.injectContext(context.Background(), &req)
+			if err != nil {
+				t.Fatalf("injectContext: %v", err)
+			}
+			if gotWs := tools.ToolWorkspaceFromCtx(ctxSetup.ctx); gotWs != effectiveWorkspace {
+				t.Fatalf("cron workspace = %q, want %q", gotWs, effectiveWorkspace)
+			}
+
+			readTool := tools.NewReadFileTool(workspaceRoot, true)
+			readTool.SetDataDir(dataDir)
+			readTool.AllowPaths(filepath.Join(dataDir, "cli-workspaces"))
+
+			got := readTool.Execute(ctxSetup.ctx, map[string]any{"path": relPath})
+			if got.IsError {
+				t.Fatalf("read_file returned error: %s", got.ForLLM)
+			}
+			if got.ForLLM != tt.want {
+				t.Fatalf("read_file = %q, want %q", got.ForLLM, tt.want)
+			}
+		})
+	}
+}
+
+func TestCronRunReadFileUsesTenantScopedDataDir(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	dataDir := t.TempDir()
+	tenantID := uuid.MustParse("0193a5b0-7000-7000-8000-000000000333")
+	tenantSlug := "tenant-bravo"
+	userID := "cron-user"
+	relPath := filepath.Join("cli-workspaces", "job-1", "note.txt")
+
+	writeAgentTestFile(t, filepath.Join(dataDir, relPath), "global-version")
+	writeAgentTestFile(t, filepath.Join(dataDir, "tenants", tenantSlug, relPath), "tenant-version")
+
+	loop := &Loop{
+		id:         "agent-cron",
+		tenantID:   tenantID,
+		tenantSlug: tenantSlug,
+		agentType:  store.AgentTypeOpen,
+		workspace:  workspaceRoot,
+		dataDir:    dataDir,
+		sessions:   noopSessionStore{},
+	}
+
+	req := RunRequest{
+		SessionKey: sessions.BuildCronSessionKey("agent-cron", "job-1"),
+		RunID:      "cron:job-1",
+		Channel:    "cron",
+		UserID:     userID,
+		Message:    "Read the tenant cron note",
+	}
+
+	ctxSetup, err := loop.injectContext(context.Background(), &req)
+	if err != nil {
+		t.Fatalf("injectContext: %v", err)
+	}
+	if got := store.TenantSlugFromContext(ctxSetup.ctx); got != tenantSlug {
+		t.Fatalf("tenant slug in context = %q, want %q", got, tenantSlug)
+	}
+
+	readTool := tools.NewReadFileTool(workspaceRoot, true)
+	readTool.SetDataDir(dataDir)
+	readTool.AllowPaths(
+		filepath.Join(dataDir, "cli-workspaces"),
+		filepath.Join(dataDir, "tenants"),
+	)
+
+	got := readTool.Execute(ctxSetup.ctx, map[string]any{"path": relPath})
+	if got.IsError {
+		t.Fatalf("read_file returned error: %s", got.ForLLM)
+	}
+	if got.ForLLM != "tenant-version" {
+		t.Fatalf("read_file = %q, want tenant-version", got.ForLLM)
+	}
+}
+
+func writeAgentTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+type noopSessionStore struct{}
+
+func (noopSessionStore) GetOrCreate(context.Context, string) *store.SessionData {
+	return &store.SessionData{}
+}
+func (noopSessionStore) Get(context.Context, string) *store.SessionData                 { return &store.SessionData{} }
+func (noopSessionStore) AddMessage(context.Context, string, providers.Message)          {}
+func (noopSessionStore) GetHistory(context.Context, string) []providers.Message         { return nil }
+func (noopSessionStore) GetSummary(context.Context, string) string                      { return "" }
+func (noopSessionStore) SetSummary(context.Context, string, string)                     {}
+func (noopSessionStore) GetLabel(context.Context, string) string                        { return "" }
+func (noopSessionStore) SetLabel(context.Context, string, string)                       {}
+func (noopSessionStore) SetAgentInfo(context.Context, string, uuid.UUID, string)        {}
+func (noopSessionStore) TruncateHistory(context.Context, string, int)                   {}
+func (noopSessionStore) SetHistory(context.Context, string, []providers.Message)        {}
+func (noopSessionStore) Reset(context.Context, string)                                  {}
+func (noopSessionStore) Delete(context.Context, string) error                           { return nil }
+func (noopSessionStore) Save(context.Context, string) error                             { return nil }
+func (noopSessionStore) UpdateMetadata(context.Context, string, string, string, string) {}
+func (noopSessionStore) AccumulateTokens(context.Context, string, int64, int64)         {}
+func (noopSessionStore) IncrementCompaction(context.Context, string)                    {}
+func (noopSessionStore) GetCompactionCount(context.Context, string) int                 { return 0 }
+func (noopSessionStore) GetMemoryFlushCompactionCount(context.Context, string) int      { return 0 }
+func (noopSessionStore) SetMemoryFlushDone(context.Context, string)                     {}
+func (noopSessionStore) GetSessionMetadata(context.Context, string) map[string]string   { return nil }
+func (noopSessionStore) SetSessionMetadata(context.Context, string, map[string]string)  {}
+func (noopSessionStore) SetSpawnInfo(context.Context, string, string, int)              {}
+func (noopSessionStore) SetContextWindow(context.Context, string, int)                  {}
+func (noopSessionStore) GetContextWindow(context.Context, string) int                   { return 0 }
+func (noopSessionStore) SetLastPromptTokens(context.Context, string, int, int)          {}
+func (noopSessionStore) GetLastPromptTokens(context.Context, string) (int, int)         { return 0, 0 }
+func (noopSessionStore) List(context.Context, string) []store.SessionInfo               { return nil }
+func (noopSessionStore) ListPaged(context.Context, store.SessionListOpts) store.SessionListResult {
+	return store.SessionListResult{}
+}
+func (noopSessionStore) ListPagedRich(context.Context, store.SessionListOpts) store.SessionListRichResult {
+	return store.SessionListRichResult{}
+}
+func (noopSessionStore) LastUsedChannel(context.Context, string) (string, string) { return "", "" }
+
+var _ store.SessionStore = noopSessionStore{}

--- a/internal/agent/loop_context.go
+++ b/internal/agent/loop_context.go
@@ -38,6 +38,9 @@ func (l *Loop) injectContext(ctx context.Context, req *RunRequest) (contextSetup
 	if l.tenantID != uuid.Nil {
 		ctx = store.WithTenantID(ctx, l.tenantID)
 	}
+	if l.tenantSlug != "" {
+		ctx = store.WithTenantSlug(ctx, l.tenantSlug)
+	}
 	// Inject user ID into context for per-user scoping (memory, context files, etc.)
 	if req.UserID != "" {
 		ctx = store.WithUserID(ctx, req.UserID)
@@ -160,23 +163,13 @@ func (l *Loop) injectContext(ctx context.Context, req *RunRequest) (contextSetup
 	if req.TeamWorkspace == "" && l.teamStore != nil && l.agentUUID != uuid.Nil {
 		if team, _ := l.teamStore.GetTeamForAgent(ctx, l.agentUUID); team != nil {
 			resolvedTeamSettings = team.Settings
-			wsChat := req.ChatID
-			if wsChat == "" {
-				wsChat = req.UserID
-			}
-			shared := tools.IsSharedWorkspace(team.Settings)
-			// Resolve team workspace via layered pipeline: tenant → team → user/chat.
-			wsDir := tools.ResolveWorkspace(l.dataDir,
-				tools.TenantLayer(store.TenantIDFromContext(ctx), store.TenantSlugFromContext(ctx)),
-				tools.TeamLayer(team.ID),
-				tools.UserChatLayer(wsChat, shared),
-			)
-			if err := os.MkdirAll(wsDir, 0750); err != nil {
-				slog.Warn("failed to create team workspace directory", "workspace", wsDir, "error", err)
-			}
-			ctx = tools.WithToolTeamWorkspace(ctx, wsDir)
-			if team.LeadAgentID == l.agentUUID {
-				ctx = tools.WithToolWorkspace(ctx, wsDir)
+			if wsDir, err := l.autoTeamWorkspaceDir(req, team); err == nil {
+				ctx = tools.WithToolTeamWorkspace(ctx, wsDir)
+				if team.LeadAgentID == l.agentUUID {
+					ctx = tools.WithToolWorkspace(ctx, wsDir)
+				}
+			} else {
+				slog.Warn("failed to create team workspace directory", "team", team.ID, "error", err)
 			}
 			if req.TeamID == "" {
 				ctx = tools.WithToolTeamID(ctx, team.ID.String())
@@ -246,6 +239,7 @@ func (l *Loop) injectContext(ctx context.Context, req *RunRequest) (contextSetup
 		AgentID:             l.agentUUID,
 		AgentKey:            l.id,
 		TenantID:            l.tenantID,
+		TenantSlug:          l.tenantSlug,
 		UserID:              req.UserID,
 		AgentType:           l.agentType,
 		SenderID:            req.SenderID,
@@ -275,4 +269,16 @@ func (l *Loop) injectContext(ctx context.Context, req *RunRequest) (contextSetup
 		ctx:                  ctx,
 		resolvedTeamSettings: resolvedTeamSettings,
 	}, nil
+}
+
+func (l *Loop) autoTeamWorkspaceDir(req *RunRequest, team *store.TeamData) (string, error) {
+	// l.dataDir is already tenant-scoped by the resolver for managed agents.
+	wsChat := req.ChatID
+	if wsChat == "" {
+		wsChat = req.UserID
+	}
+	if tools.IsSharedWorkspace(team.Settings) {
+		wsChat = ""
+	}
+	return tools.WorkspaceDir(l.dataDir, team.ID, wsChat)
 }

--- a/internal/agent/loop_types.go
+++ b/internal/agent/loop_types.go
@@ -38,25 +38,26 @@ type BootstrapCleanupFunc func(ctx context.Context, agentID uuid.UUID, userID st
 // Loop is the agent execution loop for one agent instance.
 // Think → Act → Observe cycle with tool execution.
 type Loop struct {
-	id            string
-	agentUUID     uuid.UUID // set for context propagation
-	tenantID      uuid.UUID // agent's owning tenant
-	agentType     string    // "open" or "predefined"
-	provider      providers.Provider
-	model         string
-	contextWindow int
-	maxTokens     int // max output tokens per LLM call (0 = default 8192)
-	maxIterations int
-	maxToolCalls  int
+	id               string
+	agentUUID        uuid.UUID // set for context propagation
+	tenantID         uuid.UUID // agent's owning tenant
+	tenantSlug       string    // tenant slug for tenant-scoped data/workspace paths
+	agentType        string    // "open" or "predefined"
+	provider         providers.Provider
+	model            string
+	contextWindow    int
+	maxTokens        int // max output tokens per LLM call (0 = default 8192)
+	maxIterations    int
+	maxToolCalls     int
 	workspace        string
-	dataDir          string // global workspace root for team workspace resolution
+	dataDir          string // tenant-scoped workspace root for team workspace resolution
 	workspaceSharing *store.WorkspaceSharingConfig
 
 	// Per-agent overrides from DB (nil = use global defaults)
-	restrictToWs  *bool
-	subagentsCfg  *config.SubagentsConfig
-	memoryCfg     *config.MemoryConfig
-	sandboxCfg    *sandbox.Config
+	restrictToWs *bool
+	subagentsCfg *config.SubagentsConfig
+	memoryCfg    *config.MemoryConfig
+	sandboxCfg   *sandbox.Config
 
 	eventPub        bus.EventPublisher // currently unused by Loop; kept for future use
 	sessions        store.SessionStore
@@ -140,7 +141,7 @@ type Loop struct {
 
 	// Budget enforcement: monthly spending limit in cents (0 = unlimited)
 	budgetMonthlyCents int
-	tracingStore store.TracingStore
+	tracingStore       store.TracingStore
 
 	// Memory store for extractive memory fallback (writes directly when LLM flush fails)
 	memStore store.MemoryStore
@@ -172,15 +173,15 @@ type AgentEvent struct {
 
 // LoopConfig configures a new Loop.
 type LoopConfig struct {
-	ID              string
-	Provider        providers.Provider
-	Model           string
-	ContextWindow   int
-	MaxTokens       int // max output tokens per LLM call (0 = default 8192)
-	MaxIterations   int
-	MaxToolCalls    int
+	ID               string
+	Provider         providers.Provider
+	Model            string
+	ContextWindow    int
+	MaxTokens        int // max output tokens per LLM call (0 = default 8192)
+	MaxIterations    int
+	MaxToolCalls     int
 	Workspace        string
-	DataDir          string // global workspace root for team workspace resolution
+	DataDir          string // tenant-scoped workspace root for team workspace resolution
 	WorkspaceSharing *store.WorkspaceSharingConfig
 
 	// Per-agent DB overrides (nil = use global defaults)
@@ -218,9 +219,10 @@ type LoopConfig struct {
 	ShellDenyGroups map[string]bool
 
 	// Agent UUID + tenant for context propagation to tools
-	AgentUUID uuid.UUID
-	TenantID  uuid.UUID // agent's owning tenant — injected into execution context
-	AgentType string    // "open" or "predefined"
+	AgentUUID  uuid.UUID
+	TenantID   uuid.UUID // agent's owning tenant — injected into execution context
+	TenantSlug string
+	AgentType  string // "open" or "predefined"
 
 	// Per-user file seeding + dynamic context loading
 	EnsureUserFiles   EnsureUserFilesFunc
@@ -268,7 +270,7 @@ type LoopConfig struct {
 
 	// Budget enforcement
 	BudgetMonthlyCents int
-	TracingStore store.TracingStore
+	TracingStore       store.TracingStore
 
 	// Memory store for extractive memory fallback (writes directly when LLM flush fails)
 	MemoryStore store.MemoryStore
@@ -311,6 +313,7 @@ func NewLoop(cfg LoopConfig) *Loop {
 		id:                     cfg.ID,
 		agentUUID:              cfg.AgentUUID,
 		tenantID:               cfg.TenantID,
+		tenantSlug:             cfg.TenantSlug,
 		agentType:              cfg.AgentType,
 		provider:               cfg.Provider,
 		model:                  cfg.Model,
@@ -434,7 +437,7 @@ type RunResult struct {
 type MediaResult struct {
 	Path        string `json:"path"`                   // local file path
 	ContentType string `json:"content_type,omitempty"` // MIME type
-	Size        int64  `json:"size,omitempty"`          // file size in bytes
+	Size        int64  `json:"size,omitempty"`         // file size in bytes
 	AsVoice     bool   `json:"as_voice,omitempty"`     // send as voice message (Telegram OGG)
 }
 
@@ -443,17 +446,17 @@ type MediaResult struct {
 // on *runState without passing 20+ individual variables.
 type runState struct {
 	// Loop control
-	loopDetector toolLoopState
-	totalUsage   providers.Usage
-	iteration    int
+	loopDetector   toolLoopState
+	totalUsage     providers.Usage
+	iteration      int
 	totalToolCalls int
 
 	// Output accumulators
 	finalContent   string
 	finalThinking  string
-	asyncToolCalls []string    // async spawn tool names for fallback
+	asyncToolCalls []string // async spawn tool names for fallback
 	mediaResults   []MediaResult
-	deliverables   []string   // tool output content for team task results
+	deliverables   []string // tool output content for team task results
 	pendingMsgs    []providers.Message
 
 	// Event state

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -257,11 +257,11 @@ func NewManagedResolver(deps ResolverDeps) ResolverFunc {
 				toolsReg = deps.Tools.Clone()
 			}
 			var mcpOpts []mcpbridge.ManagerOption
-		mcpOpts = append(mcpOpts, mcpbridge.WithStore(deps.MCPStore))
-		if deps.MCPPool != nil {
-			mcpOpts = append(mcpOpts, mcpbridge.WithPool(deps.MCPPool))
-		}
-		mcpMgr := mcpbridge.NewManager(toolsReg, mcpOpts...)
+			mcpOpts = append(mcpOpts, mcpbridge.WithStore(deps.MCPStore))
+			if deps.MCPPool != nil {
+				mcpOpts = append(mcpOpts, mcpbridge.WithPool(deps.MCPPool))
+			}
+			mcpMgr := mcpbridge.NewManager(toolsReg, mcpOpts...)
 			if err := mcpMgr.LoadForAgent(ctx, ag.ID, ""); err != nil {
 				slog.Warn("failed to load MCP servers for agent", "agent", agentKey, "error", err)
 			} else if mcpMgr.IsSearchMode() {
@@ -332,7 +332,7 @@ func NewManagedResolver(deps ResolverDeps) ResolverFunc {
 			}
 		}
 
-		// Resolve tenant-scoped DataDir for team workspace resolution.
+		// Resolve the tenant-scoped workspace root for team workspace resolution.
 		dataDir := deps.DataDir
 		if tenantSlug != "" {
 			dataDir = config.TenantDataDir(deps.DataDir, ag.TenantID, tenantSlug)
@@ -343,6 +343,7 @@ func NewManagedResolver(deps ResolverDeps) ResolverFunc {
 			ID:                     ag.AgentKey,
 			AgentUUID:              ag.ID,
 			TenantID:               ag.TenantID,
+			TenantSlug:             tenantSlug,
 			AgentType:              ag.AgentType,
 			Provider:               provider,
 			Model:                  ag.Model,
@@ -436,4 +437,3 @@ func derefInt(p *int) int {
 	}
 	return *p
 }
-

--- a/internal/agent/team_workspace_test.go
+++ b/internal/agent/team_workspace_test.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+func TestAutoTeamWorkspaceDirUsesTenantScopedRootOnce(t *testing.T) {
+	tenantID := uuid.MustParse("0193a5b0-7000-7000-8000-000000000444")
+	tenantSlug := "tenant-delta"
+	teamID := uuid.MustParse("0193a5b0-7000-7000-8000-000000000445")
+	workspaceRoot := t.TempDir()
+	tenantWorkspaceRoot := config.TenantWorkspace(workspaceRoot, tenantID, tenantSlug)
+
+	loop := &Loop{
+		dataDir: tenantWorkspaceRoot,
+	}
+	req := &RunRequest{
+		UserID: "user-123",
+	}
+	team := &store.TeamData{
+		BaseModel: store.BaseModel{ID: teamID},
+	}
+
+	got, err := loop.autoTeamWorkspaceDir(req, team)
+	if err != nil {
+		t.Fatalf("autoTeamWorkspaceDir returned error: %v", err)
+	}
+
+	want := filepath.Join(tenantWorkspaceRoot, "teams", teamID.String(), req.UserID)
+	if got != want {
+		t.Fatalf("autoTeamWorkspaceDir = %q, want %q", got, want)
+	}
+}

--- a/internal/store/context.go
+++ b/internal/store/context.go
@@ -268,6 +268,9 @@ func TenantSlugFromContext(ctx context.Context) string {
 	if v, ok := ctx.Value(TenantSlugKey).(string); ok {
 		return v
 	}
+	if rc := RunContextFromCtx(ctx); rc != nil {
+		return rc.TenantSlug
+	}
 	return ""
 }
 

--- a/internal/store/run_context.go
+++ b/internal/store/run_context.go
@@ -21,12 +21,13 @@ type runContextKey struct{}
 // accessor functions (which fall back to individual keys when RunContext is absent).
 type RunContext struct {
 	// Identity
-	AgentID   uuid.UUID
-	AgentKey  string
-	TenantID  uuid.UUID
-	UserID    string
-	AgentType string
-	SenderID  string
+	AgentID    uuid.UUID
+	AgentKey   string
+	TenantID   uuid.UUID
+	TenantSlug string
+	UserID     string
+	AgentType  string
+	SenderID   string
 
 	// Flags
 	SelfEvolve          bool

--- a/internal/tools/filesystem.go
+++ b/internal/tools/filesystem.go
@@ -8,7 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/nextlevelbuilder/goclaw/internal/bootstrap"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/sandbox"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
@@ -22,14 +25,15 @@ var virtualSystemFiles = map[string]string{
 
 // ReadFileTool reads file contents, optionally through a sandbox container.
 type ReadFileTool struct {
-	workspace        string
-	restrict         bool
-	allowedPrefixes  []string                // extra allowed path prefixes (e.g. skills dirs)
-	deniedPrefixes   []string                // path prefixes to deny access to (e.g. .goclaw)
-	sandboxMgr       sandbox.Manager         // nil = direct host access
-	contextFileIntc  *ContextFileInterceptor // nil = no virtual FS routing
-	memIntc          *MemoryInterceptor      // nil = no memory routing
-	permStore store.ConfigPermissionStore // nil = no group read restriction
+	workspace       string
+	dataDir         string
+	restrict        bool
+	allowedPrefixes []string                    // extra allowed path prefixes (e.g. skills dirs)
+	deniedPrefixes  []string                    // path prefixes to deny access to (e.g. .goclaw)
+	sandboxMgr      sandbox.Manager             // nil = direct host access
+	contextFileIntc *ContextFileInterceptor     // nil = no virtual FS routing
+	memIntc         *MemoryInterceptor          // nil = no memory routing
+	permStore       store.ConfigPermissionStore // nil = no group read restriction
 }
 
 // SetContextFileInterceptor enables virtual FS routing for context files.
@@ -49,6 +53,26 @@ func (t *ReadFileTool) SetConfigPermStore(s store.ConfigPermissionStore) {
 
 func NewReadFileTool(workspace string, restrict bool) *ReadFileTool {
 	return &ReadFileTool{workspace: workspace, restrict: restrict}
+}
+
+// SetDataDir configures the global data directory root used as a secondary
+// read root after the effective workspace for relative read_file paths.
+func (t *ReadFileTool) SetDataDir(dataDir string) {
+	t.dataDir = dataDir
+}
+
+// CopyConfigFrom copies read_file routing and access settings from another tool.
+// Used when rebuilding read_file for subagents with a different workspace/sandbox.
+func (t *ReadFileTool) CopyConfigFrom(src *ReadFileTool) {
+	if src == nil {
+		return
+	}
+	t.dataDir = src.dataDir
+	t.allowedPrefixes = append([]string(nil), src.allowedPrefixes...)
+	t.deniedPrefixes = append([]string(nil), src.deniedPrefixes...)
+	t.contextFileIntc = src.contextFileIntc
+	t.memIntc = src.memIntc
+	t.permStore = src.permStore
 }
 
 // AllowPaths adds extra path prefixes that read_file is allowed to access
@@ -133,24 +157,33 @@ func (t *ReadFileTool) Execute(ctx context.Context, args map[string]any) *Result
 		}
 	}
 
-	// Sandbox routing (sandboxKey from ctx — thread-safe)
-	sandboxKey := ToolSandboxKeyFromCtx(ctx)
-	if t.sandboxMgr != nil && sandboxKey != "" {
-		return t.executeInSandbox(ctx, path, sandboxKey)
-	}
-
 	// Host execution — use per-user workspace from context if available
 	workspace := ToolWorkspaceFromCtx(ctx)
 	if workspace == "" {
 		workspace = t.workspace
 	}
 	allowed := allowedWithTeamWorkspace(ctx, t.allowedPrefixes)
-	resolved, err := resolvePathWithAllowed(path, workspace, effectiveRestrict(ctx, t.restrict), allowed)
+	resolved, err := resolveReadPath(path, workspace, effectiveRestrict(ctx, t.restrict), allowed, t.preferredReadRoots(ctx, path, workspace, allowed))
 	if err != nil {
 		return ErrorResult(err.Error())
 	}
 	if err := checkDeniedPath(resolved, t.workspace, t.deniedPrefixes); err != nil {
 		return ErrorResult(err.Error())
+	}
+
+	// Sandbox routing: reads must stay inside the mounted workspace when a sandbox
+	// is active. Allowed external roots are only readable in host mode.
+	sandboxKey := ToolSandboxKeyFromCtx(ctx)
+	if t.sandboxMgr != nil && sandboxKey != "" {
+		containerPath, ok := t.sandboxContainerPath(resolved)
+		if !ok {
+			return ErrorResult("access denied: sandboxed read_file cannot access paths outside workspace")
+		}
+		if isBinaryFileExt(resolved) {
+			ext := strings.ToLower(filepath.Ext(resolved))
+			return ErrorResult(fmt.Sprintf("cannot read binary file (%s). Use the appropriate tool: read_image for images, read_document for documents, read_audio for audio, read_video for video.", ext))
+		}
+		return t.executeInSandboxPath(ctx, containerPath, sandboxKey)
 	}
 
 	// Block binary files — reading them wastes context with garbled data.
@@ -173,17 +206,98 @@ func (t *ReadFileTool) Execute(ctx context.Context, args map[string]any) *Result
 	return SilentResult(string(data))
 }
 
-func (t *ReadFileTool) executeInSandbox(ctx context.Context, path, sandboxKey string) *Result {
+func (t *ReadFileTool) preferredReadRoots(ctx context.Context, path, workspace string, allowedPrefixes []string) []string {
+	var roots []string
+	seen := make(map[string]struct{})
+	add := func(root string) {
+		if root == "" {
+			return
+		}
+		clean := filepath.Clean(root)
+		if _, ok := seen[clean]; ok {
+			return
+		}
+		seen[clean] = struct{}{}
+		roots = append(roots, clean)
+	}
+
+	add(workspace)
+	if t.dataDir != "" {
+		tenantID := store.TenantIDFromContext(ctx)
+		dataRoot := t.dataDir
+		if tenantID != uuid.Nil && tenantID != store.MasterTenantID {
+			dataRoot = config.TenantDataDir(t.dataDir, tenantID, store.TenantSlugFromContext(ctx))
+		}
+		if dataRoot != "" && allowDataDirFallback(path, t.dataDir, allowedPrefixes) {
+			add(dataRoot)
+		}
+	}
+	return roots
+}
+
+// allowDataDirFallback reports whether a relative path should be retried under the
+// tenant/global data dir. Only subdirectories already allowlisted under dataDir are
+// eligible; broad prefixes like dataDir/tenants must not expose every tenant subtree.
+func allowDataDirFallback(path, dataDir string, allowedPrefixes []string) bool {
+	if dataDir == "" || path == "" || filepath.IsAbs(path) {
+		return false
+	}
+
+	clean := filepath.Clean(path)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return false
+	}
+
+	top := clean
+	if idx := strings.IndexRune(clean, filepath.Separator); idx >= 0 {
+		top = clean[:idx]
+	}
+	if top == "" || top == "." || top == ".." || top == "tenants" {
+		return false
+	}
+
+	dataDirReal := canonicalPath(dataDir)
+	for _, prefix := range allowedPrefixes {
+		prefixReal := canonicalPath(prefix)
+		if !isPathInside(prefixReal, dataDirReal) {
+			continue
+		}
+		rel, err := filepath.Rel(dataDirReal, prefixReal)
+		if err != nil {
+			continue
+		}
+		rel = filepath.Clean(rel)
+		if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		allowedTop := rel
+		if idx := strings.IndexRune(rel, filepath.Separator); idx >= 0 {
+			allowedTop = rel[:idx]
+		}
+		if allowedTop == top && allowedTop != "tenants" {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	absPath, _ := filepath.Abs(path)
+	realPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return absPath
+	}
+	return realPath
+}
+
+func (t *ReadFileTool) executeInSandboxPath(ctx context.Context, containerPath, sandboxKey string) *Result {
 	bridge, err := t.getFsBridge(ctx, sandboxKey)
 	if err != nil {
 		return ErrorResult(fmt.Sprintf("sandbox error: %v", err))
 	}
-
-	containerCwd, cwdErr := SandboxCwd(ctx, t.workspace, sandbox.DefaultContainerWorkdir)
-	if cwdErr != nil {
-		return ErrorResult(fmt.Sprintf("sandbox path mapping: %v", cwdErr))
-	}
-	containerPath := ResolveSandboxPath(path, containerCwd)
 
 	data, err := bridge.ReadFile(ctx, containerPath)
 	if err != nil {
@@ -191,6 +305,42 @@ func (t *ReadFileTool) executeInSandbox(ctx context.Context, path, sandboxKey st
 	}
 
 	return SilentResult(data)
+}
+
+func (t *ReadFileTool) sandboxContainerPath(resolved string) (string, bool) {
+	if resolved == "" || t.workspace == "" {
+		return "", false
+	}
+
+	absWorkspace, _ := filepath.Abs(t.workspace)
+	wsReal, err := filepath.EvalSymlinks(absWorkspace)
+	if err != nil {
+		wsReal = absWorkspace
+	}
+
+	absResolved, _ := filepath.Abs(resolved)
+	resolvedReal, err := filepath.EvalSymlinks(absResolved)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", false
+		}
+		resolvedReal, err = resolveThroughExistingAncestors(absResolved)
+		if err != nil {
+			return "", false
+		}
+	}
+	if !isPathInside(resolvedReal, wsReal) {
+		return "", false
+	}
+
+	rel, err := filepath.Rel(wsReal, resolvedReal)
+	if err != nil {
+		return "", false
+	}
+	if rel == "." {
+		return sandbox.DefaultContainerWorkdir, true
+	}
+	return filepath.Join(sandbox.DefaultContainerWorkdir, rel), true
 }
 
 func (t *ReadFileTool) getFsBridge(ctx context.Context, sandboxKey string) (*sandbox.FsBridge, error) {
@@ -214,6 +364,40 @@ func allowedWithTeamWorkspace(ctx context.Context, base []string) []string {
 	return out
 }
 
+// resolveReadPath resolves the best candidate path for read_file.
+// Relative paths prefer the effective workspace first, then configured data dir roots,
+// before falling back to the workspace candidate for not-found errors.
+func resolveReadPath(path, workspace string, restrict bool, allowedPrefixes, preferredRoots []string) (string, error) {
+	if filepath.IsAbs(path) {
+		return resolvePathWithAllowed(path, workspace, restrict, allowedPrefixes)
+	}
+
+	primary, err := resolvePathWithAllowed(path, workspace, restrict, allowedPrefixes)
+	if err != nil {
+		return "", err
+	}
+	if _, statErr := os.Stat(primary); statErr == nil {
+		return primary, nil
+	}
+
+	for _, root := range preferredRoots {
+		if root == "" {
+			continue
+		}
+		candidate := filepath.Join(root, path)
+		resolved, err := resolvePathWithAllowed(candidate, workspace, restrict, allowedPrefixes)
+		if err != nil || resolved == primary {
+			continue
+		}
+		if _, statErr := os.Stat(resolved); statErr == nil {
+			slog.Debug("read_file: resolved via preferred root", "path", path, "root", root, "resolved", resolved)
+			return resolved, nil
+		}
+	}
+
+	return primary, nil
+}
+
 // resolvePathWithAllowed is like resolvePath but also allows paths under extra prefixes.
 func resolvePathWithAllowed(path, workspace string, restrict bool, allowedPrefixes []string) (string, error) {
 	resolved, err := resolvePath(path, workspace, restrict)
@@ -221,9 +405,14 @@ func resolvePathWithAllowed(path, workspace string, restrict bool, allowedPrefix
 		return resolved, nil
 	}
 	// If restricted and denied, check if path falls under an allowed prefix.
+	// Relative paths are anchored to the workspace, not the process CWD.
 	// Resolve symlinks in the candidate path for safe comparison.
 	cleaned := filepath.Clean(path)
-	absPath, _ := filepath.Abs(cleaned)
+	candidate := cleaned
+	if !filepath.IsAbs(candidate) && workspace != "" {
+		candidate = filepath.Join(workspace, candidate)
+	}
+	absPath, _ := filepath.Abs(candidate)
 	real, evalErr := filepath.EvalSymlinks(absPath)
 	if evalErr != nil {
 		// Try resolving parent for non-existent files
@@ -426,4 +615,3 @@ func resolveThroughExistingAncestors(target string) (string, error) {
 	}
 	return filepath.Clean(target), nil
 }
-

--- a/internal/tools/filesystem_read_test.go
+++ b/internal/tools/filesystem_read_test.go
@@ -1,0 +1,208 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/sandbox"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+func TestReadFilePrefersWorkspaceAndDataDirOverProcessRoot(t *testing.T) {
+	tests := []struct {
+		name         string
+		workspaceVal string
+		dataDirVal   string
+		want         string
+	}{
+		{
+			name:         "prefers workspace file first",
+			workspaceVal: "workspace-version",
+			dataDirVal:   "data-version",
+			want:         "workspace-version",
+		},
+		{
+			name:         "falls back to data dir before process root",
+			workspaceVal: "",
+			dataDirVal:   "data-version",
+			want:         "data-version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cwd := t.TempDir()
+			oldWD, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("Getwd: %v", err)
+			}
+			if err := os.Chdir(cwd); err != nil {
+				t.Fatalf("Chdir: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+			workspace := t.TempDir()
+			dataDir := t.TempDir()
+			relPath := filepath.Join("cli-workspaces", "session-1", "note.txt")
+
+			writeTestFile(t, filepath.Join(cwd, relPath), "process-root-version")
+			if tt.workspaceVal != "" {
+				writeTestFile(t, filepath.Join(workspace, relPath), tt.workspaceVal)
+			}
+			if tt.dataDirVal != "" {
+				writeTestFile(t, filepath.Join(dataDir, relPath), tt.dataDirVal)
+			}
+
+			tool := NewReadFileTool(workspace, true)
+			tool.SetDataDir(dataDir)
+			tool.AllowPaths(filepath.Join(dataDir, "cli-workspaces"))
+
+			got := tool.Execute(context.Background(), map[string]any{"path": relPath})
+			if got.IsError {
+				t.Fatalf("read_file returned error: %s", got.ForLLM)
+			}
+			if got.ForLLM != tt.want {
+				t.Fatalf("read_file = %q, want %q", got.ForLLM, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadFilePrefersTenantDataDirFromContext(t *testing.T) {
+	workspace := t.TempDir()
+	dataDir := t.TempDir()
+	tenantID := uuid.MustParse("0193a5b0-7000-7000-8000-000000000222")
+	tenantSlug := "tenant-alpha"
+	relPath := filepath.Join("cli-workspaces", "session-1", "note.txt")
+
+	writeTestFile(t, filepath.Join(dataDir, relPath), "global-version")
+	writeTestFile(t, filepath.Join(dataDir, "tenants", tenantSlug, relPath), "tenant-version")
+
+	tool := NewReadFileTool(workspace, true)
+	tool.SetDataDir(dataDir)
+	tool.AllowPaths(
+		filepath.Join(dataDir, "cli-workspaces"),
+		filepath.Join(dataDir, "tenants"),
+	)
+
+	ctx := store.WithTenantSlug(store.WithTenantID(context.Background(), tenantID), tenantSlug)
+	got := tool.Execute(ctx, map[string]any{"path": relPath})
+	if got.IsError {
+		t.Fatalf("read_file returned error: %s", got.ForLLM)
+	}
+	if got.ForLLM != "tenant-version" {
+		t.Fatalf("read_file = %q, want tenant-version", got.ForLLM)
+	}
+}
+
+func TestReadFileDoesNotFallBackToGlobalDataDirForTenantContext(t *testing.T) {
+	workspace := t.TempDir()
+	dataDir := t.TempDir()
+	tenantID := uuid.MustParse("0193a5b0-7000-7000-8000-000000000223")
+	tenantSlug := "tenant-beta"
+	relPath := filepath.Join("cli-workspaces", "session-1", "note.txt")
+
+	writeTestFile(t, filepath.Join(dataDir, relPath), "global-version")
+
+	tool := NewReadFileTool(workspace, true)
+	tool.SetDataDir(dataDir)
+	tool.AllowPaths(
+		filepath.Join(dataDir, "cli-workspaces"),
+		filepath.Join(dataDir, "tenants"),
+	)
+
+	ctx := store.WithTenantSlug(store.WithTenantID(context.Background(), tenantID), tenantSlug)
+	got := tool.Execute(ctx, map[string]any{"path": relPath})
+	if !got.IsError {
+		t.Fatalf("read_file unexpectedly succeeded with %q", got.ForLLM)
+	}
+	if strings.Contains(got.ForLLM, "global-version") {
+		t.Fatalf("read_file fell back to global data dir: %q", got.ForLLM)
+	}
+}
+
+func TestReadFileTenantFallbackOnlyUsesWhitelistedSubdirs(t *testing.T) {
+	workspace := t.TempDir()
+	dataDir := t.TempDir()
+	tenantID := uuid.MustParse("0193a5b0-7000-7000-8000-000000000224")
+	tenantSlug := "tenant-gamma"
+
+	writeTestFile(t, filepath.Join(dataDir, "tenants", tenantSlug, "teams", "team-a", "notes.txt"), "team-secret")
+	writeTestFile(t, filepath.Join(dataDir, "tenants", tenantSlug, "media", "session-a", "notes.txt"), "media-secret")
+
+	tool := NewReadFileTool(workspace, true)
+	tool.SetDataDir(dataDir)
+	tool.AllowPaths(
+		filepath.Join(dataDir, "cli-workspaces"),
+		filepath.Join(dataDir, "tenants"),
+	)
+
+	ctx := store.WithTenantSlug(store.WithTenantID(context.Background(), tenantID), tenantSlug)
+	for _, relPath := range []string{
+		filepath.Join("teams", "team-a", "notes.txt"),
+		filepath.Join("media", "session-a", "notes.txt"),
+	} {
+		got := tool.Execute(ctx, map[string]any{"path": relPath})
+		if !got.IsError {
+			t.Fatalf("read_file unexpectedly succeeded for %q with %q", relPath, got.ForLLM)
+		}
+		if strings.Contains(got.ForLLM, "secret") {
+			t.Fatalf("read_file exposed tenant data for %q: %q", relPath, got.ForLLM)
+		}
+	}
+}
+
+func TestReadFileRejectsExternalRootsWhenSandboxed(t *testing.T) {
+	workspace := t.TempDir()
+	dataDir := t.TempDir()
+	relPath := filepath.Join("cli-workspaces", "session-1", "note.txt")
+
+	writeTestFile(t, filepath.Join(dataDir, relPath), "data-version")
+
+	mgr := &recordingSandboxManager{}
+	tool := NewSandboxedReadFileTool(workspace, true, mgr)
+	tool.SetDataDir(dataDir)
+	tool.AllowPaths(filepath.Join(dataDir, "cli-workspaces"))
+
+	ctx := WithToolSandboxKey(context.Background(), "sandbox-1")
+	got := tool.Execute(ctx, map[string]any{"path": relPath})
+	if !got.IsError {
+		t.Fatal("read_file unexpectedly succeeded for sandboxed external root")
+	}
+	if !strings.Contains(got.ForLLM, "outside workspace") {
+		t.Fatalf("read_file error = %q, want outside workspace", got.ForLLM)
+	}
+	if mgr.getCalled {
+		t.Fatal("sandbox manager should not be invoked for paths outside the mounted workspace")
+	}
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+type recordingSandboxManager struct {
+	getCalled bool
+}
+
+func (m *recordingSandboxManager) Get(context.Context, string, string, *sandbox.Config) (sandbox.Sandbox, error) {
+	m.getCalled = true
+	return nil, errors.New("unexpected sandbox lookup")
+}
+
+func (m *recordingSandboxManager) Release(context.Context, string) error { return nil }
+func (m *recordingSandboxManager) ReleaseAll(context.Context) error      { return nil }
+func (m *recordingSandboxManager) Stop()                                 {}
+func (m *recordingSandboxManager) Stats() map[string]any                 { return nil }


### PR DESCRIPTION
## Summary

This fixes tenant-scoped runtime path resolution for managed agents, especially in cron and subagent flows.

Before:
- Cron and subagent `read_file` calls could resolve relative paths against the wrong fallback root instead of the active tenant scope.
- Team workspace auto-resolution could rebuild paths from a non-tenant-scoped base and point tenant runs at the wrong directory.
- Non-master tenant runs did not consistently carry `tenant_slug` through the loop context, so tools that derive tenant filesystem roots could fall back incorrectly.

After:
- Managed agent runs carry both `tenant_id` and `tenant_slug` through the loop and run context.
- Team workspace auto-resolution uses the tenant-scoped workspace root exactly once.
- `read_file` prefers the effective workspace first, then tenant-scoped allowlisted data roots, and keeps sandbox reads inside the mounted workspace.

## Changes

- propagated `tenant_slug` through agent loop config, run context, and context accessors
- updated managed resolver and team workspace auto-resolution to use tenant-scoped roots consistently
- taught `read_file` to support tenant-scoped data-dir fallback for allowlisted relative paths and to reject external fallback roots when sandboxed
- preserved parent `read_file` allow/deny configuration when rebuilding subagent tool registries
- added regression coverage for cron runs, tenant-scoped `read_file`, team workspace resolution, and subagent inherited allow paths

## Test plan

- `go build ./...`
- `go test ./cmd ./internal/agent ./internal/tools ./internal/store`
- Verified cron `read_file` behavior with tenant-scoped fallback coverage in `internal/agent/cron_readfile_test.go`
