### PR TITLE
fix(desktop): resolve Load failed and suppress unnecessary lite startup logs

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -110,7 +110,10 @@ func runGateway() {
 	// Bootstrap files live in Postgres.
 
 	// Detect server IPs for output scrubbing (prevents IP leaks via web_fetch, exec, etc.)
-	tools.DetectServerIPs(context.Background())
+	// Skip for desktop/lite — localhost-only, no multi-tenant exposure risk
+	if !edition.Current().IsLimited() {
+		tools.DetectServerIPs(context.Background())
+	}
 
 	toolsReg, execApprovalMgr, mcpMgr, sandboxMgr, browserMgr, webFetchTool, ttsTool, permPE, toolPE, dataDir, agentCfg := setupToolRegistry(cfg, workspace, providerRegistry)
 	if browserMgr != nil {
@@ -1137,7 +1140,7 @@ func runGateway() {
 	if strings.Contains(cfg.Database.PostgresDSN, ":goclaw@") {
 		slog.Warn("security.default_db_password: using default Postgres password — run ./prepare-env.sh to generate a strong one")
 	}
-	if len(cfg.Gateway.AllowedOrigins) == 0 {
+	if len(cfg.Gateway.AllowedOrigins) == 0 && !edition.Current().IsLimited() {
 		slog.Warn("security.cors_open: no allowed_origins configured — all WebSocket origins accepted. Set gateway.allowed_origins for production")
 	}
 

--- a/ui/desktop/app.go
+++ b/ui/desktop/app.go
@@ -84,7 +84,7 @@ func (a *App) startup(ctx context.Context) {
 
 // waitForGateway polls the health endpoint until the gateway is ready or times out.
 func (a *App) waitForGateway() {
-	url := fmt.Sprintf("http://localhost:%d/health", a.gatewayPort)
+	url := fmt.Sprintf("http://127.0.0.1:%d/health", a.gatewayPort)
 	for i := 0; i < 30; i++ {
 		resp, err := http.Get(url)
 		if err == nil && resp.StatusCode == 200 {
@@ -109,7 +109,7 @@ func (a *App) shutdown(ctx context.Context) {
 
 // GetGatewayURL returns the base URL of the embedded gateway.
 func (a *App) GetGatewayURL() string {
-	return fmt.Sprintf("http://localhost:%d", a.gatewayPort)
+	return fmt.Sprintf("http://127.0.0.1:%d", a.gatewayPort)
 }
 
 // GetGatewayToken returns the token for WebSocket authentication.
@@ -124,7 +124,7 @@ func (a *App) GetGatewayPort() int {
 
 // IsGatewayReady checks if the gateway health endpoint is responding.
 func (a *App) IsGatewayReady() bool {
-	url := fmt.Sprintf("http://localhost:%d/health", a.gatewayPort)
+	url := fmt.Sprintf("http://127.0.0.1:%d/health", a.gatewayPort)
 	resp, err := http.Get(url)
 	if err != nil {
 		return false


### PR DESCRIPTION
## Summary
- **Fix "Load failed" in onboarding wizard:** `GetGatewayURL()` returned `http://localhost:PORT` but gateway binds `127.0.0.1` (IPv4 only). On macOS, WebKit can resolve `localhost` to `::1` (IPv6) first → fetch fails. Changed to `http://127.0.0.1:PORT`
- **Suppress CORS warning for Lite:** Desktop is localhost-only, no need for `allowed_origins` config
- **Skip server IP detection for Lite:** No multi-tenant exposure risk, avoids leaking user's public IP in logs and unnecessary outbound network calls at startup

## Test plan
- [ ] Run desktop app (`wails dev -tags sqliteonly`) — verify no CORS warning or IP scrub logs
- [ ] Complete onboarding wizard (create provider) — verify no "Load failed" error
- [ ] Standard edition (`go run .`) — verify CORS warning and IP detection still work