### PR TITLE
fix(channels): add display_name to session metadata for Feishu/Zalo/Slack

### DIFF
--- a/internal/channels/feishu/bot.go
+++ b/internal/channels/feishu/bot.go
@@ -169,6 +169,7 @@ func (c *Channel) handleMessageEvent(ctx context.Context, event *MessageEvent) {
 		"message_id":    messageID,
 		"chat_type":     mc.ChatType,
 		"sender_name":   senderName,
+		"display_name":  senderName,
 		"mentioned_bot": fmt.Sprintf("%t", mc.MentionedBot),
 		"platform":      channels.TypeFeishu,
 	}

--- a/internal/channels/slack/handlers.go
+++ b/internal/channels/slack/handlers.go
@@ -253,6 +253,7 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 		"message_id":      ev.TimeStamp,
 		"user_id":         senderID,
 		"username":        displayName,
+		"display_name":    displayName,
 		"channel_id":      channelID,
 		"is_dm":           fmt.Sprintf("%t", isDM),
 		"local_key":       localKey,

--- a/internal/channels/zalo/personal/handlers.go
+++ b/internal/channels/zalo/personal/handlers.go
@@ -68,8 +68,9 @@ func (c *Channel) handleDM(msg protocol.UserMessage) {
 	}
 
 	metadata := map[string]string{
-		"message_id": msg.Data.MsgID,
-		"platform":   channels.TypeZaloPersonal,
+		"message_id":   msg.Data.MsgID,
+		"platform":     channels.TypeZaloPersonal,
+		"display_name": senderName,
 	}
 	c.HandleMessage(senderID, threadID, content, media, metadata, "direct")
 }
@@ -147,9 +148,10 @@ func (c *Channel) handleGroupMessage(msg protocol.GroupMessage) {
 	}
 
 	metadata := map[string]string{
-		"message_id": msg.Data.MsgID,
-		"platform":   channels.TypeZaloPersonal,
-		"group_id":   threadID,
+		"message_id":   msg.Data.MsgID,
+		"platform":     channels.TypeZaloPersonal,
+		"group_id":     threadID,
+		"display_name": senderName,
 	}
 	c.HandleMessage(senderID, threadID, finalContent, allMedia, metadata, "group")
 


### PR DESCRIPTION
## Summary
- Sessions page shows raw sender IDs instead of names for Feishu, Zalo Personal, and Slack
- Root cause: these channels didn't include `display_name` in message metadata
- The gateway's `extractSessionMetadata()` already looks for this key but it was missing
- Fix: add `display_name` to metadata map in all three channel handlers

## Test plan
- [x] Send a message via Feishu/Lark → check Sessions page shows sender name
- [x] Send a message via Zalo Personal (DM + group) → check Sessions page
- [ ] Send a message via Slack → check Sessions page