### PR TITLE
fix(providers): Ollama provider registration + Docker localhost rewrite

### DIFF
--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -279,7 +279,7 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			if host == "" {
 				host = "http://localhost:11434"
 			}
-			registry.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, "ollama", host+"/v1", "llama3.3"))
+			registry.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, "ollama", config.DockerLocalhost(host+"/v1"), "llama3.3"))
 			slog.Info("registered provider from DB", "name", p.Name)
 			continue
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
     volumes:
       - goclaw-data:/app/data
       - goclaw-workspace:/app/workspace
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     security_opt:
       - no-new-privileges:true
     init: true

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+var (
+	dockerOnce   sync.Once
+	dockerCached bool
+)
+
+// InDocker returns true when running inside a Docker container.
+// Result is cached after the first call.
+func InDocker() bool {
+	dockerOnce.Do(func() {
+		_, err := os.Stat("/.dockerenv")
+		dockerCached = err == nil
+	})
+	return dockerCached
+}
+
+// DockerLocalhost rewrites localhost in url to host.docker.internal
+// when running inside Docker, so the container can reach host services.
+// Returns the url unchanged when not in Docker or when it doesn't contain localhost.
+func DockerLocalhost(url string) string {
+	if InDocker() && strings.Contains(url, "localhost") {
+		return strings.Replace(url, "localhost", "host.docker.internal", 1)
+	}
+	return url
+}

--- a/internal/http/provider_verify.go
+++ b/internal/http/provider_verify.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
@@ -139,8 +139,7 @@ func (h *ProvidersHandler) handleClaudeCLIAuthStatus(w http.ResponseWriter, r *h
 		}
 	}
 
-	_, dockerErr := os.Stat("/.dockerenv")
-	inDocker := dockerErr == nil
+	inDocker := config.InDocker()
 
 	status, err := providers.CheckClaudeAuthStatus(ctx, cliPath)
 	if err != nil {

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/oauth"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
@@ -139,6 +140,12 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 			cliOpts = append(cliOpts, providers.WithClaudeCLIMCPConfigData(mcpData))
 		}
 		h.providerReg.RegisterForTenant(p.TenantID, providers.NewClaudeCLIProvider(cliPath, cliOpts...))
+		return
+	}
+	// Ollama doesn't need an API key — inject a dummy value like startup does.
+	// In Docker, swap localhost → host.docker.internal so the container can reach the host.
+	if p.ProviderType == store.ProviderOllama {
+		h.providerReg.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, "ollama", config.DockerLocalhost(p.APIBase), "llama3.3"))
 		return
 	}
 	if p.APIKey == "" {


### PR DESCRIPTION
## Summary
Fixes #470

- **Root cause:** `registerInMemory()` in `internal/http/providers.go` skipped providers with empty `APIKey`, but Ollama doesn't need one. The startup code (`cmd/gateway_providers.go`) had a special case for Ollama — the HTTP create handler did not.
- **Docker fix:** Inside Docker, `localhost:11434` points to the container, not the host. Auto-rewrite to `host.docker.internal` when `/.dockerenv` is detected.
- **Refactor:** Extract `config.InDocker()` (cached) and `config.DockerLocalhost()` into `internal/config/runtime.go` for reuse across packages.
- **docker-compose:** Add `extra_hosts: host.docker.internal:host-gateway` for Linux compatibility.

## Files changed
- `internal/http/providers.go` — Ollama special case in `registerInMemory()`, use `config.DockerLocalhost()`
- `cmd/gateway_providers.go` — use `config.DockerLocalhost()` for startup DB registration
- `internal/config/runtime.go` — new: `InDocker()`, `DockerLocalhost()` helpers
- `internal/http/provider_verify.go` — use `config.InDocker()` instead of inline check
- `docker-compose.yml` — add `extra_hosts` for Linux Docker

## Test plan
- [x] Verified Ollama provider creation + model verification works in Docker setup wizard
- [x] `go build ./...` and `go vet ./...` pass
- [x] Test on Linux Docker host to confirm `host.docker.internal` resolves correctly