### PR TITLE
fix(agent): preserve image ref ordering in enrichImagePaths

### DIFF
--- a/internal/agent/media.go
+++ b/internal/agent/media.go
@@ -357,7 +357,9 @@ func (l *Loop) enrichImagePaths(messages []providers.Message) {
 		}
 		content := messages[i].Content
 		changed := false
-		for _, ref := range messages[i].MediaRefs {
+		// Iterate in reverse so last-tag replacement preserves the original ref order.
+		for j := len(messages[i].MediaRefs) - 1; j >= 0; j-- {
+			ref := messages[i].MediaRefs[j]
 			if ref.Kind != "image" {
 				continue
 			}

--- a/internal/agent/media_test.go
+++ b/internal/agent/media_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -106,7 +108,7 @@ func TestEnrichImagePaths_NoDoubleEnrich(t *testing.T) {
 // TestEnrichImagePaths_AttributeOrderIndependence verifies that enrichImagePaths
 // correctly finds the id attribute regardless of attribute order in the tag.
 func TestEnrichImagePaths_AttributeOrderIndependence(t *testing.T) {
-	// url comes before id — old code would fail because it only matched <media:image id=... at tag start.
+	// url comes before id - old code would fail because it only matched <media:image id=... at tag start.
 	messages := []providers.Message{{
 		Role:    "user",
 		Content: `<media:image url="https://cdn.example.com/photo.jpg" id="img-1">`,
@@ -129,5 +131,61 @@ func TestEnrichImagePaths_AttributeOrderIndependence(t *testing.T) {
 	}
 	if !strings.Contains(got, `id="img-1"`) {
 		t.Fatalf("expected id to be preserved, got %q", got)
+	}
+}
+
+func TestEnrichImagePaths_MultipleRefsKeepTagAlignment(t *testing.T) {
+	storeDir := t.TempDir()
+	mediaStore, err := media.NewStore(storeDir)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	const (
+		sessionKey = "session-1"
+		pathA      = "/persisted/a.jpg"
+		pathB      = "/persisted/b.jpg"
+	)
+
+	srcA := filepath.Join(storeDir, "a.jpg")
+	if err := os.WriteFile(srcA, []byte("a"), 0644); err != nil {
+		t.Fatalf("WriteFile(a) error = %v", err)
+	}
+	idA, _, err := mediaStore.SaveFile(sessionKey, srcA, "image/jpeg")
+	if err != nil {
+		t.Fatalf("SaveFile(a) error = %v", err)
+	}
+
+	srcB := filepath.Join(storeDir, "b.jpg")
+	if err := os.WriteFile(srcB, []byte("b"), 0644); err != nil {
+		t.Fatalf("WriteFile(b) error = %v", err)
+	}
+	idB, _, err := mediaStore.SaveFile(sessionKey, srcB, "image/jpeg")
+	if err != nil {
+		t.Fatalf("SaveFile(b) error = %v", err)
+	}
+
+	messages := []providers.Message{{
+		Role: "user",
+		Content: strings.Join([]string{
+			`first <media:image>`,
+			`second <media:image>`,
+		}, "\n"),
+		MediaRefs: []providers.MediaRef{
+			{ID: idA, Kind: "image", Path: pathA},
+			{ID: idB, Kind: "image", Path: pathB},
+		},
+	}}
+
+	var loop Loop
+	loop.mediaStore = mediaStore
+	loop.enrichImagePaths(messages)
+
+	want := strings.Join([]string{
+		`first <media:image id="` + idA + `" path="` + pathA + `">`,
+		`second <media:image id="` + idB + `" path="` + pathB + `">`,
+	}, "\n")
+	if messages[0].Content != want {
+		t.Fatalf("enrichImagePaths() content = %q, want %q", messages[0].Content, want)
 	}
 }


### PR DESCRIPTION
## Summary

This is a follow-up to #606.

- add regression coverage for  with multiple image refs
- preserve tag/ref alignment by iterating image refs in reverse during fallback enrichment
- keep path enrichment behavior consistent with the last-tag replacement strategy already used in 

## Verification

- ok  	github.com/nextlevelbuilder/goclaw/internal/agent	(cached)
ok  	github.com/nextlevelbuilder/goclaw/internal/channels/discord	(cached)
ok  	github.com/nextlevelbuilder/goclaw/internal/channels/media	(cached)
