### PR TITLE
fix(http): preserve tenant scope for multipart uploads

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -159,6 +159,7 @@ type authResult struct {
 	Authenticated bool
 	KeyData       *store.APIKeyData // non-nil when authenticated via API key
 	TenantID      uuid.UUID         // resolved tenant; always concrete after resolution
+	TenantSlug    string
 }
 
 // resolveAuth determines the caller's role from the request.
@@ -181,17 +182,7 @@ func resolveAuthWithBearer(r *http.Request, bearer string) authResult {
 			role = permissions.RoleOwner
 		}
 		res := authResult{Role: role, Authenticated: true}
-		tenantVal := r.Header.Get("X-GoClaw-Tenant-Id")
-		if pkgTenantCache != nil && tenantVal != "" {
-			// Resolve tenant from header (works for both owner and non-owner)
-			if tid, err := uuid.Parse(tenantVal); err == nil {
-				if t, err := pkgTenantCache.GetTenant(r.Context(), tid); err == nil && t != nil {
-					res.TenantID = t.ID
-				}
-			} else if t, err := pkgTenantCache.GetTenantBySlug(r.Context(), tenantVal); err == nil && t != nil {
-				res.TenantID = t.ID
-			}
-		}
+		res.TenantID, res.TenantSlug = resolveTenantScope(r.Context(), r.Header.Get("X-GoClaw-Tenant-Id"))
 		if res.TenantID == uuid.Nil {
 			res.TenantID = store.MasterTenantID
 		}
@@ -206,6 +197,7 @@ func resolveAuthWithBearer(r *http.Request, bearer string) authResult {
 			res.TenantID = store.MasterTenantID
 		} else {
 			res.TenantID = keyData.TenantID
+			res.TenantSlug = resolveTenantSlug(r.Context(), keyData.TenantID)
 		}
 		return res
 	}
@@ -213,7 +205,12 @@ func resolveAuthWithBearer(r *http.Request, bearer string) authResult {
 	if senderID := r.Header.Get("X-GoClaw-Sender-Id"); senderID != "" && pkgPairingStore != nil {
 		paired, err := pkgPairingStore.IsPaired(r.Context(), senderID, "browser")
 		if err == nil && paired {
-			return authResult{Role: permissions.RoleOperator, Authenticated: true, TenantID: store.MasterTenantID}
+			res := authResult{Role: permissions.RoleOperator, Authenticated: true}
+			res.TenantID, res.TenantSlug = resolveTenantScope(r.Context(), r.Header.Get("X-GoClaw-Tenant-Id"))
+			if res.TenantID == uuid.Nil {
+				res.TenantID = store.MasterTenantID
+			}
+			return res
 		}
 		if err != nil {
 			slog.Warn("security.http_pairing_check_failed", "sender_id", senderID, "error", err)
@@ -223,9 +220,40 @@ func resolveAuthWithBearer(r *http.Request, bearer string) authResult {
 	}
 	// No auth configured → admin (no token = dev/single-user mode, full access)
 	if pkgGatewayToken == "" {
-		return authResult{Role: permissions.RoleAdmin, Authenticated: true, TenantID: store.MasterTenantID}
+		res := authResult{Role: permissions.RoleAdmin, Authenticated: true}
+		res.TenantID, res.TenantSlug = resolveTenantScope(r.Context(), r.Header.Get("X-GoClaw-Tenant-Id"))
+		if res.TenantID == uuid.Nil {
+			res.TenantID = store.MasterTenantID
+		}
+		return res
 	}
 	return authResult{}
+}
+
+func resolveTenantScope(ctx context.Context, tenantVal string) (uuid.UUID, string) {
+	if pkgTenantCache == nil || tenantVal == "" {
+		return uuid.Nil, ""
+	}
+	if tid, err := uuid.Parse(tenantVal); err == nil {
+		if t, err := pkgTenantCache.GetTenant(ctx, tid); err == nil && t != nil {
+			return t.ID, t.Slug
+		}
+		return uuid.Nil, ""
+	}
+	if t, err := pkgTenantCache.GetTenantBySlug(ctx, tenantVal); err == nil && t != nil {
+		return t.ID, t.Slug
+	}
+	return uuid.Nil, ""
+}
+
+func resolveTenantSlug(ctx context.Context, tenantID uuid.UUID) string {
+	if pkgTenantCache == nil || tenantID == uuid.Nil || tenantID == store.MasterTenantID {
+		return ""
+	}
+	if t, err := pkgTenantCache.GetTenant(ctx, tenantID); err == nil && t != nil {
+		return t.Slug
+	}
+	return ""
 }
 
 // httpMinRole returns the minimum role required for an HTTP endpoint based on HTTP method.
@@ -238,7 +266,7 @@ func httpMinRole(method string) permissions.Role {
 	}
 }
 
-// enrichContext injects locale, role, userID, and tenantID from authResult into ctx.
+// enrichContext injects locale, role, userID, tenantID, and tenant slug from authResult into ctx.
 // Used by requireAuth middleware and ServeHTTP handlers that do their own auth checks.
 func enrichContext(ctx context.Context, r *http.Request, auth authResult) context.Context {
 	ctx = store.WithLocale(ctx, extractLocale(r))
@@ -262,6 +290,9 @@ func enrichContext(ctx context.Context, r *http.Request, auth authResult) contex
 		tenantID = store.MasterTenantID
 	}
 	ctx = store.WithTenantID(ctx, tenantID)
+	if auth.TenantSlug != "" {
+		ctx = store.WithTenantSlug(ctx, auth.TenantSlug)
+	}
 	slog.Debug("security.http_auth_resolved",
 		"path", r.URL.Path,
 		"role", string(auth.Role),

--- a/internal/http/auth_test.go
+++ b/internal/http/auth_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,6 +33,21 @@ func setupTestToken(t *testing.T, token string) {
 	old := pkgGatewayToken
 	pkgGatewayToken = token
 	t.Cleanup(func() { pkgGatewayToken = old })
+}
+
+func setupTestTenantStore(t *testing.T, tenants ...*store.TenantData) {
+	t.Helper()
+	ts := newMockTenantStore(tenants...)
+	old := pkgTenantCache
+	pkgTenantCache = newTenantCache(ts, 5*time.Minute)
+	t.Cleanup(func() { pkgTenantCache = old })
+}
+
+func setupTestPairingStore(t *testing.T, paired bool) {
+	t.Helper()
+	old := pkgPairingStore
+	pkgPairingStore = mockPairingStore{paired: paired}
+	t.Cleanup(func() { pkgPairingStore = old })
 }
 
 func TestResolveAuth_GatewayToken(t *testing.T) {
@@ -227,6 +243,69 @@ func TestRequireAuth_InjectLocaleAndUserID(t *testing.T) {
 	}
 }
 
+func TestRequireAuth_InjectsTenantScopeFromHeader(t *testing.T) {
+	setupTestCache(t, nil)
+	setupTestToken(t, "secret")
+	tenantID := uuid.MustParse("0193a5b0-7000-7000-8000-000000000222")
+	setupTestTenantStore(t, &store.TenantData{ID: tenantID, Slug: "tenant-zalo"})
+
+	var gotTenantID uuid.UUID
+	var gotTenantSlug string
+	handler := requireAuth("", func(w http.ResponseWriter, r *http.Request) {
+		gotTenantID = store.TenantIDFromContext(r.Context())
+		gotTenantSlug = store.TenantSlugFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := httptest.NewRequest("GET", "/v1/storage/files", nil)
+	r.Header.Set("Authorization", "Bearer secret")
+	r.Header.Set("X-GoClaw-Tenant-Id", "tenant-zalo")
+	w := httptest.NewRecorder()
+	handler(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if gotTenantID != tenantID {
+		t.Fatalf("tenantID = %s, want %s", gotTenantID, tenantID)
+	}
+	if gotTenantSlug != "tenant-zalo" {
+		t.Fatalf("tenantSlug = %q, want tenant-zalo", gotTenantSlug)
+	}
+}
+
+func TestRequireAuth_BrowserPairingHonorsTenantHeader(t *testing.T) {
+	setupTestCache(t, nil)
+	setupTestToken(t, "secret-token-not-used")
+	setupTestPairingStore(t, true)
+	tenantID := uuid.MustParse("0193a5b0-7000-7000-8000-000000000223")
+	setupTestTenantStore(t, &store.TenantData{ID: tenantID, Slug: "tenant-paired"})
+
+	var gotTenantID uuid.UUID
+	var gotTenantSlug string
+	handler := requireAuth("", func(w http.ResponseWriter, r *http.Request) {
+		gotTenantID = store.TenantIDFromContext(r.Context())
+		gotTenantSlug = store.TenantSlugFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := httptest.NewRequest("GET", "/v1/storage/files", nil)
+	r.Header.Set("X-GoClaw-Sender-Id", "browser-device-1")
+	r.Header.Set("X-GoClaw-Tenant-Id", "tenant-paired")
+	w := httptest.NewRecorder()
+	handler(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if gotTenantID != tenantID {
+		t.Fatalf("tenantID = %s, want %s", gotTenantID, tenantID)
+	}
+	if gotTenantSlug != "tenant-paired" {
+		t.Fatalf("tenantSlug = %q, want tenant-paired", gotTenantSlug)
+	}
+}
+
 func TestRequireAuth_AdminRoleEnforced(t *testing.T) {
 	// No auth configured → admin role (dev/single-user mode) → admin endpoint accessible
 	setupTestCache(t, nil)
@@ -326,3 +405,73 @@ func TestInitAPIKeyCache_IgnoresOtherKinds(t *testing.T) {
 		t.Errorf("calls = %d, want 1 (non-api_keys kind should not invalidate)", ms.getCalls())
 	}
 }
+
+type mockTenantStore struct {
+	byID   map[uuid.UUID]*store.TenantData
+	bySlug map[string]*store.TenantData
+}
+
+func newMockTenantStore(tenants ...*store.TenantData) *mockTenantStore {
+	m := &mockTenantStore{
+		byID:   make(map[uuid.UUID]*store.TenantData, len(tenants)),
+		bySlug: make(map[string]*store.TenantData, len(tenants)),
+	}
+	for _, tenant := range tenants {
+		if tenant == nil {
+			continue
+		}
+		m.byID[tenant.ID] = tenant
+		m.bySlug[tenant.Slug] = tenant
+	}
+	return m
+}
+
+func (m *mockTenantStore) CreateTenant(context.Context, *store.TenantData) error { return nil }
+func (m *mockTenantStore) GetTenant(_ context.Context, id uuid.UUID) (*store.TenantData, error) {
+	return m.byID[id], nil
+}
+func (m *mockTenantStore) GetTenantBySlug(_ context.Context, slug string) (*store.TenantData, error) {
+	return m.bySlug[slug], nil
+}
+func (m *mockTenantStore) ListTenants(context.Context) ([]store.TenantData, error) { return nil, nil }
+func (m *mockTenantStore) UpdateTenant(context.Context, uuid.UUID, map[string]any) error {
+	return nil
+}
+func (m *mockTenantStore) AddUser(context.Context, uuid.UUID, string, string) error { return nil }
+func (m *mockTenantStore) RemoveUser(context.Context, uuid.UUID, string) error      { return nil }
+func (m *mockTenantStore) GetUserRole(context.Context, uuid.UUID, string) (string, error) {
+	return "", nil
+}
+func (m *mockTenantStore) ListUsers(context.Context, uuid.UUID) ([]store.TenantUserData, error) {
+	return nil, nil
+}
+func (m *mockTenantStore) ListUserTenants(context.Context, string) ([]store.TenantUserData, error) {
+	return nil, nil
+}
+func (m *mockTenantStore) ResolveUserTenant(context.Context, string) (uuid.UUID, error) {
+	return store.MasterTenantID, nil
+}
+func (m *mockTenantStore) GetTenantUser(context.Context, uuid.UUID) (*store.TenantUserData, error) {
+	return nil, nil
+}
+func (m *mockTenantStore) CreateTenantUserReturning(context.Context, uuid.UUID, string, string, string) (*store.TenantUserData, error) {
+	return nil, nil
+}
+
+type mockPairingStore struct {
+	paired bool
+}
+
+func (m mockPairingStore) RequestPairing(context.Context, string, string, string, string, map[string]string) (string, error) {
+	return "", nil
+}
+func (m mockPairingStore) ApprovePairing(context.Context, string, string) (*store.PairedDeviceData, error) {
+	return nil, nil
+}
+func (m mockPairingStore) DenyPairing(context.Context, string) error           { return nil }
+func (m mockPairingStore) RevokePairing(context.Context, string, string) error { return nil }
+func (m mockPairingStore) IsPaired(context.Context, string, string) (bool, error) {
+	return m.paired, nil
+}
+func (m mockPairingStore) ListPending(context.Context) []store.PairingRequestData { return nil }
+func (m mockPairingStore) ListPaired(context.Context) []store.PairedDeviceData    { return nil }

--- a/ui/web/src/api/http-client.ts
+++ b/ui/web/src/api/http-client.ts
@@ -69,15 +69,9 @@ export class HttpClient {
   }
 
   async upload<T>(path: string, formData: FormData): Promise<T> {
-    const headers: Record<string, string> = {};
-    const token = this.getToken();
-    if (token) headers["Authorization"] = `Bearer ${token}`;
-    const userId = this.getUserId();
-    if (userId) headers["X-GoClaw-User-Id"] = userId;
-
     const res = await fetch(this.buildUrl(path), {
       method: "POST",
-      headers,
+      headers: this.authHeaders(),
       body: formData,
     });
 
@@ -111,8 +105,8 @@ export class HttpClient {
     if (userId) h["X-GoClaw-User-Id"] = userId;
     const senderID = this.getSenderID();
     if (senderID) h["X-GoClaw-Sender-Id"] = senderID;
-    // Tenant scope: narrow cross-tenant admin to a specific tenant
-    const tenantScope = localStorage.getItem("goclaw:tenant_id");
+    // Tenant scope: owner flows persist tenant_id, browser-paired tenant users persist tenant_hint.
+    const tenantScope = localStorage.getItem("goclaw:tenant_id") || localStorage.getItem("goclaw:tenant_hint");
     if (tenantScope) h["X-GoClaw-Tenant-Id"] = tenantScope;
     return h;
   }


### PR DESCRIPTION
## Summary

This fixes tenant-scoped HTTP requests that lost their active tenant when the web app used multipart uploads or browser-paired auth.

Before:
- `HttpClient.upload()` sent a reduced header set, so multipart uploads could drop `X-GoClaw-Tenant-Id` and fall back to master scope.
- Browser-paired HTTP requests defaulted to the master tenant even when the selected tenant was provided in request headers.
- HTTP handlers that derive filesystem paths from both tenant ID and slug could resolve the wrong storage root because auth context only preserved the tenant ID.

After:
- Multipart uploads reuse the standard authenticated header set, including sender and tenant scope headers.
- HTTP auth resolves tenant scope for browser-paired and gateway-token requests from `X-GoClaw-Tenant-Id`.
- The HTTP request context now carries both `tenant_id` and `tenant_slug`, so tenant-scoped storage resolution stays aligned across handlers.

## Changes

- added tenant slug to the HTTP auth result and request context enrichment path
- resolved tenant ID and slug together from `X-GoClaw-Tenant-Id` for gateway-token and browser-paired requests
- updated `HttpClient.upload()` to reuse the shared auth headers instead of constructing a partial header set
- added auth regression tests covering tenant-scoped gateway-token and browser-paired HTTP requests

## Test plan

- `go test ./internal/http`
- `pnpm build`
