### PR TITLE
fix(slack): Thread announce routing for top-level channel mentions

### DIFF
--- a/internal/channels/slack/handlers.go
+++ b/internal/channels/slack/handlers.go
@@ -222,6 +222,16 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 		replyThreadTS = ev.TimeStamp // start thread from the triggering message
 	}
 
+	// For top-level group mentions, encode the reply thread TS into localKey so
+	// subagent/team announce flows (which reconstruct routing from origin_local_key)
+	// can route replies back to the correct thread via buildAnnounceOutMeta.
+	// History operations above already used the channel-scoped localKey; from here
+	// on the thread-qualified key is needed for placeholder storage and routing.
+	historyKey := localKey
+	if !isDM && threadTS == "" && replyThreadTS != "" {
+		localKey = fmt.Sprintf("%s:thread:%s", channelID, replyThreadTS)
+	}
+
 	placeholderOpts := []slackapi.MsgOption{
 		slackapi.MsgOptionText("Thinking...", false),
 	}
@@ -234,7 +244,9 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 		c.placeholders.Store(localKey, placeholderTS)
 	}
 
-	// Build final content with group history context
+	// Build final content with group history context.
+	// Use historyKey (channel-scoped for top-level) so accumulated pending messages
+	// from before the mention are included correctly.
 	finalContent := content
 	if peerKind == "group" {
 		annotated := fmt.Sprintf("[From: %s]\n%s", displayName, content)
@@ -282,7 +294,7 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 			participKey := channelID + ":particip:" + replyThreadTS
 			c.threadParticip.Store(participKey, time.Now())
 		}
-		c.groupHistory.Clear(localKey)
+		c.groupHistory.Clear(historyKey)
 	}
 }
 
@@ -293,7 +305,7 @@ func (c *Channel) fetchThreadParentContext(ctx context.Context, channelID, threa
 		ChannelID: channelID,
 		Latest:    threadTS,
 		Limit:     1,
-		Inclusive:  true,
+		Inclusive: true,
 	}
 	history, err := c.api.GetConversationHistoryContext(ctx, params)
 	if err != nil || len(history.Messages) == 0 {

--- a/internal/channels/slack/handlers_mention.go
+++ b/internal/channels/slack/handlers_mention.go
@@ -68,6 +68,13 @@ func (c *Channel) handleAppMention(ev *slackevents.AppMentionEvent) {
 		replyThreadTS = ev.TimeStamp
 	}
 
+	// For top-level mentions, encode the reply thread TS into localKey so
+	// subagent/team announce flows can route replies to the correct thread.
+	historyKey := localKey
+	if threadTS == "" && replyThreadTS != "" {
+		localKey = fmt.Sprintf("%s:thread:%s", channelID, replyThreadTS)
+	}
+
 	placeholderOpts := []slackapi.MsgOption{
 		slackapi.MsgOptionText("Thinking...", false),
 	}
@@ -83,7 +90,7 @@ func (c *Channel) handleAppMention(ev *slackevents.AppMentionEvent) {
 	annotated := fmt.Sprintf("[From: %s]\n%s", displayName, content)
 	finalContent := annotated
 	if c.historyLimit > 0 {
-		finalContent = c.groupHistory.BuildContext(localKey, annotated, c.historyLimit)
+		finalContent = c.groupHistory.BuildContext(historyKey, annotated, c.historyLimit)
 	}
 
 	metadata := map[string]string{
@@ -107,7 +114,7 @@ func (c *Channel) handleAppMention(ev *slackevents.AppMentionEvent) {
 		c.threadParticip.Store(participKey, time.Now())
 	}
 
-	c.groupHistory.Clear(localKey)
+	c.groupHistory.Clear(historyKey)
 }
 
 // isBotMentioned checks if the message text contains <@botUserID>.


### PR DESCRIPTION
## Summary
Fixed an issue where subagent/teammate announce messages were posted to the main channel instead of the original thread when the bot was @mentioned in a top-level message.

## Changes
- Thread-Qualified Keys: Updated `local_key` include the `{channelID}:thread:{replyThreadTS}` suffix for non-DM group messages. This ensures buildAnnounceOutMeta() correctly reconstructs the message_thread_id.

- Consistency: Applied identical thread logic to both handleMessage and handleAppMention to maintain consistency across deduplicated paths.

- Scoped Sessions: Aligned Slack group sessions to be per-thread (keyed by root TS), matching the behavior of replies within existing threads.

- History Preservation: Retained channel-scoped `historyKey` to ensure the "messages since last reply" logic remains unchanged.