### PR TITLE
fix(cmd): add --user flag to agent chat for user_id authentication

### DIFF
--- a/cmd/agent_chat.go
+++ b/cmd/agent_chat.go
@@ -15,6 +15,7 @@ import (
 func agentChatCmd() *cobra.Command {
 	var (
 		agentName  string
+		userID     string
 		message    string
 		sessionKey string
 	)
@@ -30,18 +31,19 @@ Examples:
   goclaw agent chat -m "What time is it?"    # One-shot message
   goclaw agent chat -s my-session            # Continue a session`,
 		Run: func(cmd *cobra.Command, args []string) {
-			runAgentChat(agentName, message, sessionKey)
+			runAgentChat(agentName, message, sessionKey, userID)
 		},
 	}
 
 	cmd.Flags().StringVarP(&agentName, "name", "n", "default", "agent name")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "one-shot message (omit for interactive mode)")
 	cmd.Flags().StringVarP(&sessionKey, "session", "s", "", "session key (default: auto-generated)")
+	cmd.Flags().StringVarP(&userID, "user", "u", "", "user ID for authentication")
 
 	return cmd
 }
 
-func runAgentChat(agentName, message, sessionKey string) {
+func runAgentChat(agentName, message, sessionKey, userID string) {
 	cfgPath := resolveConfigPath()
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
@@ -68,7 +70,7 @@ func runAgentChat(agentName, message, sessionKey string) {
 	}
 
 	fmt.Fprintf(os.Stderr, "Connected to gateway at %s\n", addr)
-	runClientMode(cfg, addr, agentName, message, sessionKey)
+	runClientMode(cfg, addr, agentName, message, sessionKey, userID)
 }
 
 // --- Gateway detection ---

--- a/cmd/agent_chat_client.go
+++ b/cmd/agent_chat_client.go
@@ -15,7 +15,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
 )
 
-func runClientMode(cfg *config.Config, addr, agentName, message, sessionKey string) {
+func runClientMode(cfg *config.Config, addr, agentName, message, sessionKey, userID string) {
 	wsURL := fmt.Sprintf("ws://%s/ws", addr)
 
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
@@ -26,7 +26,7 @@ func runClientMode(cfg *config.Config, addr, agentName, message, sessionKey stri
 	defer conn.Close()
 
 	// Authenticate
-	if err := wsConnect(conn, cfg.Gateway.Token); err != nil {
+	if err := wsConnect(conn, cfg.Gateway.Token, userID); err != nil {
 		fmt.Fprintf(os.Stderr, "Gateway auth failed: %v\n", err)
 		os.Exit(1)
 	}
@@ -79,10 +79,13 @@ func runClientMode(cfg *config.Config, addr, agentName, message, sessionKey stri
 }
 
 // wsConnect sends the connect RPC and waits for auth response.
-func wsConnect(conn *websocket.Conn, token string) error {
+func wsConnect(conn *websocket.Conn, token, userID string) error {
 	params := map[string]string{}
 	if token != "" {
 		params["token"] = token
+	}
+	if userID != "" {
+		params["user_id"] = userID
 	}
 	paramsJSON, _ := json.Marshal(params)
 


### PR DESCRIPTION
## Summary

- `goclaw agent chat` never sends `user_id` in the WebSocket connect frame
- Gateway requires `user_id` for `chat.send`, so the CLI always fails with `user_id is required`
- All other clients (browser, Telegram, LINE, Discord, Slack) send `user_id` during connect — CLI is the only channel missing it

## Changes

- `cmd/agent_chat.go`: Add `--user` / `-u` flag
- `cmd/agent_chat_client.go`: Pass `user_id` in connect params

## Usage

```bash
# Before: always fails
goclaw agent chat --name my-agent -m "hello"
# Error: agent error: user_id is required

# After: works
goclaw agent chat --name my-agent --user stanley -m "hello"
```

## Test plan

- [x] `goclaw agent chat --name default --user testuser -m "hello"` → agent responds (no `user_id is required` error) → [verified](https://github.com/nextlevelbuilder/goclaw/pull/714#issuecomment-4257881569)
- [x] `goclaw agent chat --name default -m "hello"` (no `--user`) → still fails with `user_id is required` (backward compatible, no silent default) → [verified](https://github.com/nextlevelbuilder/goclaw/pull/714#issuecomment-4257881569)
- [x] Interactive REPL mode with `--user` flag → works across multiple messages in same session → [verified](https://github.com/nextlevelbuilder/goclaw/pull/714#issuecomment-4257881569)

🤖 Generated with [Claude Code](https://claude.com/claude-code)