### PR TITLE
feat(providers): upgrade MiniMax to dedicated provider with M2.7 default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ internal/
 ├── memory/                   Memory system (pgvector)
 ├── oauth/                    OAuth authentication
 ├── permissions/              RBAC (admin/operator/viewer)
-├── providers/                LLM providers: Anthropic (native HTTP+SSE), OpenAI-compat (HTTP+SSE), DashScope (Alibaba Qwen), Claude CLI (stdio+MCP bridge), ACP (Anthropic Console Proxy), Codex (OpenAI)
+├── providers/                LLM providers: Anthropic (native HTTP+SSE), OpenAI-compat (HTTP+SSE), MiniMax (OpenAI-compat + temp clamp), DashScope (Alibaba Qwen), Claude CLI (stdio+MCP bridge), ACP (Anthropic Console Proxy), Codex (OpenAI)
 ├── sandbox/                  Docker-based code sandbox
 ├── scheduler/                Lane-based concurrency (main/subagent/cron)
 ├── sessions/                 Session management
@@ -56,7 +56,7 @@ ui/web/                       React SPA (pnpm, Vite, Tailwind, Radix UI)
 - **Store layer:** Interface-based (`store.SessionStore`, `store.AgentStore`, etc.) with pg/ (PostgreSQL) implementations. Uses `database/sql` + `pgx/v5/stdlib`, raw SQL, `execMapUpdate()` helper in `pg/helpers.go`
 - **Agent types:** `open` (per-user context, 7 files) vs `predefined` (shared context + USER.md per-user)
 - **Context files:** `agent_context_files` (agent-level) + `user_context_files` (per-user), routed via `ContextFileInterceptor`
-- **Providers:** Anthropic (native HTTP+SSE), OpenAI-compat (HTTP+SSE), DashScope (Alibaba Qwen), Claude CLI (stdio+MCP bridge), ACP (Anthropic Console Proxy), Codex (OpenAI). All use `RetryDo()` for retries. Loads from `llm_providers` table with encrypted API keys
+- **Providers:** Anthropic (native HTTP+SSE), OpenAI-compat (HTTP+SSE), MiniMax (OpenAI-compat + temp clamp), DashScope (Alibaba Qwen), Claude CLI (stdio+MCP bridge), ACP (Anthropic Console Proxy), Codex (OpenAI). All use `RetryDo()` for retries. Loads from `llm_providers` table with encrypted API keys
 - **Agent loop:** `RunRequest` → think→act→observe → `RunResult`. Events: `run.started`, `run.completed`, `chunk`, `tool.call`, `tool.result`. Auto-summarization at >75% context
 - **Context propagation:** `store.WithAgentType(ctx)`, `store.WithUserID(ctx)`, `store.WithAgentID(ctx)`, `store.WithLocale(ctx)`
 - **WebSocket protocol (v3):** Frame types `req`/`res`/`event`. First request must be `connect`

--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -71,8 +71,7 @@ func registerProviders(registry *providers.Registry, cfg *config.Config) {
 	}
 
 	if cfg.Providers.MiniMax.APIKey != "" {
-		registry.Register(providers.NewOpenAIProvider("minimax", cfg.Providers.MiniMax.APIKey, "https://api.minimax.io/v1", "MiniMax-M2.5").
-			WithChatPath("/text/chatcompletion_v2"))
+		registry.Register(providers.NewMiniMaxProvider("minimax", cfg.Providers.MiniMax.APIKey, cfg.Providers.MiniMax.APIBase, "MiniMax-M2.7"))
 		slog.Info("registered provider", "name", "minimax")
 	}
 
@@ -341,12 +340,11 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			prov := providers.NewOpenAIProvider(p.Name, p.APIKey, base, "")
 			prov.WithProviderType(p.ProviderType)
 			registry.RegisterForTenant(p.TenantID, prov)
+		case store.ProviderMiniMax:
+			registry.RegisterForTenant(p.TenantID, providers.NewMiniMaxProvider(p.Name, p.APIKey, p.APIBase, ""))
 		default:
 			prov := providers.NewOpenAIProvider(p.Name, p.APIKey, p.APIBase, "")
 			prov.WithProviderType(p.ProviderType)
-			if p.ProviderType == store.ProviderMiniMax {
-				prov.WithChatPath("/text/chatcompletion_v2")
-			}
 			registry.RegisterForTenant(p.TenantID, prov)
 		}
 		slog.Info("registered provider from DB", "name", p.Name)

--- a/docs/02-providers.md
+++ b/docs/02-providers.md
@@ -1,6 +1,6 @@
 # 02 - LLM Providers
 
-GoClaw abstracts LLM communication behind a single `Provider` interface, allowing the agent loop to work with any backend without knowing the wire format. Six concrete implementations exist: Anthropic (native HTTP+SSE), OpenAI-compatible (covering 10+ API endpoints), Claude CLI (local binary), Codex (OAuth-based), ACP (subagent orchestration), and DashScope (Alibaba Qwen with thinking).
+GoClaw abstracts LLM communication behind a single `Provider` interface, allowing the agent loop to work with any backend without knowing the wire format. Seven concrete implementations exist: Anthropic (native HTTP+SSE), OpenAI-compatible (covering 10+ API endpoints), MiniMax (OpenAI-compatible with temperature clamping), Claude CLI (local binary), Codex (OAuth-based), ACP (subagent orchestration), and DashScope (Alibaba Qwen with thinking).
 
 ---
 
@@ -25,7 +25,9 @@ flowchart TD
     OAI --> GROQ["Groq API"]
     OAI --> DS["DeepSeek API"]
     OAI --> GEM["Gemini API"]
-    OAI --> OTHER["Mistral / xAI / MiniMax<br/>Cohere / Perplexity / Ollama"]
+    OAI --> OTHER["Mistral / xAI<br/>Cohere / Perplexity / Ollama"]
+    PI --> MINIMAX["MiniMax Provider<br/>OpenAI-compat + temp clamp"]
+    MINIMAX --> MMAX["MiniMax API<br/>api.minimax.io/v1"]
     CLAUDE --> CLI["claude CLI binary<br/>stdio + MCP bridge"]
     CODEX --> CODEX_API["ChatGPT Responses API<br/>chatgpt.com/backend-api"]
     ACP --> AGENTS["Claude Code / Codex<br/>Gemini CLI agents"]
@@ -55,6 +57,7 @@ All HTTP-based providers (Anthropic, OpenAI-compatible, Codex) use 300-second ti
 | **codex** | OAuth Responses API | OAuth token source | `gpt-5.3-codex` |
 | **acp** | JSON-RPC 2.0 subagents | Binary + workspace dir | `claude` |
 | **dashscope** | OpenAI-compat wrapper | API key + custom models | `qwen3-max` |
+| **minimax** | OpenAI-compat wrapper | API key + temp clamp | `MiniMax-M2.7` |
 | **openai** (+ 10+ variants) | OpenAI-compatible | API key + endpoint URL | Model-specific |
 
 ### OpenAI-Compatible Providers
@@ -68,7 +71,7 @@ All HTTP-based providers (Anthropic, OpenAI-compatible, Codex) use 300-second ti
 | gemini | `https://generativelanguage.googleapis.com/v1beta/openai` | `gemini-2.0-flash` | Skips empty content fields |
 | mistral | `https://api.mistral.ai/v1` | `mistral-large-latest` | |
 | xai | `https://api.x.ai/v1` | `grok-3-mini` | |
-| minimax | `https://api.minimax.io/v1` | `MiniMax-M2.5` | Uses custom chat path |
+| minimax | `https://api.minimax.io/v1` | `MiniMax-M2.7` | Dedicated provider with temperature clamping |
 | cohere | `https://api.cohere.ai/compatibility/v1` | `command-a` | |
 | perplexity | `https://api.perplexity.ai` | `sonar-pro` | |
 | ollama | `http://localhost:11434/v1` | `llama3.3` | Local/configurable |
@@ -298,9 +301,9 @@ Anthropic requires thinking blocks (including cryptographic signatures) to be ec
 
 ---
 
-## 9. DashScope and Bailian Providers
+## 9. DashScope, MiniMax, and Bailian Providers
 
-Two providers for the Alibaba Cloud AI ecosystem.
+Three providers with OpenAI-compatible wrappers for specific API constraints.
 
 ### DashScope (Alibaba Qwen)
 
@@ -309,6 +312,15 @@ Wraps the OpenAI-compatible provider with a critical override: when tools are pr
 - **Default model**: `qwen3-max`
 - **Thinking support**: Custom budget mapping (low=4,096, medium=16,384, high=32,768)
 - **Known limitation**: No simultaneous streaming + tools
+
+### MiniMax
+
+Wraps the OpenAI-compatible provider with temperature clamping. MiniMax requires temperature in (0.0, 1.0] — values ≤ 0 are removed (server uses its default), values > 1 are clamped to 1.0.
+
+- **Default model**: `MiniMax-M2.7`
+- **Models**: M2.7, M2.7-highspeed, M2.5, M2.5-highspeed (all 204K context)
+- **Thinking support**: Supports `reasoning_effort` via the standard OpenAI-compatible parameter
+- **Provider type**: `minimax_native` (used for media tool routing)
 
 ### Bailian Coding
 
@@ -701,6 +713,7 @@ Routing behavior:
 | `internal/providers/codex_types.go` | Codex request/response types and OAuth token management |
 | `internal/providers/chatgpt_oauth_router.go` | Agent-side routing across multiple authenticated OpenAI Codex OAuth providers |
 | `internal/providers/dashscope.go` | DashScope provider: OpenAI-compat wrapper with thinking budget, tools+streaming fallback |
+| `internal/providers/minimax.go` | MiniMax provider: OpenAI-compat wrapper with temperature clamping |
 | `internal/providers/acp_provider.go` | ACPProvider: orchestrates ACP-compatible agent subprocesses |
 | `internal/providers/acp/types.go` | ACP protocol types: InitializeRequest, SessionUpdate, ContentBlock, etc. |
 | `internal/providers/acp/process.go` | ProcessPool: subprocess lifecycle, idle TTL reaping, crash recovery |

--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -193,10 +193,12 @@ func bailianModels() []ModelInfo {
 func minimaxModels() []ModelInfo {
 	return []ModelInfo{
 		// Chat / text
-		{ID: "MiniMax-Text-01", Name: "MiniMax Text 01"},
-		{ID: "MiniMax-M1", Name: "MiniMax M1"},
 		{ID: "MiniMax-M2.7", Name: "MiniMax M2.7"},
+		{ID: "MiniMax-M2.7-highspeed", Name: "MiniMax M2.7 Highspeed"},
 		{ID: "MiniMax-M2.5", Name: "MiniMax M2.5"},
+		{ID: "MiniMax-M2.5-highspeed", Name: "MiniMax M2.5 Highspeed"},
+		{ID: "MiniMax-M1", Name: "MiniMax M1"},
+		{ID: "MiniMax-Text-01", Name: "MiniMax Text 01"},
 		// Image generation
 		{ID: "image-01", Name: "Image 01"},
 		// Video generation

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -176,11 +176,10 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 			base = "https://coding-intl.dashscope.aliyuncs.com/v1"
 		}
 		h.providerReg.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, p.APIKey, base, "qwen3.5-plus"))
+	case store.ProviderMiniMax:
+		h.providerReg.RegisterForTenant(p.TenantID, providers.NewMiniMaxProvider(p.Name, p.APIKey, apiBase, ""))
 	default:
 		prov := providers.NewOpenAIProvider(p.Name, p.APIKey, apiBase, "")
-		if p.ProviderType == store.ProviderMiniMax {
-			prov.WithChatPath("/text/chatcompletion_v2")
-		}
 		h.providerReg.RegisterForTenant(p.TenantID, prov)
 	}
 }

--- a/internal/providers/minimax.go
+++ b/internal/providers/minimax.go
@@ -1,0 +1,83 @@
+package providers
+
+import (
+	"context"
+	"maps"
+)
+
+const (
+	minimaxDefaultBase  = "https://api.minimax.io/v1"
+	minimaxDefaultModel = "MiniMax-M2.7"
+)
+
+// MiniMaxProvider wraps OpenAIProvider to handle MiniMax-specific behaviors:
+//   - Temperature clamping: MiniMax requires temperature in (0.0, 1.0].
+//     Values ≤ 0 are removed (server default), values > 1 are clamped to 1.0.
+//   - Uses the standard OpenAI-compatible /chat/completions endpoint.
+//   - Sets providerType to "minimax_native" for media tool routing.
+type MiniMaxProvider struct {
+	*OpenAIProvider
+}
+
+// NewMiniMaxProvider creates a new MiniMax LLM provider.
+func NewMiniMaxProvider(name, apiKey, apiBase, defaultModel string) *MiniMaxProvider {
+	if apiBase == "" {
+		apiBase = minimaxDefaultBase
+	}
+	if defaultModel == "" {
+		defaultModel = minimaxDefaultModel
+	}
+	p := &MiniMaxProvider{
+		OpenAIProvider: NewOpenAIProvider(name, apiKey, apiBase, defaultModel),
+	}
+	p.OpenAIProvider.providerType = "minimax_native"
+	return p
+}
+
+// SupportsThinking returns true — MiniMax M2.7 supports reasoning_effort.
+func (p *MiniMaxProvider) SupportsThinking() bool { return true }
+
+// clampTemperature applies MiniMax's temperature constraint.
+// MiniMax accepts temperature in (0.0, 1.0]. Zero or negative values
+// are removed (letting the server use its default), values > 1 are clamped.
+func (p *MiniMaxProvider) clampTemperature(req ChatRequest) ChatRequest {
+	temp, ok := req.Options[OptTemperature]
+	if !ok {
+		return req
+	}
+
+	var tempVal float64
+	switch v := temp.(type) {
+	case float64:
+		tempVal = v
+	case float32:
+		tempVal = float64(v)
+	case int:
+		tempVal = float64(v)
+	default:
+		return req
+	}
+
+	opts := make(map[string]any, len(req.Options))
+	maps.Copy(opts, req.Options)
+
+	if tempVal <= 0 {
+		// MiniMax rejects temperature=0; remove to use server default
+		delete(opts, OptTemperature)
+	} else if tempVal > 1.0 {
+		opts[OptTemperature] = 1.0
+	}
+
+	req.Options = opts
+	return req
+}
+
+// Chat overrides OpenAIProvider.Chat to apply temperature clamping.
+func (p *MiniMaxProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	return p.OpenAIProvider.Chat(ctx, p.clampTemperature(req))
+}
+
+// ChatStream overrides OpenAIProvider.ChatStream to apply temperature clamping.
+func (p *MiniMaxProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk func(StreamChunk)) (*ChatResponse, error) {
+	return p.OpenAIProvider.ChatStream(ctx, p.clampTemperature(req), onChunk)
+}

--- a/internal/providers/minimax_test.go
+++ b/internal/providers/minimax_test.go
@@ -1,0 +1,272 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newMiniMaxTestServer sets up a mock SSE server for MiniMax Chat/ChatStream calls
+// and returns both the server and a pointer that will hold the last captured request body.
+func newMiniMaxTestServer(t *testing.T) (*httptest.Server, *map[string]any) {
+	t.Helper()
+	captured := &map[string]any{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(captured); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		// stream=false path (Chat): return JSON
+		if v, _ := (*captured)["stream"].(bool); !v {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+			return
+		}
+		// stream=true path (ChatStream): return SSE
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(server.Close)
+	return server, captured
+}
+
+// callMiniMaxChat sends req through Chat and returns the captured body.
+func callMiniMaxChat(t *testing.T, req ChatRequest) map[string]any {
+	t.Helper()
+	server, captured := newMiniMaxTestServer(t)
+	p := NewMiniMaxProvider("minimax-test", "test-key", server.URL, "")
+	p.retryConfig.Attempts = 1
+	p.Chat(context.Background(), req) //nolint:errcheck
+	return *captured
+}
+
+// callMiniMaxStream sends req through ChatStream and returns the captured body.
+func callMiniMaxStream(t *testing.T, req ChatRequest) map[string]any {
+	t.Helper()
+	server, captured := newMiniMaxTestServer(t)
+	p := NewMiniMaxProvider("minimax-test", "test-key", server.URL, "")
+	p.retryConfig.Attempts = 1
+	p.ChatStream(context.Background(), req, nil) //nolint:errcheck
+	return *captured
+}
+
+// TestMiniMaxDefaultModel verifies the provider defaults to MiniMax-M2.7.
+func TestMiniMaxDefaultModel(t *testing.T) {
+	p := NewMiniMaxProvider("minimax", "key", "", "")
+	if p.DefaultModel() != "MiniMax-M2.7" {
+		t.Errorf("DefaultModel() = %q, want %q", p.DefaultModel(), "MiniMax-M2.7")
+	}
+}
+
+// TestMiniMaxDefaultAPIBase verifies the default API base URL.
+func TestMiniMaxDefaultAPIBase(t *testing.T) {
+	p := NewMiniMaxProvider("minimax", "key", "", "")
+	if p.APIBase() != "https://api.minimax.io/v1" {
+		t.Errorf("APIBase() = %q, want %q", p.APIBase(), "https://api.minimax.io/v1")
+	}
+}
+
+// TestMiniMaxProviderType verifies providerType is set to minimax_native.
+func TestMiniMaxProviderType(t *testing.T) {
+	p := NewMiniMaxProvider("minimax", "key", "", "")
+	if p.ProviderType() != "minimax_native" {
+		t.Errorf("ProviderType() = %q, want %q", p.ProviderType(), "minimax_native")
+	}
+}
+
+// TestMiniMaxChatPath verifies the standard /chat/completions path is used.
+func TestMiniMaxChatPath(t *testing.T) {
+	p := NewMiniMaxProvider("minimax", "key", "", "")
+	if p.chatPath != "/chat/completions" {
+		t.Errorf("chatPath = %q, want %q", p.chatPath, "/chat/completions")
+	}
+}
+
+// TestMiniMaxSupportsThinking verifies thinking support.
+func TestMiniMaxSupportsThinking(t *testing.T) {
+	p := NewMiniMaxProvider("minimax", "key", "", "")
+	if !p.SupportsThinking() {
+		t.Error("SupportsThinking() = false, want true")
+	}
+}
+
+// TestMiniMaxName verifies the Name() method returns the configured name.
+func TestMiniMaxName(t *testing.T) {
+	p := NewMiniMaxProvider("my-minimax", "key", "", "")
+	if p.Name() != "my-minimax" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "my-minimax")
+	}
+}
+
+// TestMiniMaxTempClamped_ZeroRemoved verifies temperature=0 is removed from the request
+// (MiniMax rejects 0; server uses its default instead).
+func TestMiniMaxTempClamped_ZeroRemoved(t *testing.T) {
+	body := callMiniMaxChat(t, ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options:  map[string]any{OptTemperature: 0.0},
+	})
+	if _, has := body["temperature"]; has {
+		t.Errorf("temperature should be removed for value 0, got: %v", body["temperature"])
+	}
+}
+
+// TestMiniMaxTempClamped_NegativeRemoved verifies negative temperature is removed.
+func TestMiniMaxTempClamped_NegativeRemoved(t *testing.T) {
+	body := callMiniMaxChat(t, ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options:  map[string]any{OptTemperature: -0.5},
+	})
+	if _, has := body["temperature"]; has {
+		t.Errorf("temperature should be removed for negative value, got: %v", body["temperature"])
+	}
+}
+
+// TestMiniMaxTempClamped_Above1 verifies temperature > 1.0 is clamped to 1.0.
+func TestMiniMaxTempClamped_Above1(t *testing.T) {
+	body := callMiniMaxChat(t, ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options:  map[string]any{OptTemperature: 1.5},
+	})
+	temp, ok := body["temperature"].(float64)
+	if !ok {
+		t.Fatalf("temperature not found in request body")
+	}
+	if temp != 1.0 {
+		t.Errorf("temperature = %v, want 1.0", temp)
+	}
+}
+
+// TestMiniMaxTempPassthrough_Valid verifies valid temperature (0 < t ≤ 1) is passed as-is.
+func TestMiniMaxTempPassthrough_Valid(t *testing.T) {
+	body := callMiniMaxChat(t, ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options:  map[string]any{OptTemperature: 0.7},
+	})
+	temp, ok := body["temperature"].(float64)
+	if !ok {
+		t.Fatalf("temperature not found in request body")
+	}
+	if temp != 0.7 {
+		t.Errorf("temperature = %v, want 0.7", temp)
+	}
+}
+
+// TestMiniMaxTempPassthrough_ExactlyOne verifies temperature=1.0 is valid and passed as-is.
+func TestMiniMaxTempPassthrough_ExactlyOne(t *testing.T) {
+	body := callMiniMaxChat(t, ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options:  map[string]any{OptTemperature: 1.0},
+	})
+	temp, ok := body["temperature"].(float64)
+	if !ok {
+		t.Fatalf("temperature not found in request body")
+	}
+	if temp != 1.0 {
+		t.Errorf("temperature = %v, want 1.0", temp)
+	}
+}
+
+// TestMiniMaxNoTemperature verifies requests without temperature are unchanged.
+func TestMiniMaxNoTemperature(t *testing.T) {
+	body := callMiniMaxChat(t, ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options:  map[string]any{OptMaxTokens: 100},
+	})
+	if _, has := body["temperature"]; has {
+		t.Error("temperature should not be present when not set in options")
+	}
+}
+
+// TestMiniMaxStreamTempClamped verifies temperature clamping works for ChatStream too.
+func TestMiniMaxStreamTempClamped(t *testing.T) {
+	body := callMiniMaxStream(t, ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options:  map[string]any{OptTemperature: 2.0},
+	})
+	temp, ok := body["temperature"].(float64)
+	if !ok {
+		t.Fatalf("temperature not found in request body")
+	}
+	if temp != 1.0 {
+		t.Errorf("temperature = %v, want 1.0 (clamped from 2.0)", temp)
+	}
+}
+
+// TestMiniMaxChatResponse verifies a basic Chat call returns correct content.
+func TestMiniMaxChatResponse(t *testing.T) {
+	server, _ := newMiniMaxTestServer(t)
+	p := NewMiniMaxProvider("minimax-test", "test-key", server.URL, "")
+	p.retryConfig.Attempts = 1
+
+	resp, err := p.Chat(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Errorf("Content = %q, want %q", resp.Content, "ok")
+	}
+	if resp.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, "stop")
+	}
+}
+
+// TestMiniMaxStreamResponse verifies a basic ChatStream call returns correct content.
+func TestMiniMaxStreamResponse(t *testing.T) {
+	server, _ := newMiniMaxTestServer(t)
+	p := NewMiniMaxProvider("minimax-test", "test-key", server.URL, "")
+	p.retryConfig.Attempts = 1
+
+	var chunks []string
+	resp, err := p.ChatStream(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	}, func(chunk StreamChunk) {
+		if chunk.Content != "" {
+			chunks = append(chunks, chunk.Content)
+		}
+	})
+	if err != nil {
+		t.Fatalf("ChatStream() error: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Errorf("Content = %q, want %q", resp.Content, "ok")
+	}
+	if len(chunks) == 0 {
+		t.Error("expected at least one content chunk")
+	}
+}
+
+// TestMiniMaxCustomAPIBase verifies custom API base is respected.
+func TestMiniMaxCustomAPIBase(t *testing.T) {
+	p := NewMiniMaxProvider("minimax", "key", "https://custom.api.minimax.io/v1", "")
+	if p.APIBase() != "https://custom.api.minimax.io/v1" {
+		t.Errorf("APIBase() = %q, want %q", p.APIBase(), "https://custom.api.minimax.io/v1")
+	}
+}
+
+// TestMiniMaxCustomModel verifies custom default model is respected.
+func TestMiniMaxCustomModel(t *testing.T) {
+	p := NewMiniMaxProvider("minimax", "key", "", "MiniMax-M2.5")
+	if p.DefaultModel() != "MiniMax-M2.5" {
+		t.Errorf("DefaultModel() = %q, want %q", p.DefaultModel(), "MiniMax-M2.5")
+	}
+}
+
+// TestMiniMaxTempClamped_IntegerValue verifies integer temperature values are handled.
+func TestMiniMaxTempClamped_IntegerValue(t *testing.T) {
+	body := callMiniMaxChat(t, ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options:  map[string]any{OptTemperature: 2},
+	})
+	temp, ok := body["temperature"].(float64)
+	if !ok {
+		t.Fatalf("temperature not found in request body")
+	}
+	if temp != 1.0 {
+		t.Errorf("temperature = %v, want 1.0 (clamped from int 2)", temp)
+	}
+}


### PR DESCRIPTION
## Summary

Upgrade MiniMax from bare `OpenAIProvider` reuse to a dedicated `MiniMaxProvider` (following the DashScope wrapper pattern), with temperature clamping, M2.7 default model, and consistent registration.

### Changes

- **New `MiniMaxProvider`** (`internal/providers/minimax.go`) — wraps `OpenAIProvider` with:
  - Temperature clamping: MiniMax requires (0.0, 1.0] — zero/negative removed (server default), >1 clamped to 1.0
  - Default model upgraded: `MiniMax-M2.5` → `MiniMax-M2.7`
  - Standard `/chat/completions` endpoint (replacing legacy `/text/chatcompletion_v2`)
  - Auto-set `providerType` to `minimax_native` for media tool routing
  - Thinking support via `reasoning_effort` parameter

- **Consistent registration** across all three paths:
  - Config-based (`cmd/gateway_providers.go`)
  - DB-based (`cmd/gateway_providers.go`)
  - HTTP in-memory (`internal/http/providers.go`)

- **Updated model list** (`internal/http/provider_models.go`):
  - Added `MiniMax-M2.7-highspeed` and `MiniMax-M2.5-highspeed`
  - Reordered with latest models first

- **Documentation** (`docs/02-providers.md`, `CLAUDE.md`):
  - Added MiniMax as dedicated provider in architecture diagram
  - Added MiniMax section alongside DashScope and Bailian
  - Updated provider table with new default model

## Test Plan

- [x] 18 unit tests in `internal/providers/minimax_test.go`:
  - Temperature clamping: zero removed, negative removed, >1 clamped, valid passthrough, int values
  - Default model, API base, provider type, chat path, thinking support, name
  - Chat and ChatStream response verification
  - Custom API base and model overrides
- [x] `go build ./...` passes
- [x] `go vet` passes on all changed packages
- [x] Existing DashScope tests still pass (no regressions)
