### PR TITLE
fix: enable search filtering on knowledge graph view

### DIFF
--- a/ui/web/src/pages/memory/kg-entities-tab.tsx
+++ b/ui/web/src/pages/memory/kg-entities-tab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Network, Trash2, Search, GitFork, Sparkles, RefreshCw, LayoutGrid, Share2, Merge } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -41,6 +41,24 @@ export function KGEntitiesTab({ agentId, userId }: KGEntitiesTabProps) {
   const { stats } = useKGStats(agentId, userId);
   const graphData = useKGGraph(agentId, userId);
   const showSkeleton = useDeferredLoading(loading && entities.length === 0);
+
+  // Filter graph data by search query (client-side)
+  const filteredGraphData = useMemo(() => {
+    if (!appliedQuery) return graphData;
+    const q = appliedQuery.toLowerCase();
+    const matchedIds = new Set<string>();
+    const matched = graphData.entities.filter((e) => {
+      const hit = e.name.toLowerCase().includes(q)
+        || e.entity_type.toLowerCase().includes(q)
+        || (e.description ?? "").toLowerCase().includes(q);
+      if (hit) matchedIds.add(e.id);
+      return hit;
+    });
+    const relations = graphData.relations.filter(
+      (r) => matchedIds.has(r.source_entity_id) && matchedIds.has(r.target_entity_id),
+    );
+    return { entities: matched, relations };
+  }, [graphData, appliedQuery]);
 
   const handleSearch = () => setAppliedQuery(searchQuery.trim());
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -130,8 +148,8 @@ export function KGEntitiesTab({ agentId, userId }: KGEntitiesTabProps) {
       <div className="min-h-0 flex-1">
       {viewMode === "graph" ? (
         <KGGraphView
-          entities={graphData.entities}
-          relations={graphData.relations}
+          entities={filteredGraphData.entities}
+          relations={filteredGraphData.relations}
           onEntityClick={setViewEntity}
         />
       ) : showSkeleton ? (


### PR DESCRIPTION
## Summary

The search box on `/knowledge-graph` only filtered the table view — the graph view (default) was unaffected by search queries.

- Add client-side `useMemo` filtering of graph entities by name, type, or description
- Only show relations where both source and target entities match
- Clearing search restores the full graph

## Changes

- `ui/web/src/pages/memory/kg-entities-tab.tsx` — filter `graphData` by `appliedQuery` before passing to `KGGraphView`

## Test plan

- [ ] Type a search term and press Enter in graph view — graph filters to matching entities
- [ ] Clear search — full graph reappears
- [ ] Switch to table view — search still works as before
- [ ] Search with no matches — empty graph shown

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)