### PR TITLE
fix(ui): restore tenant selection state from localStorage on reload

### DIFF
--- a/ui/web/src/stores/use-auth-store.ts
+++ b/ui/web/src/stores/use-auth-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { LOCAL_STORAGE_KEYS } from "@/lib/constants";
 import { clearSetupSkippedState } from "@/lib/setup-skip";
 import type { TenantMembership } from "@/types/tenant";
 
@@ -43,7 +44,7 @@ export const useAuthStore = create<AuthState>()(
       tenantSlug: "",
       isOwner: false,
       availableTenants: [],
-      tenantSelected: false,
+      tenantSelected: !!localStorage.getItem(LOCAL_STORAGE_KEYS.TENANT_ID),
 
       setCredentials: (token, userId) => {
         set({ token, userId });


### PR DESCRIPTION
## Summary

- **Fix tenant selection redirect loop** — restore `tenantSelected` initialization from `localStorage` that was lost during the Zustand persist migration

Closes #692

## Root Cause

The Zustand persist migration replaced manual `localStorage.getItem()` initialization with `zustand/middleware/persist`, but `tenantSelected` was excluded from the `partialize` whitelist. On page reload:

1. `tenantSelected` resets to `false`
2. WS connects → `setConnected(true)` → re-render
3. WS async callback calls `setAvailableTenants(tenants)` → re-render
4. `require-auth` sees `connected=true, tenantSelected=false, availableTenants.length > 0` → redirects to `/select-tenant`
5. `setTenantSelected(true)` fires too late — separate `set()` call after the redirect

## Fix

One-line change: restore `tenantSelected: !!localStorage.getItem(LOCAL_STORAGE_KEYS.TENANT_ID)` so the state is `true` immediately on rehydration when a tenant was previously selected.

## Test plan

- [x] Login with `kai` user on localhost:5173 → selects tenant → navigates to dashboard (no redirect loop)
- [x] Page reload after tenant selection → stays on current page (not redirected to `/select-tenant`)
- [x] Logout → `tenantSelected` resets to `false` (localStorage cleared in `logout()`)
- [x] Fresh login (no `goclaw:tenant_id` in localStorage) → shows tenant selector as expected
- [x] TypeScript compiles clean