### PR TITLE
feat(docker): integrate Claude CLI into container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN set -eux; \
         pip3 install --no-cache-dir --break-system-packages \
             pypdf openpyxl pandas python-pptx markitdown defusedxml lxml \
             pdfplumber pdf2image anthropic; \
-        npm install -g --cache /tmp/npm-cache docx pptxgenjs; \
+        npm install -g --cache /tmp/npm-cache docx pptxgenjs @anthropic-ai/claude-code; \
         rm -rf /tmp/npm-cache /root/.cache /var/cache/apk/*; \
     else \
         if [ "$ENABLE_PYTHON" = "true" ]; then \
@@ -69,6 +69,11 @@ RUN set -eux; \
         if [ "$ENABLE_NODE" = "true" ]; then \
             apk add --no-cache nodejs npm; \
         fi; \
+    fi; \
+    # Install Claude CLI if Node.js is available
+    if command -v npm >/dev/null 2>&1; then \
+        npm install -g --cache /tmp/npm-cache @anthropic-ai/claude-code; \
+        rm -rf /tmp/npm-cache; \
     fi
 
 # Non-root user
@@ -116,7 +121,8 @@ RUN mkdir -p /app/workspace /app/data/.runtime/pip /app/data/.runtime/npm-global
     && chown -R goclaw:goclaw /app/data/.runtime/pip /app/data/.runtime/npm-global /app/data/.runtime/pip-cache /app/data/.claude
 
 # Default environment
-ENV GOCLAW_CONFIG=/app/config.json \
+ENV HOME=/app \
+    GOCLAW_CONFIG=/app/config.json \
     GOCLAW_WORKSPACE=/app/workspace \
     GOCLAW_DATA_DIR=/app/data \
     GOCLAW_SKILLS_DIR=/app/skills \

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ endif
 ifdef WITH_REDIS
 COMPOSE_EXTRA += -f docker-compose.redis.yml
 endif
+ifdef WITH_CLAUDE_CLI
+COMPOSE_EXTRA += -f docker-compose.claude-cli.yml
+endif
 COMPOSE = $(COMPOSE_BASE) $(COMPOSE_EXTRA)
 UPGRADE = docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.upgrade.yml
 

--- a/docker-compose.claude-cli.yml
+++ b/docker-compose.claude-cli.yml
@@ -8,3 +8,4 @@ services:
   goclaw:
     volumes:
       - ${HOME}/.claude:/app/.claude-host:ro
+      - ${HOME}/.claude.json:/app/.claude-host.json:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       args:
         ENABLE_OTEL: "${ENABLE_OTEL:-false}"
         ENABLE_PYTHON: "${ENABLE_PYTHON:-true}"
+        ENABLE_NODE: "${ENABLE_NODE:-false}"
         ENABLE_FULL_SKILLS: "${ENABLE_FULL_SKILLS:-false}"
         VERSION: "${GOCLAW_VERSION:-dev}"
     ports:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,9 +76,12 @@ fi
 # /app/.claude is a symlink → /app/data/.claude (writable volume, see Dockerfile).
 # Uses install(1) for atomic copy with correct ownership+permissions (no temp file needed).
 if [ -f /app/.claude-host/.credentials.json ]; then
-  (mkdir -p /app/data/.claude \
-    && install -m 600 -o goclaw -g goclaw /app/.claude-host/.credentials.json /app/data/.claude/.credentials.json \
+  (su-exec goclaw cp /app/.claude-host/.credentials.json /app/data/.claude/.credentials.json \
     && echo "Claude CLI credentials synced from host.") || echo "WARNING: Claude credentials copy failed (non-fatal)"
+fi
+if [ -f /app/.claude-host.json ]; then
+  (su-exec goclaw cp /app/.claude-host.json /app/.claude.json \
+    && echo "Claude CLI config synced from host.") || echo "WARNING: Claude config copy failed (non-fatal)"
 fi
 
 # Run command with privilege drop (su-exec in Docker, direct otherwise).


### PR DESCRIPTION
## Summary
- Add Claude Code CLI (`@anthropic-ai/claude-code`) to Docker image for both full-skills and standalone Node.js builds
- Sync host `~/.claude.json` config file into container alongside existing credentials sync
- Simplify credential copy in entrypoint using `su-exec goclaw cp`
- Add `ENABLE_NODE` build arg to `docker-compose.yml` and `WITH_CLAUDE_CLI` flag to Makefile
- Set `HOME=/app` env var so Claude CLI finds its config directory correctly

## Test plan
- [ ] Build image with `ENABLE_FULL_SKILLS=true` — verify `claude` CLI is available in container
- [ ] Build image with `ENABLE_NODE=true` only — verify `claude` CLI is installed
- [ ] Run container with `WITH_CLAUDE_CLI=1 make up` — verify host credentials and config are mounted
- [ ] Verify `docker-entrypoint.sh` syncs both `.credentials.json` and `.claude.json` on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)