### PR TITLE
fix(ui): dynamic searchable timezone picker (#614)

### DIFF
--- a/internal/gateway/methods/heartbeat.go
+++ b/internal/gateway/methods/heartbeat.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -196,6 +197,13 @@ func (m *HeartbeatMethods) handleSet(ctx context.Context, client *gateway.Client
 		hb.ActiveHoursEnd = params.ActiveHoursEnd
 	}
 	if params.Timezone != nil {
+		if *params.Timezone != "" {
+			if _, err := time.LoadLocation(*params.Timezone); err != nil {
+				client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest,
+					fmt.Sprintf("invalid timezone: %s", *params.Timezone)))
+				return
+			}
+		}
 		hb.Timezone = params.Timezone
 	}
 	if params.Channel != nil {

--- a/internal/store/pg/cron.go
+++ b/internal/store/pg/cron.go
@@ -49,6 +49,12 @@ func (s *PGCronStore) SetRetryConfig(cfg cron.RetryConfig) {
 // SetDefaultTimezone sets the fallback IANA timezone for cron expressions
 // when a job does not specify its own timezone.
 func (s *PGCronStore) SetDefaultTimezone(tz string) {
+	if tz != "" {
+		if _, err := time.LoadLocation(tz); err != nil {
+			slog.Warn("security.invalid_default_timezone", "tz", tz, "err", err)
+			return
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.defaultTZ = tz

--- a/internal/store/sqlitestore/cron.go
+++ b/internal/store/sqlitestore/cron.go
@@ -51,6 +51,12 @@ func (s *SQLiteCronStore) SetRetryConfig(cfg cron.RetryConfig) {
 }
 
 func (s *SQLiteCronStore) SetDefaultTimezone(tz string) {
+	if tz != "" {
+		if _, err := time.LoadLocation(tz); err != nil {
+			slog.Warn("security.invalid_default_timezone", "tz", tz, "err", err)
+			return
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.defaultTZ = tz

--- a/ui/web/src/lib/constants.ts
+++ b/ui/web/src/lib/constants.ts
@@ -131,3 +131,13 @@ export function getAllIanaTimezones(): TzOption[] {
   _cachedTimezones = entries.map(({ value, label }: { value: string; label: string }) => ({ value, label }));
   return _cachedTimezones;
 }
+
+let _cachedTzSet: Set<string> | undefined;
+
+/** Check if a value is a valid IANA timezone from the dynamic list. */
+export function isValidIanaTimezone(tz: string): boolean {
+  if (!_cachedTzSet) {
+    _cachedTzSet = new Set(getAllIanaTimezones().map((t) => t.value));
+  }
+  return _cachedTzSet.has(tz);
+}

--- a/ui/web/src/pages/agents/agent-detail/heartbeat-config-dialog.tsx
+++ b/ui/web/src/pages/agents/agent-detail/heartbeat-config-dialog.tsx
@@ -19,7 +19,8 @@ import { useProviders } from "@/pages/providers/hooks/use-providers";
 import { useUiStore } from "@/stores/use-ui-store";
 import { ProviderModelSelect } from "@/components/shared/provider-model-select";
 import { Combobox } from "@/components/ui/combobox";
-import { getAllIanaTimezones } from "@/lib/constants";
+import { getAllIanaTimezones, isValidIanaTimezone } from "@/lib/constants";
+import { toast } from "@/stores/use-toast-store";
 import type { HeartbeatConfig, DeliveryTarget } from "@/pages/agents/hooks/use-agent-heartbeat";
 
 interface HeartbeatConfigDialogProps {
@@ -128,6 +129,10 @@ export function HeartbeatConfigDialog({
   };
 
   const handleSave = async () => {
+    if (timezone && !isValidIanaTimezone(timezone)) {
+      toast.error(t("heartbeat.invalidTimezone", "Invalid timezone"));
+      return;
+    }
     try {
       const clampedMin = Math.max(5, intervalMin);
       await update({

--- a/ui/web/src/pages/config/sections/cron-section.tsx
+++ b/ui/web/src/pages/config/sections/cron-section.tsx
@@ -6,7 +6,8 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Combobox } from "@/components/ui/combobox";
 import { InfoLabel } from "@/components/shared/info-label";
-import { getAllIanaTimezones } from "@/lib/constants";
+import { getAllIanaTimezones, isValidIanaTimezone } from "@/lib/constants";
+import { toast } from "@/stores/use-toast-store";
 
 interface CronData {
   max_retries?: number;
@@ -91,7 +92,13 @@ export function CronSection({ data, onSave, saving }: Props) {
 
         {dirty && (
           <div className="flex justify-end pt-2">
-            <Button size="sm" onClick={() => onSave(draft)} disabled={saving} className="gap-1.5">
+            <Button size="sm" onClick={() => {
+              if (draft.default_timezone && !isValidIanaTimezone(draft.default_timezone)) {
+                toast.error(t("cron.invalidTimezone", "Invalid timezone"));
+                return;
+              }
+              onSave(draft);
+            }} disabled={saving} className="gap-1.5">
               <Save className="h-3.5 w-3.5" /> {saving ? t("saving") : t("save")}
             </Button>
           </div>

--- a/ui/web/src/pages/cron/cron-detail/cron-advanced-dialog.tsx
+++ b/ui/web/src/pages/cron/cron-detail/cron-advanced-dialog.tsx
@@ -8,7 +8,8 @@ import { Switch } from "@/components/ui/switch";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { ConfigGroupHeader } from "@/components/shared/config-group-header";
 import { Combobox } from "@/components/ui/combobox";
-import { getAllIanaTimezones } from "@/lib/constants";
+import { getAllIanaTimezones, isValidIanaTimezone } from "@/lib/constants";
+import { toast } from "@/stores/use-toast-store";
 import type { CronJob, CronJobPatch } from "../hooks/use-cron";
 
 interface CronAdvancedDialogProps {
@@ -61,6 +62,10 @@ export function CronAdvancedDialog({ open, onOpenChange, job, onUpdate }: CronAd
   const handleSave = async () => {
     if (!onUpdate) {
       onOpenChange(false);
+      return;
+    }
+    if (timezone && timezone !== "UTC" && !isValidIanaTimezone(timezone)) {
+      toast.error(t("detail.invalidTimezone", "Invalid timezone"));
       return;
     }
     setSaving(true);


### PR DESCRIPTION
## Summary
- Replace hardcoded IANA_TIMEZONES list (20 entries) with dynamic `getAllIanaTimezones()` function using `Intl.supportedValuesOf('timeZone')` (~400 IANA timezones)
- Replace static Select dropdowns with searchable Combobox in cron advanced dialog, heartbeat config, and system config timezone pickers
- Compute UTC offsets dynamically with DST awareness using browser's Intl API
- Add fallback for older browsers and Chrome UTC omission workaround

<img width="3792" height="2454" alt="CleanShot 2026-04-01 at 00 08 31@2x" src="https://github.com/user-attachments/assets/aacfea5a-0105-4e3c-8f56-abb811286ea8" />


Closes #614