### PR TITLE
fix(ui): show env var inputs for manual CLI credentials

### DIFF
--- a/ui/web/src/i18n/locales/en/cli-credentials.json
+++ b/ui/web/src/i18n/locales/en/cli-credentials.json
@@ -33,7 +33,9 @@
     "agentIdHint": "optional — leave blank for global",
     "commaSeparated": "comma-separated",
     "binaryNameRequired": "Binary name is required.",
-    "failedToSave": "Failed to save."
+    "failedToSave": "Failed to save.",
+    "addEnvVar": "Add Variable",
+    "manualEnvHint": "Add environment variables that will be injected when this CLI runs (e.g. API tokens, access keys)."
   },
   "placeholders": {
     "binaryName": "e.g. gh",
@@ -42,7 +44,9 @@
     "denyArgs": "--admin, --force",
     "denyVerbose": "-v, --verbose",
     "tips": "Usage tips for the agent",
-    "agentId": "agent-id"
+    "agentId": "agent-id",
+    "envKey": "VARIABLE_NAME",
+    "envValue": "secret value"
   },
   "toast": {
     "created": "CLI credential created",

--- a/ui/web/src/i18n/locales/vi/cli-credentials.json
+++ b/ui/web/src/i18n/locales/vi/cli-credentials.json
@@ -33,7 +33,9 @@
     "agentIdHint": "tùy chọn — để trống cho toàn cục",
     "commaSeparated": "phân cách bằng dấu phẩy",
     "binaryNameRequired": "Tên binary là bắt buộc.",
-    "failedToSave": "Không thể lưu."
+    "failedToSave": "Không thể lưu.",
+    "addEnvVar": "Thêm biến",
+    "manualEnvHint": "Thêm biến môi trường sẽ được inject khi CLI này chạy (vd: API token, access key)."
   },
   "placeholders": {
     "binaryName": "vd: gh",
@@ -42,7 +44,9 @@
     "denyArgs": "--admin, --force",
     "denyVerbose": "-v, --verbose",
     "tips": "Mẹo sử dụng cho agent",
-    "agentId": "agent-id"
+    "agentId": "agent-id",
+    "envKey": "TEN_BIEN",
+    "envValue": "giá trị bí mật"
   },
   "toast": {
     "created": "Đã tạo thông tin CLI",

--- a/ui/web/src/i18n/locales/zh/cli-credentials.json
+++ b/ui/web/src/i18n/locales/zh/cli-credentials.json
@@ -33,7 +33,9 @@
     "agentIdHint": "可选 — 留空表示全局",
     "commaSeparated": "逗号分隔",
     "binaryNameRequired": "二进制名称为必填项。",
-    "failedToSave": "保存失败。"
+    "failedToSave": "保存失败。",
+    "addEnvVar": "添加变量",
+    "manualEnvHint": "添加运行此 CLI 时注入的环境变量（如 API 令牌、访问密钥）。"
   },
   "placeholders": {
     "binaryName": "例如 gh",
@@ -42,7 +44,9 @@
     "denyArgs": "--admin, --force",
     "denyVerbose": "-v, --verbose",
     "tips": "给代理的使用提示",
-    "agentId": "agent-id"
+    "agentId": "agent-id",
+    "envKey": "变量名称",
+    "envValue": "秘密值"
   },
   "toast": {
     "created": "CLI 凭证已创建",

--- a/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
+++ b/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { Plus, X } from "lucide-react";
 import {
   Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from "@/components/ui/dialog";
@@ -13,6 +14,13 @@ import {
 } from "@/components/ui/select";
 import type { SecureCLIBinary, CLICredentialInput, CLIPreset } from "./hooks/use-cli-credentials";
 
+/** A single manual env var entry with stable identity for React keys. */
+interface ManualEnvEntry {
+  id: number;
+  key: string;
+  value: string;
+}
+
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -22,6 +30,7 @@ interface Props {
 }
 
 const NONE_PRESET = "__none__";
+let nextManualId = 1;
 
 export function CliCredentialFormDialog({ open, onOpenChange, credential, presets, onSubmit }: Props) {
   const { t } = useTranslation("cli-credentials");
@@ -38,6 +47,7 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
   const [agentId, setAgentId] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [envValues, setEnvValues] = useState<Record<string, string>>({});
+  const [manualEnvEntries, setManualEnvEntries] = useState<ManualEnvEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -50,6 +60,9 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
   // Current preset definition (for env var fields)
   const activePreset: CLIPreset | null =
     selectedPreset !== NONE_PRESET ? (presets[selectedPreset] ?? null) : null;
+
+  // Whether to show the manual env var section (no preset selected)
+  const showManualEnv = !activePreset;
 
   useEffect(() => {
     if (!open) return;
@@ -64,12 +77,17 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
     setAgentId(credential?.agent_id ?? "");
     setEnabled(credential?.enabled ?? true);
     setEnvValues({});
+    setManualEnvEntries([]);
     setError("");
   }, [open, credential]);
 
   const applyPreset = (key: string) => {
     setSelectedPreset(key);
-    if (key === NONE_PRESET) return;
+    if (key === NONE_PRESET) {
+      // Switching to manual — clear preset env values, keep manual entries
+      setEnvValues({});
+      return;
+    }
     const p = presets[key];
     if (!p) return;
     setBinaryName(p.binary_name);
@@ -79,6 +97,32 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
     setTimeout(p.timeout);
     setTips(p.tips);
     setEnvValues({});
+    setManualEnvEntries([]);
+  };
+
+  const addManualEnvEntry = () => {
+    setManualEnvEntries((prev) => [...prev, { id: nextManualId++, key: "", value: "" }]);
+  };
+
+  const removeManualEnvEntry = (id: number) => {
+    setManualEnvEntries((prev) => prev.filter((e) => e.id !== id));
+  };
+
+  const updateManualEnvEntry = (id: number, field: "key" | "value", val: string) => {
+    setManualEnvEntries((prev) =>
+      prev.map((e) => (e.id === id ? { ...e, [field]: val } : e)),
+    );
+  };
+
+  /** Merge manual env entries into a flat key-value map. */
+  const buildEnvPayload = (): Record<string, string> => {
+    if (activePreset) return envValues;
+    const merged: Record<string, string> = { ...envValues };
+    for (const entry of manualEnvEntries) {
+      const k = entry.key.trim();
+      if (k && entry.value) merged[k] = entry.value;
+    }
+    return merged;
   };
 
   const splitCommaList = (v: string): string[] =>
@@ -92,6 +136,7 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
     setLoading(true);
     setError("");
     try {
+      const env = buildEnvPayload();
       const payload: CLICredentialInput = {
         binary_name: binaryName.trim(),
         binary_path: binaryPath.trim() || undefined,
@@ -104,7 +149,7 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
         enabled,
       };
       if (selectedPreset !== NONE_PRESET) payload.preset = selectedPreset;
-      if (Object.keys(envValues).length > 0) payload.env = envValues;
+      if (Object.keys(env).length > 0) payload.env = env;
       await onSubmit(payload);
       onOpenChange(false);
     } catch (err) {
@@ -174,6 +219,53 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
                   {ev.desc && (
                     <p className="text-xs text-muted-foreground">{ev.desc}</p>
                   )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Manual env var key-value entries (no preset selected) */}
+          {showManualEnv && (
+            <div className="grid gap-3 rounded-md border p-3">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">{t("form.envVars")}</p>
+                <Button type="button" variant="outline" size="sm" onClick={addManualEnvEntry}>
+                  <Plus className="mr-1 h-3.5 w-3.5" />
+                  {t("form.addEnvVar")}
+                </Button>
+              </div>
+              {manualEnvEntries.length === 0 && (
+                <p className="text-xs text-muted-foreground">{t("form.manualEnvHint")}</p>
+              )}
+              {manualEnvEntries.map((entry) => (
+                <div key={entry.id} className="flex items-start gap-2">
+                  <div className="grid flex-1 gap-1.5">
+                    <Input
+                      placeholder={t("placeholders.envKey")}
+                      value={entry.key}
+                      onChange={(e) => updateManualEnvEntry(entry.id, "key", e.target.value)}
+                      className="text-base md:text-sm font-mono"
+                    />
+                  </div>
+                  <div className="grid flex-1 gap-1.5">
+                    <Input
+                      type="password"
+                      autoComplete="off"
+                      placeholder={t("placeholders.envValue")}
+                      value={entry.value}
+                      onChange={(e) => updateManualEnvEntry(entry.id, "value", e.target.value)}
+                      className="text-base md:text-sm"
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 shrink-0"
+                    onClick={() => removeManualEnvEntry(entry.id)}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary

Fixes #477

- Added dynamic key-value env var entry UI when "Manual (no preset)" is selected in CLI Credentials form
- Users can add/remove env var entries with name + masked value fields
- Manual entries merge into the `env` payload on submit
- Added i18n keys for all 3 locales (en/vi/zh)

## Changes

- `ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx` — manual env var section with add/remove
- `ui/web/src/i18n/locales/{en,vi,zh}/cli-credentials.json` — new i18n keys

## Test plan

- [ ] Open CLI Credentials → Add Credential
- [ ] Select "No preset (manual)" — env var section should appear
- [ ] Add env var entries (name + value), verify they submit correctly
- [ ] Switch between preset and manual mode — verify state resets properly
- [ ] Edit existing credential — verify env var section shows for re-entry