### PR TITLE
fix(sessions): use UPSERT in Save() to persist first-run cron sessions

### DIFF
--- a/internal/store/pg/sessions_list.go
+++ b/internal/store/pg/sessions_list.go
@@ -281,22 +281,45 @@ func (s *PGSessionStore) Save(ctx context.Context, key string) error {
 		metaJSON, _ = json.Marshal(snapshot.Metadata)
 	}
 
+	// UPSERT: INSERT the session if it doesn't exist yet (first-run cron jobs),
+	// or UPDATE if it does. Fixes silent 0-row UPDATE for new cron sessions.
+	tid := tenantIDForInsert(ctx)
 	_, err := s.db.ExecContext(ctx,
-		`UPDATE sessions SET
-			messages = $1, summary = $2, model = $3, provider = $4, channel = $5,
-			input_tokens = $6, output_tokens = $7, compaction_count = $8,
-			memory_flush_compaction_count = $9, memory_flush_at = $10,
-			label = $11, spawned_by = $12, spawn_depth = $13,
-			agent_id = $14, user_id = $15, metadata = $16, updated_at = $17,
-			team_id = $18
-		 WHERE session_key = $19 AND tenant_id = $20`,
+		`INSERT INTO sessions (id, session_key, tenant_id,
+			messages, summary, model, provider, channel,
+			input_tokens, output_tokens, compaction_count,
+			memory_flush_compaction_count, memory_flush_at,
+			label, spawned_by, spawn_depth,
+			agent_id, user_id, metadata, created_at, updated_at,
+			team_id)
+		 VALUES ($1, $2, $3,
+			$4, $5, $6, $7, $8,
+			$9, $10, $11,
+			$12, $13,
+			$14, $15, $16,
+			$17, $18, $19, $20, $20,
+			$21)
+		 ON CONFLICT (tenant_id, session_key) DO UPDATE SET
+			messages = EXCLUDED.messages, summary = EXCLUDED.summary,
+			model = EXCLUDED.model, provider = EXCLUDED.provider,
+			channel = EXCLUDED.channel,
+			input_tokens = EXCLUDED.input_tokens,
+			output_tokens = EXCLUDED.output_tokens,
+			compaction_count = EXCLUDED.compaction_count,
+			memory_flush_compaction_count = EXCLUDED.memory_flush_compaction_count,
+			memory_flush_at = EXCLUDED.memory_flush_at,
+			label = EXCLUDED.label, spawned_by = EXCLUDED.spawned_by,
+			spawn_depth = EXCLUDED.spawn_depth,
+			agent_id = EXCLUDED.agent_id, user_id = EXCLUDED.user_id,
+			metadata = EXCLUDED.metadata, updated_at = EXCLUDED.updated_at,
+			team_id = EXCLUDED.team_id`,
+		uuid.Must(uuid.NewV7()), key, tid,
 		msgsJSON, nilStr(snapshot.Summary), nilStr(snapshot.Model), nilStr(snapshot.Provider), nilStr(snapshot.Channel),
 		snapshot.InputTokens, snapshot.OutputTokens, snapshot.CompactionCount,
 		snapshot.MemoryFlushCompactionCount, snapshot.MemoryFlushAt,
 		nilStr(snapshot.Label), nilStr(snapshot.SpawnedBy), snapshot.SpawnDepth,
 		nilSessionUUID(snapshot.AgentUUID), nilStr(snapshot.UserID), metaJSON, snapshot.Updated,
 		snapshot.TeamID,
-		key, tenantIDForInsert(ctx),
 	)
 	return err
 }


### PR DESCRIPTION
Fixes #379

## Problem

`PGSessionStore.Save()` uses `UPDATE sessions ... WHERE session_key = $19`. When a cron job runs for the first time, the session row doesn't exist in DB yet. The UPDATE affects 0 rows and returns `nil` — **silently losing the session**.

This causes two cascading failures:

1. **Cron sessions never persist** — exist only in memory, lost on restart
2. **Stale cache on retry** — `ExecuteWithRetry` reads leftover messages from the failed attempt's in-memory cache, polluting retries with empty user messages + `"..."` assistant fallback. The stale messages cause LLM 400 errors (`messages.0.content.0.text.text: Field required`), and all retry attempts fail with the same error.

## Fix

Change `Save()` from `UPDATE` to `INSERT ... ON CONFLICT (tenant_id, session_key) DO UPDATE SET ...`.

**Before:**
```sql
UPDATE sessions SET messages = $1, ... WHERE session_key = $19 AND tenant_id = $20
-- 0 rows affected → silent data loss
```

**After:**
```sql
INSERT INTO sessions (id, session_key, tenant_id, messages, ...)
VALUES ($1, $2, $3, $4, ...)
ON CONFLICT (tenant_id, session_key) DO UPDATE SET
  messages = EXCLUDED.messages, ...
-- Always persists: INSERT on first run, UPDATE on subsequent saves
```

### Why UPSERT over alternatives?

| Option | Pro | Con |
|--------|-----|-----|
| **A: UPSERT (this PR)** | Single atomic operation, no conditional logic | Generates new UUID on every save (ignored on conflict) |
| B: Check + INSERT | Two queries | Race condition between check and insert |
| C: Ensure row before agent loop | Requires caller discipline | Misses edge cases |

The UUID generation cost on conflict is negligible — `uuid.NewV7()` is ~50ns.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `internal/store/pg/sessions_list.go` | +32, -9 | `UPDATE` → `INSERT ... ON CONFLICT ... DO UPDATE` |

## Verification

```bash
go build ./...                   # ✅ PG build
go build -tags sqliteonly ./...  # ✅ SQLite build
go vet ./...                     # ✅ Clean
```

The fix uses the same `ON CONFLICT (tenant_id, session_key)` unique index already used by `GetOrCreate()` (line 146 of `sessions.go`), confirming the constraint exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)