### PR TITLE
fix(ui): prevent first message disappearing in new chat session

### DIFF
--- a/ui/web/src/pages/chat/hooks/use-chat-messages.ts
+++ b/ui/web/src/pages/chat/hooks/use-chat-messages.ts
@@ -46,13 +46,19 @@ export function useChatMessages(sessionKey: string, agentId: string) {
   // Team task handling (extracted hook)
   const { teamTasks, setTeamTasks } = useChatTeamTasks(addLocalMessage);
 
+  // When transitioning from empty to a new session key (new-chat send flow),
+  // skip the next loadHistory() call. The optimistic user message is already
+  // in state, and loadHistory() would race with chat.send — potentially
+  // returning empty history before the server persists the message.
+  const skipNextHistoryRef = useRef(false);
+
   // Reset streaming/run state when session changes
   const prevKeyRef = useRef(sessionKey);
   useEffect(() => {
     if (sessionKey === prevKeyRef.current) return;
     const wasEmpty = !prevKeyRef.current;
     prevKeyRef.current = sessionKey;
-    if (wasEmpty) return; // new-chat send flow, don't reset
+    if (wasEmpty) { skipNextHistoryRef.current = true; return; } // new-chat send flow, don't reset
 
     setStreamText(null); setThinkingText(null); setToolStream([]);
     setIsRunning(false); setActivity(null); setBlockReplies([]); setTeamTasks([]);
@@ -76,7 +82,13 @@ export function useChatMessages(sessionKey: string, agentId: string) {
   useEffect(() => {
     let cancelled = false;
     if (sessionKey) {
-      loadHistory();
+      // Skip loadHistory for new-chat flow (empty → key) to avoid racing
+      // with chat.send. The optimistic user message is already displayed.
+      if (skipNextHistoryRef.current) {
+        skipNextHistoryRef.current = false;
+      } else {
+        loadHistory();
+      }
       ws.call<{ isRunning?: boolean; runId?: string; activity?: RunActivity }>(Methods.CHAT_SESSION_STATUS, { sessionKey })
         .then((res) => {
           if (cancelled) return;


### PR DESCRIPTION
## Summary

- Fix race condition where `loadHistory()` overwrites the optimistic user message during new-chat creation
- Skip `loadHistory()` on `"" → newKey` session transition — the user message is already displayed optimistically
- All other session flows (switching chats, page refresh) continue loading history normally

## Root Cause

When a new chat is created, `handleSend()` calls `navigate()` (changing `sessionKey` from `""` to the new key) then `send()` (which adds the user message optimistically). The `useEffect` watching `sessionKey` unconditionally calls `loadHistory()`, which races with `chat.send`. If the history RPC completes before the server persists the message, it returns empty results and `setMessages([])` overwrites the optimistic user message — leaving only the agent's reply visible.

## Changes

- `ui/web/src/pages/chat/hooks/use-chat-messages.ts`: Add `skipNextHistoryRef` flag set during the `"" → newKey` transition, checked before calling `loadHistory()`

## Test plan

- [ ] Open Chat → select agent → New Chat → send a message → verify user message stays visible while agent streams
- [ ] Navigate away and back → both messages still visible
- [ ] Send a second message → both user messages and agent replies visible
- [ ] Switch between existing chats → history loads correctly
- [ ] Refresh page on an existing chat → history loads correctly

Closes #694