### PR TITLE
fix(openai): Together-compatible chat requests (reasoning, stream, vision)

### DIFF
--- a/internal/agent/sanitize.go
+++ b/internal/agent/sanitize.go
@@ -172,11 +172,12 @@ func stripDowngradedToolCallText(content string) string {
 //         <antThinking>...</antThinking>
 // Go regexp doesn't support backreferences, so we use separate patterns.
 var thinkingTagPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?is)<think>.*?</think>`),
-	regexp.MustCompile(`(?is)<thinking>.*?</thinking>`),
-	regexp.MustCompile(`(?is)<thought>.*?</thought>`),
-	regexp.MustCompile(`(?is)<antThinking>.*?</antThinking>`),
-	regexp.MustCompile(`(?is)<antthinking>.*?</antthinking>`),
+	regexp.MustCompile(`(?is)<redacted_thinking\b[^>]*>.*?</redacted_thinking\s*>`),
+	regexp.MustCompile(`(?is)<thinking\b[^>]*>.*?</thinking\s*>`),
+	regexp.MustCompile(`(?is)<think\b[^>]*>.*?</think\s*>`),
+	regexp.MustCompile(`(?is)<thought\b[^>]*>.*?</thought\s*>`),
+	regexp.MustCompile(`(?is)<antThinking\b[^>]*>.*?</antThinking\s*>`),
+	regexp.MustCompile(`(?is)<antthinking\b[^>]*>.*?</antthinking\s*>`),
 }
 
 func stripThinkingTags(content string) string {

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -46,6 +46,33 @@ func (p *OpenAIProvider) isFireworksEndpoint() bool {
 	return strings.Contains(strings.ToLower(p.apiBase), "fireworks.ai")
 }
 
+// isTogetherAPIBase returns true for Together AI inference hosts.
+// Together rejects some OpenAI extensions (e.g. stream_options) with HTTP 400.
+func isTogetherAPIBase(apiBase string) bool {
+	b := strings.ToLower(apiBase)
+	return strings.Contains(b, "together.xyz") || strings.Contains(b, "together.ai")
+}
+
+// isDashScopeAPIBase returns true for Alibaba DashScope OpenAI-compatible endpoints.
+func isDashScopeAPIBase(apiBase string) bool {
+	return strings.Contains(strings.ToLower(apiBase), "dashscope")
+}
+
+// dashScopePassthroughKeys is true when enable_thinking / thinking_budget may be added to the JSON body.
+// Uses URL, provider_type, and name so httptest DashScope URLs still work in tests.
+func (p *OpenAIProvider) dashScopePassthroughKeys() bool {
+	if isDashScopeAPIBase(p.apiBase) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(strings.TrimSpace(p.providerType)), "dashscope") {
+		return true
+	}
+	if strings.Contains(strings.ToLower(p.name), "dashscope") {
+		return true
+	}
+	return false
+}
+
 func NewOpenAIProvider(name, apiKey, apiBase, defaultModel string) *OpenAIProvider {
 	if apiBase == "" {
 		apiBase = "https://api.openai.com/v1"
@@ -325,8 +352,9 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 			"role": role,
 		}
 
-		// Echo reasoning_content for assistant messages (required by Kimi, DeepSeek when thinking is enabled)
-		if m.Thinking != "" && m.Role == "assistant" {
+		// Echo reasoning_content only for APIs/models that accept it on assistant history.
+		// Together Qwen and many OpenAI-compat gateways reject unknown message fields → HTTP 400.
+		if m.Thinking != "" && m.Role == "assistant" && openAIWireAssistantReasoningContent(model) {
 			msg["reasoning_content"] = m.Thinking
 		}
 
@@ -334,18 +362,19 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 		// (Gemini rejects empty content → "must include at least one parts field").
 		if m.Role == "user" && len(m.Images) > 0 {
 			var parts []map[string]any
+			// Text before images — Together / Qwen vision examples use this order; OpenAI accepts both.
+			if m.Content != "" {
+				parts = append(parts, map[string]any{
+					"type": "text",
+					"text": m.Content,
+				})
+			}
 			for _, img := range m.Images {
 				parts = append(parts, map[string]any{
 					"type": "image_url",
 					"image_url": map[string]any{
 						"url": fmt.Sprintf("data:%s;base64,%s", img.MimeType, img.Data),
 					},
-				})
-			}
-			if m.Content != "" {
-				parts = append(parts, map[string]any{
-					"type": "text",
-					"text": m.Content,
 				})
 			}
 			msg["content"] = parts
@@ -408,7 +437,8 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 		body["tool_choice"] = "auto"
 	}
 
-	if stream {
+	// Together returns HTTP 400 on some requests when stream_options is present.
+	if stream && !isTogetherAPIBase(p.apiBase) {
 		body["stream_options"] = map[string]any{
 			"include_usage": true,
 		}
@@ -443,17 +473,21 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 		}
 	}
 
-	// Inject reasoning_effort for o-series models (ignored by models that don't support it)
+	// reasoning_effort is OpenAI-specific; do not send to third-party OpenAI-compatible APIs.
 	if level, ok := req.Options[OptThinkingLevel].(string); ok && level != "" && level != "off" {
-		body[OptReasoningEffort] = level
+		if openAIModelSupportsReasoningEffort(model) {
+			body[OptReasoningEffort] = level
+		}
 	}
 
-	// DashScope-specific passthrough keys
-	if v, ok := req.Options[OptEnableThinking]; ok {
-		body[OptEnableThinking] = v
-	}
-	if v, ok := req.Options[OptThinkingBudget]; ok {
-		body[OptThinkingBudget] = v
+	// DashScope-specific passthrough keys — never send to other OpenAI-compat hosts.
+	if p.dashScopePassthroughKeys() {
+		if v, ok := req.Options[OptEnableThinking]; ok {
+			body[OptEnableThinking] = v
+		}
+		if v, ok := req.Options[OptThinkingBudget]; ok {
+			body[OptThinkingBudget] = v
+		}
 	}
 
 	return body
@@ -466,6 +500,39 @@ func modelFamily(model string) string {
 		return model[idx+1:]
 	}
 	return model
+}
+
+// openAIModelSupportsReasoningEffort is true when the Chat Completions request may include
+// the top-level "reasoning_effort" field (OpenAI o-series / GPT-5 family).
+// Other OpenAI-compatible hosts (Together, Groq, vLLM, etc.) often reject unknown fields with HTTP 400.
+func openAIModelSupportsReasoningEffort(model string) bool {
+	if LookupReasoningCapability(model) != nil {
+		return true
+	}
+	fam := strings.ToLower(modelFamily(model))
+	for _, prefix := range []string{"gpt-5", "o1", "o3", "o4"} {
+		if strings.HasPrefix(fam, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// openAIWireAssistantReasoningContent is true when assistant message objects may include
+// "reasoning_content" (thinking replay). Narrow allowlist — most OpenAI-compat hosts reject it.
+func openAIWireAssistantReasoningContent(model string) bool {
+	if openAIModelSupportsReasoningEffort(model) {
+		return true
+	}
+	fam := strings.ToLower(modelFamily(model))
+	full := strings.ToLower(model)
+	if strings.Contains(fam, "deepseek") || strings.Contains(full, "deepseek") {
+		return true
+	}
+	if strings.Contains(fam, "kimi") || strings.Contains(full, "kimi") {
+		return true
+	}
+	return false
 }
 
 func (p *OpenAIProvider) doRequest(ctx context.Context, body any) (io.ReadCloser, error) {

--- a/internal/providers/openai_reasoning_alias_test.go
+++ b/internal/providers/openai_reasoning_alias_test.go
@@ -228,6 +228,36 @@ func TestBuildRequestBody_NoReasoningAliasInOutput(t *testing.T) {
 	}
 }
 
+// TestBuildRequestBody_TogetherQwenOmitsAssistantReasoningContent verifies Together-hosted Qwen
+// does not get reasoning_content on assistant history (HTTP 400 input validation otherwise).
+func TestBuildRequestBody_TogetherQwenOmitsAssistantReasoningContent(t *testing.T) {
+	p := NewOpenAIProvider("togetherai", "key", "https://api.together.xyz/v1", "")
+
+	req := ChatRequest{
+		Messages: []Message{
+			{
+				Role:     "assistant",
+				Content:  "Dạ em có thể thấy images...",
+				Thinking: "User is asking if I can read images.",
+			},
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	body := p.buildRequestBody("Qwen/Qwen3.5-397B-A17B", req, false)
+	msgs, ok := body["messages"].([]map[string]any)
+	if !ok {
+		t.Fatal("messages missing")
+	}
+	for _, m := range msgs {
+		if role, _ := m["role"].(string); role == "assistant" {
+			if _, has := m["reasoning_content"]; has {
+				t.Fatalf("Together Qwen must omit reasoning_content, got msg=%v", m)
+			}
+		}
+	}
+}
+
 // TestBuildRequestBody_NoReasoningContentWhenThinkingEmpty confirms that assistant messages
 // without Thinking content do not emit a reasoning_content key at all.
 func TestBuildRequestBody_NoReasoningContentWhenThinkingEmpty(t *testing.T) {

--- a/internal/providers/openai_test.go
+++ b/internal/providers/openai_test.go
@@ -136,6 +136,110 @@ func TestBuildRequestBody_TemperatureDependsOnModelNotAPIBase(t *testing.T) {
 	}
 }
 
+func TestBuildRequestBody_ReasoningEffortOpenAIOnly(t *testing.T) {
+	thinkOpts := map[string]any{OptThinkingLevel: "medium"}
+
+	t.Run("Together Qwen omits reasoning_effort", func(t *testing.T) {
+		p := NewOpenAIProvider("togetherai", "key", "https://api.together.xyz/v1", "")
+		req := ChatRequest{
+			Messages: []Message{{Role: "user", Content: "hi"}},
+			Options:  thinkOpts,
+		}
+		body := p.buildRequestBody("Qwen/Qwen3.5-397B-A17B", req, false)
+		if _, ok := body[OptReasoningEffort]; ok {
+			t.Fatalf("Qwen on Together must not send %q (HTTP 400 on unknown fields), body=%v", OptReasoningEffort, body)
+		}
+	})
+
+	t.Run("OpenAI gpt-5 keeps reasoning_effort", func(t *testing.T) {
+		p := NewOpenAIProvider("openai", "key", "https://api.openai.com/v1", "gpt-5")
+		req := ChatRequest{
+			Messages: []Message{{Role: "user", Content: "hi"}},
+			Options:  thinkOpts,
+		}
+		body := p.buildRequestBody("gpt-5.4", req, false)
+		if got, ok := body[OptReasoningEffort].(string); !ok || got != "medium" {
+			t.Fatalf("gpt-5.4 should send reasoning_effort medium, got body=%v", body)
+		}
+	})
+
+	t.Run("OpenAI o3-mini keeps reasoning_effort", func(t *testing.T) {
+		p := NewOpenAIProvider("openai", "key", "https://api.openai.com/v1", "")
+		req := ChatRequest{
+			Messages: []Message{{Role: "user", Content: "hi"}},
+			Options:  thinkOpts,
+		}
+		body := p.buildRequestBody("o3-mini", req, false)
+		if got, ok := body[OptReasoningEffort].(string); !ok || got != "medium" {
+			t.Fatalf("o3-mini should send reasoning_effort medium, got body=%v", body)
+		}
+	})
+}
+
+func TestBuildRequestBody_TogetherOmitsStreamOptions(t *testing.T) {
+	together := NewOpenAIProvider("togetherai", "key", "https://api.together.xyz/v1", "")
+	openai := NewOpenAIProvider("openai", "key", "https://api.openai.com/v1", "gpt-4")
+
+	req := ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	}
+
+	gotTogether := together.buildRequestBody("Qwen/Qwen3.5-397B-A17B", req, true)
+	if _, ok := gotTogether["stream_options"]; ok {
+		t.Fatalf("Together streaming must omit stream_options, got %v", gotTogether["stream_options"])
+	}
+
+	gotOpenAI := openai.buildRequestBody("gpt-4o", req, true)
+	if _, ok := gotOpenAI["stream_options"]; !ok {
+		t.Fatal("OpenAI streaming should include stream_options for usage")
+	}
+}
+
+func TestBuildRequestBody_TogetherOmitsStrayDashScopeKeys(t *testing.T) {
+	p := NewOpenAIProvider("togetherai", "key", "https://api.together.xyz/v1", "")
+	req := ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options: map[string]any{
+			OptEnableThinking: true,
+			OptThinkingBudget: 4096,
+		},
+	}
+	body := p.buildRequestBody("Qwen/Qwen3.5-397B-A17B", req, false)
+	if _, ok := body[OptEnableThinking]; ok {
+		t.Fatalf("Together must not send %q", OptEnableThinking)
+	}
+	if _, ok := body[OptThinkingBudget]; ok {
+		t.Fatalf("Together must not send %q", OptThinkingBudget)
+	}
+}
+
+func TestBuildRequestBody_MultimodalTextBeforeImages(t *testing.T) {
+	p := NewOpenAIProvider("test", "key", "https://api.openai.com/v1", "gpt-4")
+	req := ChatRequest{
+		Messages: []Message{
+			{
+				Role:    "user",
+				Content: "describe",
+				Images: []ImageContent{
+					{MimeType: "image/jpeg", Data: "qq=="},
+				},
+			},
+		},
+	}
+	body := p.buildRequestBody("gpt-4o", req, false)
+	msgs := body["messages"].([]map[string]any)
+	parts, ok := msgs[0]["content"].([]map[string]any)
+	if !ok || len(parts) < 2 {
+		t.Fatalf("want multimodal parts, got %v", msgs[0]["content"])
+	}
+	if typ, _ := parts[0]["type"].(string); typ != "text" {
+		t.Fatalf("first part should be text, got type=%q parts=%v", typ, parts)
+	}
+	if typ, _ := parts[1]["type"].(string); typ != "image_url" {
+		t.Fatalf("second part should be image_url, got type=%q", typ)
+	}
+}
+
 func TestBuildRequestBody_PrefixedModelsUseCorrectTokenField(t *testing.T) {
 	p := NewOpenAIProvider("test", "key", "https://api.openai.com/v1", "gpt-4")
 


### PR DESCRIPTION
## Summary
Fixes HTTP 400 “Input validation error” when using Together (and similar strict OpenAI-compatible hosts) with Qwen vision models, especially in group Telegram turns that carry long history, multimodal input, and stored assistant “thinking”.

## Type
<!-- Check one -->
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
