### PR TITLE
fix(agent): correct soft-trim head/tail budget allocation when tail is important

### DIFF
--- a/internal/agent/pruning.go
+++ b/internal/agent/pruning.go
@@ -205,8 +205,8 @@ func pruneContextMessages(msgs []providers.Message, contextWindowTokens int, cfg
 		tailChars := settings.softTrimTailChars
 		if hasImportantTail(msg.Content) {
 			totalBudget := headChars + tailChars
-			headChars = totalBudget * 7 / 10
-			tailChars = totalBudget - headChars
+			tailChars = totalBudget * 7 / 10
+			headChars = totalBudget - tailChars
 		}
 		head := takeHead(msg.Content, headChars)
 		tail := takeTail(msg.Content, tailChars)


### PR DESCRIPTION
## Summary
When hasImportantTail is true, 70% of the character budget should be
allocated to the tail, not the head. The previous code had the
assignment reversed, causing tail content to be over-truncated in
exactly the cases where it matters most.

