### PR TITLE
fix(storage): invalidate /v1/storage/size cache on delete and move

### DIFF
--- a/internal/http/storage.go
+++ b/internal/http/storage.go
@@ -429,6 +429,9 @@ func (h *StorageHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Invalidate cached size for this tenant after successful deletion.
+	h.sizeCache.Delete(delBase)
+
 	slog.Info("storage.deleted", "path", relPath)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
@@ -630,6 +633,9 @@ func (h *StorageHandler) handleMove(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgInternalError, "failed to move file")})
 		return
 	}
+
+	// Invalidate cached size for this tenant after successful move.
+	h.sizeCache.Delete(base)
 
 	slog.Info("storage.moved", "from", fromRel, "to", toRel)
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/internal/http/storage_test.go
+++ b/internal/http/storage_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -175,5 +176,48 @@ func TestIsHiddenPathOnlyAffectsMaster(t *testing.T) {
 	}
 	if handler.isHiddenPath(masterReq, "my-tenants") {
 		t.Fatal("partial match should not be hidden")
+	}
+}
+
+func TestStorageDeleteInvalidatesSizeCache(t *testing.T) {
+	baseDir := t.TempDir()
+	writeStorageTestFile(t, filepath.Join(baseDir, "tmp.txt"), "abc")
+
+	handler := NewStorageHandler(baseDir)
+	req := httptest.NewRequest(http.MethodDelete, "/v1/storage/files/tmp.txt", nil)
+	req = req.WithContext(store.WithTenantID(context.Background(), store.MasterTenantID))
+	req.SetPathValue("path", "tmp.txt")
+
+	sizeBase := handler.tenantBaseDir(req)
+	handler.sizeCache.Store(sizeBase, &sizeCacheEntry{total: 3, files: 1})
+
+	w := httptest.NewRecorder()
+	handler.handleDelete(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if _, ok := handler.sizeCache.Load(sizeBase); ok {
+		t.Fatal("expected size cache entry to be invalidated after delete")
+	}
+}
+
+func TestStorageMoveInvalidatesSizeCache(t *testing.T) {
+	baseDir := t.TempDir()
+	writeStorageTestFile(t, filepath.Join(baseDir, "from.txt"), "abc")
+
+	handler := NewStorageHandler(baseDir)
+	req := httptest.NewRequest(http.MethodPut, "/v1/storage/move?from=from.txt&to=to.txt", nil)
+	req = req.WithContext(store.WithTenantID(context.Background(), store.MasterTenantID))
+
+	sizeBase := handler.tenantBaseDir(req)
+	handler.sizeCache.Store(sizeBase, &sizeCacheEntry{total: 3, files: 1})
+
+	w := httptest.NewRecorder()
+	handler.handleMove(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if _, ok := handler.sizeCache.Load(sizeBase); ok {
+		t.Fatal("expected size cache entry to be invalidated after move")
 	}
 }


### PR DESCRIPTION
Fixes #683

Upload already clears the per-tenant storage size cache, but delete and move were leaving cached totals stale until TTL expiry. This clears the same cache after successful delete/move and adds focused tests for both paths.

Greetings, saschabuehrle