### PR TITLE
fix(providers): clamp max_tokens to 4096 for Fireworks non-streaming requests

### DIFF
--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -39,6 +39,12 @@ func isOpenAINativeEndpoint(apiBase string) bool {
 	lower := strings.ToLower(apiBase)
 	return strings.Contains(lower, "api.openai.com")
 }
+// isFireworksEndpoint returns true for Fireworks AI endpoints.
+// Fireworks requires stream=true for max_tokens > 4096.
+func (p *OpenAIProvider) isFireworksEndpoint() bool {
+	lower := strings.ToLower(p.apiBase)
+	return strings.Contains(lower, "fireworks.ai") || strings.Contains(lower, "fireworks")
+}
 
 func NewOpenAIProvider(name, apiKey, apiBase, defaultModel string) *OpenAIProvider {
 	if apiBase == "" {
@@ -404,15 +410,23 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 		}
 	}
 
-	// Merge options
-	capabilityModel := modelFamily(model)
-	if v, ok := req.Options[OptMaxTokens]; ok {
-		if strings.HasPrefix(capabilityModel, "gpt-5") || strings.HasPrefix(capabilityModel, "o1") || strings.HasPrefix(capabilityModel, "o3") || strings.HasPrefix(capabilityModel, "o4") {
-			body["max_completion_tokens"] = v
-		} else {
-			body["max_tokens"] = v
-		}
-	}
+// Merge options
+capabilityModel := modelFamily(model)
+if v, ok := req.Options[OptMaxTokens]; ok {
+// Fireworks requires stream=true for max_tokens > 4096
+// For non-streaming requests, clamp to 4096 to avoid 400 error
+if !stream && p.isFireworksEndpoint() {
+if maxTokens, isInt := v.(int); isInt && maxTokens > 4096 {
+v = 4096
+slog.Debug("max_tokens clamped to 4096 for Fireworks non-streaming request", "provider", p.name, "model", model)
+}
+}
+if strings.HasPrefix(capabilityModel, "gpt-5") || strings.HasPrefix(capabilityModel, "o1") || strings.HasPrefix(capabilityModel, "o3") || strings.HasPrefix(capabilityModel, "o4") {
+body["max_completion_tokens"] = v
+} else {
+body["max_tokens"] = v
+}
+}
 	if v, ok := req.Options[OptTemperature]; ok {
 		// Certain model families don't support custom temperature (locked to default).
 		// This is a model-level constraint, not provider-specific — applies to both OpenAI and Azure.


### PR DESCRIPTION
## Summary

Fireworks API requires `stream=true` when `max_tokens > 4096`. When generating agents with Fireworks provider, the hardcoded `max_tokens: 8192` in non-streaming requests caused a 400 error:

```
fireworks: HTTP 400: Requests with max_tokens > 4096 must have stream=true
```

## Changes

- Add `isFireworksEndpoint()` helper to detect Fireworks endpoints
- Clamp `max_tokens` to 4096 for Fireworks non-streaming requests

## Test

1. Configure Fireworks provider with API key
2. Create agent with Fireworks provider
3. Agent generation should complete without 400 error

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)