### PR TITLE
fix: deterministic tool ordering for prompt caching

### DIFF
--- a/internal/agent/systemprompt_sections.go
+++ b/internal/agent/systemprompt_sections.go
@@ -55,7 +55,14 @@ func buildMCPToolsInlineSection(descs map[string]string) []string {
 		mcpOptionalParamInstruction,
 		"",
 	}
-	for name, desc := range descs {
+	// Sort MCP tool names for deterministic ordering — critical for prompt caching.
+	sortedNames := make([]string, 0, len(descs))
+	for name := range descs {
+		sortedNames = append(sortedNames, name)
+	}
+	slices.Sort(sortedNames)
+	for _, name := range sortedNames {
+		desc := descs[name]
 		if len(desc) > mcpToolDescMaxLen {
 			desc = desc[:mcpToolDescMaxLen] + "…"
 		}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -130,8 +130,16 @@ func (pe *PolicyEngine) FilterTools(
 		}
 	}
 
-	// Add registry aliases for allowed canonical tools
-	for alias, canonical := range registry.Aliases() {
+	// Add registry aliases for allowed canonical tools.
+	// Sort alias names for deterministic ordering (prompt caching).
+	aliasList := make([]string, 0, len(registry.Aliases()))
+	for alias := range registry.Aliases() {
+		aliasList = append(aliasList, alias)
+	}
+	slices.Sort(aliasList)
+	aliasMap := registry.Aliases()
+	for _, alias := range aliasList {
+		canonical := aliasMap[alias]
 		if !allowedSet[canonical] {
 			continue
 		}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -222,18 +223,34 @@ func safeExecute(tool Tool, ctx context.Context, args map[string]any) (result *R
 
 // ProviderDefs returns tool definitions for LLM provider APIs.
 // Includes alias definitions (same params/description, alias name).
+// Results are sorted by tool name for deterministic ordering (prompt caching).
 func (r *Registry) ProviderDefs() []providers.ToolDefinition {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	defs := make([]providers.ToolDefinition, 0, len(r.tools)+len(r.aliases))
-	for name, tool := range r.tools {
-		if r.disabled[name] {
-			continue
+	// Sort canonical tool names for deterministic ordering.
+	sortedNames := make([]string, 0, len(r.tools))
+	for name := range r.tools {
+		if !r.disabled[name] {
+			sortedNames = append(sortedNames, name)
 		}
-		defs = append(defs, ToProviderDef(tool))
 	}
-	for alias, canonical := range r.aliases {
+	slices.Sort(sortedNames)
+
+	defs := make([]providers.ToolDefinition, 0, len(sortedNames)+len(r.aliases))
+	for _, name := range sortedNames {
+		defs = append(defs, ToProviderDef(r.tools[name]))
+	}
+
+	// Sort alias names for deterministic ordering.
+	sortedAliases := make([]string, 0, len(r.aliases))
+	for alias := range r.aliases {
+		sortedAliases = append(sortedAliases, alias)
+	}
+	slices.Sort(sortedAliases)
+
+	for _, alias := range sortedAliases {
+		canonical := r.aliases[alias]
 		if r.disabled[canonical] {
 			continue
 		}
@@ -254,6 +271,8 @@ func (r *Registry) ProviderDefs() []providers.ToolDefinition {
 }
 
 // List returns all registered canonical tool names (excludes aliases).
+// Results are sorted lexicographically for deterministic ordering — critical
+// for LLM prompt caching (Anthropic/OpenAI cache by exact prefix match).
 func (r *Registry) List() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -263,6 +282,7 @@ func (r *Registry) List() []string {
 			names = append(names, name)
 		}
 	}
+	slices.Sort(names)
 	return names
 }
 


### PR DESCRIPTION
## 🔴 CRITICAL: Non-deterministic tool ordering breaks LLM prompt caching

**Severity: HIGH** — Silently wastes money and adds latency on every request across all agents, all sessions, all providers. Prompt cache never hits.

### Problem

Go map iteration is non-deterministic. Within the **same session**, tool names in both the system prompt and tool definitions array change order every turn. This breaks prompt caching (Anthropic/OpenAI cache by **exact prefix match**), causing every request to pay full inference cost.

### Evidence (from proxy logger — BEFORE fix)

**Tool definitions order changes between turns:**
```
[REQ_TOOLS] count=41 sorted_names=['Agent', 'Bash', 'Edit', 'Read', 'Skill']...
```

**System prompt diff — Persona section reorders (IDENTITY.md vs SOUL.md swapped):**
```
[SYS_DIFF] first_diff_pos=141 prev_len=24964 curr_len=24964
PREV[61:341]: '# Persona & Identity...\n\n## IDENTITY.md\n<internal_config name="IDENTITY.md">...'
CURR[61:341]: '# Persona & Identity...\n\n## SOUL.md\n<internal_config name="SOUL.md">...'
```

**System prompt diff — Tool list in ## Tooling section reorders:**
```
[SYS_DIFF] first_diff_pos=4109 prev_len=24964 curr_len=24964
PREV[4029:4309]: '...sessions_list: List sessions...\n- message: Send a PROACTIVE message...'
CURR[4029:4309]: '...list_group_members: List all members...\n- use_skill: Invoke a skill...'
```

**Same session, next turn — tools reorder again:**
```
[SYS_DIFF] first_diff_pos=4109 prev_len=25017 curr_len=25017
PREV[4029:4309]: '...use_skill: Invoke a skill...\n- datetime: Get current date/time...'
CURR[4029:4309]: '...publish_skill: Register a skill directory...\n- memory_search: Search indexed...'
```

### Root Cause

4 locations iterate Go maps without sorting:

| Source | File | Impact |
|---|---|---|
| `Registry.List()` | `internal/tools/registry.go` | System prompt `## Tooling` section + tool defs |
| `Registry.ProviderDefs()` | `internal/tools/registry.go` | Tool definitions array (no-policy fallback) |
| `FilterTools()` alias loop | `internal/tools/policy.go` | Tool definitions array (alias ordering) |
| `buildMCPToolsInlineSection()` | `internal/agent/systemprompt_sections.go` | System prompt MCP tools section |

### Fix

Sort all map iterations lexicographically using `slices.Sort()`. Zero behavior change — only ordering becomes deterministic.

### Testing Results (AFTER fix)

> **Screenshot attached in PR comments below** — shows green "đã cache" values confirming near-100% cache hit rates.

| Time | Total Tokens | Cached Tokens | Cache Rate |
|---|---|---|---|
| 12:25:39 PM | 19.4K / 42 | 19.3K đã cache | **99.5%** |
| 12:25:29 PM | 38.7K / 106 | 38.3K đã cache | **99.0%** |
| 12:25:11 PM | 38.3K / 124 | 37.2K đã cache | **97.1%** |
| 12:24:19 PM | 74.3K / 626 | 72.4K đã cache | **97.4%** |
| 12:23:49 PM | 34.3K / 550 | 32.5K đã cache | **94.8%** |
| 12:23:26 PM | 16.2K / 60 | 16.2K đã cache | **100%** |
| 12:23:19 PM | 16.2K / 38 | 16.2K đã cache | **100%** |
| 12:22:27 PM | 16.2K / 37 | — | 0% (first request, cold) |

**Before fix**: Cache hit rate **0%** — prompt changed at position 141 (persona) and 4109 (tools) every turn.
**After fix**: Cache hit rate **95-100%** on all subsequent turns.

### Impact

- **Cost**: Before — every turn paid full inference cost. After — 95-100% cache hit → significant cost savings
- **Latency**: Before — no TTFT improvement. After — faster TTFT from cached prefix
- **Scope**: All agents, all sessions, all providers

### Files Changed

- `internal/tools/registry.go` — `List()` and `ProviderDefs()` sort output
- `internal/tools/policy.go` — `FilterTools()` sorts alias names
- `internal/agent/systemprompt_sections.go` — `buildMCPToolsInlineSection()` sorts MCP tool names

### Test Plan

- [x] `go build ./internal/tools/ ./internal/agent/` compiles clean
- [x] `go vet ./internal/tools/ ./internal/agent/` passes
- [x] Deploy and confirm cache hit rate increases (see results above)
- [ ] Run integration tests on CI