### PR TITLE
fix(web): send cron updates under patch

### DIFF
--- a/ui/web/src/pages/cron/hooks/use-cron.ts
+++ b/ui/web/src/pages/cron/hooks/use-cron.ts
@@ -152,7 +152,8 @@ export function useCron() {
   const updateJob = useCallback(
     async (jobId: string, params: Record<string, unknown>) => {
       try {
-        await ws.call(Methods.CRON_UPDATE, { jobId, ...params });
+        // The gateway expects cron updates nested under `patch`.
+        await ws.call(Methods.CRON_UPDATE, { jobId, patch: params });
         await invalidate();
         toast.success(i18next.t("cron:toast.updated"));
       } catch (err) {


### PR DESCRIPTION
## Summary

Fix the cron detail save flow in the web UI by sending `cron.update` fields under the nested `patch` object that the gateway expects.

Before:
- Editing a cron job in the overview tab or advanced dialog sent update fields at the top level.
- The gateway only reads `cron.update` changes from `patch`, so Save could complete without persisting any data.

After:
- The shared cron update hook sends `{ jobId, patch }`, matching the gateway contract.
- Saving cron detail changes now submits a payload the backend can apply.

## Changes

- Wrap cron update params under `patch` in the shared `useCron().updateJob` hook.
- Keep the fix centralized so both cron detail save surfaces use the corrected request shape.

## Test plan

- Verified the shared cron update hook now matches the gateway request contract by sending nested `patch` data instead of top-level fields (`ui/web/src/pages/cron/hooks/use-cron.ts` vs. `internal/gateway/methods/cron.go`).
- Verified the web app still type-checks and builds successfully after the contract change, covering the cron overview and advanced dialog paths that share this hook (`pnpm build` in `ui/web`).
