### PR TITLE
fix(security): decrypt downgrade warnings, pairing expiry race, sender-ID validation

### DIFF
--- a/internal/crypto/aes.go
+++ b/internal/crypto/aes.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
+	"log/slog"
 	"strings"
 )
 
@@ -55,6 +56,9 @@ func Decrypt(ciphertext, key string) (string, error) {
 	}
 
 	if !IsEncrypted(ciphertext) {
+		slog.Warn("crypto.unencrypted_value_read",
+			"hint", "value lacks aes-gcm: prefix — may be legacy plaintext or tampered",
+		)
 		return ciphertext, nil
 	}
 
@@ -65,7 +69,8 @@ func Decrypt(ciphertext, key string) (string, error) {
 
 	data, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(ciphertext, prefix))
 	if err != nil {
-		return ciphertext, nil // not valid base64 → treat as plain text
+		slog.Warn("crypto.invalid_base64_in_encrypted_value")
+		return ciphertext, nil
 	}
 
 	block, err := aes.NewCipher(keyBytes)
@@ -80,7 +85,8 @@ func Decrypt(ciphertext, key string) (string, error) {
 
 	nonceSize := gcm.NonceSize()
 	if len(data) < nonceSize {
-		return ciphertext, nil // too short → treat as plain text
+		slog.Warn("crypto.encrypted_value_too_short", "len", len(data), "min", nonceSize)
+		return ciphertext, nil
 	}
 
 	plaintext, err := gcm.Open(nil, data[:nonceSize], data[nonceSize:], nil)

--- a/internal/gateway/methods/pairing.go
+++ b/internal/gateway/methods/pairing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"regexp"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/gateway"
@@ -11,6 +12,14 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
 )
+
+var validSenderIDRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:@-]*$`)
+
+// isValidSenderID checks that a sender ID contains only safe characters.
+// Prevents log injection and bus event poisoning.
+func isValidSenderID(id string) bool {
+	return validSenderIDRe.MatchString(id)
+}
 
 // PairingApproveCallback is called after a pairing is approved.
 // channel is the channel name (e.g., "telegram"), chatID is the chat to notify,
@@ -63,6 +72,13 @@ func (m *PairingMethods) handleRequest(ctx context.Context, client *gateway.Clie
 
 	if params.SenderID == "" || params.Channel == "" {
 		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, i18n.T(locale, i18n.MsgSenderChannelRequired)))
+		return
+	}
+
+	// Validate sender ID format: alphanumeric, hyphens, underscores, colons, dots.
+	// Max 128 chars. Prevents log injection and bus event poisoning.
+	if len(params.SenderID) > 128 || !isValidSenderID(params.SenderID) {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid sender_id format"))
 		return
 	}
 
@@ -219,6 +235,13 @@ func (m *PairingMethods) handleBrowserPairingStatus(ctx context.Context, client 
 
 	if params.SenderID == "" {
 		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, i18n.T(locale, i18n.MsgSenderIDRequired)))
+		return
+	}
+
+	// Validate sender ID format: alphanumeric, hyphens, underscores, colons, dots.
+	// Max 128 chars. Prevents log injection and bus event poisoning.
+	if len(params.SenderID) > 128 || !isValidSenderID(params.SenderID) {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid sender_id format"))
 		return
 	}
 

--- a/internal/store/pg/pairing.go
+++ b/internal/store/pg/pairing.go
@@ -89,7 +89,7 @@ func (s *PGPairingStore) ApprovePairing(ctx context.Context, code, approvedBy st
 	var reqTenantID uuid.UUID
 	// Code lookup is cross-tenant (random token, approver is WS/HTTP user)
 	err := s.db.QueryRowContext(ctx,
-		"SELECT id, sender_id, channel, chat_id, COALESCE(metadata, '{}'), tenant_id FROM pairing_requests WHERE code = $1", code,
+		"SELECT id, sender_id, channel, chat_id, COALESCE(metadata, '{}'), tenant_id FROM pairing_requests WHERE code = $1 AND expires_at > NOW()", code,
 	).Scan(&reqID, &senderID, &channel, &chatID, &metaJSON, &reqTenantID)
 	if err != nil {
 		return nil, fmt.Errorf("pairing code %s not found or expired", code)


### PR DESCRIPTION
## Summary

Lower-priority security hardening — defense-in-depth improvements.

### Crypto: Decrypt downgrade detection
- Log `slog.Warn` when `Decrypt()` encounters values without `aes-gcm:` prefix (potential downgrade attack or legacy plaintext)
- Also warns on invalid base64 and too-short encrypted values
- Backward compatibility preserved — still returns plaintext, but now observable in logs

### Pairing: Expiry race condition fix
- Add `AND expires_at > NOW()` to `ApprovePairing` SELECT query
- Closes race where a pairing code could be approved after TTL expiry (between prune DELETE and lookup SELECT)

### Pairing: Sender-ID format validation
- Validate sender-ID format in `handleRequest` and `handleBrowserPairingStatus`
- Regex: `^[a-zA-Z0-9][a-zA-Z0-9._:@-]*$`, max 128 chars
- Prevents log injection and bus event poisoning via crafted sender IDs

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go vet ./...` — passes
- [ ] Decrypt a value without `aes-gcm:` prefix — should log warning and return plaintext
- [ ] Approve an expired pairing code — should fail with "not found or expired"
- [ ] Request pairing with `senderId: "admin'; DROP TABLE--"` — should return 400
- [ ] Request pairing with `senderId: "group:12345"` — should succeed