### PR TITLE
fix(docker): pin Python/npm dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@
 FROM node:22-alpine AS web-builder
 RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 WORKDIR /app
-COPY ui/web/package.json ui/web/pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+# Copy .npmrc first so pnpm fetches musl native bindings (needed on Alpine)
+COPY ui/web/.npmrc ui/web/package.json ui/web/pnpm-lock.yaml ./
+# Use --no-frozen-lockfile so pnpm can fetch musl native bindings missing from macOS-generated lockfile.
+# Lockfile is still copied above to pin versions; .npmrc sets supportedArchitectures for Alpine (musl).
+RUN pnpm install --no-frozen-lockfile
 COPY ui/web/ .
 RUN pnpm build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,10 @@
 FROM node:22-alpine AS web-builder
 RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 WORKDIR /app
-# Copy .npmrc first so pnpm fetches musl native bindings (needed on Alpine)
+# Copy .npmrc first so pnpm resolves musl native bindings (needed on Alpine).
+# The lockfile already includes musl entries thanks to supportedArchitectures in .npmrc.
 COPY ui/web/.npmrc ui/web/package.json ui/web/pnpm-lock.yaml ./
-# Use --no-frozen-lockfile so pnpm can fetch musl native bindings missing from macOS-generated lockfile.
-# Lockfile is still copied above to pin versions; .npmrc sets supportedArchitectures for Alpine (musl).
-RUN pnpm install --no-frozen-lockfile
+RUN pnpm install --frozen-lockfile
 COPY ui/web/ .
 RUN pnpm build
 
@@ -96,7 +95,7 @@ RUN set -eux; \
         fi; \
     fi; \
     if [ "$ENABLE_CLAUDE_CLI" = "true" ]; then \
-        npm install -g --cache /tmp/npm-cache @anthropic-ai/claude-code; \
+        npm install -g --cache /tmp/npm-cache @anthropic-ai/claude-code@^1.0.47; \
         rm -rf /tmp/npm-cache; \
     fi; \
     rm -f /tmp/requirements-base.txt /tmp/requirements-skills.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,11 @@ ARG ENABLE_NODE=false
 ARG ENABLE_FULL_SKILLS=false
 ARG ENABLE_CLAUDE_CLI=false
 
+# Copy pinned Python deps (cleaned up after install).
+# requirements-base.txt: shared deps for ENABLE_PYTHON and ENABLE_FULL_SKILLS.
+# requirements-skills.txt: additional deps only for ENABLE_FULL_SKILLS.
+COPY docker/requirements-base.txt docker/requirements-skills.txt /tmp/
+
 # Install ca-certificates + wget (healthcheck) + optional runtimes.
 # ENABLE_FULL_SKILLS=true pre-installs all skill deps (larger image, no on-demand install needed).
 # Otherwise, skill packages are installed on-demand via the admin UI.
@@ -77,14 +82,14 @@ RUN set -eux; \
     if [ "$ENABLE_FULL_SKILLS" = "true" ]; then \
         apk add --no-cache python3 py3-pip nodejs npm pandoc github-cli poppler-utils bash; \
         pip3 install --no-cache-dir --break-system-packages \
-            pypdf openpyxl pandas python-pptx markitdown defusedxml lxml \
-            pdfplumber pdf2image anthropic; \
-        npm install -g --cache /tmp/npm-cache docx pptxgenjs; \
+            -r /tmp/requirements-base.txt -r /tmp/requirements-skills.txt; \
+        npm install -g --cache /tmp/npm-cache docx@^9.6.1 pptxgenjs@^4.0.1; \
         rm -rf /tmp/npm-cache /root/.cache /var/cache/apk/*; \
     else \
         if [ "$ENABLE_PYTHON" = "true" ]; then \
             apk add --no-cache python3 py3-pip; \
-            pip3 install --no-cache-dir --break-system-packages edge-tts; \
+            pip3 install --no-cache-dir --break-system-packages \
+                -r /tmp/requirements-base.txt; \
         fi; \
         if [ "$ENABLE_NODE" = "true" ] || [ "$ENABLE_CLAUDE_CLI" = "true" ]; then \
             apk add --no-cache nodejs npm; \
@@ -93,7 +98,8 @@ RUN set -eux; \
     if [ "$ENABLE_CLAUDE_CLI" = "true" ]; then \
         npm install -g --cache /tmp/npm-cache @anthropic-ai/claude-code; \
         rm -rf /tmp/npm-cache; \
-    fi
+    fi; \
+    rm -f /tmp/requirements-base.txt /tmp/requirements-skills.txt
 
 # Non-root user
 RUN adduser -D -u 1000 -h /app goclaw

--- a/docker/requirements-base.txt
+++ b/docker/requirements-base.txt
@@ -1,0 +1,7 @@
+# Base Python dependencies — installed when ENABLE_PYTHON=true or ENABLE_FULL_SKILLS=true.
+# Uses compatible release (~=) to allow patch updates within the same minor version.
+# e.g. ~=7.2.8 allows >=7.2.8, <7.3.0
+#
+# Last reviewed: 2026-04-03
+
+edge-tts~=7.2.8

--- a/docker/requirements-skills.txt
+++ b/docker/requirements-skills.txt
@@ -1,0 +1,21 @@
+# Additional Python dependencies for full skill runtime (ENABLE_FULL_SKILLS=true).
+# Installed on top of requirements-base.txt.
+# Uses compatible release (~=) to allow patch updates within the same minor version.
+#
+# Last reviewed: 2026-04-03
+
+# Document processing
+pypdf~=6.9.2
+openpyxl~=3.1.5
+python-pptx~=1.0.2
+pdfplumber~=0.11.9
+pdf2image~=1.17.0
+markitdown<0.2.0
+
+# Data & XML
+pandas~=3.0.2
+defusedxml~=0.7.1
+lxml~=6.0.2
+
+# AI SDK — relaxed to allow minor updates (fast-moving SDK)
+anthropic>=0.88.0,<2.0.0

--- a/ui/web/.npmrc
+++ b/ui/web/.npmrc
@@ -1,0 +1,5 @@
+# Ensure pnpm fetches native bindings for both glibc and musl (Alpine Docker builds)
+supportedArchitectures.cpu[]=arm64
+supportedArchitectures.cpu[]=x64
+supportedArchitectures.libc[]=musl
+supportedArchitectures.libc[]=glibc


### PR DESCRIPTION
## Summary
- Add `docker/requirements-base.txt` for shared Python deps (edge-tts) — installed when `ENABLE_PYTHON=true`
- Add `docker/requirements-skills.txt` for full skill deps (10 packages) — installed when `ENABLE_FULL_SKILLS=true`
- Pin npm global packages with `@^version` (docx, pptxgenjs)
- Dockerfile now uses `-r` requirements files instead of inline package lists
- Also fixes pre-existing `-full` variant build failure (markitdown → magika → onnxruntime has no musl wheel)

## Version strategy
| Ecosystem | Operator | Meaning |
|-----------|----------|---------|
| pip | `~=X.Y.Z` | patch updates only (>=X.Y.Z, <X.(Y+1).0) |
| pip (anthropic) | `>=0.88,<2.0` | relaxed — fast-moving AI SDK |
| pip (markitdown) | `<0.2.0` | relaxed — avoids musl-incompatible transitive deps |
| npm | `@^X.Y.Z` | minor+patch updates |

## Test plan
- [x] `docker buildx build --check` passes
- [x] `make reset` builds and starts successfully
- [x] `go build ./...` compiles
- [ ] CI docker-publish workflow succeeds

Closes #662