### PR TITLE
fix(cron): resolve default agent from DB and fix update payload

### DIFF
--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -27,7 +27,15 @@ var cronHeartbeatWakeFn func(agentID string)
 func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg *config.Config, channelMgr *channels.Manager, sessionMgr store.SessionStore, agentStore store.AgentStore) func(job *store.CronJob) (*store.CronJobResult, error) {
 	return func(job *store.CronJob) (*store.CronJobResult, error) {
 		agentID := job.AgentID
-		if agentID == "" {
+		if agentID == "" && agentStore != nil {
+			// Resolve real default agent from DB instead of using literal "default" string.
+			tenantCtx := store.WithTenantID(context.Background(), job.TenantID)
+			if defaultAgent, err := agentStore.GetDefault(tenantCtx); err == nil {
+				agentID = defaultAgent.AgentKey
+			} else {
+				agentID = cfg.ResolveDefaultAgentID()
+			}
+		} else if agentID == "" {
 			agentID = cfg.ResolveDefaultAgentID()
 		} else if id, err := uuid.Parse(agentID); err == nil && agentStore != nil {
 			// Resolve agentKey from UUID so session key uses agentKey

--- a/ui/web/src/pages/cron/cron-detail/cron-overview-tab.tsx
+++ b/ui/web/src/pages/cron/cron-detail/cron-overview-tab.tsx
@@ -57,7 +57,7 @@ export function CronOverviewTab({ job, onUpdate }: CronOverviewTabProps) {
       await onUpdate(job.id, {
         schedule,
         message: message.trim(),
-        agentId: agentId.trim() || undefined,
+        agentId: agentId.trim() || "",
         enabled,
       });
       setEditingMessage(false);
@@ -176,7 +176,7 @@ export function CronOverviewTab({ job, onUpdate }: CronOverviewTabProps) {
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div className="space-y-2">
             <Label>{t("create.agentId")}</Label>
-            <Select value={agentId || "__default__"} onValueChange={(v) => setAgentId(v === "__default__" ? "" : v)} disabled={readonly}>
+            <Select name="agentId" value={agentId || "__default__"} onValueChange={(v) => setAgentId(v === "__default__" ? "" : v)} disabled={readonly}>
               <SelectTrigger className="text-base md:text-sm">
                 <SelectValue placeholder={t("create.agentIdPlaceholder")} />
               </SelectTrigger>

--- a/ui/web/src/pages/cron/cron-form-dialog.tsx
+++ b/ui/web/src/pages/cron/cron-form-dialog.tsx
@@ -11,8 +11,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { CronSchedule } from "./hooks/use-cron";
 import { slugify, isValidSlug } from "@/lib/slug";
+import { useAgents } from "@/pages/agents/hooks/use-agents";
 
 interface CronFormDialogProps {
   open: boolean;
@@ -29,6 +31,7 @@ type ScheduleKind = "every" | "cron" | "at";
 
 export function CronFormDialog({ open, onOpenChange, onSubmit }: CronFormDialogProps) {
   const { t } = useTranslation("cron");
+  const { agents } = useAgents();
   const [name, setName] = useState("");
   const [message, setMessage] = useState("");
   const [agentId, setAgentId] = useState("");
@@ -81,7 +84,19 @@ export function CronFormDialog({ open, onOpenChange, onSubmit }: CronFormDialogP
 
           <div className="space-y-2">
             <Label>{t("create.agentId")}</Label>
-            <Input value={agentId} onChange={(e) => setAgentId(e.target.value)} placeholder={t("create.agentIdPlaceholder")} />
+            <Select name="agentId" value={agentId || "__default__"} onValueChange={(v) => setAgentId(v === "__default__" ? "" : v)}>
+              <SelectTrigger className="text-base md:text-sm">
+                <SelectValue placeholder={t("create.agentIdPlaceholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__default__">{t("create.agentIdPlaceholder")}</SelectItem>
+                {agents.map((a) => (
+                  <SelectItem key={a.id} value={a.id}>
+                    {a.display_name || a.agent_key || a.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="space-y-2">

--- a/ui/web/src/pages/cron/hooks/use-cron.ts
+++ b/ui/web/src/pages/cron/hooks/use-cron.ts
@@ -152,7 +152,7 @@ export function useCron() {
   const updateJob = useCallback(
     async (jobId: string, params: Record<string, unknown>) => {
       try {
-        await ws.call(Methods.CRON_UPDATE, { jobId, ...params });
+        await ws.call(Methods.CRON_UPDATE, { jobId, patch: params });
         await invalidate();
         toast.success(i18next.t("cron:toast.updated"));
       } catch (err) {


### PR DESCRIPTION
## Summary
Fixes #549 — cron jobs fail with "agent default not found" error, and editing a cron job's agent reverts on save.

**Root causes:**
- **Execution:** when `agent_id` is NULL, handler resolved to literal string `"default"` instead of querying DB for real default agent UUID
- **Update payload:** UI sent update params at top level instead of wrapping in `patch` object — backend received empty patch, nothing persisted
- **Create form:** free-text input for agent ID instead of dropdown — users couldn't select valid agents

## Changes
- **`cmd/gateway_cron.go`** — resolve real default agent from DB via `agentStore.GetDefault()` when cron job has no agent_id
- **`ui/web/src/pages/cron/hooks/use-cron.ts`** — wrap update params in `patch` object matching `handleUpdate` expectation
- **`ui/web/src/pages/cron/cron-form-dialog.tsx`** — replace free-text input with agent dropdown (consistent with edit form)
- **`ui/web/src/pages/cron/cron-detail/cron-overview-tab.tsx`** — send explicit empty string to clear agent_id; add `name` attr to Select

## Test plan
- [x] Create cron job without selecting agent → verify it runs using the default agent (no "agent not found" error)
- [x] Create cron job with specific agent selected from dropdown → verify correct agent UUID stored
- [x] Edit existing cron job, change agent → save → verify new agent persists after page refresh
- [x] Edit cron job, set agent back to "Default" → save → verify agent_id cleared in DB