### PR TITLE
fix(agent): defer warning messages after parallel tool results

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -699,7 +699,13 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (result *RunResult, 
 
 			// 5. Process results sequentially: emit events, append messages, save to session
 			// Note: tool span start/end already emitted inside goroutines above.
+			// IMPORTANT: warning messages (role="user") must be deferred until AFTER all
+			// tool results are appended. Inserting a user message between tool results
+			// breaks the Anthropic API requirement that all tool_results for a set of
+			// tool_uses must be consecutive (causes "tool_use ids without tool_result"
+			// errors when routed through LiteLLM OpenAI→Anthropic conversion).
 			var loopStuck bool
+			var deferredWarnings []providers.Message
 			for _, r := range collected {
 				// Record tool execution time for adaptive thresholds.
 				toolTiming.Record(r.tc.Name, time.Since(r.spanStart).Milliseconds())
@@ -708,12 +714,14 @@ func (l *Loop) runLoop(ctx context.Context, req RunRequest) (result *RunResult, 
 				toolMsg, warningMsgs, action := l.processToolResult(ctx, rs, &req, emitRun, r.tc, r.registryName, r.result, hadBootstrap)
 				messages = append(messages, toolMsg)
 				rs.pendingMsgs = append(rs.pendingMsgs, toolMsg)
-				messages = append(messages, warningMsgs...)
+				deferredWarnings = append(deferredWarnings, warningMsgs...)
 				if action == toolResultBreak {
 					loopStuck = true
 					break
 				}
 			}
+			// Append deferred warnings after all tool results to preserve consecutive grouping.
+			messages = append(messages, deferredWarnings...)
 
 			// Check read-only streak after processing all parallel results.
 			if !loopStuck {


### PR DESCRIPTION
## Summary

Fixes #642 — parallel tool calls break the Anthropic API when loop detection triggers a warning message mid-processing.

When `processToolResult` generates a warning (loop detection, same-result detection), the warning message (`role="user"`) was appended **between** tool result messages (`role="tool"`). This breaks OpenAI→Anthropic format conversion because the proxy (LiteLLM, etc.) groups consecutive `tool` messages into a single `user` message with `tool_result` blocks — an intervening `user` warning splits this group, orphaning subsequent tool results.

**Fix:** accumulate warnings during parallel result processing, append them after all tool results.

## Before (broken)

```
assistant: [tool_use_1..5]
tool: result_1
tool: result_2
tool: result_3
tool: result_4
user: "WARNING: same tool returned identical results..."  ← BREAKS grouping
tool: result_5  ← orphaned, Anthropic returns HTTP 400
```

## After (fixed)

```
assistant: [tool_use_1..5]
tool: result_1
tool: result_2
tool: result_3
tool: result_4
tool: result_5  ← all consecutive
user: "WARNING: same tool returned identical results..."  ← after all results
```

## Evidence

| Trace | Status | Environment |
|-------|--------|-------------|
| `019d4d2a-dcbd-7e41-9d9b-e9423a6efffc` (before fix) | ❌ `HTTP 400: tool_use ids without tool_result` | LiteLLM → anthropic/claude-sonnet-4-6 |
| `019d4d50-5f3c-77fc-8b21-136b8394d723` (after fix) | ✅ 6 LLM calls, all completed | Same setup |

### Reproduction conditions

1. LLM returns ≥4 parallel tool calls of the **same tool** (common with search tools)
2. ≥4 calls return identical results → triggers `sameResultWarning` (threshold=4)
3. Provider is OpenAI-compatible proxy → Anthropic (e.g., LiteLLM)

### Why only parallel path is affected

The **single-tool path** (line ~594) appends `warningMsgs` inline, which is fine — there's only one tool result, so no grouping to break. The **parallel path** (line ~711) had the same pattern but with multiple tool results where the grouping matters.

## Changes

- `internal/agent/loop.go`: Replace inline `messages = append(messages, warningMsgs...)` with deferred accumulation + post-loop append

## Safety

- Warning message position relative to tool results doesn't affect LLM behavior (they're informational hints)
- `pendingMsgs` (session persistence) still gets each `toolMsg` immediately — no change to checkpoint behavior
- Single-tool path unchanged
- All existing tests pass (`go test ./internal/agent/`)

## Test plan

- [x] `go build` (PG + SQLite) pass
- [x] `go vet ./internal/agent/` pass
- [x] All agent tests pass (sanitize, history, loop detection, lazy MCP)
- [x] Deployed to production, verified with real trace