### PR TITLE
ci: publish Docker images with dev tag on push to dev branch

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+    branches:
+      - dev
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
@@ -79,10 +81,14 @@ jobs:
             ${{ env.GHCR_IMAGE }}
             ${{ env.DOCKERHUB_IMAGE }}
           tags: |
+            # Release tags (on version tag push)
             type=semver,pattern={{version}},suffix=${{ matrix.suffix }}
             type=semver,pattern={{major}}.{{minor}},suffix=${{ matrix.suffix }}
-            type=raw,value=latest,enable=${{ matrix.suffix == '' }},suffix=
-            type=raw,value=${{ matrix.variant }},enable=${{ matrix.suffix != '' }}
+            type=raw,value=latest,enable=${{ matrix.suffix == '' && github.ref_type == 'tag' }},suffix=
+            type=raw,value=${{ matrix.variant }},enable=${{ matrix.suffix != '' && github.ref_type == 'tag' }}
+            # Dev tags (on dev branch push)
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' && matrix.suffix == '' }},suffix=
+            type=raw,value=dev${{ matrix.suffix }},enable=${{ github.ref == 'refs/heads/dev' && matrix.suffix != '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -97,7 +103,7 @@ jobs:
             ENABLE_EMBEDUI=${{ matrix.enable_embedui }}
             ENABLE_PYTHON=${{ matrix.enable_python }}
             ENABLE_FULL_SKILLS=${{ matrix.enable_full_skills }}
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || format('dev-{0}', github.sha) }}
           cache-from: type=gha,scope=${{ matrix.variant }}
           cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
 
@@ -137,7 +143,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Closes #652

## Summary

- Extend `docker-publish.yaml` to also trigger on pushes to `dev` branch
- Release tag behavior unchanged — `latest`/`base`/`full`/`otel` only set on version tags
- VERSION build arg uses `dev-<sha>` for dev builds (vs `v1.2.3` for releases)

## Docker Tags

| Trigger | GHCR (`ghcr.io/nextlevelbuilder/goclaw`) | Docker Hub (`digitop/goclaw`) |
|---------|------------------------------------------|-------------------------------|
| `v*.*.*` tag (unchanged) | `:1.2.3`, `:1.2`, `:latest`, `:base`, `:full`, `:otel` | same |
| `dev` branch push (new) | `:dev`, `:dev-base`, `:dev-full`, `:dev-otel` | same |

Web UI image (`goclaw-web`) gets `:dev` on dev push, `:latest` + semver on release.

## Usage

```bash
# Pull latest dev build
docker pull digitop/goclaw:dev
docker pull digitop/goclaw:dev-full    # all runtimes
docker pull digitop/goclaw:dev-otel    # with OpenTelemetry

# Or from GHCR
docker pull ghcr.io/nextlevelbuilder/goclaw:dev
```

## Test plan

- [ ] Merge to `dev` and verify GHA workflow triggers
- [ ] Confirm all 4 gateway variants + web image pushed to GHCR and Docker Hub
- [ ] `docker pull digitop/goclaw:dev` works
- [ ] Release tag push (`v*.*.*`) still produces correct `latest`/semver tags (no regression)