### PR TITLE
fix(docs): correct team tools reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,8 +278,7 @@ Agents communicate through explicit **permission links** with direction control 
 </p>
 
 - **Shared task board** — Create, claim, complete, search tasks with `blocked_by` dependencies
-- **Team mailbox** — Direct peer-to-peer messaging and broadcasts
-- **Tools**: `team_tasks` for task management, `team_message` for mailbox
+- **Tools**: `team_tasks` for task management, `spawn` for subagent orchestration
 
 > For delegation details, permission links, and concurrency control, see the [Agent Teams docs](https://docs.goclaw.sh/#teams-what-are-teams).
 
@@ -312,7 +311,6 @@ Agents communicate through explicit **permission links** with direction control 
 | `spawn`            | —             | Spawn a subagent                                             |
 | `subagents`        | sessions      | Control running subagents                                    |
 | `team_tasks`       | teams         | Shared task board (list, create, claim, complete, search)    |
-| `team_message`     | teams         | Team mailbox (send, broadcast, read)                         |
 | `sessions_list`    | sessions      | List active sessions                                         |
 | `sessions_history` | sessions      | View session history                                         |
 | `sessions_send`    | sessions      | Send message to a session                                    |


### PR DESCRIPTION
- Replace `team_message` with `spawn` for subagent orchestration
- Update team communication description to reflect current implementation
- Align docs with actual tool capabilities

Related: Team coordination updates for agent orchestration

Related issue: https://github.com/nextlevelbuilder/goclaw/issues/645

## Summary
<!-- 1-2 sentences: What does this PR do and why? -->

## Type
<!-- Check one -->
- [ ] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [x] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [x] New user-facing strings added to all 3 locales (en/vi/zh)
- [x] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
