### PR TITLE
feat(providers): add OpenRouter identification headers

### DIFF
--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -41,7 +41,9 @@ func registerProviders(registry *providers.Registry, cfg *config.Config) {
 	}
 
 	if cfg.Providers.OpenRouter.APIKey != "" {
-		registry.Register(providers.NewOpenAIProvider("openrouter", cfg.Providers.OpenRouter.APIKey, "https://openrouter.ai/api/v1", "anthropic/claude-sonnet-4-5-20250929"))
+		orProv := providers.NewOpenAIProvider("openrouter", cfg.Providers.OpenRouter.APIKey, "https://openrouter.ai/api/v1", "anthropic/claude-sonnet-4-5-20250929")
+		orProv.WithSiteInfo("https://goclaw.sh", "GoClaw")
+		registry.Register(orProv)
 		slog.Info("registered provider", "name", "openrouter")
 	}
 
@@ -403,6 +405,9 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			prov.WithProviderType(p.ProviderType)
 			if p.ProviderType == store.ProviderMiniMax {
 				prov.WithChatPath("/text/chatcompletion_v2")
+			}
+			if p.ProviderType == store.ProviderOpenRouter {
+				prov.WithSiteInfo("https://goclaw.sh", "GoClaw")
 			}
 			registry.RegisterForTenant(p.TenantID, prov)
 		}

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -27,6 +27,8 @@ type OpenAIProvider struct {
 	authPrefix   string // auth header prefix, defaults to "Bearer " if empty
 	defaultModel string
 	providerType string // DB provider_type (e.g. "gemini_native", "openai", "minimax_native")
+	siteURL      string // optional site URL for provider identification (e.g. OpenRouter HTTP-Referer)
+	siteTitle    string // optional site title for provider identification (e.g. OpenRouter X-Title)
 	client       *http.Client
 	retryConfig  RetryConfig
 }
@@ -111,6 +113,14 @@ func (p *OpenAIProvider) WithChatPath(path string) *OpenAIProvider {
 // Default is "Bearer " if not set.
 func (p *OpenAIProvider) WithAuthPrefix(prefix string) *OpenAIProvider {
 	p.authPrefix = prefix
+	return p
+}
+
+// WithSiteInfo sets site identification headers sent with API requests.
+// Used by OpenRouter for rankings (HTTP-Referer, X-Title).
+func (p *OpenAIProvider) WithSiteInfo(url, title string) *OpenAIProvider {
+	p.siteURL = url
+	p.siteTitle = title
 	return p
 }
 
@@ -575,6 +585,13 @@ func (p *OpenAIProvider) doRequest(ctx context.Context, body any) (io.ReadCloser
 			prefix = "Bearer "
 		}
 		httpReq.Header.Set("Authorization", prefix+p.apiKey)
+	}
+	// OpenRouter identification headers for rankings/analytics
+	if p.siteURL != "" {
+		httpReq.Header.Set("HTTP-Referer", p.siteURL)
+	}
+	if p.siteTitle != "" {
+		httpReq.Header.Set("X-Title", p.siteTitle)
 	}
 
 	resp, err := p.client.Do(httpReq)


### PR DESCRIPTION
## Summary

- Add `HTTP-Referer` and `X-Title` headers to OpenRouter API requests for rankings/analytics on openrouter.ai
- New `WithSiteInfo(url, title)` builder on `OpenAIProvider` — generic, only applied for OpenRouter
- Headers set for both config-based and DB-based provider registration

Closes #704

## Test plan

- [x] `go build` passes
- [x] `go vet` passes
- [ ] Verify OpenRouter requests include `HTTP-Referer: https://goclaw.sh` and `X-Title: GoClaw` headers