### PR TITLE
fix(ui): show env var input for manual CLI credentials

### DIFF
--- a/ui/web/src/i18n/locales/en/cli-credentials.json
+++ b/ui/web/src/i18n/locales/en/cli-credentials.json
@@ -33,7 +33,11 @@
     "agentIdHint": "optional — leave blank for global",
     "commaSeparated": "comma-separated",
     "binaryNameRequired": "Binary name is required.",
-    "failedToSave": "Failed to save."
+    "failedToSave": "Failed to save.",
+    "addEnvVar": "Add Variable",
+    "noEnvVarsHint": "Click \"Add Variable\" to define environment variables for this CLI tool.",
+    "envKeyPlaceholder": "ENV_VAR_NAME",
+    "envValuePlaceholder": "value"
   },
   "placeholders": {
     "binaryName": "e.g. gh",

--- a/ui/web/src/i18n/locales/vi/cli-credentials.json
+++ b/ui/web/src/i18n/locales/vi/cli-credentials.json
@@ -33,7 +33,11 @@
     "agentIdHint": "tùy chọn — để trống cho toàn cục",
     "commaSeparated": "phân cách bằng dấu phẩy",
     "binaryNameRequired": "Tên binary là bắt buộc.",
-    "failedToSave": "Không thể lưu."
+    "failedToSave": "Không thể lưu.",
+    "addEnvVar": "Thêm biến",
+    "noEnvVarsHint": "Nhấn \"Thêm biến\" để khai báo biến môi trường cho công cụ CLI này.",
+    "envKeyPlaceholder": "TÊN_BIẾN",
+    "envValuePlaceholder": "giá trị"
   },
   "placeholders": {
     "binaryName": "vd: gh",

--- a/ui/web/src/i18n/locales/zh/cli-credentials.json
+++ b/ui/web/src/i18n/locales/zh/cli-credentials.json
@@ -33,7 +33,11 @@
     "agentIdHint": "可选 — 留空表示全局",
     "commaSeparated": "逗号分隔",
     "binaryNameRequired": "二进制名称为必填项。",
-    "failedToSave": "保存失败。"
+    "failedToSave": "保存失败。",
+    "addEnvVar": "添加变量",
+    "noEnvVarsHint": "点击\"添加变量\"为此 CLI 工具定义环境变量。",
+    "envKeyPlaceholder": "变量名",
+    "envValuePlaceholder": "值"
   },
   "placeholders": {
     "binaryName": "例如 gh",

--- a/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
+++ b/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
@@ -11,7 +11,13 @@ import { Switch } from "@/components/ui/switch";
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
+import { Plus, X } from "lucide-react";
 import type { SecureCLIBinary, CLICredentialInput, CLIPreset } from "./hooks/use-cli-credentials";
+
+interface ManualEnvEntry {
+  key: string;
+  value: string;
+}
 
 interface Props {
   open: boolean;
@@ -38,18 +44,19 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
   const [agentId, setAgentId] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [envValues, setEnvValues] = useState<Record<string, string>>({});
+  const [manualEnvEntries, setManualEnvEntries] = useState<ManualEnvEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
   const isEdit = !!credential;
-  // Build typed entry list to avoid noUncheckedIndexedAccess issues
   const presetEntries: Array<[string, CLIPreset]> = Object.entries(presets).filter(
     (e): e is [string, CLIPreset] => e[1] !== undefined,
   );
 
-  // Current preset definition (for env var fields)
   const activePreset: CLIPreset | null =
     selectedPreset !== NONE_PRESET ? (presets[selectedPreset] ?? null) : null;
+
+  const isManualMode = selectedPreset === NONE_PRESET;
 
   useEffect(() => {
     if (!open) return;
@@ -64,6 +71,7 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
     setAgentId(credential?.agent_id ?? "");
     setEnabled(credential?.enabled ?? true);
     setEnvValues({});
+    setManualEnvEntries([]);
     setError("");
   }, [open, credential]);
 
@@ -79,10 +87,35 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
     setTimeout(p.timeout);
     setTips(p.tips);
     setEnvValues({});
+    setManualEnvEntries([]);
   };
+
+  const addManualEnvEntry = useCallback(() => {
+    setManualEnvEntries((prev) => [...prev, { key: "", value: "" }]);
+  }, []);
+
+  const removeManualEnvEntry = useCallback((index: number) => {
+    setManualEnvEntries((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const updateManualEnvEntry = useCallback((index: number, field: "key" | "value", val: string) => {
+    setManualEnvEntries((prev) =>
+      prev.map((entry, i) => (i === index ? { ...entry, [field]: val } : entry)),
+    );
+  }, []);
 
   const splitCommaList = (v: string): string[] =>
     v.split(",").map((s) => s.trim()).filter(Boolean);
+
+  const buildEnvPayload = (): Record<string, string> => {
+    if (!isManualMode) return envValues;
+    const env: Record<string, string> = {};
+    for (const entry of manualEnvEntries) {
+      const k = entry.key.trim();
+      if (k && entry.value) env[k] = entry.value;
+    }
+    return env;
+  };
 
   const handleSubmit = async () => {
     if (!binaryName.trim()) {
@@ -104,7 +137,8 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
         enabled,
       };
       if (selectedPreset !== NONE_PRESET) payload.preset = selectedPreset;
-      if (Object.keys(envValues).length > 0) payload.env = envValues;
+      const env = buildEnvPayload();
+      if (Object.keys(env).length > 0) payload.env = env;
       await onSubmit(payload);
       onOpenChange(false);
     } catch (err) {
@@ -174,6 +208,53 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
                   {ev.desc && (
                     <p className="text-xs text-muted-foreground">{ev.desc}</p>
                   )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Manual env var entries (no preset selected) */}
+          {isManualMode && (
+            <div className="grid gap-3 rounded-md border p-3">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">{t("form.envVars")}</p>
+                <Button type="button" variant="outline" size="sm" onClick={addManualEnvEntry}>
+                  <Plus className="mr-1 h-3.5 w-3.5" />
+                  {t("form.addEnvVar")}
+                </Button>
+              </div>
+              {manualEnvEntries.length === 0 && (
+                <p className="text-xs text-muted-foreground">{t("form.noEnvVarsHint")}</p>
+              )}
+              {manualEnvEntries.map((entry, idx) => (
+                <div key={idx} className="flex items-start gap-2">
+                  <div className="grid flex-1 gap-1.5">
+                    <Input
+                      placeholder={t("form.envKeyPlaceholder")}
+                      value={entry.key}
+                      onChange={(e) => updateManualEnvEntry(idx, "key", e.target.value)}
+                      className="text-base md:text-sm font-mono"
+                    />
+                  </div>
+                  <div className="grid flex-1 gap-1.5">
+                    <Input
+                      type="password"
+                      autoComplete="off"
+                      placeholder={t("form.envValuePlaceholder")}
+                      value={entry.value}
+                      onChange={(e) => updateManualEnvEntry(idx, "value", e.target.value)}
+                      className="text-base md:text-sm"
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="mt-0.5 h-8 w-8 shrink-0"
+                    onClick={() => removeManualEnvEntry(idx)}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary

- Fix missing env var input section when adding CLI credentials with "Manual (no preset)" mode
- Add dynamic key-value form (add/remove entries) for custom environment variables
- Add i18n translations for new UI elements (en, vi, zh)

Closes #477

## Root Cause

The env var section only rendered when `activePreset` was non-null. Selecting "Manual (no preset)" sets `activePreset = null`, hiding the entire section — users couldn't input API keys or tokens for custom CLI tools.

## Changes

- `cli-credential-form-dialog.tsx`: Add `manualEnvEntries` state with dynamic add/remove UI when no preset is selected. Preset mode behavior unchanged.
- `cli-credentials.json` (en/vi/zh): Add 4 new i18n keys (`addEnvVar`, `noEnvVarsHint`, `envKeyPlaceholder`, `envValuePlaceholder`)

## Test plan

- [ ] Open CLI Credentials → Add Credential → select "Manual (no preset)" → verify env var section appears with "Add Variable" button
- [ ] Add multiple env var entries, verify key/value inputs work (value is masked)
- [ ] Remove env var entries via X button
- [ ] Submit form → verify env vars are sent in payload
- [ ] Select a preset → verify original preset env var fields still work
- [ ] Edit existing credential → verify manual env section shows in edit mode
- [ ] Test all 3 locales (en, vi, zh) for new strings