### PR TITLE
Fix bug followup reminder utf8 truncation

### DIFF
--- a/cmd/gateway_consumer.go
+++ b/cmd/gateway_consumer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 
@@ -212,8 +213,14 @@ func truncateForReminder(content string, maxLen int) string {
 	// Use last non-empty line as it's typically the most relevant.
 	lines := strings.Split(strings.TrimSpace(content), "\n")
 	msg := lines[len(lines)-1]
-	if len(msg) > maxLen {
-		msg = msg[:maxLen] + "..."
+	// Ensure we only persist valid UTF-8 into PostgreSQL.
+	msg = strings.ToValidUTF8(msg, "")
+	if maxLen <= 0 {
+		return msg
+	}
+	if utf8.RuneCountInString(msg) > maxLen {
+		r := []rune(msg)
+		msg = string(r[:maxLen]) + "..."
 	}
 	return msg
 }

--- a/cmd/gateway_consumer_followup_test.go
+++ b/cmd/gateway_consumer_followup_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateForReminder_TruncatesByRuneAndKeepsUTF8Valid(t *testing.T) {
+	input := strings.Repeat("a", 199) + "✌️"
+
+	got := truncateForReminder(input, 200)
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncateForReminder() produced invalid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("truncateForReminder() = %q, want suffix ...", got)
+	}
+	if strings.Contains(got, "\uFFFD") {
+		t.Fatalf("truncateForReminder() introduced replacement rune: %q", got)
+	}
+}
+
+func TestTruncateForReminder_StripsInvalidUTF8(t *testing.T) {
+	invalid := string([]byte{'a', 0xef, 0xb8, '.', 'b'})
+
+	got := truncateForReminder(invalid, 200)
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncateForReminder() produced invalid UTF-8: %q", got)
+	}
+	if strings.ContainsRune(got, '\uFFFD') {
+		t.Fatalf("truncateForReminder() = %q, want no replacement rune", got)
+	}
+}


### PR DESCRIPTION
**Error:**
```
goclaw-1  | time=2026-03-31T12:57:00.644Z level=INFO msg="inbound: scheduling message (main lane)" channel=vinaco-content-agents chat_id=-1003788933260 peer_kind=group agent=content-manager session=agent:content-manager:vinaco-content-agents:group:-1003788933260 user_id=group:vinaco-content-agents:-1003788933260
goclaw-1  | time=2026-03-31T12:57:01.465Z level=INFO msg="system prompt built" mode=full contextFiles=7 hasMemory=true hasSpawn=true isBootstrap=false promptLen=26812
goclaw-1  | time=2026-03-31T12:57:09.211Z level=WARN msg="auto-set followup failed" channel=vinaco-content-agents chat_id=-1003788933260 error="ERROR: invalid byte sequence for encoding \"UTF8\": 0xef 0xb8 0x2e (SQLSTATE 22021)"
```

**The error is caused by:**
```
byte-based truncation corrupting UTF-8 before writing to Postgres.
autoSetFollowup stores msg := truncateForReminder(content, 200), and truncateForReminder previously did msg[:maxLen].
If the 200th byte lands inside a multibyte glyph (emoji/variation selector), it creates invalid UTF-8 like your log (0xef 0xb8 0x2e), which Postgres rejects with SQLSTATE 22021.
```