### PR TITLE
feat(channels): add channel_groups directory for group name resolution

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -320,6 +320,7 @@ func runGateway() {
 	// Create gateway server and wire enforcement
 	server := gateway.NewServer(cfg, msgBus, agentRouter, pgStores.Sessions, toolsReg)
 	server.SetVersion(Version)
+	server.StartUpdateChecker(context.Background())
 	server.SetDB(pgStores.DB)
 	server.SetPolicyEngine(permPE)
 	server.SetPairingService(pgStores.Pairing)
@@ -525,6 +526,11 @@ func runGateway() {
 
 	// Channel manager
 	channelMgr := channels.NewManager(msgBus)
+
+	// Wire channel manager into HTTP handler for on-demand group refresh
+	if channelInstancesH != nil {
+		channelInstancesH.SetChannelManager(channelMgr)
+	}
 
 	// Wire channel sender + tenant checker on message tool (now that channelMgr exists)
 	if t, ok := toolsReg.Get("message"); ok {
@@ -891,6 +897,7 @@ func runGateway() {
 	heartbeatMethods.SetWakeFn(heartbeatTicker.Wake)
 	heartbeatMethods.SetAgentStore(pgStores.Agents)
 	heartbeatMethods.SetProviderStore(pgStores.Providers)
+	heartbeatMethods.SetPermissionStore(pgStores.ConfigPermissions)
 	cronHeartbeatWakeFn = func(agentID string) {
 		if id, err := uuid.Parse(agentID); err == nil {
 			heartbeatTicker.Wake(id)

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -1061,6 +1061,12 @@ func runGateway() {
 		channelMgr.SetContactCollector(contactCollector) // propagate to all channel handlers
 	}
 
+	// Group collector: auto-collect group directory from channels with in-memory dedup cache.
+	if pgStores.Groups != nil {
+		groupCollector := store.NewGroupCollector(pgStores.Groups, cache.NewInMemoryCache[string]())
+		channelMgr.SetGroupCollector(groupCollector)
+	}
+
 	go consumeInboundMessages(ctx, msgBus, agentRouter, cfg, sched, channelMgr, consumerTeamStore, quotaChecker, pgStores.Sessions, pgStores.Agents, contactCollector, postTurn)
 
 	// Task recovery ticker: re-dispatches stale/pending team tasks on startup and periodically.

--- a/cmd/gateway_http_handlers.go
+++ b/cmd/gateway_http_handlers.go
@@ -26,6 +26,12 @@ func wireHTTP(stores *store.Stores, defaultWorkspace, dataDir, bundledSkillsDir 
 			summoner = httpapi.NewAgentSummoner(stores.Agents, providerReg, msgBus)
 		}
 		agentsH = httpapi.NewAgentsHandler(stores.Agents, stores.Providers, providerReg, stores.DB, stores.Tracing, defaultWorkspace, msgBus, summoner, isOwner)
+		if stores.Memory != nil {
+			agentsH.SetMemoryStore(stores.Memory)
+		}
+		if stores.KnowledgeGraph != nil {
+			agentsH.SetKGStore(stores.KnowledgeGraph)
+		}
 	}
 
 	if stores != nil && stores.Skills != nil {

--- a/cmd/gateway_http_handlers.go
+++ b/cmd/gateway_http_handlers.go
@@ -50,7 +50,7 @@ func wireHTTP(stores *store.Stores, defaultWorkspace, dataDir, bundledSkillsDir 
 	}
 
 	if stores != nil && stores.ChannelInstances != nil {
-		channelInstancesH = httpapi.NewChannelInstancesHandler(stores.ChannelInstances, stores.Agents, stores.ConfigPermissions, stores.Contacts, stores.Tenants, msgBus)
+		channelInstancesH = httpapi.NewChannelInstancesHandler(stores.ChannelInstances, stores.Agents, stores.ConfigPermissions, stores.Contacts, stores.Groups, stores.Tenants, msgBus)
 	}
 
 	if stores != nil && stores.Providers != nil {
@@ -75,7 +75,7 @@ func wireHTTP(stores *store.Stores, defaultWorkspace, dataDir, bundledSkillsDir 
 	}
 
 	if stores != nil && stores.PendingMessages != nil {
-		pendingMessagesH = httpapi.NewPendingMessagesHandler(stores.PendingMessages, stores.Agents, providerReg)
+		pendingMessagesH = httpapi.NewPendingMessagesHandler(stores.PendingMessages, stores.Agents, stores.Groups, providerReg)
 	}
 
 	if stores != nil && stores.SecureCLI != nil {

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -160,6 +160,7 @@ type BaseChannel struct {
 	agentID          string                 // for DB instances: routes to specific agent (empty = use resolveAgentRoute)
 	tenantID         uuid.UUID              // for DB instances: tenant scope (zero = master tenant fallback)
 	contactCollector *store.ContactCollector // optional: auto-collect contacts from channel messages
+	groupCollector   *store.GroupCollector   // optional: auto-collect group directory from channel messages
 }
 
 // NewBaseChannel creates a new BaseChannel with the given parameters.
@@ -205,6 +206,12 @@ func (c *BaseChannel) SetContactCollector(cc *store.ContactCollector) { c.contac
 
 // ContactCollector returns the contact collector (may be nil).
 func (c *BaseChannel) ContactCollector() *store.ContactCollector { return c.contactCollector }
+
+// SetGroupCollector sets the group collector for auto-collecting group directory from messages.
+func (c *BaseChannel) SetGroupCollector(gc *store.GroupCollector) { c.groupCollector = gc }
+
+// GroupCollector returns the group collector (may be nil).
+func (c *BaseChannel) GroupCollector() *store.GroupCollector { return c.groupCollector }
 
 // IsRunning returns whether the channel is running.
 func (c *BaseChannel) IsRunning() bool { return c.running }

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -149,6 +149,13 @@ type ReactionChannel interface {
 	ClearReaction(ctx context.Context, chatID string, messageID string) error
 }
 
+// GroupRefresher is optionally implemented by channels that can fetch their
+// full group/conversation list on demand and populate channel_groups.
+// Used by the HTTP API to trigger on-demand refresh from the UI.
+type GroupRefresher interface {
+	RefreshGroups(ctx context.Context) error
+}
+
 // BaseChannel provides shared functionality for all channel implementations.
 // Channel implementations should embed this struct.
 type BaseChannel struct {

--- a/internal/channels/discord/discord.go
+++ b/internal/channels/discord/discord.go
@@ -49,7 +49,8 @@ func New(cfg config.DiscordConfig, msgBus *bus.MessageBus, pairingSvc store.Pair
 	}
 
 	// Request necessary intents
-	session.Identify.Intents = discordgo.IntentsGuildMessages |
+	session.Identify.Intents = discordgo.IntentsGuilds |
+		discordgo.IntentsGuildMessages |
 		discordgo.IntentsDirectMessages |
 		discordgo.IntentsMessageContent
 
@@ -85,6 +86,7 @@ func (c *Channel) Start(_ context.Context) error {
 	slog.Info("starting discord bot")
 
 	c.session.AddHandler(c.handleMessage)
+	c.session.AddHandler(c.handleGuildCreate)
 
 	if err := c.session.Open(); err != nil {
 		return fmt.Errorf("open discord session: %w", err)
@@ -100,6 +102,9 @@ func (c *Channel) Start(_ context.Context) error {
 
 	c.SetRunning(true)
 	slog.Info("discord bot connected", "username", user.Username, "id", user.ID)
+
+	// Pre-populate channel_groups with all guilds the bot is in (best-effort).
+	go c.RefreshGroups()
 
 	return nil
 }

--- a/internal/channels/discord/discord.go
+++ b/internal/channels/discord/discord.go
@@ -31,6 +31,7 @@ type Channel struct {
 	pairingService  store.PairingStore
 	pairingDebounce sync.Map // senderID → time.Time
 	approvedGroups  sync.Map // chatID → true (in-memory cache for paired groups)
+	guildNames      sync.Map // guildID → name string (cached for contact collection)
 	groupHistory    *channels.PendingHistory
 	historyLimit    int
 	agentStore      store.AgentStore             // for agent key lookup (nil = writer commands disabled)

--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -463,3 +463,61 @@ func resolveDisplayName(m *discordgo.MessageCreate) string {
 	}
 	return m.Author.Username
 }
+
+// handleGuildCreate fires when the bot joins a new guild (or on initial connect for each guild).
+// It upserts the guild into channel_groups so the UI can display it immediately.
+func (c *Channel) handleGuildCreate(_ *discordgo.Session, g *discordgo.GuildCreate) {
+	if g.Guild == nil {
+		return
+	}
+	gc := c.GroupCollector()
+	if gc == nil {
+		return
+	}
+	ctx := context.Background()
+	ctx = store.WithTenantID(ctx, c.TenantID())
+
+	memberCount := g.MemberCount
+	gc.EnsureGroup(ctx, c.Type(), c.Name(), g.ID, g.Name, memberCount)
+	c.guildNames.Store(g.ID, g.Name)
+
+	slog.Debug("discord guild collected", "guild_id", g.ID, "name", g.Name, "members", memberCount)
+}
+
+// RefreshGroups fetches all guilds the bot is in and upserts them into channel_groups.
+// Called during Start() and can be invoked on demand.
+func (c *Channel) RefreshGroups() error {
+	gc := c.GroupCollector()
+	if gc == nil {
+		return nil
+	}
+
+	ctx := context.Background()
+	ctx = store.WithTenantID(ctx, c.TenantID())
+
+	// Paginate through all guilds (API returns max 200 per call).
+	var afterID string
+	total := 0
+	for {
+		guilds, err := c.session.UserGuilds(200, "", afterID, false)
+		if err != nil {
+			slog.Warn("discord: failed to fetch guilds", "error", err, "after_id", afterID)
+			return fmt.Errorf("fetch discord guilds: %w", err)
+		}
+		if len(guilds) == 0 {
+			break
+		}
+		for _, g := range guilds {
+			gc.EnsureGroup(ctx, c.Type(), c.Name(), g.ID, g.Name, 0)
+			c.guildNames.Store(g.ID, g.Name)
+		}
+		total += len(guilds)
+		if len(guilds) < 200 {
+			break
+		}
+		afterID = guilds[len(guilds)-1].ID
+	}
+
+	slog.Info("discord: refreshed guilds", "count", total)
+	return nil
+}

--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -197,6 +197,12 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 			if cc := c.ContactCollector(); cc != nil {
 				cc.EnsureContact(ctx, c.Type(), c.Name(), senderID, senderID, senderName, m.Author.Username, "group")
 			}
+			// Collect group directory entry.
+			if gc := c.GroupCollector(); gc != nil && m.GuildID != "" {
+				if guildName := c.resolveGuildName(m.GuildID); guildName != "" {
+					gc.EnsureGroup(ctx, c.Type(), c.Name(), m.GuildID, guildName, 0)
+				}
+			}
 
 			slog.Debug("discord group message recorded (no mention)",
 				"channel_id", channelID,
@@ -289,6 +295,14 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 	if cc := c.ContactCollector(); cc != nil {
 		cc.EnsureContact(ctx, c.Type(), c.Name(), senderID, senderID, senderName, m.Author.Username, peerKind)
 	}
+	// Collect group directory entry.
+	if !isDM && m.GuildID != "" {
+		if gc := c.GroupCollector(); gc != nil {
+			if guildName := c.resolveGuildName(m.GuildID); guildName != "" {
+				gc.EnsureGroup(ctx, c.Type(), c.Name(), m.GuildID, guildName, 0)
+			}
+		}
+	}
 
 	// Publish directly to bus (to preserve MediaFile MIME types)
 	c.Bus().PublishInbound(bus.InboundMessage{
@@ -307,6 +321,22 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 	if peerKind == "group" {
 		c.groupHistory.Clear(channelID)
 	}
+}
+
+// resolveGuildName returns the cached guild name, fetching from Discord API on first call.
+func (c *Channel) resolveGuildName(guildID string) string {
+	if guildID == "" {
+		return ""
+	}
+	if name, ok := c.guildNames.Load(guildID); ok {
+		return name.(string)
+	}
+	guild, err := c.session.Guild(guildID)
+	if err != nil {
+		return ""
+	}
+	c.guildNames.Store(guildID, guild.Name)
+	return guild.Name
 }
 
 // checkGroupPolicy evaluates the group policy for a sender, with pairing support.

--- a/internal/channels/feishu/bot.go
+++ b/internal/channels/feishu/bot.go
@@ -109,6 +109,13 @@ func (c *Channel) handleMessageEvent(ctx context.Context, event *MessageEvent) {
 				cc.EnsureContact(ctx, c.Type(), c.Name(), mc.SenderID, mc.SenderID, senderName, "", "group")
 			}
 
+			// Collect group directory entry.
+			if gc := c.GroupCollector(); gc != nil {
+				if groupName := c.resolveGroupName(ctx, mc.ChatID); groupName != "" {
+					gc.EnsureGroup(ctx, c.Type(), c.Name(), mc.ChatID, groupName, 0)
+				}
+			}
+
 			slog.Debug("feishu group message recorded (no mention)",
 				"chat_id", mc.ChatID, "sender", senderName,
 			)
@@ -163,6 +170,13 @@ func (c *Channel) handleMessageEvent(ctx context.Context, event *MessageEvent) {
 	// Collect contact for processed messages (DM + group-mentioned).
 	if cc := c.ContactCollector(); cc != nil {
 		cc.EnsureContact(ctx, c.Type(), c.Name(), mc.SenderID, mc.SenderID, senderName, "", peerKind)
+	}
+
+	// Collect group directory entry.
+	if gc := c.GroupCollector(); gc != nil && mc.ChatType == "group" {
+		if groupName := c.resolveGroupName(ctx, mc.ChatID); groupName != "" {
+			gc.EnsureGroup(ctx, c.Type(), c.Name(), mc.ChatID, groupName, 0)
+		}
 	}
 
 	metadata := map[string]string{

--- a/internal/channels/feishu/bot.go
+++ b/internal/channels/feishu/bot.go
@@ -183,6 +183,7 @@ func (c *Channel) handleMessageEvent(ctx context.Context, event *MessageEvent) {
 		"message_id":    messageID,
 		"chat_type":     mc.ChatType,
 		"sender_name":   senderName,
+		"display_name":  senderName,
 		"mentioned_bot": fmt.Sprintf("%t", mc.MentionedBot),
 		"platform":      channels.TypeFeishu,
 	}

--- a/internal/channels/feishu/feishu.go
+++ b/internal/channels/feishu/feishu.go
@@ -114,12 +114,38 @@ func (c *Channel) Start(ctx context.Context) error {
 
 	c.SetRunning(true)
 
+	// Pre-populate channel_groups with all group chats (best-effort, non-blocking).
+	go c.refreshGroupsOnStartup()
+
 	switch mode {
 	case "webhook":
 		return c.startWebhook(ctx)
 	default: // "websocket"
 		return c.startWebSocket(ctx)
 	}
+}
+
+// refreshGroupsOnStartup fetches all group chats via ListChats and populates channel_groups.
+func (c *Channel) refreshGroupsOnStartup() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	chats, err := c.client.ListChats(ctx)
+	if err != nil {
+		slog.Warn("feishu: list chats on startup failed", "error", err)
+		return
+	}
+	gc := c.GroupCollector()
+	if gc == nil {
+		return
+	}
+	ctx = store.WithTenantID(ctx, c.TenantID())
+	for _, chat := range chats {
+		gc.EnsureGroup(ctx, c.Type(), c.Name(), chat.ChatID, chat.Name, chat.UserCountInt())
+		if chat.Name != "" {
+			c.groupNames.Store(chat.ChatID, chat.Name)
+		}
+	}
+	slog.Info("feishu: cached group names", "count", len(chats))
 }
 
 // BlockReplyEnabled returns the per-channel block_reply override (nil = inherit gateway default).

--- a/internal/channels/feishu/feishu.go
+++ b/internal/channels/feishu/feishu.go
@@ -44,6 +44,7 @@ type Channel struct {
 	pairingDebounce sync.Map // senderID → time.Time
 	reactions       sync.Map // chatID → *reactionState
 	approvedGroups  sync.Map // chatID → true (in-memory cache for paired groups)
+	groupNames      sync.Map // chatID → name string
 	groupAllowList  []string
 	groupHistory    *channels.PendingHistory
 	historyLimit    int
@@ -497,6 +498,29 @@ func (c *Channel) isDuplicate(messageID string) bool {
 		})
 	}
 	return loaded
+}
+
+// resolveGroupName returns the group name for a chat ID, using a local cache.
+func (c *Channel) resolveGroupName(ctx context.Context, chatID string) string {
+	if chatID == "" {
+		return ""
+	}
+
+	// Check cache
+	if name, ok := c.groupNames.Load(chatID); ok {
+		return name.(string)
+	}
+
+	// Fetch from API
+	info, err := c.client.GetChatInfo(ctx, chatID)
+	if err != nil {
+		slog.Warn("feishu: fetch group name failed", "chat_id", chatID, "error", err)
+		return ""
+	}
+	if info.Name != "" {
+		c.groupNames.Store(chatID, info.Name)
+	}
+	return info.Name
 }
 
 // --- ReactionChannel implementation ---

--- a/internal/channels/feishu/larkclient_messaging.go
+++ b/internal/channels/feishu/larkclient_messaging.go
@@ -304,6 +304,34 @@ func (c *LarkClient) ListChatMembers(ctx context.Context, chatID string) ([]Chat
 	return all, nil
 }
 
+// --- IM API: Chat Info ---
+
+// ChatInfo holds basic group/chat information from Feishu API.
+type ChatInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Avatar      string `json:"avatar"`
+	UserCount   string `json:"user_count"`
+}
+
+// GetChatInfo retrieves chat/group info by chat ID.
+// Feishu API: GET /open-apis/im/v1/chats/{chat_id}
+func (c *LarkClient) GetChatInfo(ctx context.Context, chatID string) (*ChatInfo, error) {
+	path := fmt.Sprintf("/open-apis/im/v1/chats/%s", chatID)
+	resp, err := c.doJSON(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("get chat info: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	var data ChatInfo
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, fmt.Errorf("unmarshal chat info: %w", err)
+	}
+	return &data, nil
+}
+
 // --- Contact API ---
 
 func (c *LarkClient) GetUser(ctx context.Context, userID, userIDType string) (string, error) {

--- a/internal/channels/feishu/larkclient_messaging.go
+++ b/internal/channels/feishu/larkclient_messaging.go
@@ -332,6 +332,72 @@ func (c *LarkClient) GetChatInfo(ctx context.Context, chatID string) (*ChatInfo,
 	return &data, nil
 }
 
+// --- IM API: List Chats (groups the bot is in) ---
+
+// ChatListItem represents a single chat/group from the list chats API.
+type ChatListItem struct {
+	ChatID    string `json:"chat_id"`
+	Name      string `json:"name"`
+	Avatar    string `json:"avatar"`
+	OwnerID   string `json:"owner_id"`
+	ChatMode  string `json:"chat_mode"` // "group" or "p2p"
+	ChatType  string `json:"chat_type"` // "private" or "public"
+	UserCount string `json:"user_count"`
+}
+
+// UserCountInt returns UserCount as an integer (0 if parse fails).
+func (c ChatListItem) UserCountInt() int {
+	n, _ := strconv.Atoi(c.UserCount)
+	return n
+}
+
+// ListChats returns all chats the bot is a member of, handling pagination automatically.
+// Only group chats are returned (chat_mode == "group").
+// Lark API: GET /open-apis/im/v1/chats
+// Requires scope: im:chat:readonly
+func (c *LarkClient) ListChats(ctx context.Context) ([]ChatListItem, error) {
+	var all []ChatListItem
+	pageToken := ""
+
+	for {
+		path := "/open-apis/im/v1/chats?page_size=100"
+		if pageToken != "" {
+			path += "&page_token=" + url.QueryEscape(pageToken)
+		}
+
+		resp, err := c.doJSON(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+		if resp.Code != 0 {
+			return nil, fmt.Errorf("list chats: code=%d msg=%s", resp.Code, resp.Msg)
+		}
+
+		var result struct {
+			Items     []ChatListItem `json:"items"`
+			PageToken string         `json:"page_token"`
+			HasMore   bool           `json:"has_more"`
+		}
+		if err := json.Unmarshal(resp.Data, &result); err != nil {
+			return nil, fmt.Errorf("unmarshal list chats: %w", err)
+		}
+
+		// Include all chats except p2p (DMs)
+		for _, item := range result.Items {
+			if item.ChatMode != "p2p" {
+				all = append(all, item)
+			}
+		}
+
+		if !result.HasMore || result.PageToken == "" {
+			break
+		}
+		pageToken = result.PageToken
+	}
+
+	return all, nil
+}
+
 // --- Contact API ---
 
 func (c *LarkClient) GetUser(ctx context.Context, userID, userIDType string) (string, error) {

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -54,6 +54,7 @@ type Manager struct {
 	dispatchTask     *asyncTask
 	mu               sync.RWMutex
 	contactCollector *store.ContactCollector
+	groupCollector   *store.GroupCollector
 }
 
 type asyncTask struct {
@@ -161,10 +162,15 @@ func (m *Manager) GetEnabledChannels() []string {
 func (m *Manager) RegisterChannel(name string, channel Channel) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	// Propagate contact collector to channels that embed BaseChannel.
+	// Propagate collectors to channels that embed BaseChannel.
 	if m.contactCollector != nil {
 		if bc, ok := channel.(interface{ SetContactCollector(*store.ContactCollector) }); ok {
 			bc.SetContactCollector(m.contactCollector)
+		}
+	}
+	if m.groupCollector != nil {
+		if bc, ok := channel.(interface{ SetGroupCollector(*store.GroupCollector) }); ok {
+			bc.SetGroupCollector(m.groupCollector)
 		}
 	}
 	m.channels[name] = channel
@@ -178,6 +184,18 @@ func (m *Manager) SetContactCollector(cc *store.ContactCollector) {
 	for _, ch := range m.channels {
 		if bc, ok := ch.(interface{ SetContactCollector(*store.ContactCollector) }); ok {
 			bc.SetContactCollector(cc)
+		}
+	}
+}
+
+// SetGroupCollector sets the group collector for all current and future channels.
+func (m *Manager) SetGroupCollector(gc *store.GroupCollector) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.groupCollector = gc
+	for _, ch := range m.channels {
+		if bc, ok := ch.(interface{ SetGroupCollector(*store.GroupCollector) }); ok {
+			bc.SetGroupCollector(gc)
 		}
 	}
 }

--- a/internal/channels/slack/channel.go
+++ b/internal/channels/slack/channel.go
@@ -211,6 +211,19 @@ func (c *Channel) Start(ctx context.Context) error {
 
 	c.SetRunning(true)
 	slog.Info("slack bot connected", "user_id", c.botUserID, "team", authResp.Team)
+
+	// Populate channel_groups directory in background (non-blocking).
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		defer safego.Recover(nil, "component", "slack_refresh_groups")
+		refreshCtx, refreshCancel := context.WithTimeout(smCtx, 30*time.Second)
+		defer refreshCancel()
+		if err := c.RefreshGroups(refreshCtx); err != nil {
+			slog.Warn("slack: initial group refresh failed", "error", err)
+		}
+	}()
+
 	return nil
 }
 

--- a/internal/channels/slack/channel.go
+++ b/internal/channels/slack/channel.go
@@ -43,6 +43,7 @@ type Channel struct {
 	reactions       sync.Map // chatID:messageID -> *reactionState
 	pairingDebounce sync.Map // senderID -> time.Time
 	approvedGroups  sync.Map // channelID -> true
+	channelNames    sync.Map // channelID → name string
 
 	// High-churn map: sync.Mutex + regular map for debounce timers
 	debounceMu     sync.Mutex

--- a/internal/channels/slack/handlers.go
+++ b/internal/channels/slack/handlers.go
@@ -202,6 +202,12 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 			if cc := c.ContactCollector(); cc != nil {
 				cc.EnsureContact(ctx, c.Type(), c.Name(), senderID, senderID, displayName, "", "group")
 			}
+			// Collect group directory entry.
+			if gc := c.GroupCollector(); gc != nil {
+				if chanName := c.resolveChannelName(ctx, channelID); chanName != "" {
+					gc.EnsureGroup(ctx, c.Type(), c.Name(), channelID, chanName, 0)
+				}
+			}
 
 			slog.Debug("slack group message recorded (no mention)",
 				"channel_id", channelID, "user", displayName)

--- a/internal/channels/slack/handlers.go
+++ b/internal/channels/slack/handlers.go
@@ -259,6 +259,7 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 		"message_id":      ev.TimeStamp,
 		"user_id":         senderID,
 		"username":        displayName,
+		"display_name":    displayName,
 		"channel_id":      channelID,
 		"is_dm":           fmt.Sprintf("%t", isDM),
 		"local_key":       localKey,

--- a/internal/channels/slack/utils.go
+++ b/internal/channels/slack/utils.go
@@ -113,6 +113,52 @@ func (c *Channel) resolveChannelName(ctx context.Context, channelID string) stri
 	return info.Name
 }
 
+// RefreshGroups fetches all Slack conversations the bot is a member of and
+// upserts them into the channel_groups directory via the GroupCollector.
+// Pagination is handled via cursor. Only channels with a non-empty name are recorded.
+func (c *Channel) RefreshGroups(ctx context.Context) error {
+	gc := c.GroupCollector()
+	if gc == nil {
+		return fmt.Errorf("slack: group collector not configured")
+	}
+
+	gctx := store.WithTenantID(ctx, c.TenantID())
+	var cursor string
+	var total int
+
+	for {
+		params := &slackapi.GetConversationsParameters{
+			Types:           []string{"public_channel", "private_channel"},
+			Limit:           200,
+			Cursor:          cursor,
+			ExcludeArchived: true,
+		}
+		convos, nextCursor, err := c.api.GetConversationsContext(gctx, params)
+		if err != nil {
+			return fmt.Errorf("slack: conversations.list failed: %w", err)
+		}
+		for _, ch := range convos {
+			name := ch.Name
+			if name == "" {
+				name = ch.NameNormalized
+			}
+			if name == "" {
+				continue
+			}
+			gc.EnsureGroup(gctx, c.Type(), c.Name(), ch.ID, name, ch.NumMembers)
+			c.channelNames.Store(ch.ID, name)
+			total++
+		}
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	slog.Info("slack: refreshed groups", "count", total, "channel", c.Name())
+	return nil
+}
+
 // nonRetryableAuthErrors matches Slack errors that indicate permanent auth failure.
 var nonRetryableAuthErrors = regexp.MustCompile(
 	`(?i)(invalid_auth|token_revoked|account_inactive|not_authed|team_not_found|missing_scope)`,

--- a/internal/channels/slack/utils.go
+++ b/internal/channels/slack/utils.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	slackapi "github.com/slack-go/slack"
+
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
@@ -35,6 +37,15 @@ func (c *Channel) HandleMessage(senderID, chatID, content string, mediaPaths []s
 	if cc := c.ContactCollector(); cc != nil {
 		ctx := store.WithTenantID(context.Background(), c.TenantID())
 		cc.EnsureContact(ctx, c.Type(), c.Name(), userID, userID, metadata["username"], "", peerKind)
+	}
+	// Collect group directory entry.
+	if peerKind == "group" {
+		if gc := c.GroupCollector(); gc != nil {
+			ctx := store.WithTenantID(context.Background(), c.TenantID())
+			if chanName := c.resolveChannelName(ctx, chatID); chanName != "" {
+				gc.EnsureGroup(ctx, c.Type(), c.Name(), chatID, chanName, 0)
+			}
+		}
 	}
 
 	c.Bus().PublishInbound(bus.InboundMessage{
@@ -82,6 +93,24 @@ func (c *Channel) resolveDisplayName(userID string) string {
 	c.userCacheMu.Unlock()
 
 	return name
+}
+
+// resolveChannelName returns the cached channel name, fetching from Slack API on first call.
+func (c *Channel) resolveChannelName(ctx context.Context, channelID string) string {
+	if name, ok := c.channelNames.Load(channelID); ok {
+		return name.(string)
+	}
+	info, err := c.api.GetConversationInfoContext(ctx, &slackapi.GetConversationInfoInput{
+		ChannelID: channelID,
+	})
+	if err != nil {
+		slog.Debug("slack: failed to resolve channel name", "channel_id", channelID, "error", err)
+		return ""
+	}
+	if info.Name != "" {
+		c.channelNames.Store(channelID, info.Name)
+	}
+	return info.Name
 }
 
 // nonRetryableAuthErrors matches Slack errors that indicate permanent auth failure.

--- a/internal/channels/telegram/channel.go
+++ b/internal/channels/telegram/channel.go
@@ -228,6 +228,18 @@ func (c *Channel) Start(ctx context.Context) error {
 					case <-pollCtx.Done():
 						return
 					}
+				} else if update.MyChatMember != nil {
+					select {
+					case c.handlerSem <- struct{}{}:
+						c.handlerWg.Add(1)
+						go func(m *telego.ChatMemberUpdated) {
+							defer c.handlerWg.Done()
+							defer func() { <-c.handlerSem }()
+							c.handleMyChatMember(pollCtx, m)
+						}(update.MyChatMember)
+					case <-pollCtx.Done():
+						return
+					}
 				} else {
 					// Log non-message updates for delivery diagnostics
 					updateType := "unknown"
@@ -236,8 +248,6 @@ func (c *Channel) Start(ctx context.Context) error {
 						updateType = "edited_message"
 					case update.ChannelPost != nil:
 						updateType = "channel_post"
-					case update.MyChatMember != nil:
-						updateType = "my_chat_member"
 					case update.ChatMember != nil:
 						updateType = "chat_member"
 					}

--- a/internal/channels/telegram/handlers.go
+++ b/internal/channels/telegram/handlers.go
@@ -331,7 +331,11 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 			// Collect contact even when bot is not mentioned (cache prevents DB spam).
 			if cc := c.ContactCollector(); cc != nil {
 				contactName := strings.TrimSpace(user.FirstName + " " + user.LastName)
-				cc.EnsureContact(ctx, c.Type(), c.Name(), userID, userID, contactName, user.Username, "group")
+				cc.EnsureContact(ctx, c.Type(), c.Name(), senderID, userID, contactName, user.Username, "group")
+			}
+			// Collect group directory entry.
+			if gc := c.GroupCollector(); gc != nil && message.Chat.Title != "" {
+				gc.EnsureGroup(ctx, c.Type(), c.Name(), chatIDStr, message.Chat.Title, 0)
 			}
 
 			slog.Debug("telegram group message recorded (no mention)",
@@ -584,6 +588,12 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 	// Collect contact for processed messages (DM + group-mentioned).
 	if cc := c.ContactCollector(); cc != nil {
 		cc.EnsureContact(ctx, c.Type(), c.Name(), senderID, userID, user.FirstName, user.Username, peerKind)
+	}
+	// Collect group directory entry.
+	if isGroup && message.Chat.Title != "" {
+		if gc := c.GroupCollector(); gc != nil {
+			gc.EnsureGroup(ctx, c.Type(), c.Name(), chatIDStr, message.Chat.Title, 0)
+		}
 	}
 
 	c.Bus().PublishInbound(bus.InboundMessage{

--- a/internal/channels/telegram/handlers.go
+++ b/internal/channels/telegram/handlers.go
@@ -616,3 +616,54 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 	}
 }
 
+// handleMyChatMember processes my_chat_member updates (bot added/removed from groups).
+// When the bot is added to a group (status transitions to "member" or "administrator"),
+// the group is immediately registered in the group directory so it appears in the
+// contacts picker without waiting for the first message.
+func (c *Channel) handleMyChatMember(ctx context.Context, update *telego.ChatMemberUpdated) {
+	if update == nil {
+		return
+	}
+
+	chat := update.Chat
+	newStatus := update.NewChatMember.MemberStatus()
+	oldStatus := update.OldChatMember.MemberStatus()
+
+	slog.Debug("telegram my_chat_member update",
+		"chat_id", chat.ID,
+		"chat_type", chat.Type,
+		"chat_title", chat.Title,
+		"old_status", oldStatus,
+		"new_status", newStatus,
+	)
+
+	isGroup := chat.Type == "group" || chat.Type == "supergroup"
+	if !isGroup {
+		return
+	}
+
+	// Bot was added or promoted in a group — register the group immediately.
+	switch newStatus {
+	case "member", "administrator", "creator":
+		// Only act on transitions from non-member states to avoid duplicate work
+		// on status changes between member↔administrator.
+		if oldStatus == "left" || oldStatus == "kicked" || oldStatus == "" {
+			chatIDStr := fmt.Sprintf("%d", chat.ID)
+			if gc := c.GroupCollector(); gc != nil && chat.Title != "" {
+				gc.EnsureGroup(ctx, c.Type(), c.Name(), chatIDStr, chat.Title, 0)
+				slog.Info("telegram group registered via my_chat_member",
+					"chat_id", chat.ID,
+					"title", chat.Title,
+					"new_status", newStatus,
+				)
+			}
+		}
+	case "left", "kicked":
+		slog.Info("telegram bot removed from group",
+			"chat_id", chat.ID,
+			"title", chat.Title,
+			"new_status", newStatus,
+		)
+	}
+}
+

--- a/internal/channels/zalo/personal/channel.go
+++ b/internal/channels/zalo/personal/channel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -23,8 +24,10 @@ type Channel struct {
 	config          config.ZaloPersonalConfig
 	pairingService  store.PairingStore
 	pairingDebounce sync.Map // senderID -> time.Time
-	approvedGroups  sync.Map // groupID → true (in-memory cache for paired groups)
-	typingCtrls     sync.Map // threadID → *typing.Controller
+	approvedGroups         sync.Map  // groupID → true (in-memory cache for paired groups)
+	groupNames             sync.Map  // groupID → name string (cached for contact collection)
+	groupNamesRefreshedAt  time.Time // last refresh time (throttle, protected by mu)
+	typingCtrls            sync.Map  // threadID → *typing.Controller
 
 	mu       sync.RWMutex // protects sess and listener
 	sess     *protocol.Session
@@ -118,6 +121,9 @@ func (c *Channel) Start(ctx context.Context) error {
 
 	slog.Info("zalo_personal connected", "uid", sess.UID)
 
+	// Pre-cache group names for contact collection (best-effort).
+	go c.cacheGroupNames(sess)
+
 	c.SetRunning(true)
 	go c.listenLoop(ctx)
 
@@ -132,6 +138,60 @@ func (c *Channel) SetPendingCompaction(cfg *channels.CompactionConfig) {
 
 // SetPendingHistoryTenantID propagates tenant_id to the pending history for DB operations.
 func (c *Channel) SetPendingHistoryTenantID(id uuid.UUID) { c.groupHistory.SetTenantID(id) }
+
+// cacheGroupNames fetches group list and caches names for contact collection.
+func (c *Channel) cacheGroupNames(sess *protocol.Session) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	groups, err := protocol.FetchGroups(ctx, sess)
+	if err != nil {
+		slog.Debug("zalo_personal: cache group names failed", "error", err)
+		return
+	}
+	for _, g := range groups {
+		if g.Name != "" {
+			c.groupNames.Store(g.GroupID, g.Name)
+		}
+	}
+	slog.Info("zalo_personal: cached group names", "count", len(groups))
+}
+
+// resolveGroupName returns cached group name. If unknown, triggers async refresh
+// and returns empty (name will be available on next message).
+func (c *Channel) resolveGroupName(groupID string) string {
+	if name, ok := c.groupNames.Load(groupID); ok {
+		return name.(string)
+	}
+	// Unknown group — trigger async refresh (non-blocking, throttled).
+	c.refreshGroupNamesOnce()
+	return ""
+}
+
+// refreshGroupNamesOnce triggers a background group name refresh, throttled to
+// at most once per 5 minutes to avoid API spam.
+func (c *Channel) refreshGroupNamesOnce() {
+	now := time.Now()
+	c.mu.RLock()
+	last := c.groupNamesRefreshedAt
+	c.mu.RUnlock()
+	if now.Sub(last) < 5*time.Minute {
+		return
+	}
+	c.mu.Lock()
+	// Double-check after acquiring write lock.
+	if now.Sub(c.groupNamesRefreshedAt) < 5*time.Minute {
+		c.mu.Unlock()
+		return
+	}
+	c.groupNamesRefreshedAt = now
+	c.mu.Unlock()
+
+	sess := c.session()
+	if sess == nil {
+		return
+	}
+	go c.cacheGroupNames(sess)
+}
 
 // Stop gracefully shuts down the Zalo Personal channel.
 func (c *Channel) Stop(_ context.Context) error {

--- a/internal/channels/zalo/personal/handlers.go
+++ b/internal/channels/zalo/personal/handlers.go
@@ -112,6 +112,12 @@ func (c *Channel) handleGroupMessage(msg protocol.GroupMessage) {
 			if cc := c.ContactCollector(); cc != nil {
 				cc.EnsureContact(ctx, c.Type(), c.Name(), senderID, senderID, senderName, "", "group")
 			}
+			// Collect group directory entry.
+			if gc := c.GroupCollector(); gc != nil {
+				if groupName := c.resolveGroupName(threadID); groupName != "" {
+					gc.EnsureGroup(ctx, c.Type(), c.Name(), threadID, groupName, 0)
+				}
+			}
 
 			slog.Debug("zalo_personal group message recorded (no mention)",
 				"group_id", threadID,
@@ -144,6 +150,12 @@ func (c *Channel) handleGroupMessage(msg protocol.GroupMessage) {
 	// Collect contact for group-mentioned messages.
 	if cc := c.ContactCollector(); cc != nil {
 		cc.EnsureContact(ctx, c.Type(), c.Name(), senderID, senderID, senderName, "", "group")
+	}
+	// Collect group directory entry.
+	if gc := c.GroupCollector(); gc != nil {
+		if groupName := c.resolveGroupName(threadID); groupName != "" {
+			gc.EnsureGroup(ctx, c.Type(), c.Name(), threadID, groupName, 0)
+		}
 	}
 
 	metadata := map[string]string{

--- a/internal/http/channel_instances.go
+++ b/internal/http/channel_instances.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/feishu"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
@@ -24,6 +26,12 @@ type ChannelInstancesHandler struct {
 	groupStore      store.GroupStore
 	tenantStore     store.TenantStore
 	msgBus          *bus.MessageBus
+	channelMgr      *channels.Manager // optional: for on-demand group refresh
+}
+
+// SetChannelManager sets the channel manager for on-demand operations like group refresh.
+func (h *ChannelInstancesHandler) SetChannelManager(mgr *channels.Manager) {
+	h.channelMgr = mgr
 }
 
 // NewChannelInstancesHandler creates a handler for channel instance management endpoints.
@@ -38,6 +46,7 @@ func (h *ChannelInstancesHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v1/channels/instances/{id}", h.auth(h.handleGet))
 	mux.HandleFunc("PUT /v1/channels/instances/{id}", h.auth(h.handleUpdate))
 	mux.HandleFunc("DELETE /v1/channels/instances/{id}", h.auth(h.handleDelete))
+	mux.HandleFunc("POST /v1/channels/instances/{id}/fetch-groups", h.auth(h.handleFetchGroups))
 
 	// Channel contacts (global, not per-agent)
 	if h.contactStore != nil {
@@ -519,6 +528,48 @@ func (h *ChannelInstancesHandler) handleListGroups(w http.ResponseWriter, r *htt
 	writeJSON(w, http.StatusOK, map[string]any{"groups": groups})
 }
 
+// POST /v1/channels/instances/{id}/fetch-groups
+// Triggers an on-demand refresh of the channel's group/conversation list.
+// The channel must implement channels.GroupRefresher (currently: Slack).
+func (h *ChannelInstancesHandler) handleFetchGroups(w http.ResponseWriter, r *http.Request) {
+	instID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest, "invalid instance id")
+		return
+	}
+
+	inst, err := h.store.Get(r.Context(), instID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, protocol.ErrNotFound, "instance not found")
+		return
+	}
+
+	// Try running channel first (supports live refresh)
+	if h.channelMgr != nil {
+		if ch, ok := h.channelMgr.GetChannel(inst.Name); ok && ch.IsRunning() {
+			if refresher, ok := ch.(channels.GroupRefresher); ok {
+				if err := refresher.RefreshGroups(r.Context()); err != nil {
+					slog.Error("fetch-groups failed", "instance", inst.Name, "error", err)
+					writeError(w, http.StatusInternalServerError, protocol.ErrInternal, "failed to fetch groups: "+err.Error())
+					return
+				}
+				if h.groupStore != nil {
+					if groups, err := h.groupStore.ListGroups(r.Context(), inst.ChannelType); err == nil {
+						writeJSON(w, http.StatusOK, map[string]any{"groups": groups})
+						return
+					}
+				}
+				writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+				return
+			}
+		}
+	}
+
+	// Fallback: temporary API client from credentials
+	h.fetchGroupsFallback(w, r, inst)
+
+}
+
 func (h *ChannelInstancesHandler) handleResolveContacts(w http.ResponseWriter, r *http.Request) {
 	idsParam := r.URL.Query().Get("ids")
 	if idsParam == "" {
@@ -540,6 +591,98 @@ func (h *ChannelInstancesHandler) handleResolveContacts(w http.ResponseWriter, r
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"contacts": result})
+}
+
+// fetchGroupsFallback handles channels that don't implement GroupRefresher
+// by creating a temporary API client from instance credentials.
+func (h *ChannelInstancesHandler) fetchGroupsFallback(w http.ResponseWriter, r *http.Request, inst *store.ChannelInstanceData) {
+	if len(inst.Credentials) == 0 {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest, "instance has no credentials")
+		return
+	}
+
+	switch inst.ChannelType {
+	case "feishu":
+		h.fetchFeishuGroups(w, r, inst)
+	default:
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest, "fetch-groups not supported for channel type: "+inst.ChannelType)
+	}
+}
+
+// fetchFeishuGroups fetches group chats from the Feishu/Lark API and upserts them.
+func (h *ChannelInstancesHandler) fetchFeishuGroups(w http.ResponseWriter, r *http.Request, inst *store.ChannelInstanceData) {
+	locale := store.LocaleFromContext(r.Context())
+
+	var creds struct {
+		AppID     string `json:"app_id"`
+		AppSecret string `json:"app_secret"`
+	}
+	if err := json.Unmarshal(inst.Credentials, &creds); err != nil || creds.AppID == "" || creds.AppSecret == "" {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest, "invalid feishu credentials")
+		return
+	}
+
+	// Resolve domain from instance config
+	domain := "https://open.larksuite.com"
+	if len(inst.Config) > 0 {
+		var cfg struct {
+			Domain string `json:"domain,omitempty"`
+		}
+		if json.Unmarshal(inst.Config, &cfg) == nil && cfg.Domain != "" {
+			switch cfg.Domain {
+			case "feishu":
+				domain = "https://open.feishu.cn"
+			case "lark":
+				// default
+			default:
+				if strings.HasPrefix(cfg.Domain, "http") {
+					domain = cfg.Domain
+				} else {
+					domain = "https://" + cfg.Domain
+				}
+			}
+		}
+	}
+
+	client := feishu.NewLarkClient(creds.AppID, creds.AppSecret, domain)
+
+	chats, err := client.ListChats(r.Context())
+	if err != nil {
+		slog.Error("fetch_groups.feishu", "instance", inst.ID, "error", err)
+		writeError(w, http.StatusInternalServerError, protocol.ErrInternal, i18n.T(locale, i18n.MsgFailedToList, "groups"))
+		return
+	}
+
+	// Upsert into channel_groups
+	if h.groupStore != nil {
+		for _, chat := range chats {
+			if err := h.groupStore.UpsertGroup(r.Context(), "feishu", inst.Name, chat.ChatID, chat.Name, chat.UserCountInt()); err != nil {
+				slog.Warn("fetch_groups.feishu upsert", "chat_id", chat.ChatID, "error", err)
+			}
+		}
+	}
+
+	// Build response
+	type groupResult struct {
+		GroupID     string `json:"group_id"`
+		GroupName   string `json:"group_name"`
+		MemberCount int    `json:"member_count"`
+		Avatar      string `json:"avatar,omitempty"`
+	}
+	groups := make([]groupResult, 0, len(chats))
+	for _, chat := range chats {
+		groups = append(groups, groupResult{
+			GroupID:     chat.ChatID,
+			GroupName:   chat.Name,
+			MemberCount: chat.UserCountInt(),
+			Avatar:      chat.Avatar,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"groups": groups,
+		"total":  len(groups),
+	})
 }
 
 // isValidChannelType checks if the channel type is supported.

--- a/internal/http/channel_instances.go
+++ b/internal/http/channel_instances.go
@@ -21,13 +21,14 @@ type ChannelInstancesHandler struct {
 	agentStore      store.AgentStore
 	configPermStore store.ConfigPermissionStore
 	contactStore    store.ContactStore
+	groupStore      store.GroupStore
 	tenantStore     store.TenantStore
 	msgBus          *bus.MessageBus
 }
 
 // NewChannelInstancesHandler creates a handler for channel instance management endpoints.
-func NewChannelInstancesHandler(s store.ChannelInstanceStore, agentStore store.AgentStore, configPermStore store.ConfigPermissionStore, contactStore store.ContactStore, tenantStore store.TenantStore, msgBus *bus.MessageBus) *ChannelInstancesHandler {
-	return &ChannelInstancesHandler{store: s, agentStore: agentStore, configPermStore: configPermStore, contactStore: contactStore, tenantStore: tenantStore, msgBus: msgBus}
+func NewChannelInstancesHandler(s store.ChannelInstanceStore, agentStore store.AgentStore, configPermStore store.ConfigPermissionStore, contactStore store.ContactStore, groupStore store.GroupStore, tenantStore store.TenantStore, msgBus *bus.MessageBus) *ChannelInstancesHandler {
+	return &ChannelInstancesHandler{store: s, agentStore: agentStore, configPermStore: configPermStore, contactStore: contactStore, groupStore: groupStore, tenantStore: tenantStore, msgBus: msgBus}
 }
 
 // RegisterRoutes registers all channel instance routes on the given mux.
@@ -45,6 +46,9 @@ func (h *ChannelInstancesHandler) RegisterRoutes(mux *http.ServeMux) {
 		mux.HandleFunc("POST /v1/contacts/merge", h.auth(h.handleMergeContacts))
 		mux.HandleFunc("POST /v1/contacts/unmerge", h.auth(h.handleUnmergeContacts))
 		mux.HandleFunc("GET /v1/contacts/merged/{tenantUserId}", h.auth(h.handleListMergedContacts))
+	}
+	if h.groupStore != nil {
+		mux.HandleFunc("GET /v1/groups", h.auth(h.handleListGroups))
 	}
 	if h.tenantStore != nil {
 		mux.HandleFunc("GET /v1/tenant-users", h.auth(h.handleListTenantUsers))
@@ -498,6 +502,21 @@ func (h *ChannelInstancesHandler) handleListContacts(w http.ResponseWriter, r *h
 		"limit":    opts.Limit,
 		"offset":   opts.Offset,
 	})
+}
+
+// GET /v1/groups?channel_type=telegram
+func (h *ChannelInstancesHandler) handleListGroups(w http.ResponseWriter, r *http.Request) {
+	channelType := r.URL.Query().Get("channel_type")
+	groups, err := h.groupStore.ListGroups(r.Context(), channelType)
+	if err != nil {
+		slog.Error("groups.list", "error", err)
+		writeError(w, http.StatusInternalServerError, protocol.ErrInternal, "failed to list groups")
+		return
+	}
+	if groups == nil {
+		groups = []store.ChannelGroup{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"groups": groups})
 }
 
 func (h *ChannelInstancesHandler) handleResolveContacts(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/pending_messages.go
+++ b/internal/http/pending_messages.go
@@ -18,6 +18,7 @@ import (
 type PendingMessagesHandler struct {
 	store       store.PendingMessageStore
 	agentStore  store.AgentStore
+	groupStore  store.GroupStore
 	providerReg *providers.Registry
 	keepRecent  int    // global keepRecent from config (0 = use default 15)
 	maxTokens   int    // max output tokens for LLM summarization (0 = use default)
@@ -25,8 +26,8 @@ type PendingMessagesHandler struct {
 	cfgModel    string // config-level model override (empty = resolve from agent)
 }
 
-func NewPendingMessagesHandler(s store.PendingMessageStore, agentStore store.AgentStore, providerReg *providers.Registry) *PendingMessagesHandler {
-	return &PendingMessagesHandler{store: s, agentStore: agentStore, providerReg: providerReg}
+func NewPendingMessagesHandler(s store.PendingMessageStore, agentStore store.AgentStore, groupStore store.GroupStore, providerReg *providers.Registry) *PendingMessagesHandler {
+	return &PendingMessagesHandler{store: s, agentStore: agentStore, groupStore: groupStore, providerReg: providerReg}
 }
 
 // SetKeepRecent sets the global keepRecent value from config.
@@ -65,6 +66,22 @@ func (h *PendingMessagesHandler) handleListGroups(w http.ResponseWriter, r *http
 		for i := range groups {
 			if t, ok := titles[groups[i].ChannelName+":"+groups[i].HistoryKey]; ok {
 				groups[i].GroupTitle = t
+			}
+		}
+	}
+
+	// Fallback: resolve remaining titles from channel_groups table
+	if h.groupStore != nil {
+		for i := range groups {
+			if groups[i].GroupTitle != "" {
+				continue
+			}
+			// history_key is the group ID for group chats
+			channelGroups, err := h.groupStore.GetGroupsByIDs(r.Context(), "", []string{groups[i].HistoryKey})
+			if err == nil {
+				if g, ok := channelGroups[groups[i].HistoryKey]; ok && g.GroupName != nil {
+					groups[i].GroupTitle = *g.GroupName
+				}
 			}
 		}
 	}

--- a/internal/store/group_collector.go
+++ b/internal/store/group_collector.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/nextlevelbuilder/goclaw/internal/cache"
+)
+
+// GroupCollector wraps GroupStore with an in-memory cache.
+// Only writes to DB when a group is new or its name has changed.
+type GroupCollector struct {
+	store GroupStore
+	names cache.Cache[string] // channelType:grp:groupID → cached group name
+}
+
+// NewGroupCollector creates a new collector backed by the given store and cache.
+func NewGroupCollector(s GroupStore, c cache.Cache[string]) *GroupCollector {
+	return &GroupCollector{store: s, names: c}
+}
+
+// EnsureGroup upserts a group entry only if the name changed or is new.
+func (c *GroupCollector) EnsureGroup(ctx context.Context, channelType, channelInstance, groupID, groupName string, memberCount int) {
+	key := channelType + ":grp:" + groupID
+	if cached, ok := c.names.Get(ctx, key); ok && cached == groupName {
+		return // same name, skip DB write
+	}
+	if err := c.store.UpsertGroup(ctx, channelType, channelInstance, groupID, groupName, memberCount); err != nil {
+		slog.Warn("group_collector.upsert_failed", "error", err, "channel", channelType, "group", groupID)
+		return
+	}
+	c.names.Set(ctx, key, groupName, 0) // no TTL — evict only on name change
+}

--- a/internal/store/group_store.go
+++ b/internal/store/group_store.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ChannelGroup represents a known group/chat discovered through channel interactions.
+type ChannelGroup struct {
+	ID              uuid.UUID `json:"id"`
+	ChannelType     string    `json:"channel_type"`
+	ChannelInstance *string   `json:"channel_instance,omitempty"`
+	GroupID         string    `json:"group_id"`
+	GroupName       *string   `json:"group_name,omitempty"`
+	AvatarURL       *string   `json:"avatar_url,omitempty"`
+	MemberCount     int       `json:"member_count"`
+	FirstSeenAt     time.Time `json:"first_seen_at"`
+	LastSeenAt      time.Time `json:"last_seen_at"`
+}
+
+// GroupStore manages the channel_groups directory.
+type GroupStore interface {
+	// UpsertGroup creates or updates a known group.
+	UpsertGroup(ctx context.Context, channelType, channelInstance, groupID, groupName string, memberCount int) error
+
+	// ListGroups returns all known groups for a channel type.
+	ListGroups(ctx context.Context, channelType string) ([]ChannelGroup, error)
+
+	// GetGroupsByIDs returns groups by their platform-specific IDs.
+	GetGroupsByIDs(ctx context.Context, channelType string, groupIDs []string) (map[string]ChannelGroup, error)
+}

--- a/internal/store/pg/channel_groups.go
+++ b/internal/store/pg/channel_groups.go
@@ -1,0 +1,129 @@
+package pg
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// PGGroupStore implements store.GroupStore backed by Postgres.
+type PGGroupStore struct {
+	db *sql.DB
+}
+
+func NewPGGroupStore(db *sql.DB) *PGGroupStore {
+	return &PGGroupStore{db: db}
+}
+
+func (s *PGGroupStore) UpsertGroup(ctx context.Context, channelType, channelInstance, groupID, groupName string, memberCount int) error {
+	tenantID := store.TenantIDFromContext(ctx)
+	if tenantID == uuid.Nil {
+		tenantID = store.MasterTenantID
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO channel_groups (tenant_id, channel_type, channel_instance, group_id, group_name, member_count)
+		VALUES ($1, $2, NULLIF($3,''), $4, NULLIF($5,''), $6)
+		ON CONFLICT (tenant_id, channel_type, group_id) DO UPDATE SET
+			group_name       = COALESCE(NULLIF($5,''), channel_groups.group_name),
+			channel_instance = COALESCE(NULLIF($3,''), channel_groups.channel_instance),
+			member_count     = CASE WHEN $6 > 0 THEN $6 ELSE channel_groups.member_count END,
+			last_seen_at     = NOW()`,
+		tenantID, channelType, channelInstance, groupID, groupName, memberCount,
+	)
+	return err
+}
+
+func (s *PGGroupStore) ListGroups(ctx context.Context, channelType string) ([]store.ChannelGroup, error) {
+	tenantID := store.TenantIDFromContext(ctx)
+	if tenantID == uuid.Nil {
+		tenantID = store.MasterTenantID
+	}
+	query := `SELECT id, channel_type, channel_instance, group_id, group_name, avatar_url, member_count, first_seen_at, last_seen_at
+		FROM channel_groups WHERE tenant_id = $1`
+	args := []any{tenantID}
+	if channelType != "" {
+		query += ` AND channel_type = $2`
+		args = append(args, channelType)
+	}
+	query += ` ORDER BY COALESCE(group_name, group_id)`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanGroups(rows)
+}
+
+func (s *PGGroupStore) GetGroupsByIDs(ctx context.Context, channelType string, groupIDs []string) (map[string]store.ChannelGroup, error) {
+	if len(groupIDs) == 0 {
+		return nil, nil
+	}
+	tenantID := store.TenantIDFromContext(ctx)
+	if tenantID == uuid.Nil {
+		tenantID = store.MasterTenantID
+	}
+	var query string
+	var args []any
+	if channelType != "" {
+		query, args = buildINQuery(
+			`SELECT id, channel_type, channel_instance, group_id, group_name, avatar_url, member_count, first_seen_at, last_seen_at
+			 FROM channel_groups WHERE tenant_id = $1 AND channel_type = $2 AND group_id IN `,
+			3, groupIDs, tenantID, channelType,
+		)
+	} else {
+		query, args = buildINQuery(
+			`SELECT id, channel_type, channel_instance, group_id, group_name, avatar_url, member_count, first_seen_at, last_seen_at
+			 FROM channel_groups WHERE tenant_id = $1 AND group_id IN `,
+			2, groupIDs, tenantID,
+		)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	groups, err := scanGroups(rows)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]store.ChannelGroup, len(groups))
+	for _, g := range groups {
+		m[g.GroupID] = g
+	}
+	return m, nil
+}
+
+func scanGroups(rows *sql.Rows) ([]store.ChannelGroup, error) {
+	var out []store.ChannelGroup
+	for rows.Next() {
+		var g store.ChannelGroup
+		if err := rows.Scan(
+			&g.ID, &g.ChannelType, &g.ChannelInstance,
+			&g.GroupID, &g.GroupName, &g.AvatarURL,
+			&g.MemberCount, &g.FirstSeenAt, &g.LastSeenAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, g)
+	}
+	return out, rows.Err()
+}
+
+// buildINQuery builds a query with IN ($3, $4, ...) placeholders.
+func buildINQuery(prefix string, startIdx int, ids []string, prefixArgs ...any) (string, []any) {
+	args := make([]any, 0, len(prefixArgs)+len(ids))
+	args = append(args, prefixArgs...)
+	placeholders := ""
+	for i, id := range ids {
+		if i > 0 {
+			placeholders += ","
+		}
+		placeholders += fmt.Sprintf("$%d", startIdx+i)
+		args = append(args, id)
+	}
+	return prefix + "(" + placeholders + ")", args
+}

--- a/internal/store/pg/factory.go
+++ b/internal/store/pg/factory.go
@@ -40,6 +40,7 @@ func NewPGStores(cfg store.StoreConfig) (*store.Stores, error) {
 		PendingMessages:  NewPGPendingMessageStore(db),
 		KnowledgeGraph:   NewPGKnowledgeGraphStore(db),
 		Contacts:         NewPGContactStore(db),
+		Groups:           NewPGGroupStore(db),
 		Activity:         NewPGActivityStore(db),
 		Snapshots:        NewPGSnapshotStore(db),
 		SecureCLI:        NewPGSecureCLIStore(db, cfg.EncryptionKey),

--- a/internal/store/stores.go
+++ b/internal/store/stores.go
@@ -22,6 +22,7 @@ type Stores struct {
 	PendingMessages  PendingMessageStore
 	KnowledgeGraph   KnowledgeGraphStore
 	Contacts         ContactStore
+	Groups           GroupStore
 	Activity         ActivityStore
 	Snapshots        SnapshotStore
 	SecureCLI        SecureCLIStore

--- a/internal/upgrade/version.go
+++ b/internal/upgrade/version.go
@@ -2,4 +2,4 @@ package upgrade
 
 // RequiredSchemaVersion is the schema migration version this binary requires.
 // Bump this whenever adding a new SQL migration file.
-const RequiredSchemaVersion uint = 30
+const RequiredSchemaVersion uint = 31

--- a/migrations/000031_channel_groups.down.sql
+++ b/migrations/000031_channel_groups.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS channel_groups;

--- a/migrations/000031_channel_groups.up.sql
+++ b/migrations/000031_channel_groups.up.sql
@@ -1,0 +1,18 @@
+-- Channel groups directory: stores known groups across all channel types.
+-- Used by allow_from picker, managers tab, and contacts page.
+CREATE TABLE IF NOT EXISTS channel_groups (
+    id               UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    tenant_id        UUID NOT NULL DEFAULT '0193a5b0-7000-7000-8000-000000000001',
+    channel_type     VARCHAR(50)  NOT NULL,
+    channel_instance VARCHAR(255),
+    group_id         VARCHAR(255) NOT NULL,
+    group_name       VARCHAR(255),
+    avatar_url       TEXT,
+    member_count     INT          DEFAULT 0,
+    first_seen_at    TIMESTAMPTZ  DEFAULT NOW(),
+    last_seen_at     TIMESTAMPTZ  DEFAULT NOW(),
+    UNIQUE(tenant_id, channel_type, group_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_channel_groups_channel_type ON channel_groups (tenant_id, channel_type);
+CREATE INDEX IF NOT EXISTS idx_channel_groups_name ON channel_groups (group_name);

--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -312,6 +312,16 @@
     "failedUpdate": "Failed to update channel",
     "failedDelete": "Failed to delete channel"
   },
+  "allowFromPicker": {
+    "users": "Users",
+    "groups": "Groups",
+    "search": "Search...",
+    "noMatch": "No matches",
+    "manualPlaceholder": "Enter ID manually",
+    "add": "Add",
+    "fetchGroups": "Fetch groups",
+    "fetching": "Fetching channels..."
+  },
   "zalo": {
     "allowedUsers": "Allowed Users",
     "loadContacts": "Load Contacts",

--- a/ui/web/src/i18n/locales/en/contacts.json
+++ b/ui/web/src/i18n/locales/en/contacts.json
@@ -50,5 +50,17 @@
     "allTypes": "All Types",
     "direct": "Direct",
     "group": "Group"
+  },
+  "tabs": {
+    "users": "Users",
+    "groups": "Groups"
+  },
+  "groups": {
+    "name": "Group Name",
+    "groupId": "Group ID",
+    "channel": "Channel",
+    "members": "Members",
+    "emptyTitle": "No groups",
+    "emptyDescription": "Groups will appear here as messages arrive from group chats."
   }
 }

--- a/ui/web/src/i18n/locales/vi/channels.json
+++ b/ui/web/src/i18n/locales/vi/channels.json
@@ -312,6 +312,16 @@
     "failedUpdate": "Không thể cập nhật channel",
     "failedDelete": "Không thể xóa channel"
   },
+  "allowFromPicker": {
+    "users": "Người dùng",
+    "groups": "Nhóm",
+    "search": "Tìm kiếm...",
+    "noMatch": "Không tìm thấy",
+    "manualPlaceholder": "Nhập ID thủ công",
+    "add": "Thêm",
+    "fetchGroups": "Lấy danh sách nhóm",
+    "fetching": "Đang lấy danh sách kênh..."
+  },
   "zalo": {
     "allowedUsers": "Người dùng được phép",
     "loadContacts": "Tải danh bạ",

--- a/ui/web/src/i18n/locales/vi/contacts.json
+++ b/ui/web/src/i18n/locales/vi/contacts.json
@@ -50,5 +50,17 @@
     "allTypes": "Tất cả loại",
     "direct": "Trực tiếp",
     "group": "Nhóm"
+  },
+  "tabs": {
+    "users": "Người dùng",
+    "groups": "Nhóm"
+  },
+  "groups": {
+    "name": "Tên nhóm",
+    "groupId": "ID nhóm",
+    "channel": "Channel",
+    "members": "Thành viên",
+    "emptyTitle": "Chưa có nhóm",
+    "emptyDescription": "Nhóm sẽ xuất hiện khi có tin nhắn từ group chat."
   }
 }

--- a/ui/web/src/i18n/locales/zh/channels.json
+++ b/ui/web/src/i18n/locales/zh/channels.json
@@ -312,6 +312,16 @@
     "failedUpdate": "更新Channel失败",
     "failedDelete": "删除Channel失败"
   },
+  "allowFromPicker": {
+    "users": "用户",
+    "groups": "群组",
+    "search": "搜索...",
+    "noMatch": "无匹配结果",
+    "manualPlaceholder": "手动输入 ID",
+    "add": "添加",
+    "fetchGroups": "获取群组列表",
+    "fetching": "正在获取频道..."
+  },
   "zalo": {
     "allowedUsers": "允许的用户",
     "loadContacts": "加载联系人",

--- a/ui/web/src/i18n/locales/zh/contacts.json
+++ b/ui/web/src/i18n/locales/zh/contacts.json
@@ -50,5 +50,17 @@
     "allTypes": "所有类型",
     "direct": "私聊",
     "group": "群组"
+  },
+  "tabs": {
+    "users": "用户",
+    "groups": "群组"
+  },
+  "groups": {
+    "name": "群名",
+    "groupId": "群ID",
+    "channel": "Channel",
+    "members": "成员",
+    "emptyTitle": "暂无群组",
+    "emptyDescription": "当收到群聊消息时，群组将显示在此处。"
   }
 }

--- a/ui/web/src/lib/query-keys.ts
+++ b/ui/web/src/lib/query-keys.ts
@@ -41,6 +41,10 @@ export const queryKeys = {
     search: (params: Record<string, unknown>) => ["contacts", "search", params] as const,
     resolve: (ids: string) => ["contacts", "resolve", ids] as const,
   },
+  groups: {
+    all: ["groups"] as const,
+    list: (channelType?: string) => ["groups", channelType ?? "all"] as const,
+  },
   skills: {
     all: ["skills"] as const,
     agentGrants: (agentId: string) => ["skills", "agent", agentId] as const,

--- a/ui/web/src/pages/channels/allow-from-picker.tsx
+++ b/ui/web/src/pages/channels/allow-from-picker.tsx
@@ -1,0 +1,188 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { useHttp } from "@/hooks/use-ws";
+import { useContacts } from "@/pages/contacts/hooks/use-contacts";
+import { useGroups } from "@/pages/contacts/hooks/use-groups";
+
+/** Channel types that support on-demand group fetch via API */
+const REFRESHABLE_GROUP_TYPES = new Set(["slack", "feishu", "discord"]);
+
+interface AllowFromPickerProps {
+  channelType: string;
+  value: string[];
+  onChange: (ids: string[]) => void;
+  label?: string;
+  help?: string;
+  /** "users" = show only contacts, "groups" = show only groups */
+  mode?: "users" | "groups";
+  /** Instance ID — enables on-demand group fetch for supported channels */
+  instanceId?: string;
+}
+
+export function AllowFromPicker({ channelType, value, onChange, label, help, mode = "users", instanceId }: AllowFromPickerProps) {
+  const { t } = useTranslation("channels");
+  const http = useHttp();
+  const [search, setSearch] = useState("");
+  const [manualId, setManualId] = useState("");
+  const [fetching, setFetching] = useState(false);
+
+  const { contacts, loading: contactsLoading } = useContacts(mode === "users" ? { channelType, limit: 200 } : {});
+  const { groups, loading: groupsLoading, refresh: refreshGroups } = useGroups(mode === "groups" ? channelType : undefined);
+
+  const canFetchGroups = mode === "groups" && instanceId && REFRESHABLE_GROUP_TYPES.has(channelType);
+
+  const handleFetchGroups = async () => {
+    if (!instanceId || fetching) return;
+    setFetching(true);
+    try {
+      await http.post(`/v1/channels/instances/${instanceId}/fetch-groups`);
+      refreshGroups();
+    } catch (err) {
+      console.error("Failed to fetch groups:", err);
+    } finally {
+      setFetching(false);
+    }
+  };
+
+  const toggle = (id: string) => {
+    if (value.includes(id)) {
+      onChange(value.filter((v) => v !== id));
+    } else {
+      onChange([...value, id]);
+    }
+  };
+
+  const addManual = () => {
+    const trimmed = manualId.trim();
+    if (trimmed && !value.includes(trimmed)) {
+      onChange([...value, trimmed]);
+      setManualId("");
+    }
+  };
+
+  const contactNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of contacts) {
+      if (c.display_name) map.set(c.sender_id, c.display_name);
+    }
+    return map;
+  }, [contacts]);
+
+  const groupNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const g of groups) {
+      if (g.group_name) map.set(g.group_id, g.group_name);
+    }
+    return map;
+  }, [groups]);
+
+  const resolveName = (id: string): string =>
+    contactNameMap.get(id) ?? groupNameMap.get(id) ?? id;
+
+  const lowerSearch = search.toLowerCase();
+  const loading = mode === "users" ? contactsLoading : groupsLoading;
+
+  return (
+    <div className="space-y-3">
+      {label && <Label>{label}</Label>}
+
+      {/* Selected badges */}
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {value.map((id) => (
+            <Badge key={id} variant="secondary" className="gap-1">
+              {resolveName(id)}
+              <button type="button" onClick={() => toggle(id)} className="ml-1 text-xs hover:text-destructive">
+                &times;
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Fetch groups button for channels that support on-demand refresh */}
+      {canFetchGroups && (
+        <Button type="button" variant="outline" size="sm" onClick={handleFetchGroups} disabled={fetching}>
+          {fetching ? t("allowFromPicker.fetching", "Fetching...") : t("allowFromPicker.fetchGroups", "Fetch groups")}
+        </Button>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">{t("zalo.loading")}</p>
+      ) : (
+        <>
+          <Input
+            placeholder={t("allowFromPicker.search")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8 text-base md:text-sm"
+          />
+          <div className="max-h-56 overflow-y-auto overscroll-contain rounded border p-2 space-y-1">
+            {mode === "users" ? (
+              (() => {
+                const filtered = contacts.filter(
+                  (c) =>
+                    (c.display_name ?? "").toLowerCase().includes(lowerSearch) ||
+                    c.sender_id.toLowerCase().includes(lowerSearch) ||
+                    (c.username ?? "").toLowerCase().includes(lowerSearch),
+                );
+                return filtered.length > 0 ? (
+                  filtered.map((c) => (
+                    <label key={c.id} className="flex items-center gap-2 py-0.5 text-sm cursor-pointer hover:bg-muted/50 rounded px-1">
+                      <input type="checkbox" checked={value.includes(c.sender_id)} onChange={() => toggle(c.sender_id)} />
+                      <span className="truncate">{c.display_name ?? c.sender_id}</span>
+                      {c.username && <span className="text-xs text-muted-foreground">@{c.username}</span>}
+                      <span className="text-xs text-muted-foreground ml-auto shrink-0">{c.sender_id}</span>
+                    </label>
+                  ))
+                ) : (
+                  <p className="text-sm text-muted-foreground py-2 text-center">{t("allowFromPicker.noMatch")}</p>
+                );
+              })()
+            ) : (
+              (() => {
+                const filtered = groups.filter(
+                  (g) =>
+                    (g.group_name ?? "").toLowerCase().includes(lowerSearch) ||
+                    g.group_id.toLowerCase().includes(lowerSearch),
+                );
+                return filtered.length > 0 ? (
+                  filtered.map((g) => (
+                    <label key={g.id} className="flex items-center gap-2 py-0.5 text-sm cursor-pointer hover:bg-muted/50 rounded px-1">
+                      <input type="checkbox" checked={value.includes(g.group_id)} onChange={() => toggle(g.group_id)} />
+                      <span className="truncate">{g.group_name ?? g.group_id}</span>
+                      <span className="text-xs text-muted-foreground ml-auto shrink-0">
+                        {g.member_count > 0 ? `${g.member_count} members` : g.group_id}
+                      </span>
+                    </label>
+                  ))
+                ) : (
+                  <p className="text-sm text-muted-foreground py-2 text-center">{t("allowFromPicker.noMatch")}</p>
+                );
+              })()
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Manual ID entry */}
+      <div className="flex gap-2">
+        <Input
+          placeholder={t("allowFromPicker.manualPlaceholder")}
+          value={manualId}
+          onChange={(e) => setManualId(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addManual(); } }}
+          className="h-8 text-base md:text-sm"
+        />
+        <Button type="button" variant="outline" size="sm" onClick={addManual} disabled={!manualId.trim()}>
+          {t("allowFromPicker.add")}
+        </Button>
+      </div>
+      {help && <p className="text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/ui/web/src/pages/channels/channel-detail/channel-advanced-dialog.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-advanced-dialog.tsx
@@ -179,6 +179,8 @@ export function ChannelAdvancedDialog({
                 values={values}
                 onChange={handleChange}
                 idPrefix="adv-acc"
+                channelType={instance.channel_type}
+                instanceId={instance.id}
               />
             </>
           )}

--- a/ui/web/src/pages/channels/channel-detail/channel-managers-tab.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-managers-tab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Plus, Trash2, Loader2, RefreshCw, Users, ChevronDown, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -7,6 +7,8 @@ import { Label } from "@/components/ui/label";
 import { Combobox } from "@/components/ui/combobox";
 import { EmptyState } from "@/components/shared/empty-state";
 import { useContactPicker } from "@/hooks/use-contact-picker";
+import { useContactResolver } from "@/hooks/use-contact-resolver";
+import { useGroups } from "@/pages/contacts/hooks/use-groups";
 import type { GroupManagerGroupInfo, GroupManagerData } from "../hooks/use-channel-detail";
 import type { ChannelContact } from "@/types/contact";
 
@@ -149,9 +151,23 @@ export function ChannelManagersTab({
   const [groups, setGroups] = useState<GroupManagerGroupInfo[]>([]);
   const [loadingGroups, setLoadingGroups] = useState(true);
 
+  // Fetch known groups to resolve group_id → group_name
+  const { groups: knownGroups } = useGroups();
+  const groupNameMap = useMemo(
+    () => new Map(knownGroups.map((g) => [g.group_id, g.group_name])),
+    [knownGroups],
+  );
+
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [managersMap, setManagersMap] = useState<Record<string, GroupManagerData[]>>({});
   const [loadingMap, setLoadingMap] = useState<Record<string, boolean>>({});
+
+  // Resolve manager user IDs to contact names
+  const allManagerIDs = useMemo(
+    () => Object.values(managersMap).flat().map((w) => w.user_id),
+    [managersMap],
+  );
+  const { resolve: resolveContact } = useContactResolver(allManagerIDs);
 
   const refreshGroups = useCallback(async () => {
     setLoadingGroups(true);
@@ -266,8 +282,17 @@ export function ChannelManagersTab({
                       : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
                     }
                     <div className="min-w-0 flex-1">
-                      <span className="font-mono text-sm">{shortGroupId(g.group_id)}</span>
-                      <span className="ml-2 text-xs text-muted-foreground">{g.group_id}</span>
+                      {groupNameMap.get(shortGroupId(g.group_id)) ? (
+                        <>
+                          <span className="text-sm font-medium">{groupNameMap.get(shortGroupId(g.group_id))}</span>
+                          <span className="ml-2 font-mono text-xs text-muted-foreground">{shortGroupId(g.group_id)}</span>
+                        </>
+                      ) : (
+                        <>
+                          <span className="font-mono text-sm">{shortGroupId(g.group_id)}</span>
+                          <span className="ml-2 text-xs text-muted-foreground">{g.group_id}</span>
+                        </>
+                      )}
                     </div>
                     <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium tabular-nums">
                       {g.writer_count === 1
@@ -297,8 +322,8 @@ export function ChannelManagersTab({
                               {groupManagers.map((w) => (
                                 <tr key={w.user_id} className="border-b last:border-0 hover:bg-muted/20">
                                   <td className="px-3 py-2 font-mono text-xs">{w.user_id}</td>
-                                  <td className="px-3 py-2">{w.display_name || <span className="text-muted-foreground">-</span>}</td>
-                                  <td className="px-3 py-2">{w.username ? <span className="text-muted-foreground">@{w.username}</span> : <span className="text-muted-foreground">-</span>}</td>
+                                  <td className="px-3 py-2">{w.display_name || resolveContact(w.user_id)?.display_name || <span className="text-muted-foreground">-</span>}</td>
+                                  <td className="px-3 py-2">{(w.username || resolveContact(w.user_id)?.username) ? <span className="text-muted-foreground">@{w.username || resolveContact(w.user_id)?.username}</span> : <span className="text-muted-foreground">-</span>}</td>
                                   <td className="px-3 py-2 text-right">
                                     <Button
                                       variant="ghost"

--- a/ui/web/src/pages/channels/channel-fields.tsx
+++ b/ui/web/src/pages/channels/channel-fields.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -12,6 +13,9 @@ import {
 } from "@/components/ui/select";
 import { ToolNameSelect } from "@/components/shared/tool-name-select";
 import { SkillNameSelect } from "@/components/shared/skill-name-select";
+import { useGroups } from "@/pages/contacts/hooks/use-groups";
+import { AllowFromPicker } from "./allow-from-picker";
+import { ZaloContactsPicker } from "./zalo/zalo-contacts-picker";
 import type { FieldDef } from "./channel-schemas";
 
 const INHERIT = "__inherit__";
@@ -24,9 +28,13 @@ interface ChannelFieldsProps {
   isEdit?: boolean; // for credentials: show "leave blank to keep" hint
   /** Extra values for showWhen checks (e.g. config values visible to credential fields) */
   contextValues?: Record<string, unknown>;
+  /** Channel type — used to resolve group names in tags fields */
+  channelType?: string;
+  /** Instance ID — used for Zalo contacts picker (fetches from Zalo API) */
+  instanceId?: string;
 }
 
-export function ChannelFields({ fields, values, onChange, idPrefix, isEdit, contextValues }: ChannelFieldsProps) {
+export function ChannelFields({ fields, values, onChange, idPrefix, isEdit, contextValues, channelType, instanceId }: ChannelFieldsProps) {
   const allValues = contextValues ? { ...contextValues, ...values } : values;
   return (
     <div className="grid gap-3">
@@ -56,6 +64,8 @@ export function ChannelFields({ fields, values, onChange, idPrefix, isEdit, cont
             isEdit={isEdit}
             disabled={disabled}
             disabledHint={disabledHint}
+            channelType={channelType}
+            instanceId={instanceId}
           />
         );
       })}
@@ -71,6 +81,8 @@ function FieldRenderer({
   isEdit,
   disabled,
   disabledHint,
+  channelType,
+  instanceId,
 }: {
   field: FieldDef;
   value: unknown;
@@ -79,6 +91,8 @@ function FieldRenderer({
   isEdit?: boolean;
   disabled?: boolean;
   disabledHint?: string;
+  channelType?: string;
+  instanceId?: string;
 }) {
   const { t } = useTranslation("channels");
   // i18n: try "fieldConfig.<key>.label" / "fieldConfig.<key>.help", fall back to hardcoded schema string
@@ -271,25 +285,130 @@ function FieldRenderer({
       );
 
     case "tags":
-      return (
-        <div className="grid gap-1.5">
-          <Label htmlFor={id}>{label}</Label>
-          <Textarea
-            id={id}
-            value={Array.isArray(value) ? (value as string[]).join("\n") : ""}
-            onChange={(e) => {
-              const lines = e.target.value.split(/[\n,]/).map((l) => l.trim()).filter(Boolean);
-              onChange(lines.length > 0 ? lines : undefined);
-            }}
-            placeholder={field.placeholder ?? t("groupOverrides.fields.allowedUsersPlaceholder")}
-            rows={3}
-            className="font-mono text-sm"
+      // Use ZaloContactsPicker for Zalo (fetches fresh from Zalo API)
+      if (ACCESS_TAG_KEYS.has(field.key) && channelType === "zalo_personal" && instanceId) {
+        const tags = Array.isArray(value) ? (value as string[]) : [];
+        return (
+          <ZaloContactsPicker
+            instanceId={instanceId}
+            hasCredentials={true}
+            value={tags}
+            onChange={(ids) => onChange(ids.length > 0 ? ids : undefined)}
           />
-          {help && <p className="text-xs text-muted-foreground">{help}</p>}
-        </div>
+        );
+      }
+      // Use AllowFromPicker for other channels (queries DB)
+      // allow_from → users only, group_allow_from → groups only
+      if (ACCESS_TAG_KEYS.has(field.key) && channelType) {
+        const tags = Array.isArray(value) ? (value as string[]) : [];
+        const mode = field.key === "group_allow_from" ? "groups" as const : "users" as const;
+        return (
+          <AllowFromPicker
+            channelType={channelType}
+            value={tags}
+            onChange={(ids) => onChange(ids.length > 0 ? ids : undefined)}
+            label={`${label}${labelSuffix}`}
+            help={help}
+            mode={mode}
+            instanceId={instanceId}
+          />
+        );
+      }
+      return (
+        <TagsField
+          id={id}
+          label={`${label}${labelSuffix}`}
+          help={help}
+          value={value}
+          onChange={onChange}
+          placeholder={field.placeholder}
+          channelType={channelType}
+          fieldKey={field.key}
+        />
       );
 
     default:
       return null;
   }
+}
+
+// --- Tags field with group name resolution ---
+
+const ACCESS_TAG_KEYS = new Set(["allow_from", "group_allow_from"]);
+
+function TagsField({
+  id,
+  label,
+  help,
+  value,
+  onChange,
+  placeholder,
+  channelType,
+  fieldKey,
+}: {
+  id: string;
+  label: string;
+  help: string;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  placeholder?: string;
+  channelType?: string;
+  fieldKey: string;
+}) {
+  const { t } = useTranslation("channels");
+  // Only fetch groups for access-control tags fields when channel type is known
+  const shouldResolve = ACCESS_TAG_KEYS.has(fieldKey) && !!channelType;
+  const { groups } = useGroups(shouldResolve ? channelType : undefined);
+
+  const tags = Array.isArray(value) ? (value as string[]) : [];
+
+  // Build a map of group_id -> group_name for quick lookup
+  const groupNameMap = useMemo(() => {
+    if (!shouldResolve || groups.length === 0) return new Map<string, string>();
+    const map = new Map<string, string>();
+    for (const g of groups) {
+      if (g.group_name) map.set(g.group_id, g.group_name);
+    }
+    return map;
+  }, [shouldResolve, groups]);
+
+  // Find tags that match known groups
+  const resolvedTags = useMemo(() => {
+    if (groupNameMap.size === 0 || tags.length === 0) return [];
+    return tags
+      .filter((tag) => groupNameMap.has(tag))
+      .map((tag) => ({ id: tag, name: groupNameMap.get(tag)! }));
+  }, [groupNameMap, tags]);
+
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Textarea
+        id={id}
+        value={tags.join("\n")}
+        onChange={(e) => {
+          const lines = e.target.value.split(/[\n,]/).map((l) => l.trim()).filter(Boolean);
+          onChange(lines.length > 0 ? lines : undefined);
+        }}
+        placeholder={placeholder ?? t("groupOverrides.fields.allowedUsersPlaceholder")}
+        rows={3}
+        className="font-mono text-sm"
+      />
+      {resolvedTags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {resolvedTags.map(({ id: gid, name }) => (
+            <span
+              key={gid}
+              className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+              title={gid}
+            >
+              <span className="font-medium text-foreground">{name}</span>
+              <span className="opacity-60">{gid}</span>
+            </span>
+          ))}
+        </div>
+      )}
+      {help && <p className="text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
 }

--- a/ui/web/src/pages/contacts/contacts-page.tsx
+++ b/ui/web/src/pages/contacts/contacts-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, Contact, Info, Link2, Merge, RefreshCw, Search, Unlink } from "lucide-react";
+import { ChevronDown, Contact, Info, Link2, Merge, RefreshCw, Search, Unlink, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { Pagination } from "@/components/shared/pagination";
@@ -21,6 +22,7 @@ import { useMinLoading } from "@/hooks/use-min-loading";
 import { useDeferredLoading } from "@/hooks/use-deferred-loading";
 import { useContacts } from "./hooks/use-contacts";
 import { useContactMerge } from "./hooks/use-contact-merge";
+import { useGroups } from "./hooks/use-groups";
 import { MergeContactsDialog } from "./merge-contacts-dialog";
 
 const CHANNEL_TYPES = ["telegram", "discord", "slack", "whatsapp", "zalo_oa", "zalo_personal", "feishu"];
@@ -117,11 +119,23 @@ export function ContactsPage() {
         }
       />
 
+      <Tabs defaultValue="users" className="mt-4">
+        <TabsList>
+          <TabsTrigger value="users" className="gap-1">
+            <Contact className="h-3.5 w-3.5" /> {t("tabs.users")}
+          </TabsTrigger>
+          <TabsTrigger value="groups" className="gap-1">
+            <Users className="h-3.5 w-3.5" /> {t("tabs.groups")}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="users" className="mt-0 space-y-3">
+
       {/* Permissions note */}
       <PermissionsNote />
 
       {/* Filters */}
-      <div className="mt-4 flex flex-wrap items-end gap-2">
+      <div className="flex flex-wrap items-end gap-2">
         <form onSubmit={handleSearchSubmit} className="flex gap-2 flex-1 min-w-[200px] max-w-md">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -161,10 +175,10 @@ export function ContactsPage() {
         </Select>
       </div>
 
-      {/* Selection toolbar — always rendered to avoid layout shift */}
-      <div className="mt-3 flex items-center gap-2 rounded-md border px-3 py-2 transition-colors"
-        style={{ visibility: selectedIds.size > 0 ? "visible" : "hidden" }}
-      >
+      {/* Selection toolbar */}
+      {selectedIds.size > 0 && (
+      <div className="flex items-center gap-2 rounded-md border px-3 py-2">
+
         <span className="text-sm font-medium">
           {t("selectedCount", { count: selectedIds.size })}
         </span>
@@ -179,9 +193,10 @@ export function ContactsPage() {
           )}
         </div>
       </div>
+      )}
 
       {/* Table */}
-      <div className="mt-2">
+      <div>
         {showSkeleton ? (
           <TableSkeleton rows={8} />
         ) : contacts.length === 0 ? (
@@ -275,6 +290,13 @@ export function ContactsPage() {
         )}
       </div>
 
+        </TabsContent>
+
+        <TabsContent value="groups" className="mt-0">
+          <GroupsPanel />
+        </TabsContent>
+      </Tabs>
+
       {/* Merge dialog */}
       <MergeContactsDialog
         open={mergeDialogOpen}
@@ -289,13 +311,75 @@ export function ContactsPage() {
   );
 }
 
+function GroupsPanel() {
+  const { t } = useTranslation("contacts");
+  const [channelFilter, setChannelFilter] = useState("");
+  const { groups, loading, fetching, refresh } = useGroups(channelFilter || undefined);
+  const spinning = useMinLoading(fetching);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Select value={channelFilter || "all"} onValueChange={(v) => setChannelFilter(v === "all" ? "" : v)}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t("filters.allChannels")}</SelectItem>
+            {CHANNEL_TYPES.map((ct) => (
+              <SelectItem key={ct} value={ct}>{ct}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button variant="outline" size="sm" onClick={refresh} disabled={spinning} className="gap-1">
+          <RefreshCw className={"h-3.5 w-3.5" + (spinning ? " animate-spin" : "")} />
+        </Button>
+        <span className="text-sm text-muted-foreground ml-auto">{groups.length} groups</span>
+      </div>
+
+      {loading && groups.length === 0 ? (
+        <TableSkeleton rows={5} />
+      ) : groups.length === 0 ? (
+        <EmptyState icon={Users} title={t("groups.emptyTitle")} description={t("groups.emptyDescription")} />
+      ) : (
+        <div className="rounded-md border overflow-x-auto">
+          <table className="w-full min-w-[600px] text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="px-3 py-2.5 text-left font-medium text-xs uppercase tracking-wide text-muted-foreground">{t("groups.name")}</th>
+                <th className="px-3 py-2.5 text-left font-medium text-xs uppercase tracking-wide text-muted-foreground">{t("groups.groupId")}</th>
+                <th className="px-3 py-2.5 text-left font-medium text-xs uppercase tracking-wide text-muted-foreground">{t("groups.channel")}</th>
+                <th className="px-3 py-2.5 text-left font-medium text-xs uppercase tracking-wide text-muted-foreground">{t("groups.members")}</th>
+                <th className="px-3 py-2.5 text-left font-medium text-xs uppercase tracking-wide text-muted-foreground">{t("columns.lastSeen")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map((g) => (
+                <tr key={g.id} className="border-b last:border-0 hover:bg-muted/20">
+                  <td className="px-3 py-2.5 font-medium">{g.group_name || <span className="text-muted-foreground">—</span>}</td>
+                  <td className="px-3 py-2.5 font-mono text-xs">{g.group_id}</td>
+                  <td className="px-3 py-2.5">
+                    <Badge variant="outline" className="text-[11px]">{g.channel_type}</Badge>
+                  </td>
+                  <td className="px-3 py-2.5 tabular-nums">{g.member_count || "—"}</td>
+                  <td className="px-3 py-2.5 text-muted-foreground text-xs">{formatDate(g.last_seen_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function PermissionsNote() {
   const { t } = useTranslation("contacts");
   const [open, setOpen] = useState(true);
   const p = "permissionsNote";
 
   return (
-    <div className="mt-4 rounded-md border border-blue-200 bg-blue-50/50 dark:border-blue-900 dark:bg-blue-950/30">
+    <div className="rounded-md border border-blue-200 bg-blue-50/50 dark:border-blue-900 dark:bg-blue-950/30">
       <button
         type="button"
         onClick={() => setOpen(!open)}

--- a/ui/web/src/pages/contacts/hooks/use-groups.ts
+++ b/ui/web/src/pages/contacts/hooks/use-groups.ts
@@ -1,0 +1,43 @@
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useHttp } from "@/hooks/use-ws";
+import { queryKeys } from "@/lib/query-keys";
+
+export interface ChannelGroup {
+  id: string;
+  channel_type: string;
+  channel_instance?: string;
+  group_id: string;
+  group_name?: string;
+  avatar_url?: string;
+  member_count: number;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+export function useGroups(channelType?: string) {
+  const http = useHttp();
+  const queryClient = useQueryClient();
+
+  const queryKey = queryKeys.groups.list(channelType);
+
+  const { data, isLoading: loading, isFetching } = useQuery({
+    queryKey,
+    queryFn: async () => {
+      const params: Record<string, string> = {};
+      if (channelType) params.channel_type = channelType;
+      const res = await http.get<{ groups: ChannelGroup[] }>("/v1/groups", params);
+      return res.groups ?? [];
+    },
+    placeholderData: (prev) => prev,
+  });
+
+  const groups = data ?? [];
+
+  const refresh = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: queryKeys.groups.all }),
+    [queryClient],
+  );
+
+  return { groups, loading, fetching: isFetching, refresh };
+}


### PR DESCRIPTION
## Summary
- New `channel_groups` table stores known groups across all channel types
- Each channel populates the directory when group messages arrive
- `GET /v1/groups` API endpoint for UI consumption
- Smart caching: only writes to DB when group name changes
- Pending messages page resolves group names as fallback

### Channels supported
| Channel | How group name is obtained |
|---------|---------------------------|
| Telegram | `message.Chat.Title` (in message payload) |
| Discord | `session.Guild()` API + in-memory cache |
| Feishu | New `GetChatInfo()` API + in-memory cache |
| Slack | `GetConversationInfo()` API + in-memory cache |
| Zalo Personal | `FetchGroups()` on startup + lazy refresh |

## Test plan
- [x] Migration 31 applies cleanly
- [ ] Send message in Telegram group - group appears in `channel_groups`
- [x] Send message in Zalo group - group appears
- [x] `GET /v1/groups` returns known groups
- [ ] Pending messages page shows group names
