### PR TITLE
fix: include tenant ID header in skill upload requests

### DIFF
--- a/ui/web/src/api/http-client.ts
+++ b/ui/web/src/api/http-client.ts
@@ -69,15 +69,9 @@ export class HttpClient {
   }
 
   async upload<T>(path: string, formData: FormData): Promise<T> {
-    const headers: Record<string, string> = {};
-    const token = this.getToken();
-    if (token) headers["Authorization"] = `Bearer ${token}`;
-    const userId = this.getUserId();
-    if (userId) headers["X-GoClaw-User-Id"] = userId;
-
     const res = await fetch(this.buildUrl(path), {
       method: "POST",
-      headers,
+      headers: this.authHeaders(),
       body: formData,
     });
 


### PR DESCRIPTION
## Summary
- Fix custom skill uploads always landing on Master tenant instead of the user's current tenant
- Replace manual header construction in `upload()` with `authHeaders()` which includes `X-GoClaw-Tenant-Id`
- Removes 6 lines of duplicated header logic

Closes #557

## Test plan
- [ ] Switch to a non-master tenant in the web UI
- [ ] Upload a custom skill via the Custom tab
- [ ] Verify the skill appears under the current tenant, not Master

🤖 Generated with [Claude Code](https://claude.com/claude-code)