### PR TITLE
fix(tools): credentialed exec silent failure and false positive shell operator detection

### DIFF
--- a/internal/tools/credentialed_exec.go
+++ b/internal/tools/credentialed_exec.go
@@ -42,6 +42,8 @@ func parseCommandBinary(command string) (binary string, args []string, err error
 
 // detectShellOperators scans a raw command string for shell metacharacters.
 // Returns the list of detected operators, or nil if the command is clean.
+// NOTE: This function does not respect quoting — use detectUnquotedShellOperators
+// for credentialed exec where argument values may contain metacharacters.
 func detectShellOperators(command string) []string {
 	matches := shellOperatorPattern.FindAllString(command, -1)
 	if len(matches) == 0 {
@@ -57,6 +59,57 @@ func detectShellOperators(command string) []string {
 		}
 	}
 	return unique
+}
+
+// detectUnquotedShellOperators scans a command string for shell metacharacters
+// that appear OUTSIDE of single or double quotes. This prevents false positives
+// when argument values contain characters like | (e.g. --jq '.[0] | .name').
+// Returns the list of detected operators, or nil if the command is clean.
+func detectUnquotedShellOperators(command string) []string {
+	// Extract only the unquoted portions of the command
+	unquoted := extractUnquotedSegments(command)
+	if unquoted == "" {
+		return nil
+	}
+	return detectShellOperators(unquoted)
+}
+
+// extractUnquotedSegments returns a string containing only the characters
+// from command that are outside of single-quoted and double-quoted segments.
+// Escaped quotes within double quotes (\" ) are handled.
+func extractUnquotedSegments(command string) string {
+	var buf strings.Builder
+	buf.Grow(len(command))
+
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(command); i++ {
+		ch := command[i]
+		switch {
+		case inSingle:
+			if ch == '\'' {
+				inSingle = false
+			}
+			// Everything inside single quotes is skipped
+		case inDouble:
+			if ch == '\\' && i+1 < len(command) {
+				i++ // skip escaped character inside double quotes
+			} else if ch == '"' {
+				inDouble = false
+			}
+			// Everything inside double quotes is skipped
+		default:
+			switch ch {
+			case '\'':
+				inSingle = true
+			case '"':
+				inDouble = true
+			default:
+				buf.WriteByte(ch)
+			}
+		}
+	}
+	return buf.String()
 }
 
 // resolveAndMatchBinary resolves a binary name to an absolute path and
@@ -101,11 +154,13 @@ func matchesBinaryDeny(args []string, denyPatternsJSON json.RawMessage) string {
 // executeCredentialed runs a CLI command in Direct Exec Mode (no shell).
 // Credentials are injected as env vars into the child process only.
 func (t *ExecTool) executeCredentialed(ctx context.Context, cred *store.SecureCLIBinary,
-	binary string, args []string, cwd string, sandboxKey string) *Result {
+	binary string, args []string, cwd string, sandboxKey string, rawCommand string) *Result {
 
-	// Step 1: Check for shell operators (early detection for clear error)
-	rawCommand := binary + " " + strings.Join(args, " ")
-	if ops := detectShellOperators(rawCommand); len(ops) > 0 {
+	// Step 1: Check for shell operators in the ORIGINAL command (preserves quoting).
+	// We check the raw command string (before shell-word parsing) so that characters
+	// inside quoted argument values (e.g. | in --jq '.[0] | ...') are not falsely flagged.
+	// Only top-level (unquoted) shell operators indicate actual command chaining attempts.
+	if ops := detectUnquotedShellOperators(rawCommand); len(ops) > 0 {
 		return credentialedShellOperatorError(rawCommand, ops)
 	}
 
@@ -267,6 +322,7 @@ func (t *ExecTool) lookupCredentialedBinary(ctx context.Context, command string)
 	}
 	binary, args, err := parseCommandBinary(command)
 	if err != nil {
+		slog.Debug("credentialed_exec.parse_failed", "command", truncateCmd(command, 80), "error", err)
 		return nil, "", nil
 	}
 	// Get agent ID from context for scoped lookup
@@ -276,7 +332,12 @@ func (t *ExecTool) lookupCredentialedBinary(ctx context.Context, command string)
 		agentIDPtr = &agentID
 	}
 	cred, err := t.secureCLIStore.LookupByBinary(ctx, binary, agentIDPtr)
-	if err != nil || cred == nil {
+	if err != nil {
+		slog.Warn("credentialed_exec.lookup_error", "binary", binary, "agent_id", agentID, "error", err)
+		return nil, "", nil
+	}
+	if cred == nil {
+		slog.Debug("credentialed_exec.no_config", "binary", binary, "agent_id", agentID)
 		return nil, "", nil
 	}
 	return cred, binary, args

--- a/internal/tools/credentialed_exec_test.go
+++ b/internal/tools/credentialed_exec_test.go
@@ -1,0 +1,112 @@
+package tools
+
+import "testing"
+
+func TestDetectShellOperators(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    int // number of detected operators
+	}{
+		{"clean command", "gh api repos/foo/bar", 0},
+		{"pipe operator", "gh api foo | jq .", 1},
+		{"semicolon", "echo a; echo b", 1},
+		{"ampersand", "cmd1 && cmd2", 1},
+		{"redirect", "cmd > /tmp/out", 1},
+		{"backtick", "echo `whoami`", 1},
+		{"subshell", "echo $(whoami)", 1},
+		{"multiple operators", "cmd1 | cmd2 && cmd3", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := detectShellOperators(tt.command)
+			if len(ops) != tt.want {
+				t.Errorf("detectShellOperators(%q) = %v (len %d), want len %d", tt.command, ops, len(ops), tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractUnquotedSegments(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"no quotes", "gh api foo", "gh api foo"},
+		{"single quoted pipe", "gh --jq '.[0] | .name'", "gh --jq "},
+		{"double quoted pipe", `gh --jq ".[0] | .name"`, "gh --jq "},
+		{"mixed quotes", `gh --jq '.[0] | .a' --format "b | c"`, "gh --jq  --format "},
+		{"escaped quote in double", `gh "say \"hello\""`, "gh "},
+		{"empty single quotes", "gh ''", "gh "},
+		{"unquoted metachar", "gh api foo | jq", "gh api foo | jq"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractUnquotedSegments(tt.command)
+			if got != tt.want {
+				t.Errorf("extractUnquotedSegments(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectUnquotedShellOperators(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    int
+	}{
+		// Should NOT detect (inside quotes)
+		{"pipe in single quotes", "gh api repos/foo --jq '.[0] | .name'", 0},
+		{"pipe in double quotes", `gh api repos/foo --jq ".[0] | .name"`, 0},
+		{"semicolon in quotes", `echo 'a; b'`, 0},
+		{"backtick in single quotes", "echo 'hello `world`'", 0},
+		{"complex jq", `gh api repos/org/repo/commits --jq '.[0] | "SHA: \(.sha)\nAuthor: \(.commit.author.name)"'`, 0},
+		// Should detect (outside quotes)
+		{"unquoted pipe", "gh api foo | jq .", 1},
+		{"unquoted semicolon", "echo a; echo b", 1},
+		{"mixed: quoted safe + unquoted unsafe", "gh --jq '.[0] | .x' | cat", 1},
+		{"redirect after quotes", "gh api foo --jq '.x' > out.json", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := detectUnquotedShellOperators(tt.command)
+			if len(ops) != tt.want {
+				t.Errorf("detectUnquotedShellOperators(%q) = %v (len %d), want len %d", tt.command, ops, len(ops), tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCommandBinary(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		wantBinary string
+		wantArgs   int
+		wantErr    bool
+	}{
+		{"simple", "gh api foo", "gh", 2, false},
+		{"with quotes", "gh api --jq '.[0] | .name'", "gh", 3, false},
+		{"empty", "", "", 0, true},
+		{"single binary", "gh", "gh", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binary, args, err := parseCommandBinary(tt.command)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseCommandBinary(%q) err = %v, wantErr %v", tt.command, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if binary != tt.wantBinary {
+					t.Errorf("binary = %q, want %q", binary, tt.wantBinary)
+				}
+				if len(args) != tt.wantArgs {
+					t.Errorf("args len = %d, want %d (args: %v)", len(args), tt.wantArgs, args)
+				}
+			}
+		})
+	}
+}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -179,7 +179,7 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *Result {
 			}
 		}
 		sandboxKey := ToolSandboxKeyFromCtx(ctx)
-		return t.executeCredentialed(ctx, cred, binary, cmdArgs, cwd, sandboxKey)
+		return t.executeCredentialed(ctx, cred, binary, cmdArgs, cwd, sandboxKey, command)
 	}
 
 	// Exec approval check (matching TS exec-approval.ts pipeline)


### PR DESCRIPTION
## Summary

Closes #700

- Add diagnostic logging to `lookupCredentialedBinary` — DB errors (WARN), no-match (DEBUG), parse failures (DEBUG) instead of silently returning nil
- Add quote-aware `detectUnquotedShellOperators()` preventing false positives when argument values contain shell metacharacters (e.g. `--jq '.[0] | .name'`)
- Pass raw command string to `executeCredentialed` for quote-aware detection
- Add comprehensive tests for shell operator detection and quote parsing

## Test plan

- [x] `go build ./internal/...` passes
- [x] `go vet ./internal/tools/...` passes
- [x] All 24 new + existing tests pass (`go test -v ./internal/tools/...`)
- [ ] Deploy and verify `credentialed_exec.*` log messages appear in server logs
- [ ] Verify `gh api` commands with `--jq` expressions containing `|` are not blocked
- [ ] Verify `GH_TOKEN` is properly injected when credential entry exists and is enabled