### PR TITLE
fix(telegram): duplicate contact from inconsistent senderID

### DIFF
--- a/internal/channels/telegram/handlers.go
+++ b/internal/channels/telegram/handlers.go
@@ -331,7 +331,7 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 			// Collect contact even when bot is not mentioned (cache prevents DB spam).
 			if cc := c.ContactCollector(); cc != nil {
 				contactName := strings.TrimSpace(user.FirstName + " " + user.LastName)
-				cc.EnsureContact(ctx, c.Type(), c.Name(), userID, userID, contactName, user.Username, "group")
+				cc.EnsureContact(ctx, c.Type(), c.Name(), senderID, userID, contactName, user.Username, "group")
 			}
 
 			slog.Debug("telegram group message recorded (no mention)",


### PR DESCRIPTION
## Summary
- Non-mention group message path passed raw `userID` as sender_id to `EnsureContact`
- Processed message path passed `senderID` (which includes `|username` suffix)
- `UNIQUE(channel_type, sender_id)` constraint created two rows for the same person
- Fix: use `senderID` consistently in both paths

## Test plan
- [ ] Send message in Telegram group without @mentioning bot
- [ ] Then @mention bot in same group
- [ ] Verify only one contact row exists for the user