### PR TITLE
fix(docker): resolve @rollup/rollup-linux-arm64-musl missing on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@
 FROM node:22-alpine AS web-builder
 RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 WORKDIR /app
-COPY ui/web/package.json ui/web/pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+# Copy .npmrc first so pnpm fetches musl native bindings (needed on Alpine)
+COPY ui/web/.npmrc ui/web/package.json ui/web/pnpm-lock.yaml ./
+# Use --no-frozen-lockfile so pnpm can fetch musl native bindings missing from macOS-generated lockfile.
+# Lockfile is still copied above to pin versions; .npmrc sets supportedArchitectures for Alpine (musl).
+RUN pnpm install --no-frozen-lockfile
 COPY ui/web/ .
 RUN pnpm build
 

--- a/ui/web/.npmrc
+++ b/ui/web/.npmrc
@@ -1,0 +1,5 @@
+# Ensure pnpm fetches native bindings for both glibc and musl (Alpine Docker builds)
+supportedArchitectures.cpu[]=arm64
+supportedArchitectures.cpu[]=x64
+supportedArchitectures.libc[]=musl
+supportedArchitectures.libc[]=glibc


### PR DESCRIPTION
Closes #646

## Problem
Docker build fails on ARM64/Alpine due to missing musl rollup native binding. pnpm attempts to resolve x86_64 Linux binaries from npm, causing build failures on ARM64 environments.

## Solution
- Added `ui/web/.npmrc` with `supportedArchitectures` for musl+glibc architectures (arm64, x64)
- Updated Dockerfile to copy `.npmrc` before `pnpm install` to apply architecture constraints
- Added `--no-frozen-lockfile` flag to allow pnpm to resolve correct native binaries