### PR TITLE
fix: preserve thinking block signature in streaming responses

### DIFF
--- a/internal/providers/anthropic_request.go
+++ b/internal/providers/anthropic_request.go
@@ -4,12 +4,13 @@ import "encoding/json"
 
 // buildRawBlock reconstructs a complete content block from streaming data.
 // This is needed to preserve thinking blocks (with signatures) for tool use passback.
-func (p *AnthropicProvider) buildRawBlock(blockType string, result *ChatResponse, toolCallJSON map[int]string, _ int) json.RawMessage {
+func (p *AnthropicProvider) buildRawBlock(blockType string, result *ChatResponse, toolCallJSON map[int]string, _ int, signature string) json.RawMessage {
 	switch blockType {
 	case "thinking":
 		block := map[string]any{
-			"type":     "thinking",
-			"thinking": result.Thinking,
+			"type":      "thinking",
+			"thinking":  result.Thinking,
+			"signature": signature,
 		}
 		if b, err := json.Marshal(block); err == nil {
 			return b

--- a/internal/providers/anthropic_stream.go
+++ b/internal/providers/anthropic_stream.go
@@ -30,6 +30,7 @@ func (p *AnthropicProvider) ChatStream(ctx context.Context, req ChatRequest, onC
 	// Track content blocks for RawAssistantContent (needed for thinking block passback)
 	var rawContentBlocks []json.RawMessage
 	var currentBlockType string
+	var currentSignature string
 	// Track thinking token count by accumulated chunk size
 	thinkingChars := 0
 
@@ -102,7 +103,7 @@ func (p *AnthropicProvider) ChatStream(ctx context.Context, req ChatRequest, onC
 						toolCallJSON[idx] += ev.Delta.PartialJSON
 					}
 				case "signature_delta":
-					// Signature is captured in content_block_stop via raw block reconstruction
+					currentSignature += ev.Delta.Signature
 				}
 			}
 
@@ -110,12 +111,13 @@ func (p *AnthropicProvider) ChatStream(ctx context.Context, req ChatRequest, onC
 			// Reconstruct the complete content block for RawAssistantContent
 			if len(rawContentBlocks) > 0 {
 				idx := len(rawContentBlocks) - 1
-				block := p.buildRawBlock(currentBlockType, result, toolCallJSON, idx)
+				block := p.buildRawBlock(currentBlockType, result, toolCallJSON, idx, currentSignature)
 				if block != nil {
 					rawContentBlocks[idx] = block
 				}
 			}
 			currentBlockType = ""
+			currentSignature = ""
 
 		case "message_delta":
 			var ev anthropicMessageDeltaEvent


### PR DESCRIPTION
## Summary
- Accumulate `signature_delta` events during streaming and include the signature in reconstructed thinking blocks
- Fixes multi-turn tool use with extended thinking (e.g. `claude-opus-4-5`) failing with `messages.3.content.0.thinking.signature: Field required`

Closes #566

## Root Cause
The streaming path in `buildRawBlock()` reconstructed thinking blocks without the `signature` field. The non-streaming path worked because it marshals the full `anthropicContentBlock` struct which includes the signature via json tag.

## Changes
- **`anthropic_stream.go`**: Accumulate `signature_delta` into `currentSignature`, pass to `buildRawBlock()`, reset per block
- **`anthropic_request.go`**: Accept `signature` param in `buildRawBlock()`, include in thinking block JSON

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Trigger multi-turn thinking conversation with tool use via Anthropic provider — verify no 400 error on passback

🤖 Generated with [Claude Code](https://claude.com/claude-code)