### PR TITLE
fix(http): add missing fields to update allowlists

### DIFF
--- a/internal/http/validate.go
+++ b/internal/http/validate.go
@@ -58,7 +58,7 @@ var customToolAllowedFields = map[string]bool{
 var mcpServerAllowedFields = map[string]bool{
 	"name": true, "transport": true, "command": true, "args": true,
 	"url": true, "api_key": true, "env": true, "headers": true,
-	"enabled": true, "tool_prefix": true, "timeout_seconds": true,
+	"enabled": true, "tool_prefix": true, "timeout_sec": true,
 	"agent_id": true, "config": true, "settings": true,
 }
 
@@ -66,4 +66,5 @@ var channelInstanceAllowedFields = map[string]bool{
 	"channel_type": true, "credentials": true, "agent_id": true,
 	"enabled": true, "group_policy": true, "allow_from": true,
 	"metadata": true, "webhook_secret": true, "config": true,
+	"display_name": true,
 }


### PR DESCRIPTION
## Summary
- Add `display_name` to `channelInstanceAllowedFields` — channel rename was silently dropped by `filterAllowedKeys()`
- Fix `timeout_seconds` → `timeout_sec` in `mcpServerAllowedFields` to match DB column and frontend field name

## Root Cause
`filterAllowedKeys()` strips unknown fields and logs `security.filtered_unknown_field`. The frontend sent `display_name` correctly, backend returned 200 OK but never persisted the value.

## Test plan
- [x] Rename channel display name → persists after page refresh
- [x] Update MCP server timeout → persists after page refresh

Closes #463