### PR TITLE
feat(http): support persistent sessions via X-GoClaw-User-Id header

### DIFF
--- a/internal/http/chat_completions.go
+++ b/internal/http/chat_completions.go
@@ -155,12 +155,14 @@ func (h *ChatCompletionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	runID := uuid.NewString()
-	// Include userID in session key for multi-tenant isolation
-	sessionSuffix := "http-" + runID[:8]
+	// Build stable session key per user — same user+agent always reuses the same session
+	var sessionKey string
 	if userID != "" {
-		sessionSuffix = "http-" + userID + "-" + runID[:8]
+		sessionKey = sessions.BuildSessionKey(agentID, "http", sessions.PeerDirect, userID)
+	} else {
+		// No user ID — fallback to random session (stateless)
+		sessionKey = sessions.SessionKey(agentID, "http-"+runID[:8])
 	}
-	sessionKey := sessions.SessionKey(agentID, sessionSuffix)
 
 	slog.Info("chat completions request", "agent", agentID, "stream", req.Stream, "user", userID)
 


### PR DESCRIPTION
## Summary

HTTP `/v1/chat/completions` endpoint now supports **persistent sessions** when `X-GoClaw-User-Id` header is provided. Without the header, behavior is unchanged (stateless, random session per request).

## Problem

Every HTTP API request creates a new session (random UUID in session key), even when the same user sends multiple messages. The agent always responds as if it was a new conversation — no memory of previous messages.

**Root cause**: Session key includes `runID[:8]` (random UUID per request):
```go
// Before: always random
sessionSuffix = "http-" + userID + "-" + runID[:8]
sessionKey = SessionKey(agentID, sessionSuffix)
```

This is the **only channel** without persistent sessions — Telegram, Discord, Slack, Zalo all use stable session keys.

## Solution

When `X-GoClaw-User-Id` is present, build a stable session key using the canonical `BuildSessionKey()` — same pattern as all other channels:

```go
// After: stable per user
if userID != "" {
    sessionKey = sessions.BuildSessionKey(agentID, "http", sessions.PeerDirect, userID)
    // → "agent:{id}:http:direct:{userId}" — same format as telegram/slack/discord
} else {
    sessionKey = sessions.SessionKey(agentID, "http-"+runID[:8])
    // → unchanged stateless behavior
}
```

## Impact

- **Backward compatible**: No `X-GoClaw-User-Id` header → behavior unchanged
- **No key collision**: `http:direct:` prefix is unique among all channels
- **No cross-channel interference**: Telegram/Slack/Discord sessions unaffected
- **Session lifecycle**: Same as Telegram — compaction, history limits, token tracking all work

## Test Plan

- [ ] HTTP with `X-GoClaw-User-Id: user1` → send "I'm Alice" → send "What's my name?" → agent remembers
- [ ] HTTP without header → each request independent (existing behavior)
- [ ] Different userIDs → different sessions (isolation)
- [ ] Telegram/Slack sessions unaffected
- [ ] Concurrent requests from same user → same session

## Use Case

Enables integration with Microsoft Teams (and any HTTP client) where a bridge bot sends `X-GoClaw-User-Id` header with the Teams user ID, maintaining conversation history across messages.