### PR TITLE
fix(http): allow localhost URLs for local providers

### DIFF
--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -237,10 +237,18 @@ func normalizeOllamaAPIBase(p *store.LLMProviderData) {
 	}
 }
 
+// localProviderTypes are provider types that legitimately run on localhost
+// (e.g. Ollama, Claude CLI). SSRF checks are skipped for these.
+var localProviderTypes = map[string]bool{
+	store.ProviderOllama:    true,
+	store.ProviderClaudeCLI: true,
+	store.ProviderACP:       true,
+}
+
 // validateProviderURL rejects provider base URLs pointing to internal/private networks.
 // Defense-in-depth: prevents SSRF when providers are later used for API calls.
 func validateProviderURL(rawURL string, providerType string) error {
-	if rawURL == "" || providerType == store.ProviderACP {
+	if rawURL == "" || localProviderTypes[providerType] {
 		return nil
 	}
 	u, err := url.Parse(rawURL)


### PR DESCRIPTION
## Summary
- SSRF validation blocked `http://localhost:11434/v1` for Ollama (Local) provider type
- Added `localProviderTypes` map to exempt `ollama`, `claude_cli`, `acp` from SSRF URL checks
- Non-local provider types (openai_compat, anthropic, etc.) still fully protected

Closes #673

## Test plan
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes
- [x] `go vet ./...` passes
- [x] Existing provider URL tests pass
- [x] Manual: create Ollama provider with `http://localhost:11434/v1` → succeeds
- [x] Manual: create OpenAI-compat provider with `http://localhost:8080` → still blocked