### PR TITLE
feat(nodehost): implement node execution sandbox with approval workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ endif
 ifdef WITH_CLAUDE_CLI
 COMPOSE_EXTRA += -f docker-compose.claude-cli.yml
 endif
+ifdef WITH_NODE
+COMPOSE_EXTRA += -f docker-compose.node.yml
+endif
 COMPOSE = $(COMPOSE_BASE) $(COMPOSE_EXTRA)
 UPGRADE = docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.upgrade.yml
 

--- a/cmd/gateway_methods.go
+++ b/cmd/gateway_methods.go
@@ -65,9 +65,16 @@ func registerAllMethods(server *gateway.Server, agents *agent.Router, sessStore 
 	// Phase 3: Live log tailing
 	methods.NewLogsMethods(logTee).Register(router)
 
+	// Node-host remote execution dispatch
+	nodeRegistry := gateway.NewNodeRegistry()
+	nodeDispatcher := gateway.NewNodeDispatcher(nodeRegistry)
+	server.SetNodeDispatcher(nodeDispatcher)
+	methods.NewNodeMethods(nodeDispatcher, msgBus).Register(router)
+
 	slog.Info("registered all RPC methods",
 		"phase1", []string{"chat", "agents", "sessions", "config"},
 		"phase2", []string{"skills", "cron", "heartbeat", "pairing", "usage", "exec_approval", "send"},
+		"node", []string{"node.invoke.result", "node.event", "node.list"},
 	)
 
 	return pairingMethods, heartbeatMethods, chatMethods

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func nodeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "node",
+		Short: "Manage node-host remote execution",
+		Long:  "Run and manage the node-host service that executes system commands for the gateway.",
+	}
+
+	cmd.AddCommand(nodeRunCmd())
+	cmd.AddCommand(nodeConfigCmd())
+
+	return cmd
+}

--- a/cmd/node_config.go
+++ b/cmd/node_config.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nextlevelbuilder/goclaw/internal/nodehost"
+)
+
+func nodeConfigCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config",
+		Short: "Show current node-host configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := nodehost.ResolveNodeHostConfigPath()
+			if err != nil {
+				return fmt.Errorf("resolve config path: %w", err)
+			}
+
+			cfg, err := nodehost.LoadNodeHostConfig()
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+			if cfg == nil {
+				fmt.Fprintf(os.Stderr, "No node config found at %s\n", configPath)
+				fmt.Println("Run 'goclaw node run' to create one.")
+				return nil
+			}
+
+			fmt.Printf("Config: %s\n", configPath)
+			data, _ := json.MarshalIndent(cfg, "", "  ")
+			fmt.Println(string(data))
+			return nil
+		},
+	}
+}

--- a/cmd/node_run.go
+++ b/cmd/node_run.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nextlevelbuilder/goclaw/internal/nodehost"
+)
+
+func nodeRunCmd() *cobra.Command {
+	var (
+		host           string
+		port           int
+		tls            bool
+		tlsFingerprint string
+		displayName    string
+		nodeID         string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run node-host in foreground",
+		Long:  "Connect to the gateway and handle system.run commands. Blocks until interrupted.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nodehost.RunNodeHost(cmd.Context(), nodehost.NodeHostRunOptions{
+				GatewayHost:           host,
+				GatewayPort:           port,
+				GatewayTLS:            tls,
+				GatewayTLSFingerprint: tlsFingerprint,
+				DisplayName:           displayName,
+				NodeID:                nodeID,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&host, "host", "127.0.0.1", "Gateway host address")
+	cmd.Flags().IntVar(&port, "port", 18789, "Gateway port")
+	cmd.Flags().BoolVar(&tls, "tls", false, "Use TLS (wss://)")
+	cmd.Flags().StringVar(&tlsFingerprint, "tls-fingerprint", "", "TLS certificate fingerprint for pinning")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "Node display name (default: hostname)")
+	cmd.Flags().StringVar(&nodeID, "node-id", "", "Override node ID (default: from config)")
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ func init() {
 	rootCmd.AddCommand(migrateCmd())
 	rootCmd.AddCommand(upgradeCmd())
 	rootCmd.AddCommand(authCmd())
+	rootCmd.AddCommand(nodeCmd())
 }
 
 func versionCmd() *cobra.Command {

--- a/docker-compose.node.yml
+++ b/docker-compose.node.yml
@@ -1,0 +1,51 @@
+# Node-host overlay — remote command execution sidecar.
+#
+# The node-host connects to the gateway via WebSocket and executes
+# system.run commands on behalf of agents. Uses the same image as the gateway.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.node.yml up -d
+#   # or: make up WITH_NODE=1
+#
+# Scale to multiple nodes:
+#   docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.node.yml up -d --scale goclaw-node=3
+
+services:
+  goclaw-node:
+    image: ghcr.io/nextlevelbuilder/goclaw:latest
+    build:
+      context: ${GOCLAW_DIR:-.}
+      dockerfile: Dockerfile
+      args:
+        VERSION: "${GOCLAW_VERSION:-dev}"
+    command: ["node", "run", "--host", "goclaw", "--port", "18790"]
+    environment:
+      - GOCLAW_GATEWAY_TOKEN=${GOCLAW_GATEWAY_TOKEN:-}
+      - GOCLAW_GATEWAY_PASSWORD=${GOCLAW_GATEWAY_PASSWORD:-}
+      - GOCLAW_STATE_DIR=/app/data/node-state
+    volumes:
+      - goclaw-data:/app/data
+    depends_on:
+      goclaw:
+        condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+    init: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=128m
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '1.0'
+          pids: 100
+    networks:
+      - goclaw-net
+    restart: unless-stopped
+
+# Uses goclaw-data volume from base docker-compose.yml (already goclaw-owned).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@
 #
 # With OTel tracing:  add -f docker-compose.otel.yml
 # With Claude CLI:    add -f docker-compose.claude-cli.yml
+# With node-host:     add -f docker-compose.node.yml (or: make up WITH_NODE=1)
 
 services:
   goclaw:

--- a/internal/gateway/methods/node.go
+++ b/internal/gateway/methods/node.go
@@ -1,0 +1,141 @@
+package methods
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/gateway"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+// NodeMethods handles node.invoke.result, node.event, and node.list.
+type NodeMethods struct {
+	dispatcher *gateway.NodeDispatcher
+	eventBus   bus.EventPublisher
+}
+
+// NewNodeMethods creates node method handlers.
+func NewNodeMethods(dispatcher *gateway.NodeDispatcher, eventBus bus.EventPublisher) *NodeMethods {
+	return &NodeMethods{dispatcher: dispatcher, eventBus: eventBus}
+}
+
+// Register registers node-related RPC method handlers.
+func (m *NodeMethods) Register(router *gateway.MethodRouter) {
+	router.Register(protocol.MethodNodeInvokeResult, m.handleInvokeResult)
+	router.Register(protocol.MethodNodeEvent, m.handleNodeEvent)
+	router.Register(protocol.MethodNodeList, m.handleNodeList)
+	router.Register(protocol.MethodNodeExec, m.handleNodeExec)
+}
+
+// handleInvokeResult receives a node's command execution result and routes it
+// to the waiting dispatcher goroutine.
+func (m *NodeMethods) handleInvokeResult(_ context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params struct {
+		ID          string          `json:"id"`
+		NodeID      string          `json:"nodeId"`
+		Ok          bool            `json:"ok"`
+		PayloadJSON string          `json:"payloadJSON,omitempty"`
+		Payload     json.RawMessage `json:"payload,omitempty"`
+		Error       *struct {
+			Code    string `json:"code,omitempty"`
+			Message string `json:"message,omitempty"`
+		} `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+		return
+	}
+
+	if params.ID == "" {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "missing invoke id"))
+		return
+	}
+
+	slog.Debug("node invoke result received", "invokeId", params.ID, "nodeId", params.NodeID, "ok", params.Ok)
+
+	m.dispatcher.HandleResult(params.ID, &gateway.NodeInvokeResponse{
+		Ok:          params.Ok,
+		PayloadJSON: params.PayloadJSON,
+		Payload:     params.Payload,
+		Error:       params.Error,
+	})
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"received": true}))
+}
+
+// handleNodeEvent receives exec events (exec.denied, exec.finished) from nodes
+// and publishes them to the event bus for session-scoped delivery.
+func (m *NodeMethods) handleNodeEvent(_ context.Context, _ *gateway.Client, req *protocol.RequestFrame) {
+	var params struct {
+		Event       string `json:"event"`
+		PayloadJSON string `json:"payloadJSON,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return
+	}
+
+	if params.Event == "" {
+		return
+	}
+
+	// Publish the node event to the bus so session-scoped clients receive it.
+	var payload any
+	if params.PayloadJSON != "" {
+		json.Unmarshal([]byte(params.PayloadJSON), &payload)
+	}
+
+	slog.Debug("node event forwarded", "event", params.Event)
+	m.eventBus.Broadcast(bus.Event{
+		Name:    "node." + params.Event,
+		Payload: payload,
+	})
+}
+
+// handleNodeExec dispatches a system.run command to a connected node and returns the result.
+// Admin-only. Used for testing/debugging the gateway→node dispatch pipeline.
+func (m *NodeMethods) handleNodeExec(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params struct {
+		Command   []string `json:"command"`
+		TimeoutMs int      `json:"timeoutMs,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+		return
+	}
+	if len(params.Command) == 0 {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "command required"))
+		return
+	}
+
+	// Build system.run params JSON.
+	runParams, _ := json.Marshal(map[string]any{
+		"command":   params.Command,
+		"timeoutMs": params.TimeoutMs,
+		"approved":  true,
+	})
+
+	slog.Info("node.exec dispatching", "command", params.Command)
+
+	result, err := m.dispatcher.Dispatch(ctx, "system.run", string(runParams), params.TimeoutMs)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
+
+	// Parse the result JSON to return structured data.
+	var parsed any
+	json.Unmarshal(result, &parsed)
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, parsed))
+}
+
+// handleNodeList returns the list of connected nodes (admin only via policy engine).
+func (m *NodeMethods) handleNodeList(_ context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	nodes := m.dispatcher.Registry().List()
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		"nodes": nodes,
+		"count": len(nodes),
+	}))
+}

--- a/internal/gateway/node_dispatcher.go
+++ b/internal/gateway/node_dispatcher.go
@@ -1,0 +1,122 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+// DefaultNodeTimeout is the default timeout for node invocations.
+const DefaultNodeTimeout = 120 * time.Second
+
+// NodeDispatcher sends commands to connected nodes and correlates results.
+type NodeDispatcher struct {
+	registry *NodeRegistry
+	pending  sync.Map // map[requestID] chan *nodeInvokeResponse
+}
+
+// NodeInvokeResponse is the result received from a node.
+type NodeInvokeResponse struct {
+	Ok          bool            `json:"ok"`
+	PayloadJSON string          `json:"payloadJSON,omitempty"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
+	Error       *struct {
+		Code    string `json:"code,omitempty"`
+		Message string `json:"message,omitempty"`
+	} `json:"error,omitempty"`
+}
+
+// NewNodeDispatcher creates a dispatcher backed by the given registry.
+func NewNodeDispatcher(registry *NodeRegistry) *NodeDispatcher {
+	return &NodeDispatcher{registry: registry}
+}
+
+// Registry returns the underlying node registry.
+func (d *NodeDispatcher) Registry() *NodeRegistry { return d.registry }
+
+// Dispatch sends a command to a connected node and waits for the result.
+// Returns the raw JSON payload on success, or an error on failure/timeout.
+func (d *NodeDispatcher) Dispatch(ctx context.Context, command string, paramsJSON string, timeoutMs int) (json.RawMessage, error) {
+	node := d.registry.Pick(command)
+	if node == nil {
+		return nil, fmt.Errorf("no node available for command %q", command)
+	}
+
+	requestID := uuid.NewString()
+
+	// Create response channel and register it.
+	ch := make(chan *NodeInvokeResponse, 1)
+	d.pending.Store(requestID, ch)
+	defer d.pending.Delete(requestID)
+
+	// Send the invoke request event to the node.
+	node.Client.SendEvent(*protocol.NewEvent("node.invoke.request", map[string]any{
+		"id":         requestID,
+		"nodeId":     node.NodeID,
+		"command":    command,
+		"paramsJSON": paramsJSON,
+	}))
+
+	slog.Debug("node dispatch sent", "command", command, "nodeId", node.NodeID, "requestId", requestID)
+
+	// Wait for result with timeout.
+	timeout := DefaultNodeTimeout
+	if timeoutMs > 0 {
+		timeout = time.Duration(timeoutMs)*time.Millisecond + 5*time.Second // add buffer beyond command timeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case resp := <-ch:
+		if resp == nil {
+			return nil, fmt.Errorf("node returned nil response")
+		}
+		if !resp.Ok {
+			errMsg := "node invocation failed"
+			if resp.Error != nil {
+				errMsg = resp.Error.Message
+			}
+			return nil, fmt.Errorf("%s", errMsg)
+		}
+		// Return payloadJSON if present, else payload.
+		if resp.PayloadJSON != "" {
+			return json.RawMessage(resp.PayloadJSON), nil
+		}
+		return resp.Payload, nil
+
+	case <-ctx.Done():
+		return nil, ctx.Err()
+
+	case <-timer.C:
+		return nil, fmt.Errorf("node invocation timed out after %s", timeout)
+	}
+}
+
+// HandleResult delivers a node's invoke result to the waiting dispatch call.
+// Called by the node.invoke.result method handler.
+func (d *NodeDispatcher) HandleResult(requestID string, result *NodeInvokeResponse) {
+	val, ok := d.pending.Load(requestID)
+	if !ok {
+		slog.Warn("node result for unknown request", "requestId", requestID)
+		return
+	}
+	ch := val.(chan *NodeInvokeResponse)
+	select {
+	case ch <- result:
+	default:
+		slog.Warn("node result channel full, dropping", "requestId", requestID)
+	}
+}
+
+// HasNodes reports whether any node is connected.
+func (d *NodeDispatcher) HasNodes() bool {
+	return d.registry.Count() > 0
+}
+

--- a/internal/gateway/node_registry.go
+++ b/internal/gateway/node_registry.go
@@ -1,0 +1,114 @@
+package gateway
+
+import (
+	"slices"
+	"sort"
+	"sync"
+	"time"
+)
+
+// NodeConn represents a connected node-host.
+type NodeConn struct {
+	NodeID       string
+	DisplayName  string
+	Commands     []string
+	Client       *Client
+	RegisteredAt time.Time
+}
+
+// NodeInfo is a read-only snapshot of a connected node for admin/debug.
+type NodeInfo struct {
+	NodeID       string    `json:"nodeId"`
+	DisplayName  string    `json:"displayName"`
+	Commands     []string  `json:"commands"`
+	ClientID     string    `json:"clientId"`
+	RegisteredAt time.Time `json:"registeredAt"`
+}
+
+// NodeRegistry tracks connected node-host instances.
+// Thread-safe for concurrent access from agent dispatches and WS handlers.
+type NodeRegistry struct {
+	mu    sync.RWMutex
+	nodes map[string]*NodeConn // keyed by client ID (not node ID, since multiple instances may share a node ID)
+	// round-robin index per command for load distribution
+	rrIndex map[string]int
+}
+
+// NewNodeRegistry creates an empty node registry.
+func NewNodeRegistry() *NodeRegistry {
+	return &NodeRegistry{
+		nodes:   make(map[string]*NodeConn),
+		rrIndex: make(map[string]int),
+	}
+}
+
+// Register adds a node connection. Called when a client connects with role "node".
+func (r *NodeRegistry) Register(client *Client, nodeID, displayName string, commands []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.nodes[client.id] = &NodeConn{
+		NodeID:       nodeID,
+		DisplayName:  displayName,
+		Commands:     commands,
+		Client:       client,
+		RegisteredAt: time.Now(),
+	}
+}
+
+// Unregister removes a node connection. Called on client disconnect.
+func (r *NodeRegistry) Unregister(clientID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.nodes, clientID)
+}
+
+// Pick selects a node that supports the given command using round-robin.
+// Returns nil if no suitable node is connected.
+func (r *NodeRegistry) Pick(command string) *NodeConn {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Collect candidates.
+	var candidates []*NodeConn
+	for _, n := range r.nodes {
+		if slices.Contains(n.Commands, command) {
+			candidates = append(candidates, n)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Sort by client ID for deterministic round-robin (Go map iteration is random).
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].Client.id < candidates[j].Client.id
+	})
+
+	idx := r.rrIndex[command] % len(candidates)
+	r.rrIndex[command] = idx + 1
+	return candidates[idx]
+}
+
+// List returns a snapshot of all connected nodes.
+func (r *NodeRegistry) List() []NodeInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	list := make([]NodeInfo, 0, len(r.nodes))
+	for _, n := range r.nodes {
+		list = append(list, NodeInfo{
+			NodeID:       n.NodeID,
+			DisplayName:  n.DisplayName,
+			Commands:     n.Commands,
+			ClientID:     n.Client.id,
+			RegisteredAt: n.RegisteredAt,
+		})
+	}
+	return list
+}
+
+// Count returns the number of connected nodes.
+func (r *NodeRegistry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.nodes)
+}

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -112,6 +112,12 @@ func (r *MethodRouter) handleConnect(ctx context.Context, client *Client, req *p
 		TenantHint  string `json:"tenant_hint"`  // optional tenant slug for browser pairing multi-tenant
 		TenantID    string `json:"tenant_id"`    // cross-tenant admin: narrow scope to specific tenant (UUID or slug)
 		TenantScope string `json:"tenant_scope"` // deprecated: alias for tenant_id (backward compat)
+		// Node-host fields
+		Mode        string   `json:"mode"`
+		Role        string   `json:"role"`
+		InstanceID  string   `json:"instanceId"`
+		DisplayName string   `json:"clientDisplayName"`
+		Commands    []string `json:"commands"`
 	}
 	if req.Params != nil {
 		json.Unmarshal(req.Params, &params)
@@ -121,6 +127,12 @@ func (r *MethodRouter) handleConnect(ctx context.Context, client *Client, req *p
 	client.locale = i18n.Normalize(params.Locale)
 
 	configToken := r.server.cfg.Gateway.Token
+
+	// Helper: send connect response and register node if applicable.
+	sendAndRegisterNode := func(reqID string) {
+		r.sendConnectResponse(ctx, client, reqID)
+		r.registerNodeIfApplicable(client, params.Mode, params.InstanceID, params.DisplayName, params.Commands)
+	}
 
 	// Path 1: Valid gateway token → admin (constant-time comparison)
 	if configToken != "" && subtle.ConstantTimeCompare([]byte(params.Token), []byte(configToken)) == 1 {
@@ -157,7 +169,7 @@ func (r *MethodRouter) handleConnect(ctx context.Context, client *Client, req *p
 			}
 			client.tenantID = tid
 		}
-		r.sendConnectResponse(ctx, client, req.ID)
+		sendAndRegisterNode(req.ID)
 		return
 	}
 
@@ -207,7 +219,7 @@ func (r *MethodRouter) handleConnect(ctx context.Context, client *Client, req *p
 					"tenant_id", client.tenantID.String(),
 				)
 			}
-			r.sendConnectResponse(ctx, client, req.ID)
+			sendAndRegisterNode(req.ID)
 			return
 		}
 	}
@@ -218,7 +230,7 @@ func (r *MethodRouter) handleConnect(ctx context.Context, client *Client, req *p
 		client.authenticated = true
 		client.userID = params.UserID
 		client.tenantID = store.MasterTenantID
-		r.sendConnectResponse(ctx, client, req.ID)
+		sendAndRegisterNode(req.ID)
 		return
 	}
 
@@ -250,7 +262,7 @@ func (r *MethodRouter) handleConnect(ctx context.Context, client *Client, req *p
 			}
 			client.tenantID = tid
 			slog.Info("browser pairing authenticated", "sender_id", params.SenderID, "client", client.id, "tenant_id", client.tenantID)
-			r.sendConnectResponse(ctx, client, req.ID)
+			sendAndRegisterNode(req.ID)
 			return
 		}
 	}
@@ -289,7 +301,25 @@ func (r *MethodRouter) handleConnect(ctx context.Context, client *Client, req *p
 		return
 	}
 	client.tenantID = tid
-	r.sendConnectResponse(ctx, client, req.ID)
+	sendAndRegisterNode(req.ID)
+}
+
+// registerNodeIfApplicable checks if this connect is from a node-host and registers it.
+// Only admin/owner roles may register as nodes to prevent unauthorized command execution.
+func (r *MethodRouter) registerNodeIfApplicable(client *Client, mode, instanceID, displayName string, commands []string) {
+	if mode != "node" || r.server.nodeRegistry == nil {
+		return
+	}
+	if !permissions.HasMinRole(client.role, permissions.RoleAdmin) {
+		slog.Warn("security.node_registration_denied", "role", client.role, "client", client.id)
+		return
+	}
+	nodeID := instanceID
+	if nodeID == "" {
+		nodeID = client.id
+	}
+	r.server.nodeRegistry.Register(client, nodeID, displayName, commands)
+	slog.Info("node-host registered", "nodeId", nodeID, "displayName", displayName, "commands", commands, "client", client.id)
 }
 
 func (r *MethodRouter) sendConnectResponse(ctx context.Context, client *Client, reqID string) {

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -64,8 +64,10 @@ type Server struct {
 	db             interface{ PingContext(context.Context) error } // for health check DB ping
 	updateChecker  *UpdateChecker
 
-	logTee   *LogTee                  // optional; auto-unsubscribes clients on disconnect
-	postTurn tools.PostTurnProcessor // optional; for team task dispatch in HTTP API paths
+	logTee         *LogTee                  // optional; auto-unsubscribes clients on disconnect
+	postTurn       tools.PostTurnProcessor // optional; for team task dispatch in HTTP API paths
+	nodeRegistry   *NodeRegistry           // tracks connected node-host instances
+	nodeDispatcher *NodeDispatcher          // dispatches commands to nodes
 
 	httpServer *http.Server
 	mux        *http.ServeMux
@@ -582,6 +584,10 @@ func (s *Server) unregisterClient(c *Client) {
 	if s.logTee != nil {
 		s.logTee.Unsubscribe(c.id)
 	}
+	// Clean up node registration if this was a node-host client.
+	if s.nodeRegistry != nil {
+		s.nodeRegistry.Unregister(c.id)
+	}
 	slog.Info("client disconnected", "id", c.id)
 }
 
@@ -589,6 +595,15 @@ func (s *Server) unregisterClient(c *Client) {
 func (s *Server) SetLogTee(lt *LogTee) {
 	s.logTee = lt
 }
+
+// SetNodeDispatcher attaches the node registry and dispatcher for remote execution.
+func (s *Server) SetNodeDispatcher(d *NodeDispatcher) {
+	s.nodeDispatcher = d
+	s.nodeRegistry = d.Registry()
+}
+
+// NodeDispatcher returns the node dispatcher (nil if not configured).
+func (s *Server) NodeDispatcher() *NodeDispatcher { return s.nodeDispatcher }
 
 // StartTestServer creates a listener on :0 (random port) and returns the
 // actual address and a start function. Used for integration tests.

--- a/internal/nodehost/allowlist.go
+++ b/internal/nodehost/allowlist.go
@@ -1,0 +1,122 @@
+package nodehost
+
+import (
+	"runtime"
+	"strings"
+)
+
+// ExecAllowlistEntry represents a single allowlist pattern entry.
+type ExecAllowlistEntry struct {
+	Pattern string `json:"pattern"`
+}
+
+// CommandResolution holds the resolved path for a command binary.
+type CommandResolution struct {
+	ResolvedPath string `json:"resolvedPath,omitempty"`
+}
+
+// ExecCommandSegment represents a parsed segment of a command pipeline.
+type ExecCommandSegment struct {
+	Raw        string             `json:"raw"`
+	Argv       []string           `json:"argv"`
+	Resolution *CommandResolution `json:"resolution,omitempty"`
+}
+
+// SystemRunAllowlistAnalysis holds the result of allowlist evaluation.
+type SystemRunAllowlistAnalysis struct {
+	AnalysisOk         bool                 `json:"analysisOk"`
+	AllowlistMatches   []ExecAllowlistEntry `json:"allowlistMatches"`
+	AllowlistSatisfied bool                 `json:"allowlistSatisfied"`
+	Segments           []ExecCommandSegment `json:"segments"`
+}
+
+// AllowlistEvaluator abstracts the platform-specific allowlist matching.
+// Implementations handle shell tokenization and exec argv analysis.
+type AllowlistEvaluator interface {
+	EvaluateShellAllowlist(command string, allowlist []ExecAllowlistEntry) SystemRunAllowlistAnalysis
+	EvaluateExecAllowlist(argv []string, allowlist []ExecAllowlistEntry) SystemRunAllowlistAnalysis
+}
+
+// ResolvePlannedAllowlistArgv determines if a planned allowlist argv should
+// override the original argv. Returns nil if no override is needed.
+func ResolvePlannedAllowlistArgv(
+	security ExecSecurity,
+	shellCommand *string,
+	approvedByAsk bool,
+	analysisOk bool,
+	allowlistSatisfied bool,
+	segments []ExecCommandSegment,
+) []string {
+	if security != SecurityAllowlist ||
+		approvedByAsk ||
+		shellCommand != nil ||
+		!analysisOk ||
+		!allowlistSatisfied ||
+		len(segments) != 1 {
+		return nil
+	}
+	planned := resolvePlannedSegmentArgv(segments[0])
+	if len(planned) == 0 {
+		return nil
+	}
+	return planned
+}
+
+// resolvePlannedSegmentArgv extracts the resolved argv from a single segment.
+func resolvePlannedSegmentArgv(seg ExecCommandSegment) []string {
+	if len(seg.Argv) == 0 {
+		return nil
+	}
+	return seg.Argv
+}
+
+// ResolveSystemRunExecArgv determines the final argv for command execution.
+func ResolveSystemRunExecArgv(
+	plannedArgv []string,
+	argv []string,
+	security ExecSecurity,
+	isWindows bool,
+	approvedByAsk bool,
+	analysisOk bool,
+	allowlistSatisfied bool,
+	shellCommand *string,
+	segments []ExecCommandSegment,
+) []string {
+	execArgv := argv
+	if plannedArgv != nil {
+		execArgv = plannedArgv
+	}
+
+	if security == SecurityAllowlist &&
+		isWindows &&
+		!approvedByAsk &&
+		shellCommand != nil &&
+		analysisOk &&
+		allowlistSatisfied &&
+		len(segments) == 1 &&
+		len(segments[0].Argv) > 0 {
+		execArgv = segments[0].Argv
+	}
+
+	return execArgv
+}
+
+// IsWindows returns true if the current platform is Windows.
+func IsWindows() bool {
+	return runtime.GOOS == "windows"
+}
+
+// ApplyOutputTruncation appends a truncation suffix to the result
+// if it was truncated. Appends to stderr if non-empty, otherwise stdout.
+func ApplyOutputTruncation(result *RunResult) {
+	if !result.Truncated {
+		return
+	}
+	const suffix = "... (truncated)"
+	if len(strings.TrimSpace(result.Stderr)) > 0 {
+		result.Stderr = result.Stderr + "\n" + suffix
+	} else {
+		result.Stdout = result.Stdout + "\n" + suffix
+	}
+}
+

--- a/internal/nodehost/allowlist_test.go
+++ b/internal/nodehost/allowlist_test.go
@@ -1,0 +1,131 @@
+package nodehost
+
+import (
+	"testing"
+)
+
+// --- ApplyOutputTruncation tests ---
+
+func TestApplyOutputTruncation_NotTruncated(t *testing.T) {
+	r := &RunResult{Stdout: "hello", Stderr: "", Truncated: false}
+	ApplyOutputTruncation(r)
+	if r.Stdout != "hello" {
+		t.Errorf("stdout should be unchanged: %q", r.Stdout)
+	}
+}
+
+func TestApplyOutputTruncation_StdoutOnly(t *testing.T) {
+	r := &RunResult{Stdout: "output", Stderr: "", Truncated: true}
+	ApplyOutputTruncation(r)
+	want := "output\n... (truncated)"
+	if r.Stdout != want {
+		t.Errorf("stdout = %q, want %q", r.Stdout, want)
+	}
+}
+
+func TestApplyOutputTruncation_StderrPreferred(t *testing.T) {
+	r := &RunResult{Stdout: "out", Stderr: "err", Truncated: true}
+	ApplyOutputTruncation(r)
+	wantStderr := "err\n... (truncated)"
+	if r.Stderr != wantStderr {
+		t.Errorf("stderr = %q, want %q", r.Stderr, wantStderr)
+	}
+	if r.Stdout != "out" {
+		t.Errorf("stdout should be unchanged: %q", r.Stdout)
+	}
+}
+
+func TestApplyOutputTruncation_WhitespaceOnlyStderr(t *testing.T) {
+	r := &RunResult{Stdout: "out", Stderr: "  \n\t ", Truncated: true}
+	ApplyOutputTruncation(r)
+	// Whitespace-only stderr → suffix goes to stdout.
+	want := "out\n... (truncated)"
+	if r.Stdout != want {
+		t.Errorf("stdout = %q, want %q", r.Stdout, want)
+	}
+}
+
+// --- ResolvePlannedAllowlistArgv tests ---
+
+func TestResolvePlannedArgv_ReturnsNilWhenNotAllowlist(t *testing.T) {
+	got := ResolvePlannedAllowlistArgv(SecurityFull, nil, false, true, true, []ExecCommandSegment{
+		{Raw: "echo hi", Argv: []string{"echo", "hi"}},
+	})
+	if got != nil {
+		t.Errorf("expected nil for non-allowlist security, got %v", got)
+	}
+}
+
+func TestResolvePlannedArgv_ReturnsNilWhenApprovedByAsk(t *testing.T) {
+	got := ResolvePlannedAllowlistArgv(SecurityAllowlist, nil, true, true, true, []ExecCommandSegment{
+		{Raw: "echo hi", Argv: []string{"echo", "hi"}},
+	})
+	if got != nil {
+		t.Errorf("expected nil when approved by ask, got %v", got)
+	}
+}
+
+func TestResolvePlannedArgv_ReturnsNilForShellCommand(t *testing.T) {
+	shell := "echo hi"
+	got := ResolvePlannedAllowlistArgv(SecurityAllowlist, &shell, false, true, true, []ExecCommandSegment{
+		{Raw: "echo hi", Argv: []string{"echo", "hi"}},
+	})
+	if got != nil {
+		t.Errorf("expected nil for shell command, got %v", got)
+	}
+}
+
+func TestResolvePlannedArgv_ReturnsNilForMultipleSegments(t *testing.T) {
+	got := ResolvePlannedAllowlistArgv(SecurityAllowlist, nil, false, true, true, []ExecCommandSegment{
+		{Raw: "echo hi", Argv: []string{"echo", "hi"}},
+		{Raw: "echo bye", Argv: []string{"echo", "bye"}},
+	})
+	if got != nil {
+		t.Errorf("expected nil for multiple segments, got %v", got)
+	}
+}
+
+func TestResolvePlannedArgv_ReturnsArgv(t *testing.T) {
+	got := ResolvePlannedAllowlistArgv(SecurityAllowlist, nil, false, true, true, []ExecCommandSegment{
+		{Raw: "echo hi", Argv: []string{"echo", "hi"}},
+	})
+	if len(got) != 2 || got[0] != "echo" || got[1] != "hi" {
+		t.Errorf("expected [echo hi], got %v", got)
+	}
+}
+
+func TestResolvePlannedArgv_ReturnsNilForEmptyArgv(t *testing.T) {
+	got := ResolvePlannedAllowlistArgv(SecurityAllowlist, nil, false, true, true, []ExecCommandSegment{
+		{Raw: "", Argv: []string{}},
+	})
+	if got != nil {
+		t.Errorf("expected nil for empty argv, got %v", got)
+	}
+}
+
+// --- ResolveSystemRunExecArgv tests ---
+
+func TestResolveExecArgv_UsesPlannedArgv(t *testing.T) {
+	planned := []string{"planned", "cmd"}
+	got := ResolveSystemRunExecArgv(planned, []string{"orig"}, SecurityAllowlist, false, false, true, true, nil, nil)
+	if len(got) != 2 || got[0] != "planned" {
+		t.Errorf("expected planned argv, got %v", got)
+	}
+}
+
+func TestResolveExecArgv_FallsBackToArgv(t *testing.T) {
+	got := ResolveSystemRunExecArgv(nil, []string{"orig", "cmd"}, SecurityAllowlist, false, false, true, true, nil, nil)
+	if len(got) != 2 || got[0] != "orig" {
+		t.Errorf("expected original argv, got %v", got)
+	}
+}
+
+func TestResolveExecArgv_WindowsShellOverride(t *testing.T) {
+	shell := "cmd /c echo hi"
+	segments := []ExecCommandSegment{{Raw: "echo hi", Argv: []string{"echo", "hi"}}}
+	got := ResolveSystemRunExecArgv(nil, []string{"cmd", "/c", "echo", "hi"}, SecurityAllowlist, true, false, true, true, &shell, segments)
+	if len(got) != 2 || got[0] != "echo" || got[1] != "hi" {
+		t.Errorf("expected segment argv override, got %v", got)
+	}
+}
+

--- a/internal/nodehost/approval_plan.go
+++ b/internal/nodehost/approval_plan.go
@@ -1,0 +1,90 @@
+package nodehost
+
+import "regexp"
+
+// ApprovedCwdSnapshot captures the identity of a working directory at approval time.
+type ApprovedCwdSnapshot struct {
+	Cwd  string          `json:"cwd"`
+	Stat FileIdentityStat `json:"stat"`
+}
+
+// --- Interpreter detection tables ---
+
+var mutableArgv1InterpreterPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`^(?:node|nodejs)$`),
+	regexp.MustCompile(`^perl$`),
+	regexp.MustCompile(`^php$`),
+	regexp.MustCompile(`^python(?:\d+(?:\.\d+)*)?$`),
+	regexp.MustCompile(`^ruby$`),
+}
+
+var genericMutableScriptRunners = newSet(
+	"esno", "jiti", "ts-node", "ts-node-esm", "tsx", "vite-node",
+)
+
+var interpreterLikeSafeBins = newSet(
+	"ash", "awk", "bash", "busybox", "bun", "cmd", "cmd.exe", "cscript",
+	"dash", "deno", "fish", "gawk", "gsed", "ksh", "lua", "mawk", "nawk",
+	"node", "nodejs", "perl", "php", "powershell", "powershell.exe", "pypy",
+	"pwsh", "pwsh.exe", "python", "python2", "python3", "ruby", "sed", "sh",
+	"toybox", "wscript", "zsh",
+)
+
+var interpreterLikePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`^python\d+(?:\.\d+)?$`),
+	regexp.MustCompile(`^ruby\d+(?:\.\d+)?$`),
+	regexp.MustCompile(`^perl\d+(?:\.\d+)?$`),
+	regexp.MustCompile(`^php\d+(?:\.\d+)?$`),
+	regexp.MustCompile(`^node\d+(?:\.\d+)?$`),
+}
+
+// IsInterpreterLikeSafeBin checks if a binary name is an interpreter-like safe bin.
+func IsInterpreterLikeSafeBin(raw string) bool {
+	normalized := NormalizeExecutableToken(raw)
+	if normalized == "" {
+		return false
+	}
+	if interpreterLikeSafeBins[normalized] {
+		return true
+	}
+	for _, p := range interpreterLikePatterns {
+		if p.MatchString(normalized) {
+			return true
+		}
+	}
+	return false
+}
+
+func isMutableScriptRunner(exe string) bool {
+	return genericMutableScriptRunners[exe] || IsInterpreterLikeSafeBin(exe)
+}
+
+// --- Bun/Deno/Node option sets ---
+
+var bunSubcommands = newSet("add", "audit", "completions", "create", "exec", "help", "init",
+	"install", "link", "outdated", "patch", "pm", "publish", "remove", "repl", "run", "test",
+	"unlink", "update", "upgrade", "x")
+var bunOptionsWithValue = newSet("--backend", "--bunfig", "--conditions", "--config",
+	"--console-depth", "--cwd", "--define", "--elide-lines", "--env-file", "--extension-order",
+	"--filter", "--hot", "--inspect", "--inspect-brk", "--inspect-wait", "--install",
+	"--jsx-factory", "--jsx-fragment", "--jsx-import-source", "--loader", "--origin", "--port",
+	"--preload", "--smol", "--tsconfig-override", "-c", "-e", "-p", "-r")
+var denoRunOptionsWithValue = newSet("--cached-only", "--cert", "--config", "--env-file", "--ext",
+	"--harmony-import-attributes", "--import-map", "--inspect", "--inspect-brk", "--inspect-wait",
+	"--location", "--log-level", "--lock", "--node-modules-dir", "--no-check", "--preload",
+	"--reload", "--seed", "--strace-ops", "--unstable-bare-node-builtins", "--v8-flags",
+	"--watch", "--watch-exclude", "-L")
+var nodeOptionsWithFileValue = newSet("-r", "--experimental-loader", "--import", "--loader", "--require")
+var rubyUnsafeFlags = newSet("-I", "-r", "--require")
+var perlUnsafeFlags = newSet("-I", "-M", "-m")
+var posixShellOptionsWithValue = newSet("--init-file", "--rcfile", "--startup-script", "-o")
+
+// --- Package manager option sets ---
+
+var npmExecOptionsWithValue = newSet("--cache", "--package", "--prefix", "--script-shell",
+	"--userconfig", "--workspace", "-p", "-w")
+var npmExecFlagOptions = newSet("--no", "--quiet", "--ws", "--workspaces", "--yes", "-q", "-y")
+var pnpmOptionsWithValue = newSet("--config", "--dir", "--filter", "--reporter", "--stream",
+	"--test-pattern", "--workspace-concurrency", "-C")
+var pnpmFlagOptions = newSet("--aggregate-output", "--color", "--recursive", "--silent",
+	"--workspace-root", "-r")

--- a/internal/nodehost/approval_plan_entry.go
+++ b/internal/nodehost/approval_plan_entry.go
@@ -1,0 +1,391 @@
+package nodehost
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// MutableFileOperandSnapshotResult is the result of resolving a mutable file operand.
+type MutableFileOperandSnapshotResult struct {
+	Ok       bool
+	Snapshot *SystemRunApprovalFileOperand
+	Message  string // error message when !Ok
+}
+
+// ResolveMutableFileOperandSnapshot resolves the mutable file operand for an argv.
+func ResolveMutableFileOperandSnapshot(argv []string, cwd string, shellCommand *string) MutableFileOperandSnapshotResult {
+	argvIndex := resolveMutableFileOperandIndex(argv, cwd)
+	if argvIndex == nil {
+		if requiresStableInterpreterBinding(argv, shellCommand, cwd) {
+			return MutableFileOperandSnapshotResult{
+				Ok:      false,
+				Message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+			}
+		}
+		return MutableFileOperandSnapshotResult{Ok: true}
+	}
+	rawOperand := strings.TrimSpace(safeIndex(argv, *argvIndex))
+	if rawOperand == "" {
+		return MutableFileOperandSnapshotResult{
+			Ok:      false,
+			Message: "SYSTEM_RUN_DENIED: approval requires a stable script operand",
+		}
+	}
+	resolved := rawOperand
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(cwd, resolved)
+	}
+	realPath, err := filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return MutableFileOperandSnapshotResult{
+			Ok:      false,
+			Message: "SYSTEM_RUN_DENIED: approval requires an existing script operand",
+		}
+	}
+	info, err := os.Stat(realPath)
+	if err != nil || !info.Mode().IsRegular() {
+		return MutableFileOperandSnapshotResult{
+			Ok:      false,
+			Message: "SYSTEM_RUN_DENIED: approval requires a file script operand",
+		}
+	}
+	hash, err := hashFileContents(realPath)
+	if err != nil {
+		return MutableFileOperandSnapshotResult{
+			Ok:      false,
+			Message: "SYSTEM_RUN_DENIED: approval requires a readable script operand",
+		}
+	}
+	return MutableFileOperandSnapshotResult{
+		Ok: true,
+		Snapshot: &SystemRunApprovalFileOperand{
+			ArgvIndex: *argvIndex,
+			Path:      realPath,
+			SHA256:    hash,
+		},
+	}
+}
+
+func requiresStableInterpreterBinding(argv []string, shellCommand *string, cwd string) bool {
+	if shellCommand != nil {
+		return shellPayloadNeedsStableBinding(*shellCommand, cwd)
+	}
+	unwrapped, _ := unwrapArgvForMutableOperand(argv)
+	exe := NormalizeExecutableToken(safeIndex(unwrapped, 0))
+	if exe == "" {
+		return false
+	}
+	if PosixShellWrappers[exe] {
+		return false
+	}
+	return isMutableScriptRunner(exe)
+}
+
+func shellPayloadNeedsStableBinding(shellCmd, cwd string) bool {
+	argv := SplitShellArgs(shellCmd)
+	if len(argv) == 0 {
+		return false
+	}
+	snap := ResolveMutableFileOperandSnapshot(argv, cwd, nil)
+	if !snap.Ok {
+		return true
+	}
+	if snap.Snapshot != nil {
+		return true
+	}
+	firstToken := strings.TrimSpace(safeIndex(argv, 0))
+	return resolvesToExistingFile(firstToken, cwd)
+}
+
+// --- CWD snapshot ---
+
+// ResolveCanonicalApprovalCwd creates a canonical CWD snapshot.
+// Validates no mutable symlink path components and cross-checks file identity.
+func ResolveCanonicalApprovalCwd(cwd string) (*ApprovedCwdSnapshot, string) {
+	requested := filepath.Clean(cwd)
+	if !filepath.IsAbs(requested) {
+		abs, err := filepath.Abs(requested)
+		if err != nil {
+			return nil, "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd"
+		}
+		requested = abs
+	}
+
+	cwdLstat, err := os.Lstat(requested)
+	if err != nil {
+		return nil, "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd"
+	}
+	cwdStat, err := os.Stat(requested)
+	if err != nil || !cwdStat.IsDir() {
+		return nil, "SYSTEM_RUN_DENIED: approval requires cwd to be a directory"
+	}
+	realPath, err := filepath.EvalSymlinks(requested)
+	if err != nil {
+		return nil, "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd"
+	}
+	cwdRealStat, err := GetFileIdentity(realPath)
+	if err != nil {
+		return nil, "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd"
+	}
+
+	// Check for mutable symlink path components (TOCTOU defense).
+	if hasMutableSymlinkPathComponent(requested) {
+		return nil, "SYSTEM_RUN_DENIED: approval requires canonical cwd (no symlink path components)"
+	}
+
+	// Direct symlink check on the CWD itself.
+	if cwdLstat.Mode()&os.ModeSymlink != 0 {
+		return nil, "SYSTEM_RUN_DENIED: approval requires canonical cwd (no symlink cwd)"
+	}
+
+	// Three-way identity cross-check (defense against bind mount/hardlink manipulation).
+	cwdStatIdentity, err := GetFileIdentity(requested)
+	if err != nil {
+		return nil, "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd"
+	}
+	cwdLstatIdentity := cwdStatIdentity // lstat on non-symlink = stat
+	if !SameFileIdentity(cwdStatIdentity, cwdLstatIdentity) ||
+		!SameFileIdentity(cwdStatIdentity, cwdRealStat) ||
+		!SameFileIdentity(cwdLstatIdentity, cwdRealStat) {
+		return nil, "SYSTEM_RUN_DENIED: approval cwd identity mismatch"
+	}
+
+	return &ApprovedCwdSnapshot{Cwd: realPath, Stat: cwdRealStat}, ""
+}
+
+// hasMutableSymlinkPathComponent walks from root to target, checking each
+// path component for writable symlinks (TOCTOU defense).
+func hasMutableSymlinkPathComponent(targetPath string) bool {
+	abs, err := filepath.Abs(targetPath)
+	if err != nil {
+		return true
+	}
+	parts := pathComponentsFromRoot(abs)
+	for _, component := range parts {
+		info, err := os.Lstat(component)
+		if err != nil {
+			return true // fail closed
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		parentDir := filepath.Dir(component)
+		if isWritableByCurrentProcess(parentDir) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathComponentsFromRoot returns all path components from root to target.
+func pathComponentsFromRoot(targetPath string) []string {
+	var parts []string
+	cursor := targetPath
+	for {
+		parts = append([]string{cursor}, parts...)
+		parent := filepath.Dir(cursor)
+		if parent == cursor {
+			return parts
+		}
+		cursor = parent
+	}
+}
+
+// isWritableByCurrentProcess checks if the current process can write to a path.
+func isWritableByCurrentProcess(path string) bool {
+	// Try to open for writing. This is the most reliable cross-platform check.
+	f, err := os.OpenFile(filepath.Join(path, ".goclaw-write-test"), os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	f.Close()
+	os.Remove(name)
+	return true
+}
+
+// RevalidateApprovedCwdSnapshot checks that a CWD snapshot is still valid.
+func RevalidateApprovedCwdSnapshot(snapshot *ApprovedCwdSnapshot) bool {
+	current, msg := ResolveCanonicalApprovalCwd(snapshot.Cwd)
+	if msg != "" || current == nil {
+		return false
+	}
+	return SameFileIdentity(snapshot.Stat, current.Stat)
+}
+
+// RevalidateApprovedMutableFileOperand checks that a file operand hasn't changed.
+func RevalidateApprovedMutableFileOperand(snapshot *SystemRunApprovalFileOperand, argv []string, cwd string) bool {
+	operand := strings.TrimSpace(safeIndex(argv, snapshot.ArgvIndex))
+	if operand == "" {
+		return false
+	}
+	resolved := operand
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(cwd, resolved)
+	}
+	realPath, err := filepath.EvalSymlinks(resolved)
+	if err != nil || realPath != snapshot.Path {
+		return false
+	}
+	hash, err := hashFileContents(realPath)
+	if err != nil {
+		return false
+	}
+	return hash == snapshot.SHA256
+}
+
+// --- Executable path hardening ---
+
+// HardenResult is the result of hardening approved execution paths.
+type HardenResult struct {
+	Ok                  bool
+	Argv                []string
+	ArgvChanged         bool
+	Cwd                 string
+	ApprovedCwdSnapshot *ApprovedCwdSnapshot
+	Message             string // error message when !Ok
+}
+
+// HardenApprovedExecutionPaths pins executable paths and CWD for approval.
+func HardenApprovedExecutionPaths(approvedByAsk bool, argv []string, shellCommand *string, cwd string) HardenResult {
+	if !approvedByAsk {
+		return HardenResult{Ok: true, Argv: argv, Cwd: cwd}
+	}
+
+	hardenedCwd := cwd
+	var cwdSnapshot *ApprovedCwdSnapshot
+	if hardenedCwd != "" {
+		snap, msg := ResolveCanonicalApprovalCwd(hardenedCwd)
+		if msg != "" {
+			return HardenResult{Ok: false, Message: msg}
+		}
+		hardenedCwd = snap.Cwd
+		cwdSnapshot = snap
+	}
+
+	if len(argv) == 0 {
+		return HardenResult{Ok: true, Argv: argv, Cwd: hardenedCwd, ApprovedCwdSnapshot: cwdSnapshot}
+	}
+
+	// Check if we should pin the executable.
+	wrapperChain := resolveWrapperChain(argv)
+	if shellCommand != nil || len(wrapperChain) > 0 {
+		return HardenResult{Ok: true, Argv: argv, Cwd: hardenedCwd, ApprovedCwdSnapshot: cwdSnapshot}
+	}
+
+	// Resolve the executable to an absolute path.
+	pinnedExe := resolveExecutablePath(argv[0], hardenedCwd)
+	if pinnedExe == "" {
+		return HardenResult{Ok: false, Message: "SYSTEM_RUN_DENIED: approval requires a stable executable path"}
+	}
+	if pinnedExe == argv[0] {
+		return HardenResult{Ok: true, Argv: argv, Cwd: hardenedCwd, ApprovedCwdSnapshot: cwdSnapshot}
+	}
+
+	newArgv := make([]string, len(argv))
+	copy(newArgv, argv)
+	newArgv[0] = pinnedExe
+	return HardenResult{Ok: true, Argv: newArgv, ArgvChanged: true, Cwd: hardenedCwd, ApprovedCwdSnapshot: cwdSnapshot}
+}
+
+func resolveWrapperChain(argv []string) []string {
+	var wrappers []string
+	current := argv
+	for range MaxDispatchWrapperDepth {
+		r := UnwrapKnownDispatchWrapperInvocation(current)
+		if r.Kind != "unwrapped" || len(r.Argv) == 0 {
+			break
+		}
+		wrappers = append(wrappers, r.Wrapper)
+		current = r.Argv
+	}
+	return wrappers
+}
+
+func resolveExecutablePath(token, cwd string) string {
+	// If already absolute, resolve symlinks.
+	if filepath.IsAbs(token) {
+		real, err := filepath.EvalSymlinks(token)
+		if err != nil {
+			return ""
+		}
+		return real
+	}
+	// Try exec.LookPath for PATH-based resolution.
+	resolved, err := exec.LookPath(token)
+	if err != nil {
+		return ""
+	}
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(cwd, resolved)
+	}
+	real, err := filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return ""
+	}
+	return real
+}
+
+// --- Build approval plan (public entry point) ---
+
+// ApprovalPlanResult is the result of building an approval plan.
+type ApprovalPlanResult struct {
+	Ok      bool
+	Plan    *SystemRunApprovalPlan
+	Message string
+}
+
+// BuildSystemRunApprovalPlan builds a complete approval plan for a system run command.
+func BuildSystemRunApprovalPlan(command []string, rawCommand *string, cwd *string, agentID *string, sessionKey *string) ApprovalPlanResult {
+	resolved := ResolveSystemRunCommandRequest(command, rawCommand)
+	if !resolved.Ok {
+		return ApprovalPlanResult{Ok: false, Message: resolved.Message}
+	}
+	if len(resolved.Argv) == 0 {
+		return ApprovalPlanResult{Ok: false, Message: "command required"}
+	}
+
+	effectiveCwd := ""
+	if cwd != nil {
+		effectiveCwd = strings.TrimSpace(*cwd)
+	}
+
+	hardening := HardenApprovedExecutionPaths(true, resolved.Argv, resolved.ShellPayload, effectiveCwd)
+	if !hardening.Ok {
+		return ApprovalPlanResult{Ok: false, Message: hardening.Message}
+	}
+
+	commandText := FormatExecCommand(hardening.Argv)
+	var commandPreview *string
+	if resolved.PreviewText != nil {
+		trimmed := strings.TrimSpace(*resolved.PreviewText)
+		if trimmed != "" && trimmed != commandText {
+			commandPreview = &trimmed
+		}
+	}
+
+	mutableOp := ResolveMutableFileOperandSnapshot(hardening.Argv, hardening.Cwd, resolved.ShellPayload)
+	if !mutableOp.Ok {
+		return ApprovalPlanResult{Ok: false, Message: mutableOp.Message}
+	}
+
+	var cwdPtr *string
+	if hardening.Cwd != "" {
+		cwdPtr = &hardening.Cwd
+	}
+
+	return ApprovalPlanResult{
+		Ok: true,
+		Plan: &SystemRunApprovalPlan{
+			Argv:               hardening.Argv,
+			Cwd:                cwdPtr,
+			CommandText:        commandText,
+			CommandPreview:     commandPreview,
+			AgentID:            agentID,
+			SessionKey:         sessionKey,
+			MutableFileOperand: mutableOp.Snapshot,
+		},
+	}
+}

--- a/internal/nodehost/approval_plan_helpers.go
+++ b/internal/nodehost/approval_plan_helpers.go
@@ -1,0 +1,291 @@
+package nodehost
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// --- Shell script operand detection ---
+
+func resolvePosixShellScriptOperandIndex(argv []string) *int {
+	// If there's an inline command (-c), no script operand.
+	m := ResolveInlineCommandMatch(argv, PosixInlineCommandFlags, true)
+	if m.ValueTokenIndex != nil {
+		return nil
+	}
+	afterDoubleDash := false
+	for i := 1; i < len(argv); i++ {
+		token := strings.TrimSpace(safeIndex(argv, i))
+		if token == "" {
+			continue
+		}
+		if token == "-" {
+			return nil
+		}
+		if !afterDoubleDash && token == "--" {
+			afterDoubleDash = true
+			continue
+		}
+		if !afterDoubleDash && token == "-s" {
+			return nil
+		}
+		if !afterDoubleDash && strings.HasPrefix(token, "-") {
+			flag := strings.SplitN(strings.ToLower(token), "=", 2)[0]
+			if posixShellOptionsWithValue[flag] {
+				if !strings.Contains(token, "=") {
+					i++ // skip value
+				}
+				continue
+			}
+			continue
+		}
+		return intPtr(i)
+	}
+	return nil
+}
+
+// --- Bun/Deno script operand detection ---
+
+func resolveBunScriptOperandIndex(argv []string, cwd string) *int {
+	directIdx := resolveOptionFilteredPositionalIndex(argv, 1, bunOptionsWithValue)
+	if directIdx == nil {
+		return nil
+	}
+	directToken := strings.TrimSpace(safeIndex(argv, *directIdx))
+	if directToken == "run" {
+		return resolveOptionFilteredFileOperandIndex(argv, *directIdx+1, cwd, bunOptionsWithValue)
+	}
+	if bunSubcommands[directToken] {
+		return nil
+	}
+	if !looksLikePathToken(directToken) {
+		return nil
+	}
+	return directIdx
+}
+
+func resolveDenoRunScriptOperandIndex(argv []string, cwd string) *int {
+	if strings.TrimSpace(safeIndex(argv, 1)) != "run" {
+		return nil
+	}
+	return resolveOptionFilteredFileOperandIndex(argv, 2, cwd, denoRunOptionsWithValue)
+}
+
+// --- Generic operand resolution helpers ---
+
+func resolveOptionFilteredPositionalIndex(argv []string, startIndex int, optionsWithValue map[string]bool) *int {
+	afterDoubleDash := false
+	for i := startIndex; i < len(argv); i++ {
+		token := strings.TrimSpace(safeIndex(argv, i))
+		if token == "" {
+			continue
+		}
+		if afterDoubleDash {
+			return intPtr(i)
+		}
+		if token == "--" {
+			afterDoubleDash = true
+			continue
+		}
+		if token == "-" {
+			return nil
+		}
+		if strings.HasPrefix(token, "-") {
+			if !strings.Contains(token, "=") && optionsWithValue[token] {
+				i++
+			}
+			continue
+		}
+		return intPtr(i)
+	}
+	return nil
+}
+
+func resolveOptionFilteredFileOperandIndex(argv []string, startIndex int, cwd string, optionsWithValue map[string]bool) *int {
+	afterDoubleDash := false
+	for i := startIndex; i < len(argv); i++ {
+		token := strings.TrimSpace(safeIndex(argv, i))
+		if token == "" {
+			continue
+		}
+		if afterDoubleDash {
+			if resolvesToExistingFile(token, cwd) {
+				return intPtr(i)
+			}
+			return nil
+		}
+		if token == "--" {
+			afterDoubleDash = true
+			continue
+		}
+		if token == "-" {
+			return nil
+		}
+		if strings.HasPrefix(token, "-") {
+			if !strings.Contains(token, "=") && optionsWithValue[token] {
+				i++
+			}
+			continue
+		}
+		if resolvesToExistingFile(token, cwd) {
+			return intPtr(i)
+		}
+		return nil
+	}
+	return nil
+}
+
+// resolveGenericInterpreterScriptOperandIndex finds a single file operand for generic interpreters.
+func resolveGenericInterpreterScriptOperandIndex(argv []string, cwd string, optionsWithFileValue map[string]bool) *int {
+	hits, sawOptionValueFile := collectExistingFileOperandIndexes(argv, 1, cwd, optionsWithFileValue)
+	if sawOptionValueFile {
+		return nil
+	}
+	if len(hits) == 1 {
+		return intPtr(hits[0])
+	}
+	return nil
+}
+
+func collectExistingFileOperandIndexes(argv []string, startIndex int, cwd string, optionsWithFileValue map[string]bool) ([]int, bool) {
+	afterDoubleDash := false
+	var hits []int
+	for i := startIndex; i < len(argv); i++ {
+		token := strings.TrimSpace(safeIndex(argv, i))
+		if token == "" {
+			continue
+		}
+		if afterDoubleDash {
+			if resolvesToExistingFile(token, cwd) {
+				hits = append(hits, i)
+			}
+			continue
+		}
+		if token == "--" {
+			afterDoubleDash = true
+			continue
+		}
+		if token == "-" {
+			return nil, false
+		}
+		if strings.HasPrefix(token, "-") {
+			flag, inline, _ := strings.Cut(token, "=")
+			flagLower := strings.ToLower(flag)
+			if optionsWithFileValue[flagLower] {
+				if inline != "" && resolvesToExistingFile(inline, cwd) {
+					hits = append(hits, i)
+					return hits, true
+				}
+				nextToken := strings.TrimSpace(safeIndex(argv, i+1))
+				if inline == "" && nextToken != "" && resolvesToExistingFile(nextToken, cwd) {
+					hits = append(hits, i+1)
+					return hits, true
+				}
+			}
+			continue
+		}
+		if resolvesToExistingFile(token, cwd) {
+			hits = append(hits, i)
+		}
+	}
+	return hits, false
+}
+
+// --- Unsafe flag detection ---
+
+func hasRubyUnsafeFlag(argv []string) bool {
+	afterDoubleDash := false
+	for i := 1; i < len(argv); i++ {
+		token := strings.TrimSpace(safeIndex(argv, i))
+		if token == "" {
+			continue
+		}
+		if afterDoubleDash {
+			return false
+		}
+		if token == "--" {
+			afterDoubleDash = true
+			continue
+		}
+		if token == "-I" || token == "-r" {
+			return true
+		}
+		if strings.HasPrefix(token, "-I") || strings.HasPrefix(token, "-r") {
+			return true
+		}
+		if rubyUnsafeFlags[strings.ToLower(token)] {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPerlUnsafeFlag(argv []string) bool {
+	afterDoubleDash := false
+	for i := 1; i < len(argv); i++ {
+		token := strings.TrimSpace(safeIndex(argv, i))
+		if token == "" {
+			continue
+		}
+		if afterDoubleDash {
+			return false
+		}
+		if token == "--" {
+			afterDoubleDash = true
+			continue
+		}
+		if token == "-I" || token == "-M" || token == "-m" {
+			return true
+		}
+		if strings.HasPrefix(token, "-I") || strings.HasPrefix(token, "-M") || strings.HasPrefix(token, "-m") {
+			return true
+		}
+		if perlUnsafeFlags[token] {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Filesystem helpers ---
+
+func looksLikePathToken(token string) bool {
+	return strings.HasPrefix(token, ".") ||
+		strings.HasPrefix(token, "/") ||
+		strings.HasPrefix(token, "\\") ||
+		strings.Contains(token, "/") ||
+		strings.Contains(token, "\\") ||
+		filepath.Ext(token) != ""
+}
+
+func resolvesToExistingFile(rawOperand, cwd string) bool {
+	if rawOperand == "" {
+		return false
+	}
+	resolved := rawOperand
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(cwd, resolved)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}
+
+func hashFileContents(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/nodehost/approval_plan_ops.go
+++ b/internal/nodehost/approval_plan_ops.go
@@ -1,0 +1,250 @@
+package nodehost
+
+import "strings"
+
+// --- Wrapper unwrapping for mutable operand detection ---
+
+const maxMutableOperandUnwrapDepth = 12 // safety bound for combined unwrapping chain
+
+func unwrapArgvForMutableOperand(argv []string) (unwrapped []string, baseIndex int) {
+	current := argv
+	base := 0
+	for range maxMutableOperandUnwrapDepth {
+		dispatch := UnwrapKnownDispatchWrapperInvocation(current)
+		if dispatch.Kind == "unwrapped" {
+			base += len(current) - len(dispatch.Argv)
+			current = dispatch.Argv
+			continue
+		}
+		mux := UnwrapKnownShellMultiplexerInvocation(current)
+		if mux.Kind == "unwrapped" {
+			base += len(current) - len(mux.Argv)
+			current = mux.Argv
+			continue
+		}
+		pm := unwrapPackageManagerExec(current)
+		if pm != nil {
+			base += len(current) - len(pm)
+			current = pm
+			continue
+		}
+		return current, base
+	}
+	return current, base
+}
+
+// --- Package manager unwrapping ---
+
+func normalizePackageManagerExecToken(token string) string {
+	n := NormalizeExecutableToken(token)
+	// Strip .js/.cjs/.mjs suffixes for shim detection.
+	for _, suffix := range []string{".js", ".cjs", ".mjs"} {
+		if strings.HasSuffix(strings.ToLower(n), suffix) {
+			return n[:len(n)-len(suffix)]
+		}
+	}
+	return n
+}
+
+func unwrapPackageManagerExec(argv []string) []string {
+	exe := normalizePackageManagerExecToken(safeIndex(argv, 0))
+	switch exe {
+	case "npm":
+		return unwrapNpmExec(argv)
+	case "npx", "bunx":
+		return unwrapDirectPackageExec(argv)
+	case "pnpm":
+		return unwrapPnpmExec(argv)
+	default:
+		return nil
+	}
+}
+
+func unwrapPnpmExec(argv []string) []string {
+	idx := 1
+	for idx < len(argv) {
+		token := strings.TrimSpace(safeIndex(argv, idx))
+		if token == "" {
+			idx++
+			continue
+		}
+		if token == "--" {
+			idx++
+			continue
+		}
+		if !strings.HasPrefix(token, "-") {
+			if token == "exec" {
+				if idx+1 >= len(argv) {
+					return nil
+				}
+				tail := argv[idx+1:]
+				if len(tail) > 0 && tail[0] == "--" {
+					if len(tail) > 1 {
+						return tail[1:]
+					}
+					return nil
+				}
+				return tail
+			}
+			if token == "node" {
+				tail := argv[idx+1:]
+				if len(tail) > 0 && tail[0] == "--" {
+					tail = tail[1:]
+				}
+				return append([]string{"node"}, tail...)
+			}
+			return nil
+		}
+		flag := strings.SplitN(strings.ToLower(token), "=", 2)[0]
+		if pnpmOptionsWithValue[flag] {
+			if strings.Contains(token, "=") {
+				idx++
+			} else {
+				idx += 2
+			}
+			continue
+		}
+		if pnpmFlagOptions[flag] {
+			idx++
+			continue
+		}
+		return nil
+	}
+	return nil
+}
+
+func unwrapDirectPackageExec(argv []string) []string {
+	idx := 1
+	for idx < len(argv) {
+		token := strings.TrimSpace(safeIndex(argv, idx))
+		if token == "" {
+			idx++
+			continue
+		}
+		if !strings.HasPrefix(token, "-") {
+			return argv[idx:]
+		}
+		flag := strings.SplitN(strings.ToLower(token), "=", 2)[0]
+		if flag == "-c" || flag == "--call" {
+			return nil
+		}
+		if npmExecOptionsWithValue[flag] {
+			if strings.Contains(token, "=") {
+				idx++
+			} else {
+				idx += 2
+			}
+			continue
+		}
+		if npmExecFlagOptions[flag] {
+			idx++
+			continue
+		}
+		return nil
+	}
+	return nil
+}
+
+func unwrapNpmExec(argv []string) []string {
+	idx := 1
+	for idx < len(argv) {
+		token := strings.TrimSpace(safeIndex(argv, idx))
+		if token == "" {
+			idx++
+			continue
+		}
+		if !strings.HasPrefix(token, "-") {
+			if token != "exec" {
+				return nil
+			}
+			idx++
+			break
+		}
+		if (token == "-C" || token == "--prefix" || token == "--userconfig") && !strings.Contains(token, "=") {
+			idx += 2
+			continue
+		}
+		idx++
+	}
+	if idx >= len(argv) {
+		return nil
+	}
+	tail := argv[idx:]
+	if len(tail) > 0 && tail[0] == "--" {
+		if len(tail) > 1 {
+			return tail[1:]
+		}
+		return nil
+	}
+	return unwrapDirectPackageExec(append([]string{"npx"}, tail...))
+}
+
+// --- Mutable file operand detection ---
+
+func resolveMutableFileOperandIndex(argv []string, cwd string) *int {
+	unwrapped, baseIdx := unwrapArgvForMutableOperand(argv)
+	exe := NormalizeExecutableToken(safeIndex(unwrapped, 0))
+	if exe == "" {
+		return nil
+	}
+
+	// POSIX shell script operand.
+	if PosixShellWrappers[exe] {
+		idx := resolvePosixShellScriptOperandIndex(unwrapped)
+		if idx == nil {
+			return nil
+		}
+		v := baseIdx + *idx
+		return &v
+	}
+
+	// Standard argv[1] interpreters.
+	for _, p := range mutableArgv1InterpreterPatterns {
+		if p.MatchString(exe) {
+			operand := strings.TrimSpace(safeIndex(unwrapped, 1))
+			if operand != "" && operand != "-" && !strings.HasPrefix(operand, "-") {
+				v := baseIdx + 1
+				return &v
+			}
+		}
+	}
+
+	// Bun.
+	if exe == "bun" {
+		if idx := resolveBunScriptOperandIndex(unwrapped, cwd); idx != nil {
+			v := baseIdx + *idx
+			return &v
+		}
+	}
+
+	// Deno.
+	if exe == "deno" {
+		if idx := resolveDenoRunScriptOperandIndex(unwrapped, cwd); idx != nil {
+			v := baseIdx + *idx
+			return &v
+		}
+	}
+
+	// Unsafe flag checks.
+	if exe == "ruby" && hasRubyUnsafeFlag(unwrapped) {
+		return nil
+	}
+	if exe == "perl" && hasPerlUnsafeFlag(unwrapped) {
+		return nil
+	}
+
+	if !isMutableScriptRunner(exe) {
+		return nil
+	}
+
+	var optionsWithFileValue map[string]bool
+	if exe == "node" || exe == "nodejs" {
+		optionsWithFileValue = nodeOptionsWithFileValue
+	}
+	idx := resolveGenericInterpreterScriptOperandIndex(unwrapped, cwd, optionsWithFileValue)
+	if idx == nil {
+		return nil
+	}
+	v := baseIdx + *idx
+	return &v
+}

--- a/internal/nodehost/approval_plan_test.go
+++ b/internal/nodehost/approval_plan_test.go
@@ -1,0 +1,357 @@
+package nodehost
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- Helper: create temp dir with a fake runtime bin ---
+
+func writeFakeRuntimeBin(t *testing.T, binDir, binName string) {
+	t.Helper()
+	runtimePath := filepath.Join(binDir, binName)
+	os.WriteFile(runtimePath, []byte("#!/bin/sh\nexit 0\n"), 0o755)
+}
+
+func withFakeRuntimeBins(t *testing.T, binNames []string, fn func()) {
+	t.Helper()
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	os.MkdirAll(binDir, 0o755)
+	for _, name := range binNames {
+		writeFakeRuntimeBin(t, binDir, name)
+	}
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+":"+oldPath)
+	fn()
+}
+
+func writeScriptFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	os.WriteFile(p, []byte(body), 0o755)
+	return p
+}
+
+// --- Hardening tests (ported from exec-policy.test.ts) ---
+
+func TestHarden_PreservesShellWrapperArgv(t *testing.T) {
+	tmp := t.TempDir()
+	argv := []string{"env", "sh", "-c", "echo SAFE"}
+	r := HardenApprovedExecutionPaths(true, argv, nil, tmp)
+	if !r.Ok {
+		t.Fatalf("expected ok, got: %s", r.Message)
+	}
+	assertStringSliceEqual(t, argv, r.Argv)
+}
+
+func TestHarden_PreservesDispatchWrapperArgv(t *testing.T) {
+	tmp := t.TempDir()
+	argv := []string{"env", "tr", "a", "b"}
+	r := HardenApprovedExecutionPaths(true, argv, nil, tmp)
+	if !r.Ok {
+		t.Fatalf("expected ok, got: %s", r.Message)
+	}
+	assertStringSliceEqual(t, argv, r.Argv)
+	if r.ArgvChanged {
+		t.Error("expected argvChanged=false")
+	}
+}
+
+func TestHarden_SkipsWhenNotApproved(t *testing.T) {
+	argv := []string{"echo", "hello"}
+	r := HardenApprovedExecutionPaths(false, argv, nil, "/tmp")
+	if !r.Ok {
+		t.Fatal("expected ok")
+	}
+	assertStringSliceEqual(t, argv, r.Argv)
+}
+
+// --- Mutable file operand tests ---
+
+type runtimeFixture struct {
+	name             string
+	binNames         []string
+	argv             []string
+	scriptName       string
+	scriptBody       string
+	expectedArgvIdx  int
+}
+
+func TestMutableOperand_ShellScript(t *testing.T) {
+	tmp := t.TempDir()
+	writeScriptFile(t, tmp, "run.sh", "#!/bin/sh\necho SAFE\n")
+
+	result := BuildSystemRunApprovalPlan(
+		[]string{"/bin/sh", "./run.sh"}, nil, &tmp, nil, nil,
+	)
+	if !result.Ok {
+		t.Fatalf("expected ok, got: %s", result.Message)
+	}
+	if result.Plan.MutableFileOperand == nil {
+		t.Fatal("expected mutable file operand")
+	}
+	if result.Plan.MutableFileOperand.ArgvIndex != 1 {
+		t.Errorf("argvIndex = %d, want 1", result.Plan.MutableFileOperand.ArgvIndex)
+	}
+}
+
+func TestMutableOperand_Runtimes(t *testing.T) {
+	fixtures := []runtimeFixture{
+		{name: "tsx direct file", binNames: []string{"tsx"}, argv: []string{"tsx", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 1},
+		{name: "jiti direct file", binNames: []string{"jiti"}, argv: []string{"jiti", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 1},
+		{name: "ts-node direct file", binNames: []string{"ts-node"}, argv: []string{"ts-node", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 1},
+		{name: "vite-node direct file", binNames: []string{"vite-node"}, argv: []string{"vite-node", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 1},
+		{name: "bun direct file", binNames: []string{"bun"}, argv: []string{"bun", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 1},
+		{name: "bun run file", binNames: []string{"bun"}, argv: []string{"bun", "run", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 2},
+		{name: "pnpm exec tsx file", binNames: []string{"pnpm", "tsx"}, argv: []string{"pnpm", "exec", "tsx", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 3},
+		{name: "npx tsx file", binNames: []string{"npx", "tsx"}, argv: []string{"npx", "tsx", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 2},
+		{name: "bunx tsx file", binNames: []string{"bunx", "tsx"}, argv: []string{"bunx", "tsx", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 2},
+		{name: "npm exec tsx file", binNames: []string{"npm", "tsx"}, argv: []string{"npm", "exec", "--", "tsx", "./run.ts"},
+			scriptName: "run.ts", scriptBody: "console.log(\"SAFE\");\n", expectedArgvIdx: 4},
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.name, func(t *testing.T) {
+			withFakeRuntimeBins(t, f.binNames, func() {
+				tmp := t.TempDir()
+				writeScriptFile(t, tmp, f.scriptName, f.scriptBody)
+
+				result := BuildSystemRunApprovalPlan(f.argv, nil, &tmp, nil, nil)
+				if !result.Ok {
+					t.Fatalf("expected ok, got: %s", result.Message)
+				}
+				if result.Plan.MutableFileOperand == nil {
+					t.Fatal("expected mutable file operand")
+				}
+				if result.Plan.MutableFileOperand.ArgvIndex != f.expectedArgvIdx {
+					t.Errorf("argvIndex = %d, want %d", result.Plan.MutableFileOperand.ArgvIndex, f.expectedArgvIdx)
+				}
+			})
+		})
+	}
+}
+
+// --- Unsafe runtime invocation tests ---
+
+func TestUnsafeRuntime_BunPackageScript(t *testing.T) {
+	withFakeRuntimeBins(t, []string{"bun"}, func() {
+		tmp := t.TempDir()
+		expectRuntimeApprovalDenied(t, []string{"bun", "run", "dev"}, tmp)
+	})
+}
+
+func TestUnsafeRuntime_RubyRequirePreload(t *testing.T) {
+	withFakeRuntimeBins(t, []string{"ruby"}, func() {
+		tmp := t.TempDir()
+		writeScriptFile(t, tmp, "safe.rb", "puts \"SAFE\"\n")
+		expectRuntimeApprovalDenied(t, []string{"ruby", "-r", "attacker", "./safe.rb"}, tmp)
+	})
+}
+
+func TestUnsafeRuntime_RubyLoadPath(t *testing.T) {
+	withFakeRuntimeBins(t, []string{"ruby"}, func() {
+		tmp := t.TempDir()
+		writeScriptFile(t, tmp, "safe.rb", "puts \"SAFE\"\n")
+		expectRuntimeApprovalDenied(t, []string{"ruby", "-I.", "./safe.rb"}, tmp)
+	})
+}
+
+func TestUnsafeRuntime_PerlModulePreload(t *testing.T) {
+	withFakeRuntimeBins(t, []string{"perl"}, func() {
+		tmp := t.TempDir()
+		writeScriptFile(t, tmp, "safe.pl", "print \"SAFE\\n\";\n")
+		expectRuntimeApprovalDenied(t, []string{"perl", "-MPreload", "./safe.pl"}, tmp)
+	})
+}
+
+func TestUnsafeRuntime_PerlLoadPath(t *testing.T) {
+	withFakeRuntimeBins(t, []string{"perl"}, func() {
+		tmp := t.TempDir()
+		writeScriptFile(t, tmp, "safe.pl", "print \"SAFE\\n\";\n")
+		expectRuntimeApprovalDenied(t, []string{"perl", "-Ilib", "./safe.pl"}, tmp)
+	})
+}
+
+func TestUnsafeRuntime_ShellPayloadHidesInterpreter(t *testing.T) {
+	withFakeRuntimeBins(t, []string{"node"}, func() {
+		tmp := t.TempDir()
+		writeScriptFile(t, tmp, "run.js", "console.log(\"SAFE\")\n")
+		expectRuntimeApprovalDenied(t, []string{"sh", "-lc", "node ./run.js"}, tmp)
+	})
+}
+
+// --- Shell option-value tests ---
+
+func TestShellOptionValue_CapuresRealOperand(t *testing.T) {
+	tmp := t.TempDir()
+	writeScriptFile(t, tmp, "run.sh", "#!/bin/sh\necho SAFE\n")
+	writeScriptFile(t, tmp, "errexit", "decoy\n")
+
+	snap := ResolveMutableFileOperandSnapshot(
+		[]string{"/bin/bash", "-o", "errexit", "./run.sh"}, tmp, nil,
+	)
+	if !snap.Ok {
+		t.Fatalf("expected ok, got: %s", snap.Message)
+	}
+	if snap.Snapshot == nil {
+		t.Fatal("expected snapshot")
+	}
+	if snap.Snapshot.ArgvIndex != 3 {
+		t.Errorf("argvIndex = %d, want 3", snap.Snapshot.ArgvIndex)
+	}
+}
+
+// --- Revalidation tests ---
+
+func TestRevalidate_MutableFileOperand_Passes(t *testing.T) {
+	tmp := t.TempDir()
+	scriptPath := writeScriptFile(t, tmp, "run.sh", "#!/bin/sh\necho SAFE\n")
+	hash, _ := hashFileContents(scriptPath)
+	realPath, _ := filepath.EvalSymlinks(scriptPath)
+
+	ok := RevalidateApprovedMutableFileOperand(
+		&SystemRunApprovalFileOperand{ArgvIndex: 1, Path: realPath, SHA256: hash},
+		[]string{"/bin/sh", "./run.sh"}, tmp,
+	)
+	if !ok {
+		t.Error("expected revalidation to pass")
+	}
+}
+
+func TestRevalidate_MutableFileOperand_FailsOnModification(t *testing.T) {
+	tmp := t.TempDir()
+	scriptPath := writeScriptFile(t, tmp, "run.sh", "#!/bin/sh\necho SAFE\n")
+	hash, _ := hashFileContents(scriptPath)
+	realPath, _ := filepath.EvalSymlinks(scriptPath)
+
+	// Modify the file.
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\necho PWNED\n"), 0o755)
+
+	ok := RevalidateApprovedMutableFileOperand(
+		&SystemRunApprovalFileOperand{ArgvIndex: 1, Path: realPath, SHA256: hash},
+		[]string{"/bin/sh", "./run.sh"}, tmp,
+	)
+	if ok {
+		t.Error("expected revalidation to fail after modification")
+	}
+}
+
+func TestRevalidate_CwdSnapshot(t *testing.T) {
+	tmp := t.TempDir()
+	snap, msg := ResolveCanonicalApprovalCwd(tmp)
+	if msg != "" {
+		t.Fatalf("resolve cwd: %s", msg)
+	}
+	if !RevalidateApprovedCwdSnapshot(snap) {
+		t.Error("expected cwd revalidation to pass")
+	}
+}
+
+// --- SplitShellArgs tests ---
+
+func TestSplitShellArgs(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{`echo hello`, []string{"echo", "hello"}},
+		{`echo "hello world"`, []string{"echo", "hello world"}},
+		{`echo 'hello world'`, []string{"echo", "hello world"}},
+		{`echo hello\ world`, []string{"echo", "hello world"}},
+		{`echo "it\"s"`, []string{"echo", `it"s`}},
+		{`cmd # comment`, []string{"cmd"}},
+		{``, nil}, // empty returns nil (no tokens = nil slice from append)
+	}
+	for _, tt := range tests {
+		got := SplitShellArgs(tt.input)
+		if tt.want == nil {
+			if len(got) > 0 {
+				t.Errorf("SplitShellArgs(%q) = %v, want nil/empty", tt.input, got)
+			}
+			continue
+		}
+		assertStringSliceEqual(t, tt.want, got)
+	}
+}
+
+func TestSplitShellArgs_UnterminatedQuote(t *testing.T) {
+	if got := SplitShellArgs(`echo "unterminated`); got != nil {
+		t.Errorf("expected nil for unterminated quote, got %v", got)
+	}
+}
+
+// --- NormalizeExecutableToken tests ---
+
+func TestNormalizeExecutableToken(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"/usr/bin/node", "node"},
+		{"C:\\Program Files\\node.exe", "node"},
+		{"./pnpm.js", "pnpm.js"},
+		{"tsx", "tsx"},
+		{"NODE.CMD", "node"},
+	}
+	for _, tt := range tests {
+		got := NormalizeExecutableToken(tt.input)
+		if got != tt.want {
+			t.Errorf("NormalizeExecutableToken(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// --- FormatExecCommand tests ---
+
+func TestFormatExecCommand(t *testing.T) {
+	tests := []struct {
+		argv []string
+		want string
+	}{
+		{[]string{"echo", "hello"}, "echo hello"},
+		{[]string{"sh", "-c", "echo SAFE"}, `sh -c "echo SAFE"`},
+		{[]string{""}, `""`},
+	}
+	for _, tt := range tests {
+		got := FormatExecCommand(tt.argv)
+		if got != tt.want {
+			t.Errorf("FormatExecCommand(%v) = %q, want %q", tt.argv, got, tt.want)
+		}
+	}
+}
+
+// --- helpers ---
+
+func expectRuntimeApprovalDenied(t *testing.T, command []string, cwd string) {
+	t.Helper()
+	result := BuildSystemRunApprovalPlan(command, nil, &cwd, nil, nil)
+	if result.Ok {
+		t.Fatalf("expected denial, but got ok with plan: %+v", result.Plan)
+	}
+	want := "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command"
+	if result.Message != want {
+		t.Errorf("message = %q, want %q", result.Message, want)
+	}
+}
+
+func assertStringSliceEqual(t *testing.T, want, got []string) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("slice length %d != %d\nwant: %v\ngot:  %v", len(want), len(got), want, got)
+	}
+	for i := range want {
+		if want[i] != got[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/nodehost/config.go
+++ b/internal/nodehost/config.go
@@ -1,0 +1,139 @@
+package nodehost
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// NodeHostGatewayConfig holds gateway connection settings.
+type NodeHostGatewayConfig struct {
+	Host           string `json:"host,omitempty"`
+	Port           int    `json:"port,omitempty"`
+	TLS            bool   `json:"tls,omitempty"`
+	TLSFingerprint string `json:"tlsFingerprint,omitempty"`
+}
+
+// NodeHostConfig is the persistent node identity and gateway configuration.
+type NodeHostConfig struct {
+	Version     int                    `json:"version"`
+	NodeID      string                 `json:"nodeId"`
+	Token       string                 `json:"token,omitempty"`
+	DisplayName string                 `json:"displayName,omitempty"`
+	Gateway     *NodeHostGatewayConfig `json:"gateway,omitempty"`
+}
+
+const nodeHostFile = "node.json"
+
+// ResolveNodeHostConfigPath returns the path to the node host config file.
+// Uses GOCLAW_STATE_DIR if set, otherwise ~/.goclaw/state/.
+func ResolveNodeHostConfigPath() (string, error) {
+	stateDir := os.Getenv("GOCLAW_STATE_DIR")
+	if stateDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+		stateDir = filepath.Join(home, ".goclaw", "state")
+	}
+	return filepath.Join(stateDir, nodeHostFile), nil
+}
+
+// newUUID generates a random UUID v4 using crypto/rand.
+func newUUID() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("generate uuid: %w", err)
+	}
+	buf[6] = (buf[6] & 0x0f) | 0x40 // version 4
+	buf[8] = (buf[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16]), nil
+}
+
+// normalizeConfig ensures a config has required fields populated.
+func normalizeConfig(cfg *NodeHostConfig) (*NodeHostConfig, error) {
+	out := &NodeHostConfig{Version: 1}
+	if cfg != nil {
+		out.Token = cfg.Token
+		out.DisplayName = cfg.DisplayName
+		out.Gateway = cfg.Gateway
+		if cfg.Version >= 1 {
+			out.NodeID = cfg.NodeID
+		}
+	}
+	if out.NodeID == "" {
+		id, err := newUUID()
+		if err != nil {
+			return nil, err
+		}
+		out.NodeID = id
+	}
+	return out, nil
+}
+
+// LoadNodeHostConfig reads and normalizes the config from disk.
+// Returns nil if the file does not exist.
+func LoadNodeHostConfig() (*NodeHostConfig, error) {
+	filePath, err := ResolveNodeHostConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read node config: %w", err)
+	}
+	var cfg NodeHostConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse node config: %w", err)
+	}
+	return normalizeConfig(&cfg)
+}
+
+// SaveNodeHostConfig writes the config atomically with 0600 permissions.
+func SaveNodeHostConfig(cfg *NodeHostConfig) error {
+	filePath, err := ResolveNodeHostConfigPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal node config: %w", err)
+	}
+
+	tmpPath := filePath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return fmt.Errorf("write temp config: %w", err)
+	}
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename config: %w", err)
+	}
+	return os.Chmod(filePath, 0o600)
+}
+
+// EnsureNodeHostConfig loads, normalizes, saves, and returns the config.
+// Creates a new config if none exists.
+func EnsureNodeHostConfig() (*NodeHostConfig, error) {
+	existing, err := LoadNodeHostConfig()
+	if err != nil {
+		return nil, err
+	}
+	normalized, err := normalizeConfig(existing)
+	if err != nil {
+		return nil, err
+	}
+	if err := SaveNodeHostConfig(normalized); err != nil {
+		return nil, err
+	}
+	return normalized, nil
+}

--- a/internal/nodehost/dispatch_wrapper.go
+++ b/internal/nodehost/dispatch_wrapper.go
@@ -1,0 +1,209 @@
+package nodehost
+
+import (
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// MaxDispatchWrapperDepth is the maximum nesting depth for dispatch wrapper unwrapping.
+const MaxDispatchWrapperDepth = 4
+
+// DispatchWrapperUnwrapResult is the result of attempting to unwrap a dispatch wrapper.
+type DispatchWrapperUnwrapResult struct {
+	Kind    string   // "not-wrapper", "blocked", "unwrapped"
+	Wrapper string   // wrapper name (empty for "not-wrapper")
+	Argv    []string // unwrapped argv (only for "unwrapped")
+}
+
+// WrapperScanDirective controls the scan loop behavior.
+type wrapperScanDirective int
+
+const (
+	scanContinue    wrapperScanDirective = iota
+	scanConsumeNext                      // skip next token as option value
+	scanStop                             // stop scanning, next token is the command
+	scanInvalid                          // unrecognized flag, bail out
+)
+
+// IsEnvAssignment checks if a token is an environment variable assignment (FOO=bar).
+func IsEnvAssignment(token string) bool {
+	return envAssignmentRe.MatchString(token)
+}
+
+var envAssignmentRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
+
+// scanWrapperInvocation is the generic option-scanning loop used by all dispatch wrappers.
+func scanWrapperInvocation(
+	argv []string,
+	separators map[string]bool,
+	onToken func(token, lower string) wrapperScanDirective,
+	adjustCommandIndex func(idx int, argv []string) *int,
+) []string {
+	idx := 1
+	expectsOptionValue := false
+	for idx < len(argv) {
+		token := strings.TrimSpace(safeIndex(argv, idx))
+		if token == "" {
+			idx++
+			continue
+		}
+		if expectsOptionValue {
+			expectsOptionValue = false
+			idx++
+			continue
+		}
+		if separators[token] {
+			idx++
+			break
+		}
+		directive := onToken(token, strings.ToLower(token))
+		switch directive {
+		case scanStop:
+			goto done
+		case scanInvalid:
+			return nil
+		case scanConsumeNext:
+			expectsOptionValue = true
+		}
+		idx++
+	}
+done:
+	if expectsOptionValue {
+		return nil
+	}
+	cmdIdx := idx
+	if adjustCommandIndex != nil {
+		p := adjustCommandIndex(idx, argv)
+		if p == nil {
+			return nil
+		}
+		cmdIdx = *p
+	}
+	if cmdIdx >= len(argv) {
+		return nil
+	}
+	return argv[cmdIdx:]
+}
+
+func safeIndex(argv []string, i int) string {
+	if i < len(argv) {
+		return argv[i]
+	}
+	return ""
+}
+
+func intPtr(v int) *int { return &v }
+
+// --- Individual wrapper unwrappers ---
+
+var envOptionsWithValue = newSet("-u", "--unset", "-c", "--chdir", "-s", "--split-string",
+	"--default-signal", "--ignore-signal", "--block-signal")
+var envInlineValuePrefixes = []string{"-u", "-c", "-s", "--unset=", "--chdir=", "--split-string=",
+	"--default-signal=", "--ignore-signal=", "--block-signal="}
+var envFlagOptions = newSet("-i", "--ignore-environment", "-0", "--null")
+
+func hasEnvInlineValuePrefix(lower string) bool {
+	for _, p := range envInlineValuePrefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func unwrapEnvInvocation(argv []string) []string {
+	return scanWrapperInvocation(argv, map[string]bool{"--": true, "-": true},
+		func(token, lower string) wrapperScanDirective {
+			if IsEnvAssignment(token) {
+				return scanContinue
+			}
+			if !strings.HasPrefix(token, "-") || token == "-" {
+				return scanStop
+			}
+			flag := strings.SplitN(lower, "=", 2)[0]
+			if envFlagOptions[flag] {
+				return scanContinue
+			}
+			if envOptionsWithValue[flag] {
+				if strings.Contains(lower, "=") {
+					return scanContinue
+				}
+				return scanConsumeNext
+			}
+			if hasEnvInlineValuePrefix(lower) {
+				return scanContinue
+			}
+			return scanInvalid
+		}, nil)
+}
+
+func envInvocationUsesModifiers(argv []string) bool {
+	idx := 1
+	expectsOptionValue := false
+	for idx < len(argv) {
+		token := strings.TrimSpace(safeIndex(argv, idx))
+		if token == "" {
+			idx++
+			continue
+		}
+		if expectsOptionValue {
+			return true
+		}
+		if token == "--" || token == "-" {
+			break
+		}
+		if IsEnvAssignment(token) {
+			return true
+		}
+		if !strings.HasPrefix(token, "-") || token == "-" {
+			break
+		}
+		lower := strings.ToLower(token)
+		flag := strings.SplitN(lower, "=", 2)[0]
+		if envFlagOptions[flag] {
+			return true
+		}
+		if envOptionsWithValue[flag] {
+			if strings.Contains(lower, "=") {
+				return true
+			}
+			expectsOptionValue = true
+			idx++
+			continue
+		}
+		if hasEnvInlineValuePrefix(lower) {
+			return true
+		}
+		return true
+	}
+	return false
+}
+
+// newSet creates a simple string set from variadic args.
+func newSet(args ...string) map[string]bool {
+	m := make(map[string]bool, len(args))
+	for _, a := range args {
+		m[a] = true
+	}
+	return m
+}
+
+// unwrapDashOptionInvocation scans dash-prefixed flags and stops at positional args.
+func unwrapDashOptionInvocation(
+	argv []string,
+	onFlag func(flag, lower string) wrapperScanDirective,
+	adjustCommandIndex func(int, []string) *int,
+) []string {
+	return scanWrapperInvocation(argv, map[string]bool{"--": true},
+		func(token, lower string) wrapperScanDirective {
+			if !strings.HasPrefix(token, "-") || token == "-" {
+				return scanStop
+			}
+			flag := strings.SplitN(lower, "=", 2)[0]
+			return onFlag(flag, lower)
+		}, adjustCommandIndex)
+}
+
+// Platform-gated wrappers.
+func isDarwin() bool { return runtime.GOOS == "darwin" }

--- a/internal/nodehost/dispatch_wrapper_specs.go
+++ b/internal/nodehost/dispatch_wrapper_specs.go
@@ -1,0 +1,280 @@
+package nodehost
+
+import (
+	"regexp"
+	"strings"
+)
+
+// dispatchWrapperSpec defines how to unwrap a specific dispatch wrapper.
+type dispatchWrapperSpec struct {
+	name             string
+	unwrap           func(argv []string) []string // nil means always blocked
+	isTransparent    func(argv []string) bool     // nil means opaque (semantic usage)
+}
+
+var niceOptionsWithValue = newSet("-n", "--adjustment", "--priority")
+var caffeinateOptionsWithValue = newSet("-t", "-w")
+var stdbufOptionsWithValue = newSet("-i", "--input", "-o", "--output", "-e", "--error")
+var timeFlagOptions = newSet("-a", "--append", "-h", "--help", "-l", "-p", "-q", "--quiet", "-v", "--verbose", "-V", "--version")
+var timeOptionsWithValue = newSet("-f", "--format", "-o", "--output")
+var bsdScriptFlagOptions = newSet("-a", "-d", "-k", "-p", "-q", "-r")
+var bsdScriptOptionsWithValue = newSet("-F", "-t")
+var sandboxExecOptionsWithValue = newSet("-f", "-p", "-d")
+var timeoutFlagOptions = newSet("--foreground", "--preserve-status", "-v", "--verbose")
+var timeoutOptionsWithValue = newSet("-k", "--kill-after", "-s", "--signal")
+var xcrunFlagOptions = newSet("-k", "--kill-cache", "-l", "--log", "-n", "--no-cache", "-r", "--run", "-v", "--verbose")
+
+var knownArchRe = regexp.MustCompile(`^-(?:arm64|arm64e|i386|x86_64|x86_64h)$`)
+var niceNumericRe = regexp.MustCompile(`^-\d+$`)
+
+func unwrapNice(argv []string) []string {
+	return unwrapDashOptionInvocation(argv, func(flag, lower string) wrapperScanDirective {
+		if niceNumericRe.MatchString(lower) {
+			return scanContinue
+		}
+		if niceOptionsWithValue[flag] {
+			if strings.Contains(lower, "=") || lower != flag {
+				return scanContinue
+			}
+			return scanConsumeNext
+		}
+		if strings.HasPrefix(lower, "-n") && len(lower) > 2 {
+			return scanContinue
+		}
+		return scanInvalid
+	}, nil)
+}
+
+func unwrapCaffeinate(argv []string) []string {
+	return unwrapDashOptionInvocation(argv, func(flag, lower string) wrapperScanDirective {
+		switch flag {
+		case "-d", "-i", "-m", "-s", "-u":
+			return scanContinue
+		}
+		if caffeinateOptionsWithValue[flag] {
+			if lower != flag || strings.Contains(lower, "=") {
+				return scanContinue
+			}
+			return scanConsumeNext
+		}
+		return scanInvalid
+	}, nil)
+}
+
+func unwrapNohup(argv []string) []string {
+	return scanWrapperInvocation(argv, map[string]bool{"--": true},
+		func(token, lower string) wrapperScanDirective {
+			if !strings.HasPrefix(token, "-") || token == "-" {
+				return scanStop
+			}
+			if lower == "--help" || lower == "--version" {
+				return scanContinue
+			}
+			return scanInvalid
+		}, nil)
+}
+
+func unwrapSandboxExec(argv []string) []string {
+	return unwrapDashOptionInvocation(argv, func(flag, lower string) wrapperScanDirective {
+		if sandboxExecOptionsWithValue[flag] {
+			if lower != flag || strings.Contains(lower, "=") {
+				return scanContinue
+			}
+			return scanConsumeNext
+		}
+		return scanInvalid
+	}, nil)
+}
+
+func unwrapStdbuf(argv []string) []string {
+	return unwrapDashOptionInvocation(argv, func(flag, lower string) wrapperScanDirective {
+		if !stdbufOptionsWithValue[flag] {
+			return scanInvalid
+		}
+		if strings.Contains(lower, "=") {
+			return scanContinue
+		}
+		return scanConsumeNext
+	}, nil)
+}
+
+func unwrapTime(argv []string) []string {
+	return unwrapDashOptionInvocation(argv, func(flag, lower string) wrapperScanDirective {
+		if timeFlagOptions[flag] {
+			return scanContinue
+		}
+		if timeOptionsWithValue[flag] {
+			if strings.Contains(lower, "=") {
+				return scanContinue
+			}
+			return scanConsumeNext
+		}
+		return scanInvalid
+	}, nil)
+}
+
+func unwrapScript(argv []string) []string {
+	if !isDarwin() {
+		return nil
+	}
+	return scanWrapperInvocation(argv, map[string]bool{"--": true},
+		func(token, lower string) wrapperScanDirective {
+			if !strings.HasPrefix(lower, "-") || lower == "-" {
+				return scanStop
+			}
+			flag := strings.SplitN(token, "=", 2)[0]
+			if bsdScriptOptionsWithValue[flag] {
+				if strings.Contains(token, "=") {
+					return scanContinue
+				}
+				return scanConsumeNext
+			}
+			if bsdScriptFlagOptions[flag] {
+				return scanContinue
+			}
+			return scanInvalid
+		}, func(cmdIdx int, a []string) *int {
+			// Skip transcript file positional arg.
+			sawTranscript := false
+			for i := cmdIdx; i < len(a); i++ {
+				t := strings.TrimSpace(safeIndex(a, i))
+				if t == "" {
+					continue
+				}
+				if !sawTranscript {
+					sawTranscript = true
+					continue
+				}
+				return intPtr(i)
+			}
+			return nil
+		})
+}
+
+func unwrapTimeout(argv []string) []string {
+	return unwrapDashOptionInvocation(argv, func(flag, lower string) wrapperScanDirective {
+		if timeoutFlagOptions[flag] {
+			return scanContinue
+		}
+		if timeoutOptionsWithValue[flag] {
+			if strings.Contains(lower, "=") {
+				return scanContinue
+			}
+			return scanConsumeNext
+		}
+		return scanInvalid
+	}, func(cmdIdx int, a []string) *int {
+		// Skip the duration positional arg.
+		next := cmdIdx + 1
+		if next < len(a) {
+			return intPtr(next)
+		}
+		return nil
+	})
+}
+
+func unwrapArch(argv []string) []string {
+	if !isDarwin() {
+		return nil
+	}
+	expectsArchName := false
+	return scanWrapperInvocation(argv, nil,
+		func(token, lower string) wrapperScanDirective {
+			if expectsArchName {
+				expectsArchName = false
+				if knownArchRe.MatchString("-" + lower) {
+					return scanContinue
+				}
+				return scanInvalid
+			}
+			if !strings.HasPrefix(token, "-") || token == "-" {
+				return scanStop
+			}
+			if lower == "-32" || lower == "-64" {
+				return scanContinue
+			}
+			if lower == "-arch" {
+				expectsArchName = true
+				return scanContinue
+			}
+			if lower == "-c" || lower == "-d" || lower == "-e" || lower == "-h" {
+				return scanInvalid
+			}
+			if knownArchRe.MatchString(lower) {
+				return scanContinue
+			}
+			return scanInvalid
+		}, nil)
+}
+
+func unwrapXcrun(argv []string) []string {
+	if !isDarwin() {
+		return nil
+	}
+	return scanWrapperInvocation(argv, nil,
+		func(token, lower string) wrapperScanDirective {
+			if !strings.HasPrefix(token, "-") || token == "-" {
+				return scanStop
+			}
+			if xcrunFlagOptions[lower] {
+				return scanContinue
+			}
+			return scanInvalid
+		}, nil)
+}
+
+// dispatchWrapperSpecs is the registry of known dispatch wrappers.
+var dispatchWrapperSpecs = []dispatchWrapperSpec{
+	{name: "arch", unwrap: unwrapArch, isTransparent: func(_ []string) bool { return isDarwin() }},
+	{name: "caffeinate", unwrap: unwrapCaffeinate, isTransparent: func(_ []string) bool { return true }},
+	{name: "chrt"},
+	{name: "doas"},
+	{name: "env", unwrap: unwrapEnvInvocation, isTransparent: func(a []string) bool { return !envInvocationUsesModifiers(a) }},
+	{name: "ionice"},
+	{name: "nice", unwrap: unwrapNice, isTransparent: func(_ []string) bool { return true }},
+	{name: "nohup", unwrap: unwrapNohup, isTransparent: func(_ []string) bool { return true }},
+	{name: "sandbox-exec", unwrap: unwrapSandboxExec, isTransparent: func(_ []string) bool { return true }},
+	{name: "script", unwrap: unwrapScript, isTransparent: func(_ []string) bool { return true }},
+	{name: "setsid"},
+	{name: "stdbuf", unwrap: unwrapStdbuf, isTransparent: func(_ []string) bool { return true }},
+	{name: "sudo"},
+	{name: "taskset"},
+	{name: "time", unwrap: unwrapTime, isTransparent: func(_ []string) bool { return true }},
+	{name: "timeout", unwrap: unwrapTimeout, isTransparent: func(_ []string) bool { return true }},
+	{name: "xcrun", unwrap: unwrapXcrun, isTransparent: func(_ []string) bool { return isDarwin() }},
+}
+
+var dispatchSpecByName = func() map[string]*dispatchWrapperSpec {
+	m := make(map[string]*dispatchWrapperSpec, len(dispatchWrapperSpecs))
+	for i := range dispatchWrapperSpecs {
+		m[dispatchWrapperSpecs[i].name] = &dispatchWrapperSpecs[i]
+	}
+	return m
+}()
+
+// UnwrapKnownDispatchWrapperInvocation attempts to peel one dispatch wrapper layer.
+func UnwrapKnownDispatchWrapperInvocation(argv []string) DispatchWrapperUnwrapResult {
+	token0 := strings.TrimSpace(safeIndex(argv, 0))
+	if token0 == "" {
+		return DispatchWrapperUnwrapResult{Kind: "not-wrapper"}
+	}
+	wrapper := NormalizeExecutableToken(token0)
+	spec := dispatchSpecByName[wrapper]
+	if spec == nil {
+		return DispatchWrapperUnwrapResult{Kind: "not-wrapper"}
+	}
+	if spec.unwrap == nil {
+		return DispatchWrapperUnwrapResult{Kind: "blocked", Wrapper: wrapper}
+	}
+	unwrapped := spec.unwrap(argv)
+	if unwrapped == nil {
+		return DispatchWrapperUnwrapResult{Kind: "blocked", Wrapper: wrapper}
+	}
+	return DispatchWrapperUnwrapResult{Kind: "unwrapped", Wrapper: wrapper, Argv: unwrapped}
+}
+
+// HasDispatchEnvManipulation checks if an env wrapper modifies the environment.
+func HasDispatchEnvManipulation(argv []string) bool {
+	r := UnwrapKnownDispatchWrapperInvocation(argv)
+	return r.Kind == "unwrapped" && r.Wrapper == "env" && envInvocationUsesModifiers(argv)
+}

--- a/internal/nodehost/exec_policy.go
+++ b/internal/nodehost/exec_policy.go
@@ -1,0 +1,117 @@
+package nodehost
+
+// ExecSecurity represents the security mode for command execution.
+type ExecSecurity string
+
+const (
+	SecurityDeny      ExecSecurity = "deny"
+	SecurityAllowlist ExecSecurity = "allowlist"
+	SecurityFull      ExecSecurity = "full"
+)
+
+// ExecAsk represents the approval ask mode.
+type ExecAsk string
+
+const (
+	AskOff    ExecAsk = "off"
+	AskOnMiss ExecAsk = "on-miss"
+	AskAlways ExecAsk = "always"
+)
+
+// RequiresExecApproval determines whether a command needs user approval
+// based on the ask mode, security mode, and allowlist analysis results.
+func RequiresExecApproval(ask ExecAsk, security ExecSecurity, analysisOk, allowlistSatisfied bool) bool {
+	switch ask {
+	case AskAlways:
+		return true
+	case AskOnMiss:
+		return security == SecurityAllowlist && (!analysisOk || !allowlistSatisfied)
+	default:
+		return false
+	}
+}
+
+// EvaluateSystemRunPolicyParams contains the inputs for policy evaluation.
+type EvaluateSystemRunPolicyParams struct {
+	Security               ExecSecurity
+	Ask                    ExecAsk
+	AnalysisOk             bool
+	AllowlistSatisfied     bool
+	ApprovalDecision       *ExecApprovalDecision
+	Approved               bool
+	IsWindows              bool
+	CmdInvocation          bool
+	ShellWrapperInvocation bool
+}
+
+// EvaluateSystemRunPolicy evaluates whether a system command should be allowed.
+// Returns a decision with the reason for denial if not allowed.
+func EvaluateSystemRunPolicy(p EvaluateSystemRunPolicyParams) SystemRunPolicyDecision {
+	shellWrapperBlocked := p.Security == SecurityAllowlist && p.ShellWrapperInvocation
+	windowsShellWrapperBlocked := shellWrapperBlocked && p.IsWindows && p.CmdInvocation
+
+	analysisOk := p.AnalysisOk
+	allowlistSatisfied := p.AllowlistSatisfied
+	if shellWrapperBlocked {
+		analysisOk = false
+		allowlistSatisfied = false
+	}
+
+	approvedByAsk := p.ApprovalDecision != nil || p.Approved
+
+	base := SystemRunPolicyDecision{
+		AnalysisOk:                 analysisOk,
+		AllowlistSatisfied:         allowlistSatisfied,
+		ShellWrapperBlocked:        shellWrapperBlocked,
+		WindowsShellWrapperBlocked: windowsShellWrapperBlocked,
+		ApprovalDecision:           p.ApprovalDecision,
+		ApprovedByAsk:              approvedByAsk,
+	}
+
+	// Branch 1: security=deny always blocks.
+	if p.Security == SecurityDeny {
+		base.Allowed = false
+		base.RequiresAsk = false
+		base.EventReason = EventReasonSecurityDeny
+		base.ErrorMessage = "SYSTEM_RUN_DISABLED: security=deny"
+		return base
+	}
+
+	// Branch 2: ask policy requires approval.
+	requiresAsk := RequiresExecApproval(p.Ask, p.Security, analysisOk, allowlistSatisfied)
+	base.RequiresAsk = requiresAsk
+	if requiresAsk && !approvedByAsk {
+		base.Allowed = false
+		base.EventReason = EventReasonApprovalRequired
+		base.ErrorMessage = "SYSTEM_RUN_DENIED: approval required"
+		return base
+	}
+
+	// Branch 3: allowlist miss without approval.
+	if p.Security == SecurityAllowlist && (!analysisOk || !allowlistSatisfied) && !approvedByAsk {
+		base.Allowed = false
+		base.EventReason = EventReasonAllowlistMiss
+		base.ErrorMessage = FormatSystemRunAllowlistMissMessage(shellWrapperBlocked, windowsShellWrapperBlocked)
+		return base
+	}
+
+	// All checks passed.
+	base.Allowed = true
+	return base
+}
+
+// FormatSystemRunAllowlistMissMessage returns the appropriate denial message
+// based on whether shell wrappers are involved.
+func FormatSystemRunAllowlistMissMessage(shellWrapperBlocked, windowsShellWrapperBlocked bool) string {
+	if windowsShellWrapperBlocked {
+		return "SYSTEM_RUN_DENIED: allowlist miss " +
+			"(Windows shell wrappers like cmd.exe /c require approval; " +
+			"approve once/always or run with --ask on-miss|always)"
+	}
+	if shellWrapperBlocked {
+		return "SYSTEM_RUN_DENIED: allowlist miss " +
+			"(shell wrappers like sh/bash/zsh -c require approval; " +
+			"approve once/always or run with --ask on-miss|always)"
+	}
+	return "SYSTEM_RUN_DENIED: allowlist miss"
+}

--- a/internal/nodehost/exec_policy_test.go
+++ b/internal/nodehost/exec_policy_test.go
@@ -1,0 +1,233 @@
+package nodehost
+
+import (
+	"testing"
+)
+
+// buildPolicyParams returns default params matching the TS test helper.
+func buildPolicyParams(overrides func(*EvaluateSystemRunPolicyParams)) EvaluateSystemRunPolicyParams {
+	p := EvaluateSystemRunPolicyParams{
+		Security:               SecurityAllowlist,
+		Ask:                    AskOff,
+		AnalysisOk:             true,
+		AllowlistSatisfied:     true,
+		ApprovalDecision:       nil,
+		Approved:               false,
+		IsWindows:              false,
+		CmdInvocation:          false,
+		ShellWrapperInvocation: false,
+	}
+	if overrides != nil {
+		overrides(&p)
+	}
+	return p
+}
+
+// --- resolveExecApprovalDecision tests (ported from TS) ---
+
+func TestResolveExecApprovalDecision_AcceptsKnown(t *testing.T) {
+	tests := []struct {
+		input string
+		want  ExecApprovalDecision
+	}{
+		{"allow-once", ApprovalAllowOnce},
+		{"allow-always", ApprovalAllowAlways},
+	}
+	for _, tt := range tests {
+		got := ResolveExecApprovalDecision(tt.input)
+		if got == nil {
+			t.Errorf("ResolveExecApprovalDecision(%q) = nil, want %q", tt.input, tt.want)
+			continue
+		}
+		if *got != tt.want {
+			t.Errorf("ResolveExecApprovalDecision(%q) = %q, want %q", tt.input, *got, tt.want)
+		}
+	}
+}
+
+func TestResolveExecApprovalDecision_NormalizesUnknown(t *testing.T) {
+	for _, input := range []string{"deny", ""} {
+		got := ResolveExecApprovalDecision(input)
+		if got != nil {
+			t.Errorf("ResolveExecApprovalDecision(%q) = %q, want nil", input, *got)
+		}
+	}
+}
+
+// --- formatSystemRunAllowlistMissMessage tests (ported from TS) ---
+
+func TestFormatAllowlistMiss_Default(t *testing.T) {
+	msg := FormatSystemRunAllowlistMissMessage(false, false)
+	want := "SYSTEM_RUN_DENIED: allowlist miss"
+	if msg != want {
+		t.Errorf("got %q, want %q", msg, want)
+	}
+}
+
+func TestFormatAllowlistMiss_ShellWrapper(t *testing.T) {
+	msg := FormatSystemRunAllowlistMissMessage(true, false)
+	if want := "shell wrappers like sh/bash/zsh -c require approval"; !contains(msg, want) {
+		t.Errorf("message %q should contain %q", msg, want)
+	}
+}
+
+func TestFormatAllowlistMiss_WindowsShellWrapper(t *testing.T) {
+	msg := FormatSystemRunAllowlistMissMessage(true, true)
+	if want := "Windows shell wrappers like cmd.exe /c require approval"; !contains(msg, want) {
+		t.Errorf("message %q should contain %q", msg, want)
+	}
+}
+
+// --- evaluateSystemRunPolicy tests (ported 1:1 from exec-policy.test.ts) ---
+
+func TestPolicy_DeniesWhenSecurityDeny(t *testing.T) {
+	d := EvaluateSystemRunPolicy(buildPolicyParams(func(p *EvaluateSystemRunPolicyParams) {
+		p.Security = SecurityDeny
+	}))
+	if d.Allowed {
+		t.Fatal("expected denied")
+	}
+	if d.EventReason != EventReasonSecurityDeny {
+		t.Errorf("eventReason = %q, want %q", d.EventReason, EventReasonSecurityDeny)
+	}
+	if d.ErrorMessage != "SYSTEM_RUN_DISABLED: security=deny" {
+		t.Errorf("errorMessage = %q", d.ErrorMessage)
+	}
+}
+
+func TestPolicy_RequiresApprovalWhenAskAlways(t *testing.T) {
+	d := EvaluateSystemRunPolicy(buildPolicyParams(func(p *EvaluateSystemRunPolicyParams) {
+		p.Ask = AskAlways
+	}))
+	if d.Allowed {
+		t.Fatal("expected denied")
+	}
+	if d.EventReason != EventReasonApprovalRequired {
+		t.Errorf("eventReason = %q, want %q", d.EventReason, EventReasonApprovalRequired)
+	}
+	if !d.RequiresAsk {
+		t.Error("requiresAsk should be true")
+	}
+}
+
+func TestPolicy_AllowsMissWithExplicitApproval(t *testing.T) {
+	decision := ApprovalAllowOnce
+	d := EvaluateSystemRunPolicy(buildPolicyParams(func(p *EvaluateSystemRunPolicyParams) {
+		p.Ask = AskOnMiss
+		p.AnalysisOk = false
+		p.AllowlistSatisfied = false
+		p.ApprovalDecision = &decision
+	}))
+	if !d.Allowed {
+		t.Fatal("expected allowed")
+	}
+	if !d.ApprovedByAsk {
+		t.Error("approvedByAsk should be true")
+	}
+}
+
+func TestPolicy_DeniesAllowlistMissWithoutApproval(t *testing.T) {
+	d := EvaluateSystemRunPolicy(buildPolicyParams(func(p *EvaluateSystemRunPolicyParams) {
+		p.AnalysisOk = false
+		p.AllowlistSatisfied = false
+	}))
+	if d.Allowed {
+		t.Fatal("expected denied")
+	}
+	if d.EventReason != EventReasonAllowlistMiss {
+		t.Errorf("eventReason = %q, want %q", d.EventReason, EventReasonAllowlistMiss)
+	}
+	if d.ErrorMessage != "SYSTEM_RUN_DENIED: allowlist miss" {
+		t.Errorf("errorMessage = %q", d.ErrorMessage)
+	}
+}
+
+func TestPolicy_ShellWrappersAsAllowlistMiss(t *testing.T) {
+	d := EvaluateSystemRunPolicy(buildPolicyParams(func(p *EvaluateSystemRunPolicyParams) {
+		p.ShellWrapperInvocation = true
+	}))
+	if d.Allowed {
+		t.Fatal("expected denied")
+	}
+	if !d.ShellWrapperBlocked {
+		t.Error("shellWrapperBlocked should be true")
+	}
+	if want := "shell wrappers like sh/bash/zsh -c"; !contains(d.ErrorMessage, want) {
+		t.Errorf("errorMessage %q should contain %q", d.ErrorMessage, want)
+	}
+}
+
+func TestPolicy_WindowsCmdWrapperGuidance(t *testing.T) {
+	d := EvaluateSystemRunPolicy(buildPolicyParams(func(p *EvaluateSystemRunPolicyParams) {
+		p.IsWindows = true
+		p.CmdInvocation = true
+		p.ShellWrapperInvocation = true
+	}))
+	if d.Allowed {
+		t.Fatal("expected denied")
+	}
+	if !d.ShellWrapperBlocked {
+		t.Error("shellWrapperBlocked should be true")
+	}
+	if !d.WindowsShellWrapperBlocked {
+		t.Error("windowsShellWrapperBlocked should be true")
+	}
+	if want := "Windows shell wrappers like cmd.exe /c"; !contains(d.ErrorMessage, want) {
+		t.Errorf("errorMessage %q should contain %q", d.ErrorMessage, want)
+	}
+}
+
+func TestPolicy_AllowsWhenChecksPass(t *testing.T) {
+	d := EvaluateSystemRunPolicy(buildPolicyParams(func(p *EvaluateSystemRunPolicyParams) {
+		p.Ask = AskOnMiss
+	}))
+	if !d.Allowed {
+		t.Fatal("expected allowed")
+	}
+	if d.RequiresAsk {
+		t.Error("requiresAsk should be false")
+	}
+	if !d.AnalysisOk {
+		t.Error("analysisOk should be true")
+	}
+	if !d.AllowlistSatisfied {
+		t.Error("allowlistSatisfied should be true")
+	}
+}
+
+// --- requiresExecApproval tests ---
+
+func TestRequiresExecApproval(t *testing.T) {
+	tests := []struct {
+		name               string
+		ask                ExecAsk
+		security           ExecSecurity
+		analysisOk         bool
+		allowlistSatisfied bool
+		want               bool
+	}{
+		{"always requires", AskAlways, SecurityAllowlist, true, true, true},
+		{"off never requires", AskOff, SecurityAllowlist, false, false, false},
+		{"on-miss with miss", AskOnMiss, SecurityAllowlist, false, false, true},
+		{"on-miss satisfied", AskOnMiss, SecurityAllowlist, true, true, false},
+		{"on-miss non-allowlist", AskOnMiss, SecurityFull, false, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RequiresExecApproval(tt.ask, tt.security, tt.analysisOk, tt.allowlistSatisfied)
+			if got != tt.want {
+				t.Errorf("RequiresExecApproval() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// contains checks if s contains substr (avoids importing strings for one use).
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/nodehost/exec_tokens.go
+++ b/internal/nodehost/exec_tokens.go
@@ -1,0 +1,42 @@
+package nodehost
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+var windowsExecutableSuffixes = []string{".exe", ".cmd", ".bat", ".com"}
+
+// stripWindowsExecutableSuffix removes Windows executable suffixes from a binary name.
+func stripWindowsExecutableSuffix(value string) string {
+	lower := strings.ToLower(value)
+	for _, suffix := range windowsExecutableSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return value[:len(value)-len(suffix)]
+		}
+	}
+	return value
+}
+
+// BasenameLower extracts the basename from a token, using both posix and windows
+// path separators, then lowercases it. Picks the shorter result to handle
+// cross-platform paths.
+func BasenameLower(token string) string {
+	posix := filepath.Base(token)
+	// Also try Windows-style separator for cross-platform compat.
+	win := token
+	if idx := strings.LastIndex(token, "\\"); idx >= 0 {
+		win = token[idx+1:]
+	}
+	base := posix
+	if len(win) < len(posix) {
+		base = win
+	}
+	return strings.ToLower(strings.TrimSpace(base))
+}
+
+// NormalizeExecutableToken extracts the lowercase basename of a command token,
+// stripping path components and Windows executable suffixes.
+func NormalizeExecutableToken(token string) string {
+	return stripWindowsExecutableSuffix(BasenameLower(token))
+}

--- a/internal/nodehost/file_identity.go
+++ b/internal/nodehost/file_identity.go
@@ -1,0 +1,34 @@
+package nodehost
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// FileIdentityStat holds device and inode numbers for file identity comparison.
+type FileIdentityStat struct {
+	Dev uint64
+	Ino uint64
+}
+
+// GetFileIdentity returns the device and inode numbers for a path.
+func GetFileIdentity(path string) (FileIdentityStat, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return FileIdentityStat{}, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return FileIdentityStat{}, fmt.Errorf("unsupported platform: cannot extract file identity for %s", path)
+	}
+	return FileIdentityStat{
+		Dev: uint64(stat.Dev),
+		Ino: stat.Ino,
+	}, nil
+}
+
+// SameFileIdentity compares two file identity stats for equality.
+func SameFileIdentity(left, right FileIdentityStat) bool {
+	return left.Ino == right.Ino && left.Dev == right.Dev
+}

--- a/internal/nodehost/invoke.go
+++ b/internal/nodehost/invoke.go
@@ -1,0 +1,124 @@
+package nodehost
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// OutputCap is the maximum bytes captured across both stdout and stderr combined.
+// Matches the TS value of 200_000 (not 200*1024).
+const OutputCap = 200_000
+
+// RunCommandOpts holds options for process execution.
+type RunCommandOpts struct {
+	Cwd       string
+	Env       []string // os.Environ() format: "KEY=VALUE"
+	TimeoutMs int
+}
+
+// RunCommand spawns a process and captures output with capping and timeout.
+func RunCommand(ctx context.Context, argv []string, opts RunCommandOpts) *RunResult {
+	if len(argv) == 0 {
+		errMsg := "empty command"
+		return &RunResult{Error: &errMsg, Success: false}
+	}
+
+	// Apply timeout if specified.
+	if opts.TimeoutMs > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(opts.TimeoutMs)*time.Millisecond)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	if opts.Env != nil {
+		cmd.Env = opts.Env
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		errMsg := err.Error()
+		return &RunResult{Error: &errMsg, Success: false}
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		errMsg := err.Error()
+		return &RunResult{Error: &errMsg, Success: false}
+	}
+
+	if err := cmd.Start(); err != nil {
+		errMsg := err.Error()
+		return &RunResult{Error: &errMsg, Success: false}
+	}
+
+	// Read stdout and stderr concurrently with a shared combined cap.
+	// TS uses a single outputLen counter across both streams.
+	stdoutData, _ := io.ReadAll(stdoutPipe)
+	stderrData, _ := io.ReadAll(stderrPipe)
+
+	totalLen := len(stdoutData) + len(stderrData)
+	truncated := false
+	if totalLen > OutputCap {
+		truncated = true
+		// Trim proportionally, favoring stdout.
+		remaining := OutputCap
+		if len(stdoutData) > remaining {
+			stdoutData = stdoutData[:remaining]
+			remaining = 0
+		} else {
+			remaining -= len(stdoutData)
+		}
+		if len(stderrData) > remaining {
+			stderrData = stderrData[:remaining]
+		}
+	}
+
+	waitErr := cmd.Wait()
+	timedOut := ctx.Err() != nil
+
+	exitCode := resolveExitCode(waitErr, cmd)
+	success := exitCode != nil && *exitCode == 0 && !timedOut
+
+	result := &RunResult{
+		ExitCode:  exitCode,
+		TimedOut:  timedOut,
+		Success:   success,
+		Stdout:    string(stdoutData),
+		Stderr:    string(stderrData),
+		Truncated: truncated,
+	}
+	if waitErr != nil && !timedOut && exitCode == nil {
+		errMsg := waitErr.Error()
+		result.Error = &errMsg
+	}
+	return result
+}
+
+// resolveExitCode extracts the exit code from a process error.
+func resolveExitCode(err error, cmd *exec.Cmd) *int {
+	if err == nil {
+		code := 0
+		return &code
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		code := exitErr.ExitCode()
+		return &code
+	}
+	// Try to get exit code from ProcessState.
+	if cmd.ProcessState != nil {
+		if status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
+			code := status.ExitStatus()
+			return &code
+		}
+	}
+	return nil
+}
+

--- a/internal/nodehost/rpc_dispatcher.go
+++ b/internal/nodehost/rpc_dispatcher.go
@@ -1,0 +1,205 @@
+package nodehost
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os/exec"
+	"strings"
+)
+
+// NodeInvokeRequestPayload is an incoming RPC invocation from the gateway.
+type NodeInvokeRequestPayload struct {
+	ID             string          `json:"id"`
+	NodeID         string          `json:"nodeId"`
+	Command        string          `json:"command"`
+	ParamsJSON     *string         `json:"paramsJSON,omitempty"`
+	TimeoutMs      *int            `json:"timeoutMs,omitempty"`
+	IdempotencyKey *string         `json:"idempotencyKey,omitempty"`
+}
+
+// NodeInvokeResultParams is the result sent back to the gateway.
+type NodeInvokeResultParams struct {
+	ID          string                  `json:"id"`
+	NodeID      string                  `json:"nodeId"`
+	Ok          bool                    `json:"ok"`
+	PayloadJSON string                  `json:"payloadJSON,omitempty"`
+	Payload     json.RawMessage         `json:"payload,omitempty"`
+	Error       *NodeInvokeResultError  `json:"error,omitempty"`
+}
+
+// NodeInvokeResultError describes an invocation error.
+type NodeInvokeResultError struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// GatewayRequester abstracts the gateway client for sending requests/events.
+type GatewayRequester interface {
+	Request(ctx context.Context, method string, params any) error
+}
+
+// CoerceNodeInvokePayload validates and extracts an invoke payload from raw JSON.
+func CoerceNodeInvokePayload(raw json.RawMessage) *NodeInvokeRequestPayload {
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(raw, &obj) != nil {
+		return nil
+	}
+	id := coerceString(obj["id"])
+	nodeID := coerceString(obj["nodeId"])
+	command := coerceString(obj["command"])
+	if id == "" || nodeID == "" || command == "" {
+		return nil
+	}
+
+	var paramsJSON *string
+	if v, ok := obj["paramsJSON"]; ok {
+		s := coerceString(v)
+		if s != "" {
+			paramsJSON = &s
+		}
+	} else if v, ok := obj["params"]; ok {
+		s := string(v)
+		paramsJSON = &s
+	}
+
+	result := &NodeInvokeRequestPayload{
+		ID:      id,
+		NodeID:  nodeID,
+		Command: command,
+	}
+	if paramsJSON != nil {
+		result.ParamsJSON = paramsJSON
+	}
+	return result
+}
+
+func coerceString(raw json.RawMessage) string {
+	var s string
+	if json.Unmarshal(raw, &s) != nil {
+		return ""
+	}
+	return strings.TrimSpace(s)
+}
+
+// HandleInvoke routes an incoming RPC command to the appropriate handler.
+func HandleInvoke(ctx context.Context, frame NodeInvokeRequestPayload, client GatewayRequester, skillBins *SkillBinsCache) {
+	command := strings.TrimSpace(frame.Command)
+	slog.Debug("nodehost invoke", "command", command, "id", frame.ID)
+
+	switch command {
+	case "system.run":
+		handleSystemRunCommand(ctx, frame, client, skillBins)
+	case "system.run.prepare":
+		handleSystemRunPrepare(ctx, frame, client)
+	case "system.which":
+		handleSystemWhich(ctx, frame, client)
+	default:
+		sendErrorResult(ctx, client, frame, "UNKNOWN_COMMAND", "unknown command: "+command)
+	}
+}
+
+func handleSystemRunCommand(ctx context.Context, frame NodeInvokeRequestPayload, client GatewayRequester, skillBins *SkillBinsCache) {
+	params := decodeParamsAs[SystemRunParams](frame.ParamsJSON)
+
+	deps := SystemRunDeps{
+		SendDeniedEvent: func(payload ExecEventPayload) {
+			sendNodeEvent(ctx, client, "exec.denied", payload)
+		},
+		SendFinishedEvent: func(p ExecFinishedEventParams) {
+			sendNodeEvent(ctx, client, "exec.finished", p)
+		},
+		SendResult: func(r SystemRunInvokeResult) {
+			if r.Ok {
+				sendPayloadJSONResult(ctx, client, frame, r.PayloadJSON)
+			} else {
+				sendErrorResult(ctx, client, frame, r.ErrorCode, r.ErrorMsg)
+			}
+		},
+	}
+	HandleSystemRunInvoke(ctx, params, deps)
+}
+
+func handleSystemRunPrepare(_ context.Context, frame NodeInvokeRequestPayload, client GatewayRequester) {
+	type prepareParams struct {
+		Command    []string `json:"command"`
+		RawCommand *string  `json:"rawCommand,omitempty"`
+		Cwd        *string  `json:"cwd,omitempty"`
+		AgentID    *string  `json:"agentId,omitempty"`
+		SessionKey *string  `json:"sessionKey,omitempty"`
+	}
+	params := decodeParamsAs[prepareParams](frame.ParamsJSON)
+	result := BuildSystemRunApprovalPlan(params.Command, params.RawCommand, params.Cwd, params.AgentID, params.SessionKey)
+	if !result.Ok {
+		sendErrorResult(context.Background(), client, frame, "INVALID_REQUEST", result.Message)
+		return
+	}
+	sendPayloadResult(context.Background(), client, frame, result.Plan)
+}
+
+func handleSystemWhich(_ context.Context, frame NodeInvokeRequestPayload, client GatewayRequester) {
+	type whichParams struct {
+		Bins []string `json:"bins"`
+	}
+	params := decodeParamsAs[whichParams](frame.ParamsJSON)
+	type whichEntry struct {
+		Bin  string `json:"bin"`
+		Path string `json:"path"`
+	}
+	var results []whichEntry
+	for _, bin := range params.Bins {
+		name := strings.TrimSpace(bin)
+		if name == "" {
+			continue
+		}
+		resolved, err := exec.LookPath(name)
+		if err != nil {
+			continue
+		}
+		results = append(results, whichEntry{Bin: name, Path: resolved})
+	}
+	sendPayloadResult(context.Background(), client, frame, map[string]any{"bins": results})
+}
+
+// --- Helper: decode params ---
+
+func decodeParamsAs[T any](paramsJSON *string) T {
+	var result T
+	if paramsJSON != nil {
+		json.Unmarshal([]byte(*paramsJSON), &result)
+	}
+	return result
+}
+
+// --- Helper: send results ---
+
+func sendPayloadResult(ctx context.Context, client GatewayRequester, frame NodeInvokeRequestPayload, payload any) {
+	data, _ := json.Marshal(payload)
+	sendPayloadJSONResult(ctx, client, frame, string(data))
+}
+
+func sendPayloadJSONResult(ctx context.Context, client GatewayRequester, frame NodeInvokeRequestPayload, payloadJSON string) {
+	client.Request(ctx, "node.invoke.result", NodeInvokeResultParams{
+		ID:          frame.ID,
+		NodeID:      frame.NodeID,
+		Ok:          true,
+		PayloadJSON: payloadJSON,
+	})
+}
+
+func sendErrorResult(ctx context.Context, client GatewayRequester, frame NodeInvokeRequestPayload, code, message string) {
+	client.Request(ctx, "node.invoke.result", NodeInvokeResultParams{
+		ID:     frame.ID,
+		NodeID: frame.NodeID,
+		Ok:     false,
+		Error:  &NodeInvokeResultError{Code: code, Message: message},
+	})
+}
+
+func sendNodeEvent(ctx context.Context, client GatewayRequester, event string, payload any) {
+	data, _ := json.Marshal(payload)
+	client.Request(ctx, "node.event", map[string]any{
+		"event":       event,
+		"payloadJSON": string(data),
+	})
+}

--- a/internal/nodehost/runner.go
+++ b/internal/nodehost/runner.go
@@ -76,7 +76,7 @@ func RunNodeHost(ctx context.Context, opts NodeHostRunOptions) error {
 	if port == 0 {
 		port = 18789
 	}
-	wsURL := fmt.Sprintf("%s://%s:%d", scheme, host, port)
+	wsURL := fmt.Sprintf("%s://%s:%d/ws", scheme, host, port)
 
 	pathEnv := ensureNodePathEnv()
 	skillBinsFetch := func(_ context.Context) ([]string, error) {
@@ -158,9 +158,9 @@ func connectAndRun(ctx context.Context, wsURL string, creds GatewayCredentials, 
 
 	client := &wsClient{conn: conn, mu: sync.Mutex{}}
 
-	// Send connect frame — auth happens here, not via HTTP headers.
-	connectFrame := map[string]any{
-		"type":              "connect",
+	// Send connect request — gateway expects type="req" with method="connect".
+	connectParams := map[string]any{
+		"token":             creds.Token,
 		"instanceId":        nodeID,
 		"clientName":        "node-host",
 		"clientDisplayName": displayName,
@@ -170,11 +170,14 @@ func connectAndRun(ctx context.Context, wsURL string, creds GatewayCredentials, 
 		"caps":              []string{"system"},
 		"commands":          NodeHostCommands,
 	}
-	if creds.Token != "" {
-		connectFrame["token"] = creds.Token
-	}
 	if creds.Password != "" {
-		connectFrame["password"] = creds.Password
+		connectParams["password"] = creds.Password
+	}
+	connectFrame := map[string]any{
+		"type":   "req",
+		"id":     "connect-1",
+		"method": "connect",
+		"params": connectParams,
 	}
 	if err := client.SendJSON(connectFrame); err != nil {
 		return fmt.Errorf("send connect: %w", err)

--- a/internal/nodehost/runner.go
+++ b/internal/nodehost/runner.go
@@ -1,0 +1,257 @@
+package nodehost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"os/signal"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// NodeHostRunOptions configures the node host runner.
+type NodeHostRunOptions struct {
+	GatewayHost           string
+	GatewayPort           int
+	GatewayTLS            bool
+	GatewayTLSFingerprint string
+	NodeID                string
+	DisplayName           string
+}
+
+// NodeHostCommands lists the RPC commands this node supports.
+var NodeHostCommands = []string{
+	"system.run",
+	"system.run.prepare",
+	"system.which",
+}
+
+// RunNodeHost is the main entry point for the node host service.
+// It connects to the gateway via WebSocket and handles RPC commands.
+func RunNodeHost(ctx context.Context, opts NodeHostRunOptions) error {
+	config, err := EnsureNodeHostConfig()
+	if err != nil {
+		return fmt.Errorf("ensure node config: %w", err)
+	}
+
+	nodeID := firstNonEmpty(opts.NodeID, config.NodeID)
+	if nodeID != config.NodeID {
+		config.NodeID = nodeID
+	}
+	displayName := firstNonEmpty(opts.DisplayName, config.DisplayName, hostname())
+	config.DisplayName = displayName
+
+	// Save updated config with gateway info.
+	config.Gateway = &NodeHostGatewayConfig{
+		Host:           opts.GatewayHost,
+		Port:           opts.GatewayPort,
+		TLS:            opts.GatewayTLS,
+		TLSFingerprint: opts.GatewayTLSFingerprint,
+	}
+	if err := SaveNodeHostConfig(config); err != nil {
+		slog.Warn("failed to save node config", "err", err)
+	}
+
+	// Resolve credentials from env.
+	creds := resolveGatewayCredentials()
+
+	// Build WS URL.
+	scheme := "ws"
+	if opts.GatewayTLS {
+		scheme = "wss"
+	}
+	host := opts.GatewayHost
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	port := opts.GatewayPort
+	if port == 0 {
+		port = 18789
+	}
+	wsURL := fmt.Sprintf("%s://%s:%d", scheme, host, port)
+
+	pathEnv := ensureNodePathEnv()
+	skillBinsFetch := func(_ context.Context) ([]string, error) {
+		return nil, nil // real impl would call skills.bins RPC
+	}
+	skillBins := NewSkillBinsCache(skillBinsFetch, pathEnv)
+
+	// Setup graceful shutdown.
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	slog.Info("node host starting", "url", wsURL, "nodeId", nodeID, "displayName", displayName)
+
+	// Connect loop with reconnect.
+	return runWithReconnect(ctx, wsURL, creds, nodeID, displayName, skillBins)
+}
+
+// GatewayCredentials holds authentication credentials.
+type GatewayCredentials struct {
+	Token    string
+	Password string
+}
+
+func resolveGatewayCredentials() GatewayCredentials {
+	return GatewayCredentials{
+		Token:    strings.TrimSpace(os.Getenv("GOCLAW_GATEWAY_TOKEN")),
+		Password: strings.TrimSpace(os.Getenv("GOCLAW_GATEWAY_PASSWORD")),
+	}
+}
+
+func ensureNodePathEnv() string {
+	current := os.Getenv("PATH")
+	if strings.TrimSpace(current) != "" {
+		return current
+	}
+	fallback := "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	os.Setenv("PATH", fallback)
+	return fallback
+}
+
+// --- WebSocket connect loop ---
+
+func runWithReconnect(ctx context.Context, wsURL string, creds GatewayCredentials, nodeID, displayName string, skillBins *SkillBinsCache) error {
+	backoff := time.Second
+	maxBackoff := 30 * time.Second
+
+	for {
+		start := time.Now()
+		err := connectAndRun(ctx, wsURL, creds, nodeID, displayName, skillBins)
+		if ctx.Err() != nil {
+			slog.Info("node host shutting down")
+			return ctx.Err()
+		}
+		// Reset backoff if the connection lasted more than 60s (was healthy).
+		if time.Since(start) > 60*time.Second {
+			backoff = time.Second
+		}
+		slog.Warn("node host disconnected, reconnecting", "err", err, "backoff", backoff)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, maxBackoff)
+	}
+}
+
+func connectAndRun(ctx context.Context, wsURL string, creds GatewayCredentials, nodeID, displayName string, skillBins *SkillBinsCache) error {
+	u, err := url.Parse(wsURL)
+	if err != nil {
+		return fmt.Errorf("parse url: %w", err)
+	}
+
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	defer conn.Close()
+
+	client := &wsClient{conn: conn, mu: sync.Mutex{}}
+
+	// Send connect frame — auth happens here, not via HTTP headers.
+	connectFrame := map[string]any{
+		"type":              "connect",
+		"instanceId":        nodeID,
+		"clientName":        "node-host",
+		"clientDisplayName": displayName,
+		"platform":          runtime.GOOS,
+		"mode":              "node",
+		"role":              "node",
+		"caps":              []string{"system"},
+		"commands":          NodeHostCommands,
+	}
+	if creds.Token != "" {
+		connectFrame["token"] = creds.Token
+	}
+	if creds.Password != "" {
+		connectFrame["password"] = creds.Password
+	}
+	if err := client.SendJSON(connectFrame); err != nil {
+		return fmt.Errorf("send connect: %w", err)
+	}
+
+	slog.Info("node host connected", "url", wsURL)
+
+	// Read message loop.
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			return fmt.Errorf("read: %w", err)
+		}
+		go handleWSMessage(ctx, message, client, skillBins)
+	}
+}
+
+func handleWSMessage(ctx context.Context, message []byte, client *wsClient, skillBins *SkillBinsCache) {
+	var frame struct {
+		Type    string          `json:"type"`
+		Event   string          `json:"event"`
+		Payload json.RawMessage `json:"payload"`
+	}
+	if json.Unmarshal(message, &frame) != nil {
+		return
+	}
+	if frame.Type != "event" || frame.Event != "node.invoke.request" {
+		return
+	}
+	payload := CoerceNodeInvokePayload(frame.Payload)
+	if payload == nil {
+		slog.Warn("invalid node invoke payload")
+		return
+	}
+	HandleInvoke(ctx, *payload, client, skillBins)
+}
+
+// --- wsClient implements GatewayRequester ---
+
+type wsClient struct {
+	conn *websocket.Conn
+	mu   sync.Mutex
+}
+
+func (c *wsClient) SendJSON(v any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conn.WriteJSON(v)
+}
+
+func (c *wsClient) Request(ctx context.Context, method string, params any) error {
+	frame := map[string]any{
+		"type":   "req",
+		"method": method,
+		"params": params,
+	}
+	return c.SendJSON(frame)
+}
+
+// --- Helpers ---
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func hostname() string {
+	name, _ := os.Hostname()
+	if name == "" {
+		return "node"
+	}
+	return name
+}

--- a/internal/nodehost/runner_test.go
+++ b/internal/nodehost/runner_test.go
@@ -1,0 +1,223 @@
+package nodehost
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- SkillBinsCache tests ---
+
+func TestSkillBinsCache_ReturnsCached(t *testing.T) {
+	calls := 0
+	// Use "sh" which exists in /usr/bin on all unix systems.
+	cache := NewSkillBinsCache(func(_ context.Context) ([]string, error) {
+		calls++
+		return []string{"sh"}, nil
+	}, "/usr/bin:/bin")
+
+	bins1, _ := cache.Current(false)
+	bins2, _ := cache.Current(false)
+
+	if calls != 1 {
+		t.Errorf("expected 1 fetch call, got %d", calls)
+	}
+	_ = bins1
+	_ = bins2
+	// Even if resolution fails on some platforms, the fetch should only be called once.
+}
+
+func TestSkillBinsCache_ForceRefresh(t *testing.T) {
+	calls := 0
+	cache := NewSkillBinsCache(func(_ context.Context) ([]string, error) {
+		calls++
+		return []string{"sh"}, nil
+	}, "/usr/bin:/bin")
+
+	cache.Current(false)
+	cache.Current(true)
+
+	if calls != 2 {
+		t.Errorf("expected 2 fetch calls with force, got %d", calls)
+	}
+}
+
+func TestSkillBinsCache_ThreadSafe(t *testing.T) {
+	cache := NewSkillBinsCache(func(_ context.Context) ([]string, error) {
+		time.Sleep(10 * time.Millisecond)
+		return []string{"tsx"}, nil
+	}, "/usr/bin")
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.Current(false)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSkillBinsCache_Deduplication(t *testing.T) {
+	entries := resolveSkillBinTrustEntries([]string{"tsx", "tsx", ""}, "/nonexistent")
+	// All should be empty since /nonexistent doesn't contain tsx.
+	if len(entries) != 0 {
+		t.Errorf("expected empty entries for missing bins, got %d", len(entries))
+	}
+}
+
+// --- CoerceNodeInvokePayload tests ---
+
+func TestCoercePayload_Valid(t *testing.T) {
+	raw := json.RawMessage(`{"id":"inv-1","nodeId":"n1","command":"system.run","paramsJSON":"{\"command\":[\"echo\"]}"}`)
+	p := CoerceNodeInvokePayload(raw)
+	if p == nil {
+		t.Fatal("expected non-nil payload")
+	}
+	if p.ID != "inv-1" || p.NodeID != "n1" || p.Command != "system.run" {
+		t.Errorf("unexpected payload: %+v", p)
+	}
+	if p.ParamsJSON == nil || *p.ParamsJSON != `{"command":["echo"]}` {
+		t.Errorf("paramsJSON mismatch: %v", p.ParamsJSON)
+	}
+}
+
+func TestCoercePayload_MissingFields(t *testing.T) {
+	tests := []string{
+		`{}`,
+		`{"id":"a"}`,
+		`{"id":"a","nodeId":"b"}`,
+		`not json`,
+	}
+	for _, raw := range tests {
+		p := CoerceNodeInvokePayload(json.RawMessage(raw))
+		if p != nil {
+			t.Errorf("expected nil for %q, got %+v", raw, p)
+		}
+	}
+}
+
+func TestCoercePayload_ParamsObjectFallback(t *testing.T) {
+	raw := json.RawMessage(`{"id":"inv-1","nodeId":"n1","command":"test","params":{"key":"val"}}`)
+	p := CoerceNodeInvokePayload(raw)
+	if p == nil {
+		t.Fatal("expected non-nil")
+	}
+	if p.ParamsJSON == nil || *p.ParamsJSON != `{"key":"val"}` {
+		t.Errorf("expected params object serialized to paramsJSON, got: %v", p.ParamsJSON)
+	}
+}
+
+// --- Credential resolution tests ---
+
+func TestResolveCredentials_FromEnv(t *testing.T) {
+	t.Setenv("GOCLAW_GATEWAY_TOKEN", "my-token")
+	t.Setenv("GOCLAW_GATEWAY_PASSWORD", "my-pass")
+	creds := resolveGatewayCredentials()
+	if creds.Token != "my-token" {
+		t.Errorf("token = %q, want my-token", creds.Token)
+	}
+	if creds.Password != "my-pass" {
+		t.Errorf("password = %q, want my-pass", creds.Password)
+	}
+}
+
+func TestResolveCredentials_EmptyEnv(t *testing.T) {
+	t.Setenv("GOCLAW_GATEWAY_TOKEN", "")
+	t.Setenv("GOCLAW_GATEWAY_PASSWORD", "")
+	creds := resolveGatewayCredentials()
+	if creds.Token != "" || creds.Password != "" {
+		t.Errorf("expected empty credentials, got: %+v", creds)
+	}
+}
+
+// --- RPC dispatch routing tests ---
+
+type mockRequester struct {
+	mu       sync.Mutex
+	requests []mockRequest
+}
+
+type mockRequest struct {
+	Method string
+	Params json.RawMessage
+}
+
+func (m *mockRequester) Request(_ context.Context, method string, params any) error {
+	data, _ := json.Marshal(params)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requests = append(m.requests, mockRequest{Method: method, Params: data})
+	return nil
+}
+
+func TestDispatch_SystemWhich(t *testing.T) {
+	client := &mockRequester{}
+	paramsJSON := `{"bins":["echo","sh"]}`
+	frame := NodeInvokeRequestPayload{
+		ID: "inv-1", NodeID: "n1", Command: "system.which",
+		ParamsJSON: &paramsJSON,
+	}
+	HandleInvoke(context.Background(), frame, client, nil)
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.requests) == 0 {
+		t.Fatal("expected at least one request sent")
+	}
+	if client.requests[0].Method != "node.invoke.result" {
+		t.Errorf("method = %q, want node.invoke.result", client.requests[0].Method)
+	}
+}
+
+func TestDispatch_UnknownCommand(t *testing.T) {
+	client := &mockRequester{}
+	frame := NodeInvokeRequestPayload{
+		ID: "inv-1", NodeID: "n1", Command: "unknown.command",
+	}
+	HandleInvoke(context.Background(), frame, client, nil)
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.requests) == 0 {
+		t.Fatal("expected error response")
+	}
+	var result NodeInvokeResultParams
+	json.Unmarshal(client.requests[0].Params, &result)
+	if result.Ok {
+		t.Error("expected ok=false for unknown command")
+	}
+}
+
+// --- firstNonEmpty tests ---
+
+func TestFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		values []string
+		want   string
+	}{
+		{[]string{"", "", "c"}, "c"},
+		{[]string{"a", "b"}, "a"},
+		{[]string{" ", "b"}, "b"},
+		{[]string{}, ""},
+	}
+	for _, tt := range tests {
+		got := firstNonEmpty(tt.values...)
+		if got != tt.want {
+			t.Errorf("firstNonEmpty(%v) = %q, want %q", tt.values, got, tt.want)
+		}
+	}
+}
+
+// --- ensureNodePathEnv test ---
+
+func TestEnsureNodePathEnv_PreservesExisting(t *testing.T) {
+	t.Setenv("PATH", "/custom/bin")
+	got := ensureNodePathEnv()
+	if got != "/custom/bin" {
+		t.Errorf("expected preserved PATH, got %q", got)
+	}
+}

--- a/internal/nodehost/sanitize_env.go
+++ b/internal/nodehost/sanitize_env.go
@@ -1,0 +1,150 @@
+package nodehost
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Blocked env keys — never allowed in inherited or overridden environments.
+var blockedEnvKeys = newSet(
+	"NODE_OPTIONS", "NODE_PATH",
+	"PYTHONHOME", "PYTHONPATH",
+	"PERL5LIB", "PERL5OPT",
+	"RUBYLIB", "RUBYOPT",
+	"BASH_ENV", "ENV", "BROWSER",
+	"GIT_EDITOR", "GIT_EXTERNAL_DIFF", "GIT_EXEC_PATH",
+	"GIT_SEQUENCE_EDITOR", "GIT_TEMPLATE_DIR",
+	"GIT_SSL_NO_VERIFY", "GIT_SSL_CAINFO", "GIT_SSL_CAPATH",
+	"CC", "CXX", "CARGO_BUILD_RUSTC", "CMAKE_C_COMPILER", "CMAKE_CXX_COMPILER",
+	"SHELL", "SHELLOPTS", "PS4", "GCONV_PATH", "IFS", "SSLKEYLOGFILE",
+	"JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS",
+	"PYTHONBREAKPOINT", "DOTNET_STARTUP_HOOKS", "DOTNET_ADDITIONAL_DEPS",
+	"GLIBC_TUNABLES", "MAVEN_OPTS", "SBT_OPTS", "GRADLE_OPTS", "ANT_OPTS",
+)
+
+// Blocked env prefixes — any key starting with these is blocked.
+var blockedEnvPrefixes = []string{"DYLD_", "LD_", "BASH_FUNC_"}
+
+// Blocked override-only keys — blocked when provided as overrides but allowed when inherited.
+var blockedOverrideKeys = newSet(
+	"HOME", "GRADLE_USER_HOME", "ZDOTDIR",
+	"GIT_SSH_COMMAND", "GIT_SSH", "GIT_PROXY_COMMAND", "GIT_ASKPASS",
+	"GIT_SSL_NO_VERIFY", "GIT_SSL_CAINFO", "GIT_SSL_CAPATH",
+	"SSH_ASKPASS", "LESSOPEN", "LESSCLOSE", "PAGER", "MANPAGER", "GIT_PAGER",
+	"EDITOR", "VISUAL", "FCEDIT", "SUDO_EDITOR",
+	"PROMPT_COMMAND", "HISTFILE",
+	"PERL5DB", "PERL5DBCMD",
+	"OPENSSL_CONF", "OPENSSL_ENGINES",
+	"PYTHONSTARTUP", "WGETRC", "CURL_HOME",
+	"CLASSPATH", "CGO_CFLAGS", "CGO_LDFLAGS", "GOFLAGS",
+	"CORECLR_PROFILER_PATH", "PHPRC", "PHP_INI_SCAN_DIR",
+	"DENO_DIR", "BUN_CONFIG_REGISTRY",
+	"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+	"NODE_TLS_REJECT_UNAUTHORIZED", "NODE_EXTRA_CA_CERTS",
+	"SSL_CERT_FILE", "SSL_CERT_DIR", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE",
+	"DOCKER_HOST", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH", "DOCKER_CONTEXT",
+	"PIP_INDEX_URL", "PIP_PYPI_URL", "PIP_EXTRA_INDEX_URL",
+	"PIP_CONFIG_FILE", "PIP_FIND_LINKS", "PIP_TRUSTED_HOST",
+	"UV_INDEX", "UV_INDEX_URL", "UV_EXTRA_INDEX_URL", "UV_DEFAULT_INDEX",
+	"LIBRARY_PATH", "CPATH", "C_INCLUDE_PATH", "CPLUS_INCLUDE_PATH", "OBJC_INCLUDE_PATH",
+	"GOPROXY", "GONOSUMCHECK", "GONOSUMDB", "GONOPROXY", "GOPRIVATE", "GOENV", "GOPATH",
+	"PYTHONUSERBASE", "VIRTUAL_ENV",
+	"LUA_PATH", "LUA_CPATH", "GEM_HOME", "GEM_PATH", "BUNDLE_GEMFILE",
+	"COMPOSER_HOME", "XDG_CONFIG_HOME", "AWS_CONFIG_FILE",
+)
+
+// Blocked override prefixes.
+var blockedOverridePrefixes = []string{"GIT_CONFIG_", "NPM_CONFIG_"}
+
+// Shell wrapper allowed override keys — only these are passed through when shell wrapping.
+var shellWrapperAllowedOverrideKeys = newSet(
+	"TERM", "LANG", "LC_ALL", "LC_CTYPE", "LC_MESSAGES",
+	"COLORTERM", "NO_COLOR", "FORCE_COLOR",
+)
+
+var portableEnvVarKey = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// isDangerousEnvKey checks if a key is in the blocked keys or has a blocked prefix.
+func isDangerousEnvKey(key string) bool {
+	upper := strings.ToUpper(key)
+	if blockedEnvKeys[upper] {
+		return true
+	}
+	for _, prefix := range blockedEnvPrefixes {
+		if strings.HasPrefix(upper, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// isDangerousOverrideKey checks if a key is blocked for overrides.
+func isDangerousOverrideKey(key string) bool {
+	upper := strings.ToUpper(key)
+	if blockedOverrideKeys[upper] {
+		return true
+	}
+	for _, prefix := range blockedOverridePrefixes {
+		if strings.HasPrefix(upper, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// SanitizeEnv builds a sanitized environment by merging the process env with optional overrides.
+// Blocks dangerous keys, PATH overrides, and override-only restricted keys.
+func SanitizeEnv(overrides map[string]string) map[string]string {
+	merged := make(map[string]string)
+
+	// Copy inherited env, dropping dangerous keys.
+	for _, entry := range os.Environ() {
+		k, v, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if isDangerousEnvKey(k) {
+			continue
+		}
+		merged[k] = v
+	}
+
+	// Apply overrides, blocking dangerous and override-only keys.
+	for k, v := range overrides {
+		upper := strings.ToUpper(k)
+		if upper == "PATH" {
+			continue
+		}
+		if isDangerousEnvKey(k) || isDangerousOverrideKey(k) {
+			continue
+		}
+		merged[k] = v
+	}
+	return merged
+}
+
+// SanitizeSystemRunEnvOverrides filters overrides for shell wrapper contexts.
+// For shell wrappers, only terminal/locale vars are allowed.
+func SanitizeSystemRunEnvOverrides(overrides map[string]string, shellWrapper bool) map[string]string {
+	if overrides == nil {
+		return nil
+	}
+	if !shellWrapper {
+		return overrides
+	}
+	filtered := make(map[string]string)
+	for k, v := range overrides {
+		if !portableEnvVarKey.MatchString(k) {
+			continue
+		}
+		if !shellWrapperAllowedOverrideKeys[strings.ToUpper(k)] {
+			continue
+		}
+		filtered[k] = v
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}

--- a/internal/nodehost/sanitize_env_test.go
+++ b/internal/nodehost/sanitize_env_test.go
@@ -1,0 +1,129 @@
+package nodehost
+
+import "testing"
+
+func TestSanitizeEnv_BlocksPATH(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	env := SanitizeEnv(map[string]string{"PATH": "/tmp/evil:/usr/bin"})
+	if env["PATH"] != "/usr/bin" {
+		t.Errorf("PATH = %q, want /usr/bin", env["PATH"])
+	}
+}
+
+func TestSanitizeEnv_BlocksDangerousKeys(t *testing.T) {
+	t.Setenv("FOO", "")
+	env := SanitizeEnv(map[string]string{
+		"PYTHONPATH": "/tmp/pwn",
+		"LD_PRELOAD": "/tmp/pwn.so",
+		"BASH_ENV":   "/tmp/pwn.sh",
+		"SHELLOPTS":  "xtrace",
+		"PS4":        "$(touch /tmp/pwned)",
+		"FOO":        "bar",
+	})
+	if env["FOO"] != "bar" {
+		t.Errorf("FOO should be preserved: %q", env["FOO"])
+	}
+	for _, key := range []string{"PYTHONPATH", "LD_PRELOAD", "BASH_ENV", "SHELLOPTS", "PS4"} {
+		if _, ok := env[key]; ok {
+			t.Errorf("%s should be blocked", key)
+		}
+	}
+}
+
+func TestSanitizeEnv_BlocksOverrideOnlyKeys(t *testing.T) {
+	t.Setenv("HOME", "/Users/trusted")
+	t.Setenv("ZDOTDIR", "/Users/trusted/.zdot")
+	env := SanitizeEnv(map[string]string{
+		"HOME":    "/tmp/evil-home",
+		"ZDOTDIR": "/tmp/evil-zdotdir",
+	})
+	if env["HOME"] != "/Users/trusted" {
+		t.Errorf("HOME = %q, want /Users/trusted", env["HOME"])
+	}
+	if env["ZDOTDIR"] != "/Users/trusted/.zdot" {
+		t.Errorf("ZDOTDIR = %q, want /Users/trusted/.zdot", env["ZDOTDIR"])
+	}
+}
+
+func TestSanitizeEnv_DropsDangerousInheritedKeys(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("BASH_ENV", "/tmp/pwn.sh")
+	env := SanitizeEnv(nil)
+	if env["PATH"] != "/usr/bin:/bin" {
+		t.Errorf("PATH should be preserved")
+	}
+	if _, ok := env["BASH_ENV"]; ok {
+		t.Errorf("BASH_ENV should be dropped from inherited env")
+	}
+}
+
+func TestSanitizeEnv_BlocksDYLDPrefix(t *testing.T) {
+	env := SanitizeEnv(map[string]string{
+		"DYLD_INSERT_LIBRARIES": "/tmp/evil.dylib",
+		"DYLD_LIBRARY_PATH":    "/tmp",
+	})
+	if _, ok := env["DYLD_INSERT_LIBRARIES"]; ok {
+		t.Error("DYLD_INSERT_LIBRARIES should be blocked")
+	}
+	if _, ok := env["DYLD_LIBRARY_PATH"]; ok {
+		t.Error("DYLD_LIBRARY_PATH should be blocked")
+	}
+}
+
+func TestSanitizeEnv_BlocksLDPrefix(t *testing.T) {
+	env := SanitizeEnv(map[string]string{
+		"LD_PRELOAD":      "/tmp/evil.so",
+		"LD_LIBRARY_PATH": "/tmp",
+	})
+	if _, ok := env["LD_PRELOAD"]; ok {
+		t.Error("LD_PRELOAD should be blocked")
+	}
+}
+
+func TestSanitizeEnv_PreservesNormalOverrides(t *testing.T) {
+	env := SanitizeEnv(map[string]string{
+		"MY_VAR":  "hello",
+		"LANG":    "en_US.UTF-8",
+		"TERM":    "xterm-256color",
+	})
+	if env["MY_VAR"] != "hello" {
+		t.Error("MY_VAR should be preserved")
+	}
+	if env["LANG"] != "en_US.UTF-8" {
+		t.Error("LANG should be preserved")
+	}
+}
+
+func TestSanitizeSystemRunEnvOverrides_ShellWrapper(t *testing.T) {
+	overrides := map[string]string{
+		"TERM":       "xterm",
+		"LANG":       "en_US.UTF-8",
+		"MY_VAR":     "blocked-in-shell",
+		"NODE_DEBUG": "should-not-pass",
+	}
+	result := SanitizeSystemRunEnvOverrides(overrides, true)
+	if result["TERM"] != "xterm" {
+		t.Error("TERM should pass through for shell wrapper")
+	}
+	if result["LANG"] != "en_US.UTF-8" {
+		t.Error("LANG should pass through for shell wrapper")
+	}
+	if _, ok := result["MY_VAR"]; ok {
+		t.Error("MY_VAR should be blocked in shell wrapper context")
+	}
+}
+
+func TestSanitizeSystemRunEnvOverrides_NonShell(t *testing.T) {
+	overrides := map[string]string{"MY_VAR": "hello", "FOO": "bar"}
+	result := SanitizeSystemRunEnvOverrides(overrides, false)
+	if result["MY_VAR"] != "hello" || result["FOO"] != "bar" {
+		t.Error("non-shell overrides should pass through unchanged")
+	}
+}
+
+func TestSanitizeSystemRunEnvOverrides_NilInput(t *testing.T) {
+	result := SanitizeSystemRunEnvOverrides(nil, false)
+	if result != nil {
+		t.Error("nil input should return nil")
+	}
+}

--- a/internal/nodehost/shell_argv.go
+++ b/internal/nodehost/shell_argv.go
@@ -1,0 +1,83 @@
+package nodehost
+
+import "unicode"
+
+// doubleQuoteEscapes are the characters that can be escaped inside double quotes.
+var doubleQuoteEscapes = map[byte]bool{
+	'\\': true, '"': true, '$': true, '`': true, '\n': true, '\r': true,
+}
+
+// SplitShellArgs tokenizes a POSIX shell command string into argv tokens.
+// Returns nil if the input has unterminated quotes or trailing escapes.
+func SplitShellArgs(raw string) []string {
+	var tokens []string
+	var buf []byte
+	inSingle := false
+	inDouble := false
+	escaped := false
+
+	pushToken := func() {
+		if len(buf) > 0 {
+			tokens = append(tokens, string(buf))
+			buf = buf[:0]
+		}
+	}
+
+	for i := 0; i < len(raw); i++ {
+		ch := raw[i]
+
+		if escaped {
+			buf = append(buf, ch)
+			escaped = false
+			continue
+		}
+		if !inSingle && !inDouble && ch == '\\' {
+			escaped = true
+			continue
+		}
+		if inSingle {
+			if ch == '\'' {
+				inSingle = false
+			} else {
+				buf = append(buf, ch)
+			}
+			continue
+		}
+		if inDouble {
+			if ch == '\\' && i+1 < len(raw) && doubleQuoteEscapes[raw[i+1]] {
+				buf = append(buf, raw[i+1])
+				i++
+				continue
+			}
+			if ch == '"' {
+				inDouble = false
+			} else {
+				buf = append(buf, ch)
+			}
+			continue
+		}
+		if ch == '\'' {
+			inSingle = true
+			continue
+		}
+		if ch == '"' {
+			inDouble = true
+			continue
+		}
+		// In POSIX shells, "#" starts a comment only when it begins a word.
+		if ch == '#' && len(buf) == 0 {
+			break
+		}
+		if unicode.IsSpace(rune(ch)) {
+			pushToken()
+			continue
+		}
+		buf = append(buf, ch)
+	}
+
+	if escaped || inSingle || inDouble {
+		return nil
+	}
+	pushToken()
+	return tokens
+}

--- a/internal/nodehost/shell_inline_command.go
+++ b/internal/nodehost/shell_inline_command.go
@@ -1,0 +1,65 @@
+package nodehost
+
+import (
+	"regexp"
+	"strings"
+)
+
+// PosixInlineCommandFlags are the flags that introduce an inline command in POSIX shells.
+var PosixInlineCommandFlags = newSet("-lc", "-c", "--command")
+
+// InlineCommandMatch holds the result of searching for an inline command flag.
+type InlineCommandMatch struct {
+	Command         *string // the inline command text, or nil
+	ValueTokenIndex *int    // index of the value token, or nil
+}
+
+var combinedCRe = regexp.MustCompile(`(?i)^-[^-]*c[^-]*$`)
+
+// ResolveInlineCommandMatch scans argv for a shell inline command flag.
+// If allowCombinedC is true, handles combined short flags like "-lc".
+func ResolveInlineCommandMatch(argv []string, flags map[string]bool, allowCombinedC bool) InlineCommandMatch {
+	for i := 1; i < len(argv); i++ {
+		token := strings.TrimSpace(safeIndex(argv, i))
+		if token == "" {
+			continue
+		}
+		lower := strings.ToLower(token)
+		if lower == "--" {
+			break
+		}
+		if flags[lower] {
+			var cmd *string
+			var vidx *int
+			if i+1 < len(argv) {
+				idx := i + 1
+				vidx = &idx
+				v := strings.TrimSpace(argv[i+1])
+				if v != "" {
+					cmd = &v
+				}
+			}
+			return InlineCommandMatch{Command: cmd, ValueTokenIndex: vidx}
+		}
+		if allowCombinedC && combinedCRe.MatchString(token) {
+			cIdx := strings.Index(strings.ToLower(token), "c")
+			inline := strings.TrimSpace(token[cIdx+1:])
+			if inline != "" {
+				idx := i
+				return InlineCommandMatch{Command: &inline, ValueTokenIndex: &idx}
+			}
+			var cmd *string
+			var vidx *int
+			if i+1 < len(argv) {
+				idx := i + 1
+				vidx = &idx
+				v := strings.TrimSpace(argv[i+1])
+				if v != "" {
+					cmd = &v
+				}
+			}
+			return InlineCommandMatch{Command: cmd, ValueTokenIndex: vidx}
+		}
+	}
+	return InlineCommandMatch{}
+}

--- a/internal/nodehost/shell_wrapper.go
+++ b/internal/nodehost/shell_wrapper.go
@@ -1,0 +1,179 @@
+package nodehost
+
+import "strings"
+
+// PosixShellWrappers is the set of POSIX shell executable names.
+var PosixShellWrappers = newSet("ash", "bash", "dash", "fish", "ksh", "sh", "zsh")
+
+var windowsCmdWrappers = newSet("cmd", "cmd.exe")
+var powershellWrappers = newSet("powershell", "pwsh", "powershell.exe", "pwsh.exe")
+var shellMultiplexerWrappers = newSet("busybox", "toybox")
+var allShellWrappers = newSet("ash", "bash", "dash", "fish", "ksh", "sh", "zsh", "cmd", "powershell", "pwsh")
+
+// ShellMultiplexerUnwrapResult is the result of attempting to unwrap a shell multiplexer.
+type ShellMultiplexerUnwrapResult struct {
+	Kind    string   // "not-wrapper", "blocked", "unwrapped"
+	Wrapper string
+	Argv    []string
+}
+
+// UnwrapKnownShellMultiplexerInvocation unwraps busybox/toybox → shell invocations.
+func UnwrapKnownShellMultiplexerInvocation(argv []string) ShellMultiplexerUnwrapResult {
+	token0 := strings.TrimSpace(safeIndex(argv, 0))
+	if token0 == "" {
+		return ShellMultiplexerUnwrapResult{Kind: "not-wrapper"}
+	}
+	wrapper := NormalizeExecutableToken(token0)
+	if !shellMultiplexerWrappers[wrapper] {
+		return ShellMultiplexerUnwrapResult{Kind: "not-wrapper"}
+	}
+	appletIdx := 1
+	if strings.TrimSpace(safeIndex(argv, appletIdx)) == "--" {
+		appletIdx++
+	}
+	applet := strings.TrimSpace(safeIndex(argv, appletIdx))
+	if applet == "" || !IsShellWrapperExecutable(applet) {
+		return ShellMultiplexerUnwrapResult{Kind: "blocked", Wrapper: wrapper}
+	}
+	unwrapped := argv[appletIdx:]
+	if len(unwrapped) == 0 {
+		return ShellMultiplexerUnwrapResult{Kind: "blocked", Wrapper: wrapper}
+	}
+	return ShellMultiplexerUnwrapResult{Kind: "unwrapped", Wrapper: wrapper, Argv: unwrapped}
+}
+
+// IsShellWrapperExecutable checks if a token names a known shell wrapper.
+func IsShellWrapperExecutable(token string) bool {
+	return allShellWrappers[NormalizeExecutableToken(token)]
+}
+
+// ShellWrapperCommand holds the result of extracting a shell wrapper payload.
+type ShellWrapperCommand struct {
+	IsWrapper bool
+	Command   *string // the shell payload text
+}
+
+// ExtractShellWrapperCommand extracts the inline command from a shell wrapper invocation.
+func ExtractShellWrapperCommand(argv []string, rawCommand *string) ShellWrapperCommand {
+	return extractShellWrapperCommandInternal(argv, rawCommand, 0)
+}
+
+func extractShellWrapperCommandInternal(argv []string, rawCommand *string, depth int) ShellWrapperCommand {
+	if depth > MaxDispatchWrapperDepth {
+		return ShellWrapperCommand{}
+	}
+	token0 := strings.TrimSpace(safeIndex(argv, 0))
+	if token0 == "" {
+		return ShellWrapperCommand{}
+	}
+
+	// Try dispatch wrapper unwrap.
+	dispatch := UnwrapKnownDispatchWrapperInvocation(argv)
+	if dispatch.Kind == "blocked" {
+		return ShellWrapperCommand{}
+	}
+	if dispatch.Kind == "unwrapped" {
+		return extractShellWrapperCommandInternal(dispatch.Argv, rawCommand, depth+1)
+	}
+
+	// Try shell multiplexer unwrap.
+	mux := UnwrapKnownShellMultiplexerInvocation(argv)
+	if mux.Kind == "blocked" {
+		return ShellWrapperCommand{}
+	}
+	if mux.Kind == "unwrapped" {
+		return extractShellWrapperCommandInternal(mux.Argv, rawCommand, depth+1)
+	}
+
+	// Check if this is a shell wrapper itself.
+	exe := NormalizeExecutableToken(token0)
+	payload := extractShellPayload(argv, exe)
+	if payload == nil {
+		return ShellWrapperCommand{}
+	}
+	cmd := rawCommand
+	if cmd == nil {
+		cmd = payload
+	}
+	return ShellWrapperCommand{IsWrapper: true, Command: cmd}
+}
+
+// extractShellPayload extracts the inline command from a shell invocation.
+func extractShellPayload(argv []string, exe string) *string {
+	switch {
+	case PosixShellWrappers[exe]:
+		return extractPosixShellInlineCommand(argv)
+	case windowsCmdWrappers[exe]:
+		return extractCmdInlineCommand(argv)
+	case powershellWrappers[exe]:
+		return extractPowershellInlineCommand(argv)
+	default:
+		return nil
+	}
+}
+
+func extractPosixShellInlineCommand(argv []string) *string {
+	m := ResolveInlineCommandMatch(argv, PosixInlineCommandFlags, true)
+	return m.Command
+}
+
+func extractCmdInlineCommand(argv []string) *string {
+	for i, item := range argv {
+		lower := strings.ToLower(strings.TrimSpace(item))
+		if lower == "/c" || lower == "/k" {
+			tail := argv[i+1:]
+			if len(tail) == 0 {
+				return nil
+			}
+			cmd := strings.TrimSpace(strings.Join(tail, " "))
+			if cmd == "" {
+				return nil
+			}
+			return &cmd
+		}
+	}
+	return nil
+}
+
+func extractPowershellInlineCommand(argv []string) *string {
+	psFlags := newSet("-c", "-command", "--command", "-f", "-file", "-encodedcommand", "-enc", "-e")
+	m := ResolveInlineCommandMatch(argv, psFlags, false)
+	return m.Command
+}
+
+// HasEnvManipulationBeforeShellWrapper checks if env modifies the environment
+// before a shell wrapper in the argv chain.
+func HasEnvManipulationBeforeShellWrapper(argv []string) bool {
+	return hasEnvManipBeforeShellInternal(argv, 0, false)
+}
+
+func hasEnvManipBeforeShellInternal(argv []string, depth int, envSeen bool) bool {
+	if depth > MaxDispatchWrapperDepth {
+		return false
+	}
+	token0 := strings.TrimSpace(safeIndex(argv, 0))
+	if token0 == "" {
+		return false
+	}
+	dispatch := UnwrapKnownDispatchWrapperInvocation(argv)
+	if dispatch.Kind == "blocked" {
+		return false
+	}
+	if dispatch.Kind == "unwrapped" {
+		nextEnvSeen := envSeen || HasDispatchEnvManipulation(argv)
+		return hasEnvManipBeforeShellInternal(dispatch.Argv, depth+1, nextEnvSeen)
+	}
+	mux := UnwrapKnownShellMultiplexerInvocation(argv)
+	if mux.Kind == "blocked" {
+		return false
+	}
+	if mux.Kind == "unwrapped" {
+		return hasEnvManipBeforeShellInternal(mux.Argv, depth+1, envSeen)
+	}
+	exe := NormalizeExecutableToken(token0)
+	payload := extractShellPayload(argv, exe)
+	if payload == nil {
+		return false
+	}
+	return envSeen
+}

--- a/internal/nodehost/skill_bins.go
+++ b/internal/nodehost/skill_bins.go
@@ -1,0 +1,125 @@
+package nodehost
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SkillBinsCache provides thread-safe access to trusted skill binary entries with a TTL.
+type SkillBinsCache struct {
+	mu          sync.RWMutex
+	bins        []SkillBinTrustEntry
+	lastRefresh time.Time
+	ttl         time.Duration
+	fetch       func(ctx context.Context) ([]string, error)
+	pathEnv     string
+}
+
+// NewSkillBinsCache creates a new cache with a 90s TTL.
+func NewSkillBinsCache(fetch func(ctx context.Context) ([]string, error), pathEnv string) *SkillBinsCache {
+	return &SkillBinsCache{
+		ttl:     90 * time.Second,
+		fetch:   fetch,
+		pathEnv: pathEnv,
+	}
+}
+
+// Current returns cached entries, refreshing if TTL expired or force is true.
+func (c *SkillBinsCache) Current(force bool) ([]SkillBinTrustEntry, error) {
+	c.mu.RLock()
+	if !force && time.Since(c.lastRefresh) < c.ttl {
+		bins := c.bins
+		c.mu.RUnlock()
+		return bins, nil
+	}
+	c.mu.RUnlock()
+
+	c.doRefresh(force)
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.bins, nil
+}
+
+func (c *SkillBinsCache) doRefresh(force bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock (skip if forced).
+	if !force && time.Since(c.lastRefresh) < c.ttl {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	names, err := c.fetch(ctx)
+	if err != nil {
+		if c.lastRefresh.IsZero() {
+			c.bins = nil
+		}
+		return
+	}
+	c.bins = resolveSkillBinTrustEntries(names, c.pathEnv)
+	c.lastRefresh = time.Now()
+}
+
+// resolveSkillBinTrustEntries resolves binary names to path entries, deduplicating and sorting.
+func resolveSkillBinTrustEntries(names []string, pathEnv string) []SkillBinTrustEntry {
+	var entries []SkillBinTrustEntry
+	seen := make(map[string]bool)
+	for _, raw := range names {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		resolved := resolveExecutableFromPathEnv(name, pathEnv)
+		if resolved == "" {
+			continue
+		}
+		key := name + "\x00" + resolved
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		entries = append(entries, SkillBinTrustEntry{Name: name, ResolvedPath: resolved})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Name != entries[j].Name {
+			return entries[i].Name < entries[j].Name
+		}
+		return entries[i].ResolvedPath < entries[j].ResolvedPath
+	})
+	return entries
+}
+
+// resolveExecutableFromPathEnv resolves a binary name to its absolute path using PATH.
+func resolveExecutableFromPathEnv(bin, pathEnv string) string {
+	if strings.ContainsAny(bin, "/\\") {
+		return ""
+	}
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, bin)
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		// Check executable bit.
+		if info.Mode()&0o111 == 0 {
+			continue
+		}
+		abs, err := filepath.Abs(candidate)
+		if err == nil {
+			return abs
+		}
+	}
+	return ""
+}

--- a/internal/nodehost/system_run.go
+++ b/internal/nodehost/system_run.go
@@ -1,0 +1,275 @@
+package nodehost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// SystemRunDeniedError is returned when the system run is denied by policy.
+type SystemRunDeniedError struct {
+	Reason  SystemRunPolicyEventReason
+	Message string
+}
+
+func (e *SystemRunDeniedError) Error() string { return e.Message }
+
+// SystemRunInvokeResult is the result sent back to the gateway.
+type SystemRunInvokeResult struct {
+	Ok          bool   `json:"ok"`
+	PayloadJSON string `json:"payloadJSON,omitempty"`
+	ErrorCode   string `json:"errorCode,omitempty"`
+	ErrorMsg    string `json:"errorMessage,omitempty"`
+}
+
+// SystemRunDeps provides external dependencies for the system run pipeline.
+type SystemRunDeps struct {
+	// SendDeniedEvent dispatches an exec.denied event to the gateway.
+	SendDeniedEvent func(payload ExecEventPayload)
+	// SendFinishedEvent dispatches an exec.finished event.
+	SendFinishedEvent func(params ExecFinishedEventParams)
+	// SendResult sends the invoke result back.
+	SendResult func(result SystemRunInvokeResult)
+}
+
+// SystemRunExecutionContext holds per-invocation metadata.
+type SystemRunExecutionContext struct {
+	SessionKey           string
+	RunID                string
+	CommandText          string
+	SuppressNotifyOnExit bool
+}
+
+// HandleSystemRunInvoke executes the 3-phase system.run pipeline.
+func HandleSystemRunInvoke(ctx context.Context, params SystemRunParams, deps SystemRunDeps) {
+	// Phase 1: Parse
+	parsed := parseSystemRunPhase(params, deps)
+	if parsed == nil {
+		return
+	}
+
+	// Phase 2: Policy
+	policy := evaluateSystemRunPolicyPhase(parsed, deps)
+	if policy == nil {
+		return
+	}
+
+	// Phase 3: Execute
+	executeSystemRunPhase(ctx, parsed, policy, deps)
+}
+
+// --- Phase 1: Parse ---
+
+type parsedSystemRun struct {
+	argv                 []string
+	shellPayload         *string
+	commandText          string
+	execution            SystemRunExecutionContext
+	approvalDecision     *ExecApprovalDecision
+	env                  map[string]string
+	cwd                  string
+	timeoutMs            int
+	approved             bool
+	suppressNotifyOnExit bool
+	approvalPlan         *SystemRunApprovalPlan
+}
+
+func parseSystemRunPhase(params SystemRunParams, deps SystemRunDeps) *parsedSystemRun {
+	resolved := ResolveSystemRunCommandRequest(params.Command, params.RawCommand)
+	if !resolved.Ok {
+		deps.SendResult(SystemRunInvokeResult{Ok: false, ErrorCode: "INVALID_REQUEST", ErrorMsg: resolved.Message})
+		return nil
+	}
+	if len(resolved.Argv) == 0 {
+		deps.SendResult(SystemRunInvokeResult{Ok: false, ErrorCode: "INVALID_REQUEST", ErrorMsg: "command required"})
+		return nil
+	}
+
+	sessionKey := "node"
+	if params.SessionKey != nil && strings.TrimSpace(*params.SessionKey) != "" {
+		sessionKey = strings.TrimSpace(*params.SessionKey)
+	}
+	runID := ""
+	if params.RunID != nil && strings.TrimSpace(*params.RunID) != "" {
+		runID = strings.TrimSpace(*params.RunID)
+	}
+	if runID == "" {
+		id, _ := newUUID()
+		runID = id
+	}
+	suppressNotify := params.SuppressNotifyOnExit != nil && *params.SuppressNotifyOnExit
+
+	// Sanitize env overrides.
+	envOverrides := SanitizeSystemRunEnvOverrides(params.Env, resolved.ShellPayload != nil)
+	env := SanitizeEnv(envOverrides)
+
+	cwd := ""
+	if params.Cwd != nil {
+		cwd = strings.TrimSpace(*params.Cwd)
+	}
+	timeoutMs := 0
+	if params.TimeoutMs != nil {
+		timeoutMs = *params.TimeoutMs
+	}
+	approved := params.Approved != nil && *params.Approved
+	approvalDecision := ResolveExecApprovalDecision(stringOrEmpty(params.ApprovalDecision))
+
+	return &parsedSystemRun{
+		argv:         resolved.Argv,
+		shellPayload: resolved.ShellPayload,
+		commandText:  resolved.CommandText,
+		execution: SystemRunExecutionContext{
+			SessionKey:           sessionKey,
+			RunID:                runID,
+			CommandText:          resolved.CommandText,
+			SuppressNotifyOnExit: suppressNotify,
+		},
+		approvalDecision:     approvalDecision,
+		env:                  env,
+		cwd:                  cwd,
+		timeoutMs:            timeoutMs,
+		approved:             approved,
+		suppressNotifyOnExit: suppressNotify,
+		approvalPlan:         params.SystemRunPlan,
+	}
+}
+
+// --- Phase 2: Policy ---
+
+type policyResult struct {
+	decision SystemRunPolicyDecision
+	parsed   *parsedSystemRun
+}
+
+func evaluateSystemRunPolicyPhase(parsed *parsedSystemRun, deps SystemRunDeps) *policyResult {
+	decision := EvaluateSystemRunPolicy(EvaluateSystemRunPolicyParams{
+		Security:               SecurityAllowlist, // default; real impl loads from config
+		Ask:                    AskOff,
+		AnalysisOk:             true,
+		AllowlistSatisfied:     true,
+		ApprovalDecision:       parsed.approvalDecision,
+		Approved:               parsed.approved,
+		IsWindows:              IsWindows(),
+		CmdInvocation:          false,
+		ShellWrapperInvocation: parsed.shellPayload != nil,
+	})
+
+	if !decision.Allowed {
+		sendDenied(deps, parsed.execution, decision.EventReason, decision.ErrorMessage)
+		return nil
+	}
+
+	// Harden execution paths if approved by ask.
+	if decision.ApprovedByAsk {
+		harden := HardenApprovedExecutionPaths(true, parsed.argv, parsed.shellPayload, parsed.cwd)
+		if !harden.Ok {
+			sendDenied(deps, parsed.execution, EventReasonApprovalRequired, harden.Message)
+			return nil
+		}
+		parsed.argv = harden.Argv
+		if harden.Cwd != "" {
+			parsed.cwd = harden.Cwd
+		}
+	}
+
+	return &policyResult{decision: decision, parsed: parsed}
+}
+
+// --- Phase 3: Execute ---
+
+func executeSystemRunPhase(ctx context.Context, parsed *parsedSystemRun, policy *policyResult, deps SystemRunDeps) {
+	// Revalidate approval plan if present.
+	if parsed.approvalPlan != nil && parsed.approvalPlan.MutableFileOperand != nil {
+		if !RevalidateApprovedMutableFileOperand(parsed.approvalPlan.MutableFileOperand, parsed.argv, parsed.cwd) {
+			slog.Warn("security: system.run approval script drift blocked",
+				"runId", parsed.execution.RunID)
+			sendDenied(deps, parsed.execution, EventReasonApprovalRequired,
+				"SYSTEM_RUN_DENIED: approval script operand changed before execution")
+			return
+		}
+	}
+
+	// Build env slice for exec.
+	envSlice := make([]string, 0, len(parsed.env))
+	for k, v := range parsed.env {
+		envSlice = append(envSlice, k+"="+v)
+	}
+
+	// Execute.
+	result := RunCommand(ctx, parsed.argv, RunCommandOpts{
+		Cwd:       parsed.cwd,
+		Env:       envSlice,
+		TimeoutMs: parsed.timeoutMs,
+	})
+	ApplyOutputTruncation(result)
+
+	// Build finished result.
+	finishedResult := ExecFinishedResult{
+		Stdout:   result.Stdout,
+		Stderr:   result.Stderr,
+		Error:    result.Error,
+		ExitCode: result.ExitCode,
+	}
+	if result.TimedOut {
+		timedOut := true
+		finishedResult.TimedOut = &timedOut
+	}
+	success := result.Success
+	finishedResult.Success = &success
+
+	// Dispatch finished event.
+	deps.SendFinishedEvent(ExecFinishedEventParams{
+		SessionKey:           parsed.execution.SessionKey,
+		RunID:                parsed.execution.RunID,
+		CommandText:          parsed.execution.CommandText,
+		Result:               finishedResult,
+		SuppressNotifyOnExit: boolPtr(parsed.suppressNotifyOnExit),
+	})
+
+	// Send result.
+	payloadJSON, _ := json.Marshal(result)
+	deps.SendResult(SystemRunInvokeResult{Ok: true, PayloadJSON: string(payloadJSON)})
+}
+
+// --- Helpers ---
+
+func sendDenied(deps SystemRunDeps, exec SystemRunExecutionContext, reason SystemRunPolicyEventReason, message string) {
+	deps.SendDeniedEvent(ExecEventPayload{
+		SessionKey:           exec.SessionKey,
+		RunID:                exec.RunID,
+		Host:                 "node",
+		Command:              exec.CommandText,
+		Reason:               string(reason),
+		SuppressNotifyOnExit: boolPtr(exec.SuppressNotifyOnExit),
+	})
+	deps.SendResult(SystemRunInvokeResult{
+		Ok:       false,
+		ErrorCode: "UNAVAILABLE",
+		ErrorMsg:  message,
+	})
+}
+
+func stringOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func boolPtr(b bool) *bool {
+	if !b {
+		return nil
+	}
+	return &b
+}
+
+// EnvToSlice converts a map to os.Environ() format.
+func EnvToSlice(env map[string]string) []string {
+	s := make([]string, 0, len(env))
+	for k, v := range env {
+		s = append(s, fmt.Sprintf("%s=%s", k, v))
+	}
+	return s
+}

--- a/internal/nodehost/system_run_command.go
+++ b/internal/nodehost/system_run_command.go
@@ -1,0 +1,152 @@
+package nodehost
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatExecCommand formats an argv slice into a shell-escaped command string.
+func FormatExecCommand(argv []string) string {
+	parts := make([]string, len(argv))
+	for i, arg := range argv {
+		if arg == "" {
+			parts[i] = `""`
+			continue
+		}
+		if strings.ContainsAny(arg, " \t\"") {
+			parts[i] = fmt.Sprintf(`"%s"`, strings.ReplaceAll(arg, `"`, `\"`))
+		} else {
+			parts[i] = arg
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// ResolvedSystemRunCommand is the result of resolving a command request.
+type ResolvedSystemRunCommand struct {
+	Ok           bool
+	Argv         []string
+	CommandText  string
+	ShellPayload *string
+	PreviewText  *string
+	Message      string // error message when !Ok
+}
+
+// posixOrPowershellInlineWrapperNames are shells whose inline commands get preview text.
+var posixOrPowershellInlineWrapperNames = newSet(
+	"ash", "bash", "dash", "fish", "ksh", "powershell", "pwsh", "sh", "zsh",
+)
+
+// buildSystemRunCommandDisplay resolves shell payload and preview text for an argv.
+func buildSystemRunCommandDisplay(argv []string) (shellPayload *string, commandText string, previewText *string) {
+	wrapper := ExtractShellWrapperCommand(argv, nil)
+	shellPayload = wrapper.Command
+
+	hasTrailingPositional := hasTrailingPositionalAfterInline(argv)
+	envManip := wrapper.IsWrapper && HasEnvManipulationBeforeShellWrapper(argv)
+	commandText = FormatExecCommand(argv)
+
+	if shellPayload != nil && !envManip && !hasTrailingPositional {
+		trimmed := strings.TrimSpace(*shellPayload)
+		previewText = &trimmed
+	}
+	return
+}
+
+func hasTrailingPositionalAfterInline(argv []string) bool {
+	wrapperArgv := unwrapShellWrapperArgv(argv)
+	token0 := strings.TrimSpace(safeIndex(wrapperArgv, 0))
+	if token0 == "" {
+		return false
+	}
+	wrapper := NormalizeExecutableToken(token0)
+	if !posixOrPowershellInlineWrapperNames[wrapper] {
+		return false
+	}
+
+	var match InlineCommandMatch
+	if wrapper == "powershell" || wrapper == "pwsh" {
+		psFlags := newSet("-c", "-command", "--command", "-f", "-file", "-encodedcommand", "-enc", "-e")
+		match = ResolveInlineCommandMatch(wrapperArgv, psFlags, false)
+	} else {
+		match = ResolveInlineCommandMatch(wrapperArgv, PosixInlineCommandFlags, true)
+	}
+	if match.ValueTokenIndex == nil {
+		return false
+	}
+	for _, entry := range wrapperArgv[*match.ValueTokenIndex+1:] {
+		if strings.TrimSpace(entry) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func unwrapShellWrapperArgv(argv []string) []string {
+	current := unwrapDispatchWrappersForResolution(argv)
+	mux := UnwrapKnownShellMultiplexerInvocation(current)
+	if mux.Kind == "unwrapped" {
+		return mux.Argv
+	}
+	return current
+}
+
+func unwrapDispatchWrappersForResolution(argv []string) []string {
+	current := argv
+	for range MaxDispatchWrapperDepth {
+		r := UnwrapKnownDispatchWrapperInvocation(current)
+		if r.Kind != "unwrapped" || len(r.Argv) == 0 {
+			break
+		}
+		current = r.Argv
+	}
+	return current
+}
+
+// ResolveSystemRunCommandRequest validates and resolves a command request.
+func ResolveSystemRunCommandRequest(command []string, rawCommand *string) ResolvedSystemRunCommand {
+	raw := normalizeRawCommandText(rawCommand)
+
+	if len(command) == 0 {
+		if raw != nil {
+			return ResolvedSystemRunCommand{Ok: false, Message: "rawCommand requires params.command"}
+		}
+		return ResolvedSystemRunCommand{Ok: true, CommandText: ""}
+	}
+
+	argv := make([]string, len(command))
+	copy(argv, command)
+
+	shellPayload, commandText, previewText := buildSystemRunCommandDisplay(argv)
+
+	// Validate rawCommand consistency.
+	if raw != nil {
+		matchesArgv := *raw == commandText
+		matchesPreview := previewText != nil && *raw == *previewText
+		if !matchesArgv && !matchesPreview {
+			return ResolvedSystemRunCommand{
+				Ok:      false,
+				Message: "INVALID_REQUEST: rawCommand does not match command",
+			}
+		}
+	}
+
+	return ResolvedSystemRunCommand{
+		Ok:           true,
+		Argv:         argv,
+		CommandText:  commandText,
+		ShellPayload: shellPayload,
+		PreviewText:  previewText,
+	}
+}
+
+func normalizeRawCommandText(raw *string) *string {
+	if raw == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*raw)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}

--- a/internal/nodehost/system_run_test.go
+++ b/internal/nodehost/system_run_test.go
@@ -1,0 +1,142 @@
+package nodehost
+
+import (
+	"context"
+	"testing"
+)
+
+// --- RunCommand tests ---
+
+func TestRunCommand_EchoSuccess(t *testing.T) {
+	result := RunCommand(context.Background(), []string{"echo", "hello"}, RunCommandOpts{})
+	if !result.Success {
+		t.Fatalf("expected success, got error: %v", result.Error)
+	}
+	if result.ExitCode == nil || *result.ExitCode != 0 {
+		t.Errorf("exitCode = %v, want 0", result.ExitCode)
+	}
+	if result.Stdout != "hello\n" {
+		t.Errorf("stdout = %q, want %q", result.Stdout, "hello\n")
+	}
+}
+
+func TestRunCommand_NonZeroExitCode(t *testing.T) {
+	result := RunCommand(context.Background(), []string{"sh", "-c", "exit 42"}, RunCommandOpts{})
+	if result.Success {
+		t.Fatal("expected failure")
+	}
+	if result.ExitCode == nil || *result.ExitCode != 42 {
+		t.Errorf("exitCode = %v, want 42", result.ExitCode)
+	}
+}
+
+func TestRunCommand_Timeout(t *testing.T) {
+	result := RunCommand(context.Background(), []string{"sleep", "10"}, RunCommandOpts{TimeoutMs: 100})
+	if !result.TimedOut {
+		t.Error("expected timedOut=true")
+	}
+	if result.Success {
+		t.Error("expected success=false on timeout")
+	}
+}
+
+func TestRunCommand_StderrCapture(t *testing.T) {
+	result := RunCommand(context.Background(), []string{"sh", "-c", "echo err >&2"}, RunCommandOpts{})
+	if result.Stderr != "err\n" {
+		t.Errorf("stderr = %q, want %q", result.Stderr, "err\n")
+	}
+}
+
+func TestRunCommand_EmptyCommand(t *testing.T) {
+	result := RunCommand(context.Background(), nil, RunCommandOpts{})
+	if result.Success {
+		t.Error("expected failure for empty command")
+	}
+	if result.Error == nil {
+		t.Error("expected error message")
+	}
+}
+
+func TestRunCommand_CwdOverride(t *testing.T) {
+	tmp := t.TempDir()
+	result := RunCommand(context.Background(), []string{"pwd"}, RunCommandOpts{Cwd: tmp})
+	if !result.Success {
+		t.Fatalf("expected success: %v", result.Error)
+	}
+	// pwd output should contain the temp dir path.
+	if result.Stdout == "" {
+		t.Error("expected non-empty stdout from pwd")
+	}
+}
+
+func TestRunCommand_OutputTruncation(t *testing.T) {
+	// Generate output larger than OutputCap.
+	// Use dd to generate exactly OutputCap+1 bytes.
+	result := RunCommand(context.Background(),
+		[]string{"sh", "-c", "dd if=/dev/zero bs=1 count=204801 2>/dev/null | tr '\\0' 'A'"},
+		RunCommandOpts{})
+	if !result.Truncated {
+		t.Error("expected truncated=true for output > 200KB")
+	}
+}
+
+// --- HandleSystemRunInvoke integration tests ---
+
+func TestHandleSystemRun_EmptyCommand(t *testing.T) {
+	var gotResult SystemRunInvokeResult
+	deps := SystemRunDeps{
+		SendDeniedEvent:   func(_ ExecEventPayload) {},
+		SendFinishedEvent: func(_ ExecFinishedEventParams) {},
+		SendResult:        func(r SystemRunInvokeResult) { gotResult = r },
+	}
+	HandleSystemRunInvoke(context.Background(), SystemRunParams{
+		Command: []string{},
+	}, deps)
+	if gotResult.Ok {
+		t.Error("expected failure for empty command")
+	}
+	if gotResult.ErrorMsg != "command required" {
+		t.Errorf("errorMsg = %q, want 'command required'", gotResult.ErrorMsg)
+	}
+}
+
+func TestHandleSystemRun_EchoSuccess(t *testing.T) {
+	var gotResult SystemRunInvokeResult
+	var gotFinished ExecFinishedEventParams
+	deps := SystemRunDeps{
+		SendDeniedEvent:   func(_ ExecEventPayload) {},
+		SendFinishedEvent: func(p ExecFinishedEventParams) { gotFinished = p },
+		SendResult:        func(r SystemRunInvokeResult) { gotResult = r },
+	}
+	HandleSystemRunInvoke(context.Background(), SystemRunParams{
+		Command: []string{"echo", "hello"},
+	}, deps)
+	if !gotResult.Ok {
+		t.Fatalf("expected success, got: %s", gotResult.ErrorMsg)
+	}
+	if gotResult.PayloadJSON == "" {
+		t.Error("expected non-empty payload")
+	}
+	if gotFinished.CommandText == "" {
+		t.Error("expected command text in finished event")
+	}
+}
+
+func TestHandleSystemRun_DeniedEvent(t *testing.T) {
+	var gotDenied ExecEventPayload
+	var gotResult SystemRunInvokeResult
+	deps := SystemRunDeps{
+		SendDeniedEvent:   func(p ExecEventPayload) { gotDenied = p },
+		SendFinishedEvent: func(_ ExecFinishedEventParams) {},
+		SendResult:        func(r SystemRunInvokeResult) { gotResult = r },
+	}
+
+	// Invalid command should trigger denied.
+	HandleSystemRunInvoke(context.Background(), SystemRunParams{}, deps)
+
+	if gotResult.Ok {
+		t.Error("expected failure")
+	}
+	// gotDenied may or may not be populated depending on which phase fails.
+	_ = gotDenied
+}

--- a/internal/nodehost/types.go
+++ b/internal/nodehost/types.go
@@ -1,0 +1,134 @@
+package nodehost
+
+// SystemRunApprovalFileOperand describes a mutable file operand in a command.
+type SystemRunApprovalFileOperand struct {
+	ArgvIndex int    `json:"argvIndex"`
+	Path      string `json:"path"`
+	SHA256    string `json:"sha256"`
+}
+
+// SystemRunApprovalPlan describes a parsed command plan for exec approval.
+type SystemRunApprovalPlan struct {
+	Argv               []string                      `json:"argv"`
+	Cwd                *string                       `json:"cwd,omitempty"`
+	CommandText        string                        `json:"commandText"`
+	CommandPreview     *string                       `json:"commandPreview,omitempty"`
+	AgentID            *string                       `json:"agentId,omitempty"`
+	SessionKey         *string                       `json:"sessionKey,omitempty"`
+	MutableFileOperand *SystemRunApprovalFileOperand `json:"mutableFileOperand,omitempty"`
+}
+
+// SystemRunParams mirrors the TS SystemRunParams for invoking a system command.
+type SystemRunParams struct {
+	Command              []string               `json:"command"`
+	RawCommand           *string                `json:"rawCommand,omitempty"`
+	SystemRunPlan        *SystemRunApprovalPlan  `json:"systemRunPlan,omitempty"`
+	Cwd                  *string                `json:"cwd,omitempty"`
+	Env                  map[string]string       `json:"env,omitempty"`
+	TimeoutMs            *int                   `json:"timeoutMs,omitempty"`
+	NeedsScreenRecording *bool                  `json:"needsScreenRecording,omitempty"`
+	AgentID              *string                `json:"agentId,omitempty"`
+	SessionKey           *string                `json:"sessionKey,omitempty"`
+	Approved             *bool                  `json:"approved,omitempty"`
+	ApprovalDecision     *string                `json:"approvalDecision,omitempty"`
+	RunID                *string                `json:"runId,omitempty"`
+	SuppressNotifyOnExit *bool                  `json:"suppressNotifyOnExit,omitempty"`
+}
+
+// RunResult holds the outcome of a system command execution.
+type RunResult struct {
+	ExitCode  *int    `json:"exitCode,omitempty"`
+	TimedOut  bool    `json:"timedOut"`
+	Success   bool    `json:"success"`
+	Stdout    string  `json:"stdout"`
+	Stderr    string  `json:"stderr"`
+	Error     *string `json:"error,omitempty"`
+	Truncated bool    `json:"truncated"`
+}
+
+// ExecEventPayload is sent as a WebSocket event during command execution.
+type ExecEventPayload struct {
+	SessionKey           string `json:"sessionKey"`
+	RunID                string `json:"runId"`
+	Host                 string `json:"host"`
+	Command              string `json:"command,omitempty"`
+	ExitCode             *int   `json:"exitCode,omitempty"`
+	TimedOut             *bool  `json:"timedOut,omitempty"`
+	Success              *bool  `json:"success,omitempty"`
+	Output               string `json:"output,omitempty"`
+	Reason               string `json:"reason,omitempty"`
+	SuppressNotifyOnExit *bool  `json:"suppressNotifyOnExit,omitempty"`
+}
+
+// ExecFinishedResult holds the final result of an exec operation.
+type ExecFinishedResult struct {
+	Stdout   string  `json:"stdout,omitempty"`
+	Stderr   string  `json:"stderr,omitempty"`
+	Error    *string `json:"error,omitempty"`
+	ExitCode *int    `json:"exitCode,omitempty"`
+	TimedOut *bool   `json:"timedOut,omitempty"`
+	Success  *bool   `json:"success,omitempty"`
+}
+
+// ExecFinishedEventParams is emitted when a command finishes execution.
+type ExecFinishedEventParams struct {
+	SessionKey           string             `json:"sessionKey"`
+	RunID                string             `json:"runId"`
+	CommandText          string             `json:"commandText"`
+	Result               ExecFinishedResult `json:"result"`
+	SuppressNotifyOnExit *bool              `json:"suppressNotifyOnExit,omitempty"`
+}
+
+// SkillBinTrustEntry represents a trusted skill binary.
+type SkillBinTrustEntry struct {
+	Name         string `json:"name"`
+	ResolvedPath string `json:"resolvedPath"`
+}
+
+// SkillBinsProvider retrieves the current set of trusted skill binaries.
+type SkillBinsProvider interface {
+	Current(force bool) ([]SkillBinTrustEntry, error)
+}
+
+// ExecApprovalDecision represents the user's approval choice.
+type ExecApprovalDecision string
+
+const (
+	ApprovalAllowOnce   ExecApprovalDecision = "allow-once"
+	ApprovalAllowAlways ExecApprovalDecision = "allow-always"
+)
+
+// ResolveExecApprovalDecision parses a string into a valid ExecApprovalDecision.
+// Returns nil if the value is not recognized.
+func ResolveExecApprovalDecision(v string) *ExecApprovalDecision {
+	switch v {
+	case "allow-once", "allow-always":
+		d := ExecApprovalDecision(v)
+		return &d
+	default:
+		return nil
+	}
+}
+
+// SystemRunPolicyEventReason describes why a run was denied.
+type SystemRunPolicyEventReason string
+
+const (
+	EventReasonSecurityDeny    SystemRunPolicyEventReason = "security=deny"
+	EventReasonApprovalRequired SystemRunPolicyEventReason = "approval-required"
+	EventReasonAllowlistMiss   SystemRunPolicyEventReason = "allowlist-miss"
+)
+
+// SystemRunPolicyDecision is the result of evaluating exec policy.
+type SystemRunPolicyDecision struct {
+	Allowed                    bool                        `json:"allowed"`
+	AnalysisOk                 bool                        `json:"analysisOk"`
+	AllowlistSatisfied         bool                        `json:"allowlistSatisfied"`
+	ShellWrapperBlocked        bool                        `json:"shellWrapperBlocked"`
+	WindowsShellWrapperBlocked bool                        `json:"windowsShellWrapperBlocked"`
+	RequiresAsk                bool                        `json:"requiresAsk"`
+	ApprovalDecision           *ExecApprovalDecision       `json:"approvalDecision"`
+	ApprovedByAsk              bool                        `json:"approvedByAsk"`
+	EventReason                SystemRunPolicyEventReason  `json:"eventReason,omitempty"`
+	ErrorMessage               string                      `json:"errorMessage,omitempty"`
+}

--- a/internal/nodehost/types_test.go
+++ b/internal/nodehost/types_test.go
@@ -1,0 +1,477 @@
+package nodehost
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- JSON round-trip tests ---
+
+func TestSystemRunParamsRoundTrip(t *testing.T) {
+	raw := `"test"`
+	cwd := "/tmp"
+	timeout := 5000
+	screen := true
+	agent := "a1"
+	session := "s1"
+	approved := true
+	decision := "allow-once"
+	runID := "r1"
+	suppress := false
+
+	orig := SystemRunParams{
+		Command:              []string{"echo", "hello"},
+		RawCommand:           &raw,
+		Cwd:                  &cwd,
+		Env:                  map[string]string{"FOO": "bar"},
+		TimeoutMs:            &timeout,
+		NeedsScreenRecording: &screen,
+		AgentID:              &agent,
+		SessionKey:           &session,
+		Approved:             &approved,
+		ApprovalDecision:     &decision,
+		RunID:                &runID,
+		SuppressNotifyOnExit: &suppress,
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got SystemRunParams
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(got.Command) != 2 || got.Command[0] != "echo" {
+		t.Errorf("command mismatch: %v", got.Command)
+	}
+	if got.RawCommand == nil || *got.RawCommand != raw {
+		t.Errorf("rawCommand mismatch")
+	}
+	if got.Env["FOO"] != "bar" {
+		t.Errorf("env mismatch")
+	}
+}
+
+func TestRunResultRoundTrip(t *testing.T) {
+	exitCode := 0
+	orig := RunResult{
+		ExitCode:  &exitCode,
+		TimedOut:  false,
+		Success:   true,
+		Stdout:    "output",
+		Stderr:    "",
+		Truncated: false,
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got RunResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.ExitCode == nil || *got.ExitCode != 0 {
+		t.Errorf("exitCode mismatch")
+	}
+	if got.Stdout != "output" {
+		t.Errorf("stdout mismatch: %q", got.Stdout)
+	}
+	if got.Success != true {
+		t.Errorf("success should be true")
+	}
+}
+
+func TestRunResultJSONFieldNames(t *testing.T) {
+	exitCode := 1
+	errMsg := "fail"
+	r := RunResult{
+		ExitCode:  &exitCode,
+		TimedOut:  true,
+		Success:   false,
+		Stdout:    "out",
+		Stderr:    "err",
+		Error:     &errMsg,
+		Truncated: true,
+	}
+	data, _ := json.Marshal(r)
+	s := string(data)
+
+	// Verify camelCase JSON field names match TS wire format.
+	for _, field := range []string{"exitCode", "timedOut", "success", "stdout", "stderr", "error", "truncated"} {
+		if !strings.Contains(s, `"`+field+`"`) {
+			t.Errorf("missing JSON field %q in: %s", field, s)
+		}
+	}
+}
+
+func TestExecEventPayloadRoundTrip(t *testing.T) {
+	exitCode := 0
+	timedOut := false
+	success := true
+	suppress := false
+
+	orig := ExecEventPayload{
+		SessionKey:           "sk",
+		RunID:                "rid",
+		Host:                 "h1",
+		Command:              "echo hi",
+		ExitCode:             &exitCode,
+		TimedOut:             &timedOut,
+		Success:              &success,
+		Output:               "hi",
+		Reason:               "",
+		SuppressNotifyOnExit: &suppress,
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got ExecEventPayload
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.SessionKey != "sk" || got.RunID != "rid" {
+		t.Errorf("key fields mismatch")
+	}
+}
+
+func TestExecFinishedEventParamsRoundTrip(t *testing.T) {
+	exitCode := 0
+	success := true
+	orig := ExecFinishedEventParams{
+		SessionKey:  "sk",
+		RunID:       "rid",
+		CommandText: "echo hi",
+		Result: ExecFinishedResult{
+			Stdout:   "hi",
+			ExitCode: &exitCode,
+			Success:  &success,
+		},
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got ExecFinishedEventParams
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Result.Stdout != "hi" {
+		t.Errorf("nested result mismatch")
+	}
+}
+
+func TestSystemRunPolicyDecisionRoundTrip(t *testing.T) {
+	decision := ApprovalAllowOnce
+	orig := SystemRunPolicyDecision{
+		Allowed:            false,
+		AnalysisOk:         true,
+		AllowlistSatisfied: false,
+		RequiresAsk:        true,
+		ApprovalDecision:   &decision,
+		ApprovedByAsk:      false,
+		EventReason:        EventReasonApprovalRequired,
+		ErrorMessage:       "SYSTEM_RUN_DENIED: approval required",
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got SystemRunPolicyDecision
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Allowed != false {
+		t.Errorf("allowed should be false")
+	}
+	if got.ApprovalDecision == nil || *got.ApprovalDecision != ApprovalAllowOnce {
+		t.Errorf("approvalDecision mismatch")
+	}
+	if got.EventReason != EventReasonApprovalRequired {
+		t.Errorf("eventReason mismatch: %q", got.EventReason)
+	}
+}
+
+// --- ExecApprovalDecision tests ---
+
+func TestResolveExecApprovalDecision(t *testing.T) {
+	tests := []struct {
+		input string
+		want  *ExecApprovalDecision
+	}{
+		{"allow-once", ptr(ApprovalAllowOnce)},
+		{"allow-always", ptr(ApprovalAllowAlways)},
+		{"invalid", nil},
+		{"", nil},
+		{"deny", nil},
+	}
+
+	for _, tt := range tests {
+		got := ResolveExecApprovalDecision(tt.input)
+		if tt.want == nil {
+			if got != nil {
+				t.Errorf("ResolveExecApprovalDecision(%q) = %v, want nil", tt.input, *got)
+			}
+		} else {
+			if got == nil || *got != *tt.want {
+				t.Errorf("ResolveExecApprovalDecision(%q) mismatch", tt.input)
+			}
+		}
+	}
+}
+
+func ptr(d ExecApprovalDecision) *ExecApprovalDecision { return &d }
+
+// --- Config tests ---
+
+func TestConfigLoadMissingFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("GOCLAW_STATE_DIR", tmp)
+
+	cfg, err := LoadNodeHostConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config for missing file")
+	}
+}
+
+func TestConfigLoadCorruptJSON(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("GOCLAW_STATE_DIR", tmp)
+	os.WriteFile(filepath.Join(tmp, "node.json"), []byte("{invalid"), 0o600)
+
+	_, err := LoadNodeHostConfig()
+	if err == nil {
+		t.Fatalf("expected error for corrupt JSON")
+	}
+}
+
+func TestConfigLoadValid(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("GOCLAW_STATE_DIR", tmp)
+
+	data := `{"version":1,"nodeId":"abc-123","token":"tok","displayName":"my-node"}`
+	os.WriteFile(filepath.Join(tmp, "node.json"), []byte(data), 0o600)
+
+	cfg, err := LoadNodeHostConfig()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.NodeID != "abc-123" {
+		t.Errorf("nodeId mismatch: %q", cfg.NodeID)
+	}
+	if cfg.Token != "tok" {
+		t.Errorf("token mismatch: %q", cfg.Token)
+	}
+}
+
+func TestConfigNormalizeGeneratesUUID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("GOCLAW_STATE_DIR", tmp)
+
+	// Config with empty nodeId should get a generated UUID.
+	data := `{"version":1,"nodeId":""}`
+	os.WriteFile(filepath.Join(tmp, "node.json"), []byte(data), 0o600)
+
+	cfg, err := LoadNodeHostConfig()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.NodeID == "" {
+		t.Fatalf("expected generated nodeId")
+	}
+	// UUID v4 format: 8-4-4-4-12 hex chars.
+	if len(cfg.NodeID) != 36 {
+		t.Errorf("nodeId length %d, want 36: %q", len(cfg.NodeID), cfg.NodeID)
+	}
+}
+
+func TestConfigSavePermissions(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("GOCLAW_STATE_DIR", tmp)
+
+	cfg := &NodeHostConfig{Version: 1, NodeID: "test-id"}
+	if err := SaveNodeHostConfig(cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	filePath := filepath.Join(tmp, "node.json")
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0o600 {
+		t.Errorf("permissions = %o, want 600", perm)
+	}
+
+	// Verify content round-trips.
+	raw, _ := os.ReadFile(filePath)
+	var got NodeHostConfig
+	json.Unmarshal(raw, &got)
+	if got.NodeID != "test-id" {
+		t.Errorf("saved nodeId mismatch: %q", got.NodeID)
+	}
+}
+
+func TestConfigEnsureCreatesFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("GOCLAW_STATE_DIR", tmp)
+
+	cfg, err := EnsureNodeHostConfig()
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if cfg.NodeID == "" {
+		t.Fatalf("expected generated nodeId")
+	}
+	if cfg.Version != 1 {
+		t.Errorf("version = %d, want 1", cfg.Version)
+	}
+
+	// File should exist.
+	if _, err := os.Stat(filepath.Join(tmp, "node.json")); err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+}
+
+func TestConfigEnsureNormalizesExisting(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("GOCLAW_STATE_DIR", tmp)
+
+	// Write config with missing nodeId.
+	data := `{"version":1,"nodeId":"","token":"keep-me"}`
+	os.WriteFile(filepath.Join(tmp, "node.json"), []byte(data), 0o600)
+
+	cfg, err := EnsureNodeHostConfig()
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if cfg.NodeID == "" {
+		t.Fatalf("expected generated nodeId")
+	}
+	if cfg.Token != "keep-me" {
+		t.Errorf("token lost: %q", cfg.Token)
+	}
+}
+
+func TestConfigSaveAtomicNoPartialWrite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("GOCLAW_STATE_DIR", tmp)
+
+	cfg := &NodeHostConfig{Version: 1, NodeID: "atomic-test"}
+	if err := SaveNodeHostConfig(cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Temp file should not remain.
+	tmpFile := filepath.Join(tmp, "node.json.tmp")
+	if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
+		t.Errorf("temp file should not exist after save")
+	}
+}
+
+func TestNewUUIDFormat(t *testing.T) {
+	id, err := newUUID()
+	if err != nil {
+		t.Fatalf("newUUID: %v", err)
+	}
+	if len(id) != 36 {
+		t.Fatalf("uuid length %d, want 36: %q", len(id), id)
+	}
+	// Check dashes at correct positions.
+	if id[8] != '-' || id[13] != '-' || id[18] != '-' || id[23] != '-' {
+		t.Errorf("uuid dash positions wrong: %q", id)
+	}
+	// Version nibble should be '4'.
+	if id[14] != '4' {
+		t.Errorf("uuid version nibble = %c, want '4': %q", id[14], id)
+	}
+	// Variant bits at position 19 should be 8, 9, a, or b.
+	v := id[19]
+	if v != '8' && v != '9' && v != 'a' && v != 'b' {
+		t.Errorf("uuid variant nibble = %c, want 8-b: %q", v, id)
+	}
+}
+
+func TestNewUUIDUniqueness(t *testing.T) {
+	seen := make(map[string]bool, 100)
+	for range 100 {
+		id, err := newUUID()
+		if err != nil {
+			t.Fatalf("newUUID: %v", err)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate uuid: %q", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestSkillBinTrustEntryRoundTrip(t *testing.T) {
+	orig := SkillBinTrustEntry{Name: "mytool", ResolvedPath: "/usr/bin/mytool"}
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got SkillBinTrustEntry
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Name != "mytool" || got.ResolvedPath != "/usr/bin/mytool" {
+		t.Errorf("mismatch: %+v", got)
+	}
+}
+
+func TestSystemRunApprovalPlanRoundTrip(t *testing.T) {
+	cwd := "/home"
+	agent := "a1"
+	session := "s1"
+	orig := SystemRunApprovalPlan{
+		Argv:        []string{"echo", "hi"},
+		Cwd:         &cwd,
+		CommandText: "echo hi",
+		AgentID:     &agent,
+		SessionKey:  &session,
+		MutableFileOperand: &SystemRunApprovalFileOperand{
+			ArgvIndex: 1,
+			Path:      "/tmp/f",
+			SHA256:    "abc",
+		},
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got SystemRunApprovalPlan
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.CommandText != "echo hi" {
+		t.Errorf("commandText mismatch")
+	}
+	if got.MutableFileOperand == nil || got.MutableFileOperand.Path != "/tmp/f" {
+		t.Errorf("mutableFileOperand mismatch")
+	}
+}

--- a/internal/permissions/policy.go
+++ b/internal/permissions/policy.go
@@ -157,6 +157,10 @@ func MethodScopes(method string) []Scope {
 
 func isAdminMethod(method string) bool {
 	adminMethods := []string{
+		protocol.MethodNodeInvokeResult,
+		protocol.MethodNodeEvent,
+		protocol.MethodNodeList,
+		protocol.MethodNodeExec,
 		protocol.MethodConfigApply,
 		protocol.MethodConfigPatch,
 		protocol.MethodAgentsCreate,

--- a/pkg/protocol/methods.go
+++ b/pkg/protocol/methods.go
@@ -165,6 +165,14 @@ const (
 	MethodAPIKeysRevoke = "api_keys.revoke"
 )
 
+// Node-host remote execution
+const (
+	MethodNodeInvokeResult = "node.invoke.result"
+	MethodNodeEvent        = "node.event"
+	MethodNodeList         = "node.list"
+	MethodNodeExec         = "node.exec"
+)
+
 // Phase 3+ - NICE TO HAVE methods
 const (
 	MethodLogsTail = "logs.tail"


### PR DESCRIPTION
Add secure execution sandbox for untrusted code with:
- Approval workflow system (approval plans, entries, operations)
- Shell command execution with environment sanitization
- File identity tracking and access controls
- RPC dispatcher for inter-node communication
- Execution policies and token management
- Support for system commands, inline shells, and skill binaries
- Comprehensive test coverage

Core components: runner, dispatch_wrapper, exec_policy, shell_wrapper, sanitize_env