### PR TITLE
chore(docker): add uv package manager to Python installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,13 +59,13 @@ RUN set -eux; \
         apk add --no-cache python3 py3-pip nodejs npm pandoc github-cli poppler-utils bash; \
         pip3 install --no-cache-dir --break-system-packages \
             pypdf openpyxl pandas python-pptx markitdown defusedxml lxml \
-            pdfplumber pdf2image anthropic; \
+            pdfplumber pdf2image anthropic uv; \
         npm install -g --cache /tmp/npm-cache docx pptxgenjs; \
         rm -rf /tmp/npm-cache /root/.cache /var/cache/apk/*; \
     else \
         if [ "$ENABLE_PYTHON" = "true" ]; then \
             apk add --no-cache python3 py3-pip; \
-            pip3 install --no-cache-dir --break-system-packages edge-tts; \
+            pip3 install --no-cache-dir --break-system-packages edge-tts uv; \
         fi; \
         if [ "$ENABLE_NODE" = "true" ] || [ "$ENABLE_CLAUDE_CLI" = "true" ]; then \
             apk add --no-cache nodejs npm; \


### PR DESCRIPTION
## Summary
- Add `uv` to pip installs in both full (ENABLE_TOOLS) and minimal
  (ENABLE_PYTHON) Docker build paths
- Enables MCP servers written in Python that initialize via `uvx`