### PR TITLE
feat(cron): enhance cron job handler with recent chat history context

### DIFF
--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 
@@ -61,14 +62,20 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 		// Resolve channel type for system prompt context.
 		channelType := resolveChannelType(channelMgr, channel)
 
+		cronCtx := store.WithTenantID(context.Background(), job.TenantID)
+
 		// Build cron context so the agent knows delivery target and requester.
+		// When delivery targets a channel chat, inject recent history from that chat's
+		// session (same key as inbound messages). Cron runs use a separate cron:* session,
+		// so without this the model only sees the job payload — not group chat history.
 		var extraPrompt string
 		if job.Deliver && job.DeliverChannel != "" && job.DeliverTo != "" {
+			linked := linkedDeliveryChatContextBlock(cronCtx, sessionMgr, agentID, job, peerKind)
 			extraPrompt = fmt.Sprintf(
 				"[Cron Job]\nThis is scheduled job \"%s\" (ID: %s).\n"+
 					"Requester: user %s on channel \"%s\" (chat %s).\n"+
-					"Your response will be automatically delivered to that chat — just produce the content directly.",
-				job.Name, job.ID, job.UserID, job.DeliverChannel, job.DeliverTo,
+					"Your response will be automatically delivered to that chat — just produce the content directly.%s",
+				job.Name, job.ID, job.UserID, job.DeliverChannel, job.DeliverTo, linked,
 			)
 		} else {
 			extraPrompt = fmt.Sprintf(
@@ -77,9 +84,6 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 				job.Name, job.ID, job.UserID,
 			)
 		}
-
-		// Build context with tenant scope so agent loop events are scoped correctly.
-		cronCtx := store.WithTenantID(context.Background(), job.TenantID)
 
 		// Reset session before each cron run to prevent tool errors from previous
 		// runs from polluting the context and blocking future executions (#294).
@@ -151,9 +155,79 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 
 // resolveCronPeerKind infers peer kind from the cron job's user ID.
 // Group cron jobs have userID prefixed with "group:" or "guild:" (set during job creation).
+// Telegram supergroups/channels use negative chat IDs starting with -100 — treat as group when
+// deliver target looks like one (API-created jobs may omit group-scoped user IDs).
 func resolveCronPeerKind(job *store.CronJob) string {
 	if strings.HasPrefix(job.UserID, "group:") || strings.HasPrefix(job.UserID, "guild:") {
 		return "group"
 	}
+	if strings.HasPrefix(job.DeliverTo, "-100") {
+		return "group"
+	}
 	return ""
+}
+
+const (
+	linkedChatMaxMessages     = 35
+	linkedChatMaxCharsPerMsg  = 2500
+	linkedChatMaxTotalBytes   = 48 * 1024
+)
+
+// linkedDeliveryChatContextBlock returns text to append to the cron extra system prompt:
+// recent messages from the delivery chat's normal session (where @mentions and worklogs land).
+// Empty string if there is no history or session store.
+func linkedDeliveryChatContextBlock(ctx context.Context, sessionMgr store.SessionStore, agentID string, job *store.CronJob, peerKind string) string {
+	if sessionMgr == nil || job.DeliverChannel == "" || job.DeliverTo == "" {
+		return ""
+	}
+	var pk sessions.PeerKind
+	if peerKind == "group" {
+		pk = sessions.PeerGroup
+	} else {
+		pk = sessions.PeerDirect
+	}
+	chatKey := sessions.BuildScopedSessionKey(agentID, job.DeliverChannel, pk, job.DeliverTo)
+	history := sessionMgr.GetHistory(ctx, chatKey)
+	if len(history) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\n[Recent messages from this chat session — session_key ")
+	b.WriteString(chatKey)
+	b.WriteString("]\n")
+	// Same visibility rules as sessions_history (no raw tool I/O).
+	var lines []string
+	for _, m := range history {
+		if m.Role == "tool" {
+			continue
+		}
+		if m.Role == "assistant" && len(m.ToolCalls) > 0 && strings.TrimSpace(m.Content) == "" {
+			continue
+		}
+		content := strings.TrimSpace(m.Content)
+		if content == "" {
+			continue
+		}
+		if utf8.RuneCountInString(content) > linkedChatMaxCharsPerMsg {
+			runes := []rune(content)
+			content = string(runes[:linkedChatMaxCharsPerMsg]) + "... [truncated]"
+		}
+		lines = append(lines, fmt.Sprintf("%s: %s", m.Role, content))
+	}
+	if len(lines) > linkedChatMaxMessages {
+		lines = lines[len(lines)-linkedChatMaxMessages:]
+	}
+	for _, line := range lines {
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	out := b.String()
+	if len(out) > linkedChatMaxTotalBytes {
+		out = out[:linkedChatMaxTotalBytes]
+		for len(out) > 0 && !utf8.ValidString(out) {
+			out = out[:len(out)-1]
+		}
+		out += "\n... [chat context truncated]"
+	}
+	return out
 }


### PR DESCRIPTION

## Summary
- Introduced linkedDeliveryChatContextBlock function to append recent messages from the delivery chat's session to the cron job's prompt.
- Updated makeCronJobHandler to include chat history when delivering messages to group chats.
- Improved peer kind resolution to treat Telegram supergroups/channels as group types based on chat ID format.
- Added constants for message and character limits to manage chat history output.

This enhancement allows the cron job to provide more context-aware responses by including relevant chat history, improving user experience in group interactions.

## Type
<!-- Check one -->
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
