### PR TITLE
fix(ui): remove provider_type from update payload

### DIFF
--- a/ui/desktop/frontend/src/types/provider.ts
+++ b/ui/desktop/frontend/src/types/provider.ts
@@ -14,7 +14,7 @@ export interface ProviderData {
 export interface ProviderInput {
   name: string
   display_name?: string
-  provider_type: string
+  provider_type?: string
   api_base?: string
   api_key?: string
   enabled?: boolean

--- a/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
@@ -85,7 +85,6 @@ export function ProviderAdvancedDialog({
     try {
       const data: ProviderInput = {
         name: provider.name,
-        provider_type: provider.provider_type,
       };
 
       if (isACP) {

--- a/ui/web/src/pages/providers/provider-detail/provider-overview.tsx
+++ b/ui/web/src/pages/providers/provider-detail/provider-overview.tsx
@@ -436,7 +436,6 @@ export function ProviderOverview({ provider, onUpdate }: ProviderOverviewProps) 
       const data: ProviderInput = {
         name: provider.name,
         display_name: nextDisplayName || undefined,
-        provider_type: provider.provider_type,
         enabled,
       };
       if (submittedAPIKey) {

--- a/ui/web/src/types/provider.ts
+++ b/ui/web/src/types/provider.ts
@@ -19,7 +19,7 @@ export interface ProviderData {
 export interface ProviderInput {
   name: string;
   display_name?: string;
-  provider_type: string;
+  provider_type?: string;
   api_base?: string;
   api_key?: string;
   enabled?: boolean;


### PR DESCRIPTION
## Summary

- Remove redundant `provider_type` from detail page update payloads (overview, advanced dialog) — these pages don't expose a type selector during edit
- Make `provider_type` optional in `ProviderInput` type (only required for creation)

## Context

Backend `abcb9614` now accepts `provider_type` changes on update with SSRF re-validation. Onboarding/setup flows (web `step-provider`, desktop `ProviderStep`, `ProviderFormDialog`) intentionally keep sending `provider_type` so users can change provider type during setup.

Closes #635

## Test plan

- [ ] Open provider detail page → change name/settings → Save → succeeds
- [ ] Open provider advanced dialog → change settings → Save → succeeds
- [ ] Web onboarding: edit existing provider, change type → Save → type updates correctly
- [ ] Desktop onboarding: edit existing provider, change type → Save → type updates correctly