### PR TITLE
feat(docker): make goclaw-ui stop instantly

### DIFF
--- a/docker-compose.selfservice.yml
+++ b/docker-compose.selfservice.yml
@@ -24,3 +24,4 @@ services:
     depends_on:
       - goclaw
     restart: unless-stopped
+    stop_signal: SIGTERM


### PR DESCRIPTION
## Summary
This PR optimizes the container lifecycle for the `goclaw-ui` service by refining its termination signal.

## Description
Currently, the `goclaw-ui` container (Nginx) may not respond optimally to the default Docker stop signal, leading to unnecessary delays during deployments or restarts. By explicitly defining `stop_signal: SIGTERM`, we ensure:
- **Immediate Response**: Nginx catches the signal to trigger a fast shutdown.
- **Efficiency**: Reduces the overall wait time during `docker compose down` or service updates.

## Technical Details
Added stop_signal: SIGTERM to the goclaw-ui service configuration.

## Checklist
- [x] I have tested this change by running docker stop and verified the shutdown speed.