### PR TITLE
feat(cron): enforce unique active cron job names per agent+user

### DIFF
--- a/internal/store/cron_store.go
+++ b/internal/store/cron_store.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	ErrCronJobNotFound    = errors.New("cron job not found")
-	ErrCronJobNoFutureRun = errors.New("cron job has no future run")
+	ErrCronJobNotFound      = errors.New("cron job not found")
+	ErrCronJobNoFutureRun   = errors.New("cron job has no future run")
+	ErrCronJobDuplicateName = errors.New("an active cron job with this name already exists")
 )
 
 // CronJob represents a scheduled job.

--- a/internal/store/pg/cron_crud.go
+++ b/internal/store/pg/cron_crud.go
@@ -3,11 +3,13 @@ package pg
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
@@ -74,6 +76,13 @@ func (s *PGCronStore) AddJob(ctx context.Context, name string, schedule store.Cr
 		intervalMS, payloadJSON, deleteAfterRun, deliver, channel, to, false, nextRun, now, now,
 	)
 	if err != nil {
+		// Unique constraint violation (race condition) — return existing job instead of error.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "idx_cron_jobs_unique_active_name" {
+			if existing := s.findJobByName(ctx, name, agentID, userID); existing != nil {
+				return existing, nil
+			}
+		}
 		return nil, fmt.Errorf("create cron job: %w", err)
 	}
 
@@ -216,5 +225,16 @@ func (s *PGCronStore) EnableJob(ctx context.Context, jobID string, enabled bool)
 	}
 
 	s.InvalidateCache()
+	return nil
+}
+
+// findJobByName returns the first enabled job matching name for the given agent+user scope.
+func (s *PGCronStore) findJobByName(ctx context.Context, name, agentID, userID string) *store.CronJob {
+	jobs := s.ListJobs(ctx, false, agentID, userID)
+	for _, j := range jobs {
+		if j.Name == name {
+			return &j
+		}
+	}
 	return nil
 }

--- a/internal/store/pg/cron_update.go
+++ b/internal/store/pg/cron_update.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
@@ -212,6 +213,10 @@ func execCronJobUpdateTx(ctx context.Context, tx *sql.Tx, id uuid.UUID, updates 
 
 	res, err := tx.ExecContext(ctx, q, args...)
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "idx_cron_jobs_unique_active_name" {
+			return store.ErrCronJobDuplicateName
+		}
 		return err
 	}
 	if n, _ := res.RowsAffected(); n == 0 {

--- a/internal/store/sqlitestore/cron_crud.go
+++ b/internal/store/sqlitestore/cron_crud.go
@@ -77,6 +77,12 @@ func (s *SQLiteCronStore) AddJob(ctx context.Context, name string, schedule stor
 		intervalMS, payloadJSON, deleteAfterRun, deliver, channel, to, false, nextRun, now, now,
 	)
 	if err != nil {
+		// Handle unique constraint violation (race condition with concurrent tool calls).
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") || strings.Contains(err.Error(), "idx_cron_jobs_unique_active_name") {
+			if existing := s.findJobByName(ctx, name, agentID, userID); existing != nil {
+				return existing, nil
+			}
+		}
 		return nil, fmt.Errorf("create cron job: %w", err)
 	}
 
@@ -426,10 +432,24 @@ func execCronJobUpdateTx(ctx context.Context, tx *sql.Tx, id uuid.UUID, updates 
 
 	res, err := tx.ExecContext(ctx, q, args...)
 	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return store.ErrCronJobDuplicateName
+		}
 		return err
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
 		return store.ErrCronJobNotFound
+	}
+	return nil
+}
+
+// findJobByName returns the first enabled job matching name for the given agent+user scope.
+func (s *SQLiteCronStore) findJobByName(ctx context.Context, name, agentID, userID string) *store.CronJob {
+	jobs := s.ListJobs(ctx, false, agentID, userID)
+	for _, j := range jobs {
+		if j.Name == name {
+			return &j
+		}
 	}
 	return nil
 }

--- a/internal/tools/cron.go
+++ b/internal/tools/cron.go
@@ -211,6 +211,19 @@ func (t *CronTool) handleAdd(ctx context.Context, args map[string]any, agentID, 
 		return ErrorResult("job.message is required")
 	}
 
+	// Dedup: return existing enabled job with same name for this agent+user.
+	existingJobs := t.cronStore.ListJobs(ctx, false, agentID, userID)
+	for _, ej := range existingJobs {
+		if ej.Name == name {
+			data, _ := json.MarshalIndent(map[string]any{
+				"existing": true,
+				"job":      ej,
+				"note":     fmt.Sprintf("cron job %q already exists (id: %s). Use 'update' action to modify it.", name, ej.ID),
+			}, "", "  ")
+			return NewResult(string(data))
+		}
+	}
+
 	// Parse schedule
 	schedule := store.CronSchedule{
 		Kind: stringFromMap(scheduleObj, "kind"),

--- a/internal/upgrade/version.go
+++ b/internal/upgrade/version.go
@@ -2,4 +2,4 @@ package upgrade
 
 // RequiredSchemaVersion is the schema migration version this binary requires.
 // Bump this whenever adding a new SQL migration file.
-const RequiredSchemaVersion uint = 36
+const RequiredSchemaVersion uint = 37

--- a/migrations/000037_cron_unique_active_name.down.sql
+++ b/migrations/000037_cron_unique_active_name.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_cron_jobs_unique_active_name;

--- a/migrations/000037_cron_unique_active_name.up.sql
+++ b/migrations/000037_cron_unique_active_name.up.sql
@@ -1,5 +1,5 @@
--- Deduplicate existing active jobs before adding constraint.
--- Keep the oldest job (smallest created_at) for each (tenant_id, agent_id, user_id, name) group.
+-- Rename duplicate active jobs before adding constraint (safe: no data loss, reversible).
+-- Oldest job (smallest created_at) keeps its name; newer duplicates get a '-dup-{id[:8]}' suffix.
 WITH dupes AS (
     SELECT id, ROW_NUMBER() OVER (
         PARTITION BY tenant_id, COALESCE(agent_id, '00000000-0000-0000-0000-000000000000'),
@@ -9,7 +9,9 @@ WITH dupes AS (
     FROM cron_jobs
     WHERE enabled = true
 )
-DELETE FROM cron_jobs WHERE id IN (SELECT id FROM dupes WHERE rn > 1);
+UPDATE cron_jobs
+SET name = name || '-dup-' || substr(id::text, 1, 8)
+WHERE id IN (SELECT id FROM dupes WHERE rn > 1);
 
 -- Partial unique index: one active job per name per tenant+agent+user.
 CREATE UNIQUE INDEX idx_cron_jobs_unique_active_name

--- a/migrations/000037_cron_unique_active_name.up.sql
+++ b/migrations/000037_cron_unique_active_name.up.sql
@@ -1,0 +1,17 @@
+-- Deduplicate existing active jobs before adding constraint.
+-- Keep the oldest job (smallest created_at) for each (tenant_id, agent_id, user_id, name) group.
+WITH dupes AS (
+    SELECT id, ROW_NUMBER() OVER (
+        PARTITION BY tenant_id, COALESCE(agent_id, '00000000-0000-0000-0000-000000000000'),
+                     COALESCE(user_id, ''), name
+        ORDER BY created_at ASC
+    ) AS rn
+    FROM cron_jobs
+    WHERE enabled = true
+)
+DELETE FROM cron_jobs WHERE id IN (SELECT id FROM dupes WHERE rn > 1);
+
+-- Partial unique index: one active job per name per tenant+agent+user.
+CREATE UNIQUE INDEX idx_cron_jobs_unique_active_name
+    ON cron_jobs (tenant_id, COALESCE(agent_id, '00000000-0000-0000-0000-000000000000'), COALESCE(user_id, ''), name)
+    WHERE enabled = true;


### PR DESCRIPTION
## Summary

- Add migration `000037`: partial unique index `idx_cron_jobs_unique_active_name` on `cron_jobs` (scoped to `tenant_id + agent_id + user_id + name` where `enabled = true`). Deduplicates existing rows before adding constraint.
- PG store (`cron_crud.go`, `cron_update.go`): detect `23505` unique constraint violation on insert (return existing job) and on update (return `ErrCronJobDuplicateName`).
- SQLite store: same logic using string-match on error message.
- `CronTool`: pre-check for duplicate name before attempting insert, returning clear feedback to the agent.
- Bump `RequiredSchemaVersion` → 37.

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go build -tags sqliteonly ./...` passes
- [ ] `go vet ./...` passes
- [ ] Apply migration on existing DB — dedup runs without error, index created
- [ ] Creating a cron job with duplicate name returns the existing job (no error, no duplicate row)
- [ ] Renaming a cron job to an existing active name returns `ErrCronJobDuplicateName`