### PR TITLE
fix(docker): set correct ownership on migration files to prevent permission denied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ WORKDIR /app
 # Copy binary, migrations, and bundled skills
 COPY --from=builder /out/goclaw /app/goclaw
 COPY --from=builder /out/pkg-helper /app/pkg-helper
-COPY --from=builder /src/migrations/ /app/migrations/
+COPY --from=builder --chown=goclaw:goclaw /src/migrations/ /app/migrations/
 COPY --from=builder /src/skills/ /app/bundled-skills/
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 


### PR DESCRIPTION
## Summary
Migration files were copied as root in the Docker image, causing `permission denied` when the `goclaw` user attempted to read them during auto-upgrade. Adds `--chown=goclaw:goclaw` to the migration COPY instruction.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
`dev`

## Checklist
- [x] `go build ./...` passes
- [x] No hardcoded secrets or credentials
- N/A: Go code, tests, UI, locales, and migration version unchanged (Dockerfile-only change)

## Test Plan
Rebuilt image and verified the container starts without `permission denied` on migration files. Confirmed `ls -la /app/migrations/` shows `goclaw:goclaw` ownership.
