### PR TITLE
fix(pg): align SearchByEmbedding SQL placeholders with scope args

### DIFF
--- a/internal/store/pg/skills_embedding.go
+++ b/internal/store/pg/skills_embedding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -22,16 +23,13 @@ func (s *PGSkillStore) SearchByEmbedding(ctx context.Context, embedding []float3
 	}
 	vecStr := vectorToString(embedding)
 
-	// $1=vec, $2=vec → tenant at $3 (if needed), ORDER vec at $3+len(tcArgs), LIMIT after
-	tc, tcArgs, _, err := scopeClause(ctx, 3)
+	// $1=vec, scope starts at $2 (if present), ORDER vec uses next available param, LIMIT after.
+	tc, tcArgs, nextParam, err := scopeClause(ctx, 2)
 	if err != nil {
 		return nil, err
 	}
-	tenantCond := ""
-	if tc != "" {
-		tenantCond = fmt.Sprintf(" AND (is_system = true OR tenant_id = $%d)", 3)
-	}
-	orderN := 3 + len(tcArgs)
+	tenantCond := buildSkillEmbeddingTenantCond(tc)
+	orderN := nextParam
 	limitN := orderN + 1
 	q := fmt.Sprintf(`SELECT name, slug, COALESCE(description, ''), version, file_path,
 			1 - (embedding <=> $1::vector) AS score
@@ -41,9 +39,9 @@ func (s *PGSkillStore) SearchByEmbedding(ctx context.Context, embedding []float3
 		ORDER BY embedding <=> $%d::vector
 		LIMIT $%d`, tenantCond, orderN, limitN)
 
-	rows, err := s.db.QueryContext(ctx, q,
-		append(append([]any{vecStr}, tcArgs...), vecStr, limit)...,
-	)
+	args := append([]any{vecStr}, tcArgs...)
+	args = append(args, vecStr, limit)
+	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("embedding skill search: %w", err)
 	}
@@ -66,6 +64,15 @@ func (s *PGSkillStore) SearchByEmbedding(ctx context.Context, embedding []float3
 		results = append(results, r)
 	}
 	return results, nil
+}
+
+
+func buildSkillEmbeddingTenantCond(scope string) string {
+	if scope == "" {
+		return ""
+	}
+	tenantExpr := strings.TrimPrefix(scope, " AND ")
+	return fmt.Sprintf(" AND (is_system = true OR (%s))", tenantExpr)
 }
 
 // BackfillSkillEmbeddings generates embeddings for all active skills that don't have one yet.

--- a/internal/store/pg/skills_embedding_test.go
+++ b/internal/store/pg/skills_embedding_test.go
@@ -1,0 +1,28 @@
+package pg
+
+import (
+	"testing"
+)
+
+func TestBuildSkillEmbeddingTenantCond_Empty(t *testing.T) {
+	got := buildSkillEmbeddingTenantCond("")
+	if got != "" {
+		t.Fatalf("expected empty tenant condition, got %q", got)
+	}
+}
+
+func TestBuildSkillEmbeddingTenantCond_WithTenant(t *testing.T) {
+	got := buildSkillEmbeddingTenantCond(" AND tenant_id = $2")
+	want := " AND (is_system = true OR (tenant_id = $2))"
+	if got != want {
+		t.Fatalf("unexpected tenant condition\nwant: %q\n got: %q", want, got)
+	}
+}
+
+func TestBuildSkillEmbeddingTenantCond_WithTenantAndProject(t *testing.T) {
+	got := buildSkillEmbeddingTenantCond(" AND tenant_id = $2 AND project_id = $3")
+	want := " AND (is_system = true OR (tenant_id = $2 AND project_id = $3))"
+	if got != want {
+		t.Fatalf("unexpected tenant/project condition\nwant: %q\n got: %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
Fix placeholder index alignment in `PGSkillStore.SearchByEmbedding` when scope args are present/absent.

## Problem
Issue #601 reports:
`SQLSTATE 42P18: could not determine data type of parameter $2`

`SearchByEmbedding` built a dynamic query with hardcoded placeholder offsets (starting scope at `$3`) while argument composition was dynamic. This could produce placeholder/index mismatch depending on scope shape.

## Changes
- `internal/store/pg/skills_embedding.go`
  - start scope placeholders at `$2` (after `$1` vector)
  - use `nextParam` returned by `scopeClause()` for `ORDER BY ... <=> $n`
  - use `n+1` for `LIMIT`
  - centralize tenant/system condition formatting in helper:
    - `buildSkillEmbeddingTenantCond(scope string)`
- `internal/store/pg/skills_embedding_test.go`
  - add tests for tenant condition builder:
    - empty scope
    - tenant-only scope
    - tenant + project scope

Closes #601
