### PR TITLE
fix(docker): remove manual network creation causing Compose label mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo dev)
 LDFLAGS  = -s -w -X github.com/nextlevelbuilder/goclaw/cmd.Version=$(VERSION)
 BINARY   = goclaw
 
-.PHONY: build run clean version net up down logs reset test vet check-web dev migrate setup ci desktop-dev desktop-build desktop-dmg
+.PHONY: build run clean version up down logs reset test vet check-web dev migrate setup ci desktop-dev desktop-build desktop-dmg
 
 build:
 	CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o $(BINARY) .
@@ -36,13 +36,10 @@ endif
 COMPOSE = $(COMPOSE_BASE) $(COMPOSE_EXTRA)
 UPGRADE = docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.upgrade.yml
 
-net:
-	docker network inspect goclaw-net >/dev/null 2>&1 || docker network create goclaw-net
-
 version-file:
 	@echo $(VERSION) > VERSION
 
-up: net version-file
+up: version-file
 	$(COMPOSE) up -d --build
 	$(UPGRADE) run --rm upgrade
 
@@ -52,7 +49,7 @@ down:
 logs:
 	$(COMPOSE) logs -f goclaw
 
-reset: net version-file
+reset: version-file
 	$(COMPOSE) down -v
 	$(COMPOSE) up -d --build
 


### PR DESCRIPTION
## Summary

- Remove the Makefile `net` target that manually creates `goclaw-net` via `docker network create`
- Remove `net` dependency from `up` and `reset` targets
- Docker Compose already defines and manages this network automatically with correct labels

## Problem

`make up` fails on macOS (Docker Desktop) with:
```
network goclaw-net was found but has incorrect label com.docker.compose.network set to "" (expected: "goclaw-net")
```

The `net` target creates the network without the `com.docker.compose.network` label that Docker Compose expects. Since `docker-compose.yml` already declares `goclaw-net` as a Compose-managed network, the manual creation is redundant and causes this conflict.

## Test plan

- [ ] Run `docker network rm goclaw-net` to clean stale network (if exists)
- [ ] Run `make up` — should succeed without label mismatch error
- [ ] Run `make reset` — should succeed without label mismatch error
- [ ] Verify `docker network inspect goclaw-net` shows correct Compose labels

Closes #488