### PR TITLE
fix(openai): normalize Mistral tool call IDs

### DIFF
--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -606,23 +605,18 @@ func clampedLimit(body map[string]any) any {
 
 const maxToolCallIDLen = 40
 
-var mistralToolIDNonAlnum = regexp.MustCompile(`[^a-zA-Z0-9]+`)
-
-func stripMistralToolIDAlnum(s string) string {
-	return mistralToolIDNonAlnum.ReplaceAllString(s, "")
-}
-
+// normalizeMistralToolCallID deterministically maps any tool call ID to a
+// 9-character alphanumeric string required by the Mistral API.
+// Uses SHA-256 of the full ID to avoid prefix-dependent collisions.
 func normalizeMistralToolCallID(id string) string {
-	s := stripMistralToolIDAlnum(id)
-	if len(s) < 9 {
-		sum := sha1.Sum([]byte(id))
-		s = stripMistralToolIDAlnum(s + hex.EncodeToString(sum[:]))
-	}
-	return s[:9]
+	h := sha256.Sum256([]byte(id))
+	return hex.EncodeToString(h[:])[:9]
 }
 
+// wireToolCallID dispatches to Mistral-specific normalization (9-char alnum)
+// or the standard OpenAI truncation (40-char max) based on the provider.
 func (p *OpenAIProvider) wireToolCallID(id string) string {
-	if p.name == "mistral" {
+	if p.name == "mistral" || p.providerType == "mistral" {
 		return normalizeMistralToolCallID(id)
 	}
 	return truncateToolCallID(id)

--- a/internal/providers/openai_test.go
+++ b/internal/providers/openai_test.go
@@ -260,7 +260,7 @@ func TestBuildRequestBody_LegacyLongToolCallIDsStayUnique(t *testing.T) {
 	}
 }
 
-var mistralWireIDRe = regexp.MustCompile(`^[a-zA-Z0-9]{9}$`)
+var mistralWireIDRe = regexp.MustCompile(`^[0-9a-f]{9}$`)
 
 func TestNormalizeMistralToolCallID_DeterministicNineChars(t *testing.T) {
 	id := "call_85f419357e554e8983a7edb4d2317e93e15"
@@ -270,7 +270,16 @@ func TestNormalizeMistralToolCallID_DeterministicNineChars(t *testing.T) {
 		t.Fatalf("normalizeMistralToolCallID not deterministic: %q vs %q", a, b)
 	}
 	if !mistralWireIDRe.MatchString(a) {
-		t.Fatalf("got %q, want exactly 9 alphanumeric chars", a)
+		t.Fatalf("got %q, want exactly 9 hex chars", a)
+	}
+}
+
+func TestNormalizeMistralToolCallID_DistinctIDsStayUnique(t *testing.T) {
+	// IDs sharing a long prefix must not collide after normalization.
+	id1 := "call_a1b2c3d4e5f6a1b2c3d4e5f6_suffix1"
+	id2 := "call_a1b2c3d4e5f6a1b2c3d4e5f6_suffix2"
+	if normalizeMistralToolCallID(id1) == normalizeMistralToolCallID(id2) {
+		t.Fatal("distinct IDs must not collide after normalization")
 	}
 }
 
@@ -309,6 +318,18 @@ func TestBuildRequestBody_MistralToolCallIDsWireFormat(t *testing.T) {
 		t.Fatalf("IDs must match: tool_calls.id=%q tool_call_id=%q", assistantID, toolResultID)
 	}
 	if !mistralWireIDRe.MatchString(assistantID) {
-		t.Fatalf("mistral wire id %q must be 9 alphanumeric chars", assistantID)
+		t.Fatalf("mistral wire id %q must be 9 hex chars", assistantID)
+	}
+}
+
+func TestBuildRequestBody_MistralDBProviderTypeDetected(t *testing.T) {
+	// DB-loaded Mistral providers use providerType="mistral" with a user-chosen name.
+	p := NewOpenAIProvider("my-mistral", "key", "https://api.mistral.ai/v1", "mistral-large-latest")
+	p.WithProviderType("mistral")
+
+	id := "call_85f419357e554e8983a7edb4d2317e93e15"
+	got := p.wireToolCallID(id)
+	if !mistralWireIDRe.MatchString(got) {
+		t.Fatalf("DB provider with providerType=mistral: got %q, want 9 hex chars", got)
 	}
 }


### PR DESCRIPTION
## Summary

Fix Mistral tool call ID formatting on the outbound OpenAI-compatible payload.

For provider `mistral` only, this PR normalizes both `tool_calls[].id` and `tool` message `tool_call_id` to a 9-character alphanumeric value before sending the request. Other providers keep the existing `truncateToolCallID` behavior unchanged.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch

`dev`

## Checklist

- [ ] `go build ./...` passes
- [ ] `go build -tags sqliteonly ./...` passes (if Go changes)
- [ ] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials

## Test Plan

- `go test ./internal/providers/... -count=1 -short`
- Manual smoke test with Mistral tool calling
- Verified outbound IDs are 9-character alphanumeric values
- Verified non-Mistral behavior is unchanged