### PR TITLE
fix(desktop): crash on dialog open — undefined.trim()

### DIFF
--- a/ui/desktop/frontend/src/components/agents/AgentFormDialog.tsx
+++ b/ui/desktop/frontend/src/components/agents/AgentFormDialog.tsx
@@ -25,6 +25,7 @@ export function AgentFormDialog({ open, onOpenChange, agent, onSubmit }: AgentFo
   const { register, handleSubmit, watch, setValue, reset, formState: { errors, isSubmitting } } = useForm<AgentFormData>({
     resolver: zodResolver(agentFormSchema),
     mode: 'onChange',
+    defaultValues: { displayName: '', emoji: '🦊', agentKey: '', providerName: '', model: '', description: '', isDefault: false },
   })
 
   // UI-only state (not form data)

--- a/ui/desktop/frontend/src/components/channels/ChannelFormDialog.tsx
+++ b/ui/desktop/frontend/src/components/channels/ChannelFormDialog.tsx
@@ -25,6 +25,7 @@ export function ChannelFormDialog({ open, onOpenChange, agents, telegramExists, 
   const { handleSubmit, watch, setValue, reset, formState: { errors, isSubmitting } } = useForm<ChannelFormData>({
     resolver: zodResolver(channelFormSchema),
     mode: 'onChange',
+    defaultValues: { displayName: '', channelType: '', agentId: '', enabled: true, credentials: {} },
   })
 
   const channelType = watch('channelType')

--- a/ui/desktop/frontend/src/components/mcp/McpFormDialog.tsx
+++ b/ui/desktop/frontend/src/components/mcp/McpFormDialog.tsx
@@ -26,6 +26,7 @@ export function McpFormDialog({ open, onOpenChange, server, onSubmit, onTest }: 
   const { register, handleSubmit, watch, setValue, reset, formState: { errors, isSubmitting } } = useForm<MCPFormData>({
     resolver: zodResolver(mcpFormSchema),
     mode: 'onChange',
+    defaultValues: { name: '', displayName: '', transport: 'stdio', command: '', args: '', url: '', headers: {}, env: {}, toolPrefix: '', timeoutSec: 30, enabled: true },
   })
 
   // Test connection state (UI-only, not form data)

--- a/ui/desktop/frontend/src/components/providers/ProviderFormDialog.tsx
+++ b/ui/desktop/frontend/src/components/providers/ProviderFormDialog.tsx
@@ -23,6 +23,7 @@ export function ProviderFormDialog({ open, onOpenChange, provider, onSubmit }: P
   const { register, handleSubmit, watch, setValue, reset, formState: { errors, isSubmitting } } = useForm<ProviderFormData>({
     resolver: zodResolver(providerFormSchema),
     mode: 'onChange',
+    defaultValues: { providerType: '', displayName: '', apiBase: '', apiKey: '', enabled: true },
   })
 
   // Reset form when dialog opens

--- a/ui/desktop/frontend/src/components/teams/TeamSettingsModal.tsx
+++ b/ui/desktop/frontend/src/components/teams/TeamSettingsModal.tsx
@@ -35,6 +35,7 @@ export function TeamSettingsModal({ teamId, onClose, onSaved }: TeamSettingsModa
   const { watch, setValue, reset, handleSubmit, formState: { isSubmitting } } = useForm<TeamSettingsFormData>({
     resolver: zodResolver(teamSettingsSchema),
     mode: 'onChange',
+    defaultValues: { name: '', description: '', notify: { dispatched: true, progress: true, failed: true, completed: true, new_task: true }, notifyMode: 'direct' },
   })
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Desktop form dialogs (MCP, Agent, Team Settings) crash with `undefined is not an object (evaluating 'l("name").trim')` when opened
- Root cause: `useForm()` called without `defaultValues` — `watch()` returns `undefined` on first render before `useEffect` fires `reset()`
- Fix: add `defaultValues` to `useForm()` in all 3 affected dialogs

## Files Changed

- `ui/desktop/frontend/src/components/mcp/McpFormDialog.tsx`
- `ui/desktop/frontend/src/components/agents/AgentFormDialog.tsx`
- `ui/desktop/frontend/src/components/teams/TeamSettingsModal.tsx`

Closes #732, closes #735

## Test Plan

- [ ] Open desktop app → Settings → MCP → Add MCP Server → form renders without crash
- [ ] Open desktop app → Agents → "+" button → form renders without crash
- [ ] Open desktop app → Teams → settings on any team → modal renders without crash
- [ ] Fill and submit all 3 forms — verify data saves correctly