### PR TITLE
fix(channels): scope channel manager keys by tenant to prevent cross-tenant collisions

### DIFF
--- a/internal/channels/instance_loader.go
+++ b/internal/channels/instance_loader.go
@@ -200,15 +200,26 @@ func (l *InstanceLoader) LoadedNames() map[string]struct{} {
 	return result
 }
 
+// qualifiedChannelName creates a tenant-scoped key for the channel manager.
+// Uses first 8 chars of tenant UUID as prefix for brevity.
+// Returns name as-is for zero UUID (single-tenant / legacy).
+func qualifiedChannelName(tenantID uuid.UUID, name string) string {
+	if tenantID == uuid.Nil {
+		return name
+	}
+	return tenantID.String()[:8] + ":" + name
+}
+
 // loadInstance creates and registers a single channel from a DB instance (caller must hold lock).
 // If autoStart is true, the channel is started immediately (used by Reload).
 // If false, the caller is responsible for starting (used by LoadAll, where StartAll handles it).
 func (l *InstanceLoader) loadInstance(ctx context.Context, inst store.ChannelInstanceData, autoStart bool) error {
-	l.loaded[inst.Name] = struct{}{}
+	qName := qualifiedChannelName(inst.TenantID, inst.Name)
+	l.loaded[qName] = struct{}{}
 
 	factory, ok := l.factories[inst.ChannelType]
 	if !ok {
-		l.manager.RecordHealth(inst.Name, NewChannelHealthForType(
+		l.manager.RecordHealth(qName, NewChannelHealthForType(
 			inst.ChannelType,
 			ChannelHealthStateFailed,
 			"Unsupported channel type",
@@ -216,7 +227,7 @@ func (l *InstanceLoader) loadInstance(ctx context.Context, inst store.ChannelIns
 			ChannelFailureKindConfig,
 			false,
 		))
-		slog.Warn("no factory for channel type", "type", inst.ChannelType, "name", inst.Name)
+		slog.Warn("no factory for channel type", "type", inst.ChannelType, "name", qName)
 		return nil
 	}
 
@@ -224,13 +235,13 @@ func (l *InstanceLoader) loadInstance(ctx context.Context, inst store.ChannelIns
 	// Older UI versions saved select-based bool fields as strings.
 	cfg := coerceStringBools(inst.Config)
 
-	ch, err := factory(inst.Name, inst.Credentials, cfg, l.msgBus, l.pairingSvc)
+	ch, err := factory(qName, inst.Credentials, cfg, l.msgBus, l.pairingSvc)
 	if err != nil {
-		l.manager.RecordFailureForType(inst.Name, inst.ChannelType, "", err)
+		l.manager.RecordFailureForType(qName, inst.ChannelType, "", err)
 		return err
 	}
 	if ch == nil {
-		l.manager.RecordHealth(inst.Name, NewChannelHealthForType(
+		l.manager.RecordHealth(qName, NewChannelHealthForType(
 			inst.ChannelType,
 			ChannelHealthStateFailed,
 			"Missing credentials",
@@ -238,7 +249,7 @@ func (l *InstanceLoader) loadInstance(ctx context.Context, inst store.ChannelIns
 			ChannelFailureKindConfig,
 			false,
 		))
-		slog.Info("channel instance not ready (missing credentials)", "name", inst.Name, "type", inst.ChannelType)
+		slog.Info("channel instance not ready (missing credentials)", "name", qName, "type", inst.ChannelType)
 		return nil
 	}
 
@@ -250,8 +261,8 @@ func (l *InstanceLoader) loadInstance(ctx context.Context, inst store.ChannelIns
 		var err error
 		ag, err = l.agentStore.GetByID(instCtx, inst.AgentID)
 		if err != nil {
-			l.manager.RecordFailureForType(inst.Name, inst.ChannelType, "", fmt.Errorf("agent %s not found for channel %s: %w", inst.AgentID, inst.Name, err))
-			return fmt.Errorf("agent %s not found for channel %s: %w", inst.AgentID, inst.Name, err)
+			l.manager.RecordFailureForType(qName, inst.ChannelType, "", fmt.Errorf("agent %s not found for channel %s: %w", inst.AgentID, qName, err))
+			return fmt.Errorf("agent %s not found for channel %s: %w", inst.AgentID, qName, err)
 		}
 		base.SetAgentID(ag.AgentKey)
 	}
@@ -308,7 +319,7 @@ func (l *InstanceLoader) loadInstance(ctx context.Context, inst store.ChannelIns
 				cc.MaxTokens = l.pendingCompactCfg.MaxTokens
 			}
 			pc.SetPendingCompaction(cc)
-			slog.Debug("pending compaction configured", "channel", inst.Name, "provider", p.Name(), "model", model,
+			slog.Debug("pending compaction configured", "channel", qName, "provider", p.Name(), "model", model,
 				"threshold", cc.Threshold, "keep_recent", cc.KeepRecent, "max_tokens", cc.MaxTokens)
 		} else {
 			attemptedProvider := ""
@@ -319,23 +330,23 @@ func (l *InstanceLoader) loadInstance(ctx context.Context, inst store.ChannelIns
 				attemptedProvider = ag.Provider
 			}
 			slog.Warn("pending compaction not configured: provider/model unavailable",
-				"channel", inst.Name, "agent_id", inst.AgentID, "attempted_provider", attemptedProvider)
+				"channel", qName, "agent_id", inst.AgentID, "attempted_provider", attemptedProvider)
 		}
 	}
-	l.manager.RegisterChannel(inst.Name, ch)
+	l.manager.RegisterChannel(qName, ch)
 
 	// Start the channel if requested (Reload path). LoadAll defers to StartAll.
 	if autoStart {
 		if err := ch.Start(ctx); err != nil {
-			l.manager.recordChannelStartFailure(inst.Name, ch, "", err)
-			slog.Error("channel instance start failed", "name", inst.Name, "error", err)
+			l.manager.recordChannelStartFailure(qName, ch, "", err)
+			slog.Error("channel instance start failed", "name", qName, "error", err)
 			// Still registered — will show as not running.
 		} else {
-			l.manager.RecordHealth(inst.Name, snapshotChannelHealth(ch))
+			l.manager.RecordHealth(qName, snapshotChannelHealth(ch))
 		}
 	}
 
 	slog.Info("channel instance loaded",
-		"name", inst.Name, "type", inst.ChannelType, "agent_id", inst.AgentID)
+		"name", qName, "type", inst.ChannelType, "agent_id", inst.AgentID)
 	return nil
 }

--- a/internal/channels/instance_loader.go
+++ b/internal/channels/instance_loader.go
@@ -201,13 +201,13 @@ func (l *InstanceLoader) LoadedNames() map[string]struct{} {
 }
 
 // qualifiedChannelName creates a tenant-scoped key for the channel manager.
-// Uses first 8 chars of tenant UUID as prefix for brevity.
+// Uses full tenant UUID to guarantee uniqueness across tenants.
 // Returns name as-is for zero UUID (single-tenant / legacy).
 func qualifiedChannelName(tenantID uuid.UUID, name string) string {
 	if tenantID == uuid.Nil {
 		return name
 	}
-	return tenantID.String()[:8] + ":" + name
+	return tenantID.String() + ":" + name
 }
 
 // loadInstance creates and registers a single channel from a DB instance (caller must hold lock).
@@ -347,6 +347,6 @@ func (l *InstanceLoader) loadInstance(ctx context.Context, inst store.ChannelIns
 	}
 
 	slog.Info("channel instance loaded",
-		"name", qName, "type", inst.ChannelType, "agent_id", inst.AgentID)
+		"name", qName, "type", inst.ChannelType, "agent_id", inst.AgentID, "tenant_id", inst.TenantID)
 	return nil
 }

--- a/internal/channels/instance_loader_test.go
+++ b/internal/channels/instance_loader_test.go
@@ -1,0 +1,68 @@
+package channels
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestQualifiedChannelName(t *testing.T) {
+	fixedUUID := uuid.MustParse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+	tests := []struct {
+		name     string
+		tenantID uuid.UUID
+		chName   string
+		want     string
+	}{
+		{
+			name:     "zero UUID returns name unchanged (single-tenant / legacy)",
+			tenantID: uuid.Nil,
+			chName:   "zalo-personal",
+			want:     "zalo-personal",
+		},
+		{
+			name:     "non-zero UUID prefixes with first 8 chars",
+			tenantID: fixedUUID,
+			chName:   "zalo-personal",
+			want:     "a1b2c3d4:zalo-personal",
+		},
+		{
+			name:     "different tenants with same channel name produce distinct keys",
+			tenantID: uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000000"),
+			chName:   "zalo-personal",
+			want:     "bbbbbbbb:zalo-personal",
+		},
+		{
+			name:     "same tenant, different channel names produce distinct keys",
+			tenantID: fixedUUID,
+			chName:   "telegram-main",
+			want:     "a1b2c3d4:telegram-main",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := qualifiedChannelName(tc.tenantID, tc.chName)
+			if got != tc.want {
+				t.Fatalf("qualifiedChannelName(%v, %q) = %q; want %q", tc.tenantID, tc.chName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestQualifiedChannelNameMultiTenantUniqueness verifies that two tenants sharing
+// the same channel name produce different qualified keys — the core invariant
+// that prevents the manager map collision bug.
+func TestQualifiedChannelNameMultiTenantUniqueness(t *testing.T) {
+	tenantA := uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000000")
+	tenantB := uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000000")
+	sharedName := "zalo-personal"
+
+	keyA := qualifiedChannelName(tenantA, sharedName)
+	keyB := qualifiedChannelName(tenantB, sharedName)
+
+	if keyA == keyB {
+		t.Fatalf("expected distinct keys for different tenants, both returned %q", keyA)
+	}
+}

--- a/internal/channels/instance_loader_test.go
+++ b/internal/channels/instance_loader_test.go
@@ -22,22 +22,22 @@ func TestQualifiedChannelName(t *testing.T) {
 			want:     "zalo-personal",
 		},
 		{
-			name:     "non-zero UUID prefixes with first 8 chars",
+			name:     "non-zero UUID prefixes with full UUID",
 			tenantID: fixedUUID,
 			chName:   "zalo-personal",
-			want:     "a1b2c3d4:zalo-personal",
+			want:     "a1b2c3d4-e5f6-7890-abcd-ef1234567890:zalo-personal",
 		},
 		{
 			name:     "different tenants with same channel name produce distinct keys",
 			tenantID: uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000000"),
 			chName:   "zalo-personal",
-			want:     "bbbbbbbb:zalo-personal",
+			want:     "bbbbbbbb-0000-0000-0000-000000000000:zalo-personal",
 		},
 		{
 			name:     "same tenant, different channel names produce distinct keys",
 			tenantID: fixedUUID,
 			chName:   "telegram-main",
-			want:     "a1b2c3d4:telegram-main",
+			want:     "a1b2c3d4-e5f6-7890-abcd-ef1234567890:telegram-main",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Multi-tenant deployments with same channel name across tenants (e.g., `zalo-personal`) cause duplicate WebSocket connection loops
- Channel manager uses flat `map[string]Channel` keyed by `inst.Name` — second tenant overwrites first
- Fix: qualify names with full tenant UUID prefix (`{tenantUUID}:{name}`) in instance loader

Closes #680

## Root Cause
DB constraint is `UNIQUE(tenant_id, name)` — correctly allows same name across tenants. But `instance_loader.go:325` registers with `inst.Name` only, so `channels["zalo-personal"]` gets overwritten.

## Changes
- `instance_loader.go`: Add `qualifiedChannelName()` helper using full tenant UUID, use qualified name for all manager/loader operations, add `tenant_id` structured slog field
- `instance_loader_test.go`: Unit tests for qualified name generation and multi-tenant uniqueness

## Test plan
- [x] `go test ./internal/channels/...` — all pass
- [x] `go build ./...` — clean build
- [x] CI green (go + web)
- [ ] Manual test with 2 tenants having same channel name