### PR TITLE
fix(docker): Claude CLI overlay + sandbox capability fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,9 @@ POSTGRES_PASSWORD=
 # Docker Compose auto-builds this from POSTGRES_USER/PASSWORD/DB.
 # GOCLAW_POSTGRES_DSN=postgres://user:pass@host:5432/dbname?sslmode=disable
 
+# --- Sandbox (only when using docker-compose.sandbox.yml) ---
+# Docker socket GID: 999 on Linux, 0 on Windows/macOS Docker Desktop.
+# DOCKER_GID=0
+
 # --- Debug ---
 # GOCLAW_TRACE_VERBOSE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ARG ENABLE_SANDBOX=false
 ARG ENABLE_PYTHON=false
 ARG ENABLE_NODE=false
 ARG ENABLE_FULL_SKILLS=false
+ARG ENABLE_CLAUDE_CLI=false
 
 # Install ca-certificates + wget (healthcheck) + optional runtimes.
 # ENABLE_FULL_SKILLS=true pre-installs all skill deps (larger image, no on-demand install needed).
@@ -66,9 +67,13 @@ RUN set -eux; \
             apk add --no-cache python3 py3-pip; \
             pip3 install --no-cache-dir --break-system-packages edge-tts; \
         fi; \
-        if [ "$ENABLE_NODE" = "true" ]; then \
+        if [ "$ENABLE_NODE" = "true" ] || [ "$ENABLE_CLAUDE_CLI" = "true" ]; then \
             apk add --no-cache nodejs npm; \
         fi; \
+    fi; \
+    if [ "$ENABLE_CLAUDE_CLI" = "true" ]; then \
+        npm install -g --cache /tmp/npm-cache @anthropic-ai/claude-code; \
+        rm -rf /tmp/npm-cache; \
     fi
 
 # Non-root user

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ endif
 ifdef WITH_REDIS
 COMPOSE_EXTRA += -f docker-compose.redis.yml
 endif
+ifdef WITH_CLAUDE_CLI
+COMPOSE_EXTRA += -f docker-compose.claude-cli.yml
+endif
 COMPOSE = $(COMPOSE_BASE) $(COMPOSE_EXTRA)
 UPGRADE = docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.upgrade.yml
 

--- a/docker-compose.claude-cli.yml
+++ b/docker-compose.claude-cli.yml
@@ -1,10 +1,14 @@
-# Optional overlay: sync Claude CLI credentials from host into container.
+# Optional overlay: install Claude CLI and sync credentials from host into container.
 # Mounts host ~/.claude as read-only; entrypoint copies credentials to the data volume.
+# Adds ENABLE_CLAUDE_CLI build arg to install nodejs + @anthropic-ai/claude-code.
 #
 # Usage:
-#   docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.claude-cli.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.claude-cli.yml up -d --build
 
 services:
   goclaw:
+    build:
+      args:
+        ENABLE_CLAUDE_CLI: "true"
     volumes:
       - ${HOME}/.claude:/app/.claude-host:ro

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -28,6 +28,8 @@ services:
       - GOCLAW_SANDBOX_NETWORK=false
     # Override base cap_drop to allow Docker socket access.
     # Re-include base caps (SETUID/SETGID/CHOWN) lost when overriding cap_add.
+    # WARNING: SETUID/SETGID with security_opt cleared (no no-new-privileges)
+    # increases attack surface. Only use in trusted environments.
     cap_drop: []
     cap_add:
       - NET_BIND_SERVICE

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -26,10 +26,14 @@ services:
       - GOCLAW_SANDBOX_CPUS=1.0
       - GOCLAW_SANDBOX_TIMEOUT_SEC=300
       - GOCLAW_SANDBOX_NETWORK=false
-    # Override base cap_drop to allow Docker socket access
+    # Override base cap_drop to allow Docker socket access.
+    # Re-include base caps (SETUID/SETGID/CHOWN) lost when overriding cap_add.
     cap_drop: []
     cap_add:
       - NET_BIND_SERVICE
+      - SETUID
+      - SETGID
+      - CHOWN
     security_opt: []
     group_add:
       - ${DOCKER_GID:-999}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -74,10 +74,17 @@ fi
 
 # Copy Claude CLI credentials from root-owned read-only mount to goclaw-accessible location.
 # /app/.claude is a symlink → /app/data/.claude (writable volume, see Dockerfile).
-# Uses install(1) for atomic copy with correct ownership+permissions (no temp file needed).
+# Uses su-exec to copy as goclaw user (who owns /app/data/.claude) because
+# install -o fails under no-new-privileges + sandbox overlay cap_add override.
 if [ -f /app/.claude-host/.credentials.json ]; then
   (mkdir -p /app/data/.claude \
-    && install -m 600 -o goclaw -g goclaw /app/.claude-host/.credentials.json /app/data/.claude/.credentials.json \
+    && if command -v su-exec >/dev/null 2>&1 && [ "$(id -u)" = "0" ]; then
+         su-exec goclaw cp /app/.claude-host/.credentials.json /app/data/.claude/.credentials.json \
+           && su-exec goclaw chmod 600 /app/data/.claude/.credentials.json
+       else
+         cp /app/.claude-host/.credentials.json /app/data/.claude/.credentials.json \
+           && chmod 600 /app/data/.claude/.credentials.json
+       fi \
     && echo "Claude CLI credentials synced from host.") || echo "WARNING: Claude credentials copy failed (non-fatal)"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -74,18 +74,21 @@ fi
 
 # Copy Claude CLI credentials from root-owned read-only mount to goclaw-accessible location.
 # /app/.claude is a symlink → /app/data/.claude (writable volume, see Dockerfile).
-# Uses su-exec to copy as goclaw user (who owns /app/data/.claude) because
-# install -o fails under no-new-privileges + sandbox overlay cap_add override.
+# Uses su-exec to copy as goclaw user because sandbox overlay's cap_add override
+# may remove CHOWN needed by install(1). umask 077 ensures file is created with 600.
 if [ -f /app/.claude-host/.credentials.json ]; then
   (mkdir -p /app/data/.claude \
     && if command -v su-exec >/dev/null 2>&1 && [ "$(id -u)" = "0" ]; then
-         su-exec goclaw cp /app/.claude-host/.credentials.json /app/data/.claude/.credentials.json \
-           && su-exec goclaw chmod 600 /app/data/.claude/.credentials.json
+         su-exec goclaw sh -c 'umask 077 && cp /app/.claude-host/.credentials.json /app/data/.claude/.credentials.json'
        else
-         cp /app/.claude-host/.credentials.json /app/data/.claude/.credentials.json \
-           && chmod 600 /app/data/.claude/.credentials.json
+         ( umask 077 && cp /app/.claude-host/.credentials.json /app/data/.claude/.credentials.json )
        fi \
     && echo "Claude CLI credentials synced from host.") || echo "WARNING: Claude credentials copy failed (non-fatal)"
+fi
+
+# Warn if Claude credentials are mounted but CLI binary is missing (forgot --build).
+if [ -d /app/.claude-host ] && ! command -v claude >/dev/null 2>&1; then
+  echo "WARNING: Claude credentials mounted but claude CLI not installed. Rebuild with: --build"
 fi
 
 # Run command with privilege drop (su-exec in Docker, direct otherwise).


### PR DESCRIPTION
## Summary
- **Entrypoint credential copy:** `install -o goclaw` fails under `no-new-privileges` when sandbox overlay overrides capabilities. Changed to `su-exec goclaw cp` which runs as the dir owner directly.
- **Sandbox `cap_add` override:** Docker Compose replaces (not merges) `cap_add` lists. Re-included base capabilities (`SETUID/SETGID/CHOWN`) in sandbox overlay.
- **Claude CLI binary missing:** The claude-cli overlay only mounted credentials but didn't install the `claude` binary. Added `ENABLE_CLAUDE_CLI` build arg to Dockerfile that installs nodejs + `@anthropic-ai/claude-code`.
- **`DOCKER_GID` documentation:** Added sandbox `DOCKER_GID` to `.env.example` — defaults to 999 (Linux) but must be 0 on Windows/macOS Docker Desktop.

## Test plan
- [x] Clean `docker compose down -v` then `up -d --build` with all overlays (postgres + selfservice + claude-cli + sandbox)
- [x] No `Permission denied` or `WARNING: Claude credentials copy failed` in logs
- [x] `claude` binary available inside container (`which claude`)
- [x] `claude auth status` returns `loggedIn: true`
- [x] No sandbox Docker socket permission errors (with `DOCKER_GID=0` on Windows)