### PR TITLE
feat: harden Claude CLI backend for collaborative production workflows

### DIFF
--- a/docs/claude-cli-collab-audit-matrix.md
+++ b/docs/claude-cli-collab-audit-matrix.md
@@ -20,19 +20,45 @@ Each scenario should record:
 4. Actual observed behavior
 5. Severity and disposition
 
+## Findings Summary
+
+### Top blockers
+
+1. Collaborative group sessions are shared by design on most platforms. GoClaw collapses non-Discord group users into one group-scoped `userID`, reuses one session key per chat, and allows up to three concurrent runs in that session. This is workable for shared repo work, but it is not per-collaborator isolation.
+2. Claude account state is instance-global. Backend creation allows only one `claude_cli` provider per instance, and auth status is exposed through one server-level endpoint instead of a provider/account-aware health model.
+3. There is no explicit no-send or failover gate. If Claude auth degrades, GoClaw discovers it only when the next CLI call fails; the current provider card UI can still imply healthy authentication.
+
+### Likely-safe behaviors
+
+1. Solo flows are deterministic: `sessionKey -> workDir -> CLI session UUID -> resume/reset lifecycle`.
+2. The MCP bridge is materially hardened: the config lives outside the agent workdir, the request carries HMAC-signed context headers, and unsigned tenant headers are not trusted.
+3. Thread and topic session keys isolate Claude history files correctly, even though they do not automatically isolate the underlying repo workspace.
+
+### What later phases must solve
+
+- `#598` must decide whether collaborative repo workflows remain intentionally shared or gain stricter session/workspace boundaries.
+- `#597` must add provider/account-aware health, degraded state, and no-send behavior for Claude CLI.
+- `#599` should stay deferred until the isolation and health model are explicit; current code does not provide a safe native Claude pool vocabulary.
+
 ## Scenario Matrix
 
-| ID | Scenario | Focus | Expected invariant | Evidence to capture | Severity | Status |
-|----|----------|-------|--------------------|---------------------|----------|--------|
-| A1 | Single user, one repository, one Claude CLI session | Baseline behavior | Session state stays isolated to the selected repo and user intent | Request log, workspace path, session identifiers, tool access footprint | pending | pending |
-| A2 | Group chat or multi-user collaboration on one repository | Shared-repo safety | One user must not silently inherit another user's Claude CLI state, auth, or unintended filesystem scope | Prompt transcript, session routing path, workspace sharing markers, repo diff | pending | pending |
-| A3 | Concurrent Claude CLI runs against the same repository | Concurrency | Concurrent work must serialize or fail safely without corrupting session history or tool state | Timeline, locks or queues, output interleaving, resulting repo state | pending | pending |
-| A4 | Separate repositories on the same host | Cross-repo isolation | Repo A state must never leak into Repo B through session files, MCP bridge, or workspace reuse | Workspace roots, session storage locations, tool call targets, repo diff | pending | pending |
-| A5 | Auth loss during active work | Account health | GoClaw must detect degraded auth and stop sending unsafe work or route it per policy | Auth status transition, user-visible state, retry behavior, queued work outcome | pending | pending |
-| A6 | Resume, reset, and restart behavior | Lifecycle safety | Resume/reset must preserve intended isolation boundaries and remove stale session coupling | Restart steps, restored session metadata, post-reset behavior | pending | pending |
-| A7 | Per-user credential override or future pool-member override | Credential routing | Credential selection rules must be explicit, deterministic, and observable | Config source, selected account, fallback path, user-visible status | pending | pending |
-| A8 | MCP bridge and tool boundary review | Effective isolation | Session files alone are not enough; bridge and workspace/tool permissions must align with repo scope | Bridge config, workspace mounts, tool permission decisions, filesystem reach | pending | pending |
-| A9 | Failure mode when eligibility is unknown | No-send rule | Ambiguous account or routing eligibility should degrade to a no-send or blocked state, not silent best effort | Eligibility check path, user-visible error, absence of outbound request | pending | pending |
+| ID | Scenario | Expected invariant | Observed behavior | Code evidence | Severity | Classification | Follow-up |
+|----|----------|--------------------|-------------------|---------------|----------|----------------|-----------|
+| A1 | Single user, one repository, one Claude CLI session | Session history, workspace, and bridge context should stay tied to one user and one repo flow. | Meets the baseline. The loop passes session/user/channel/chat/workspace into the provider, the provider creates a stable workdir from `sessionKey`, and Claude resume state is deterministic. | `internal/agent/loop.go:246`, `internal/agent/loop_context.go:110`, `internal/providers/claude_cli_chat.go:18`, `internal/providers/claude_cli_session.go:87` | low | supported baseline | Preserve during `#598` hardening |
+| A2 | Group chat or multi-user collaboration on one repository | Collaborators should have explicit, well-understood sharing boundaries. | Non-Discord groups intentionally collapse to one group-scoped `userID`, one chat-scoped session key, and one effective workspace lineage. Discord guilds are per-user, but other group channels are shared-by-design. | `cmd/gateway_consumer_normal.go:49`, `cmd/gateway_consumer_normal.go:83`, `internal/agent/loop_context.go:115`, `internal/agent/loop_utils.go:36` | high | operational limitation plus documentation gap | `#598` |
+| A3 | Same repository, two concurrent runs, same session key | Concurrent work should serialize end-to-end or fail safely. | Group sessions allow `maxConcurrent = 3`, but Claude CLI only locks the subprocess call per session key. That means run scheduling can overlap while tool execution and workspace writes still interleave. | `cmd/gateway_consumer_normal.go:201`, `internal/scheduler/queue.go:36`, `internal/providers/claude_cli_chat.go:29` | high | product gap | `#598` |
+| A4 | Same repository, two concurrent runs, different session keys | Different session keys should isolate both history and workspace if reviewers expect separate work streams. | History isolation is better than workspace isolation. Thread/topic session keys split Claude history, but workspace resolution is based on user/chat scope rather than session key, so different sessions can still touch the same repo files. | `cmd/gateway_consumer_normal.go:56`, `cmd/gateway_consumer_normal.go:64`, `internal/agent/loop_context.go:115`, `internal/store/pg/agents_context.go:238` | medium | product gap | `#598` |
+| A5 | Different repositories on the same host | Repo A should not silently bleed into Repo B through session files or bridge config. | Mostly safe when the agents point at different base workspaces. Session workdirs and MCP config directories are derived from `sessionKey` and stored outside the repo workspace; the bridge carries the explicit workspace path. | `internal/providers/claude_cli_session.go:87`, `internal/providers/claude_cli_mcp.go:79`, `internal/providers/claude_cli_mcp.go:127`, `internal/gateway/server.go:214` | low | supported baseline with operator caveat | Reconfirm in `#598` tests |
+| A6 | Resume after successful run | Resuming should continue the same Claude history without guessing. | Meets the baseline. Claude CLI resumes from the deterministic workdir/session-id pair whenever the `.jsonl` session file exists. | `internal/providers/claude_cli_session.go:45`, `internal/providers/claude_cli_session.go:87` | low | supported baseline | None |
+| A7 | Reset after poisoned history or bad tool state | Reset should remove stale Claude history and prompt state. | Meets the baseline. `/reset` removes the Claude session file and `CLAUDE.md`, forcing a fresh session on the next run. | `internal/providers/claude_cli_session.go:243`, `cmd/gateway_consumer_handlers.go:459` | low | supported baseline | None |
+| A8 | Auth loss before a run | GoClaw should detect degraded Claude eligibility before sending unsafe work. | Not implemented. Auth status is checked only through a global endpoint, and the agent loop does not gate Claude CLI calls on that signal before execution. | `internal/http/provider_verify.go:124`, `internal/providers/claude_cli_auth.go:17`, `internal/agent/loop.go:246` | high | product gap | `#597` |
+| A9 | Auth loss during a resumed workflow | A resumed run should degrade into blocked/no-send instead of generic runtime failure. | Not implemented. The next Claude CLI subprocess call simply fails; there is no provider/account health state machine or no-send mode. | `internal/providers/claude_cli_chat.go:61`, `internal/http/provider_verify.go:127` | high | product gap | `#597` |
+| A10 | Per-user override or account switch interaction | Account routing should be explicit, observable, and per-provider or per-user when promised. | Not implemented. Backend creation blocks a second `claude_cli` provider per instance, the setup UI disables adding another one, and the UI instructs operators to log out and log back in globally. | `internal/http/providers.go:293`, `ui/web/src/pages/providers/provider-form-dialog.tsx:57`, `ui/web/src/pages/providers/provider-cli-section.tsx:67` | high | unsupported architecture / deferred enhancement | `#599` after `#597` and `#598` |
+
+## Doc and UI Drift
+
+- `docs/02-providers.md` describes Claude CLI as a local CLI session path, but it does not state the stronger current invariant that only one Claude CLI provider is allowed per instance and that auth visibility is global rather than provider-aware.
+- Provider list badges currently render Claude CLI as authenticated unconditionally, even though actual auth state is fetched separately through `/v1/providers/claude-cli/auth-status`. That overstates healthy account status in exactly the area `#597` needs to harden.
 
 ## Severity Guide
 
@@ -43,5 +69,5 @@ Each scenario should record:
 
 ## Notes
 
-- Do not close `#596` without filling the Evidence column for every applicable scenario.
-- If one scenario reveals multiple failure modes, add a follow-up row instead of overloading the original entry.
+- This pass is a code-path audit. It gives Phase 3 a defensible starting point without pretending runtime chaos testing has already happened.
+- Do not close `#596` until the matrix is backed by at least one targeted verification run for the high-severity rows.

--- a/docs/claude-cli-hardening-decision-log.md
+++ b/docs/claude-cli-hardening-decision-log.md
@@ -48,6 +48,13 @@ This log is the maintainer record for the `#595` to `#599` series. Each entry sh
 - Evidence: Prior repo analysis showed Claude CLI does not currently have the Codex/OpenAI-style routing vocabulary needed for a safe pool.
 - Follow-up: Revisit in `#599` after the audit, isolation, and failover model are concrete.
 
+### 2026-04-02: Initial Phase 2 audit confirms the current baseline is shared-session collaboration, not account-aware isolation
+
+- Decision: Treat the present Claude CLI model as one-account-per-instance with shared collaborative sessions on most group channels.
+- Why: The backend blocks a second `claude_cli` provider, auth visibility is global, and non-Discord group chats intentionally collapse collaborators into one group-scoped user/workspace lineage.
+- Evidence: `internal/http/providers.go`, `internal/http/provider_verify.go`, `cmd/gateway_consumer_normal.go`, `internal/agent/loop_context.go`, `docs/claude-cli-collab-audit-matrix.md`.
+- Follow-up: `#598` must harden or document the shared-session boundary explicitly, and `#597` must introduce account-aware degraded/no-send behavior before any pooling discussion is credible.
+
 ## Open Questions
 
 - What exact filesystem and MCP-bridge boundaries are in effect for Claude CLI sessions today?


### PR DESCRIPTION
## Summary
- start the single-branch Claude CLI hardening stream for #595
- add the initial audit matrix and maintainer decision log
- keep #596 to #599 flowing through one dedicated branch/worktree

## Serial Checklist
- [ ] #596 audit Claude CLI behavior across collaborative repo workflows
- [ ] #598 harden Claude CLI workspace and session isolation boundaries
- [ ] #597 define Claude CLI account health and failover model
- [ ] #599 evaluate external routing options for Claude CLI account pooling
- [ ] #595 synthesize the supported baseline and close the serial

## Notes
- One branch and one worktree only for this series.
- Current kickoff commit is docs-first by design; audit evidence comes before hardening code.
- Default stance remains no native Claude account pooling in the first rollout unless the audit proves it is required.

Refs #595
