### PR TITLE
fix(scheduler): drain queued runs in DropOldPolicy test to prevent CI hang

### DIFF
--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -292,8 +292,15 @@ func TestScheduler_DropOldPolicy(t *testing.T) {
 		// OK, still pending
 	}
 
-	// Unblock everything
+	// Unblock everything and drain queued runs before Stop().
+	// Without draining, Stop() races with scheduleNext() causing wg.Wait() to hang.
 	close(blockCh)
+
+	select {
+	case <-ch3:
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued run didn't complete after unblock")
+	}
 }
 
 func TestScheduler_InterruptMode(t *testing.T) {


### PR DESCRIPTION
## Summary

- Drain queued runs before `defer sched.Stop()` in `TestScheduler_DropOldPolicy` to prevent race between `scheduleNext()` and `lane.wg.Wait()`

Closes #677

## Test Plan

- [x] `go test -race -run TestScheduler_DropOldPolicy -count=10` — 10/10 pass
- [x] 1 file, 10 lines changed (test only, no production code)