### PR TITLE
Add GitHub Copilot OAuth provider

### DIFF
--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -340,6 +340,9 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 				codex.WithRoutingDefaults(oauthSettings.CodexPool.Strategy, oauthSettings.CodexPool.ExtraProviderNames)
 			}
 			registry.RegisterForTenant(p.TenantID, codex)
+		case store.ProviderGitHubCopilotOAuth:
+			ts := oauth.NewGitHubCopilotTokenSource(provStore, secretStore, p.Name).WithTenantID(p.TenantID)
+			registry.RegisterForTenant(p.TenantID, providers.NewGitHubCopilotProvider(p.Name, ts, p.APIBase, ""))
 		case store.ProviderAnthropicNative:
 			registry.RegisterForTenant(p.TenantID, providers.NewAnthropicProvider(p.APIKey,
 				providers.WithAnthropicName(p.Name),

--- a/internal/http/oauth.go
+++ b/internal/http/oauth.go
@@ -33,6 +33,7 @@ type OAuthHandler struct {
 
 	mu            sync.Mutex
 	pending       map[string]*pendingOAuthFlow
+	pendingCopilot map[string]*pendingGitHubCopilotFlow
 	activeFlowKey string // only one active flow at a time (fixed callback port)
 }
 
@@ -55,6 +56,7 @@ func NewOAuthHandler(provStore store.ProviderStore, secretStore store.ConfigSecr
 		providerReg: providerReg,
 		msgBus:      msgBus,
 		pending:     make(map[string]*pendingOAuthFlow),
+		pendingCopilot: make(map[string]*pendingGitHubCopilotFlow),
 	}
 }
 
@@ -65,6 +67,9 @@ func (h *OAuthHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /v1/auth/chatgpt/{provider}/start", h.auth(h.handleStart))
 	mux.HandleFunc("POST /v1/auth/chatgpt/{provider}/callback", h.auth(h.handleManualCallback))
 	mux.HandleFunc("POST /v1/auth/chatgpt/{provider}/logout", h.auth(h.handleLogout))
+	mux.HandleFunc("GET /v1/auth/copilot/{provider}/status", h.auth(h.handleGitHubCopilotStatus))
+	mux.HandleFunc("POST /v1/auth/copilot/{provider}/start", h.auth(h.handleGitHubCopilotStart))
+	mux.HandleFunc("POST /v1/auth/copilot/{provider}/logout", h.auth(h.handleGitHubCopilotLogout))
 
 	mux.HandleFunc("GET /v1/auth/openai/status", h.auth(h.handleStatus))
 	mux.HandleFunc("GET /v1/auth/openai/quota", h.auth(h.handleQuota))

--- a/internal/http/oauth_github_copilot.go
+++ b/internal/http/oauth_github_copilot.go
@@ -1,0 +1,209 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/oauth"
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+type pendingGitHubCopilotFlow struct {
+	login            *oauth.PendingGitHubCopilotLogin
+	cancel           context.CancelFunc
+	flowKey          string
+	tenantID         uuid.UUID
+	userID           string
+	providerName     string
+	displayName      string
+	apiBase          string
+	enterpriseDomain string
+}
+
+func (h *OAuthHandler) newGitHubCopilotTokenSource(ctx context.Context, providerName, displayName, apiBase string) *oauth.GitHubCopilotTokenSource {
+	return oauth.NewGitHubCopilotTokenSource(h.provStore, h.secretStore, providerName).
+		WithTenantID(oauthTenantID(ctx)).
+		WithProviderMeta(displayName, apiBase)
+}
+
+func (h *OAuthHandler) ensureGitHubCopilotProviderName(ctx context.Context, providerName string) error {
+	if h.provStore == nil {
+		return nil
+	}
+	p, err := h.provStore.GetProviderByName(ctx, providerName)
+	if err != nil {
+		return nil
+	}
+	if p.ProviderType != store.ProviderGitHubCopilotOAuth {
+		return &oauth.ProviderTypeConflictError{ProviderName: providerName, ProviderType: p.ProviderType}
+	}
+	return nil
+}
+
+func (h *OAuthHandler) handleGitHubCopilotStatus(w http.ResponseWriter, r *http.Request) {
+	locale := extractLocale(r)
+	providerName := oauthProviderName(r)
+	if !isValidSlug(providerName) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidSlug, "provider")})
+		return
+	}
+	if err := h.ensureGitHubCopilotProviderName(r.Context(), providerName); err != nil {
+		writeOAuthProviderConflict(w, err)
+		return
+	}
+	flowKey := oauthFlowKey(r.Context(), providerName)
+	h.mu.Lock()
+	pending := h.pendingCopilot[flowKey]
+	h.mu.Unlock()
+	if pending != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"authenticated":    false,
+			"pending":          true,
+			"provider_name":    providerName,
+			"verification_uri": pending.login.Device.VerificationURI,
+			"user_code":        pending.login.Device.UserCode,
+		})
+		return
+	}
+	ts := h.newGitHubCopilotTokenSource(r.Context(), providerName, "", "")
+	if !ts.Exists(r.Context()) {
+		writeJSON(w, http.StatusOK, map[string]any{"authenticated": false, "pending": false})
+		return
+	}
+	if _, err := ts.Token(); err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"authenticated": false, "pending": false, "error": "token invalid or expired"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"authenticated": true, "pending": false, "provider_name": providerName})
+}
+
+func (h *OAuthHandler) handleGitHubCopilotStart(w http.ResponseWriter, r *http.Request) {
+	locale := extractLocale(r)
+	providerName := oauthProviderName(r)
+	if !isValidSlug(providerName) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidSlug, "provider")})
+		return
+	}
+	var body struct {
+		DisplayName      string `json:"display_name"`
+		APIBase          string `json:"api_base"`
+		EnterpriseDomain string `json:"enterprise_domain"`
+	}
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidJSON)})
+			return
+		}
+	}
+	if err := h.ensureGitHubCopilotProviderName(r.Context(), providerName); err != nil {
+		writeOAuthProviderConflict(w, err)
+		return
+	}
+	ts := h.newGitHubCopilotTokenSource(r.Context(), providerName, body.DisplayName, body.APIBase)
+	if ts.Exists(r.Context()) {
+		if _, err := ts.Token(); err == nil {
+			writeJSON(w, http.StatusOK, map[string]any{"status": "already_authenticated", "provider_name": providerName})
+			return
+		}
+	}
+	flowKey := oauthFlowKey(r.Context(), providerName)
+	h.mu.Lock()
+	if pending := h.pendingCopilot[flowKey]; pending != nil {
+		h.mu.Unlock()
+		writeJSON(w, http.StatusOK, map[string]any{"provider_name": providerName, "verification_uri": pending.login.Device.VerificationURI, "user_code": pending.login.Device.UserCode, "expires_in": pending.login.Device.ExpiresIn, "interval": pending.login.Device.Interval})
+		return
+	}
+	pending, err := oauth.StartLoginGitHubCopilot(body.EnterpriseDomain)
+	if err != nil {
+		h.mu.Unlock()
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": i18n.T(locale, i18n.MsgInternalError, err.Error())})
+		return
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Duration(pending.Device.ExpiresIn+30)*time.Second)
+	flow := &pendingGitHubCopilotFlow{login: pending, cancel: cancel, flowKey: flowKey, tenantID: oauthTenantID(r.Context()), userID: store.UserIDFromContext(r.Context()), providerName: providerName, displayName: body.DisplayName, apiBase: body.APIBase, enterpriseDomain: body.EnterpriseDomain}
+	h.pendingCopilot[flowKey] = flow
+	h.mu.Unlock()
+	go h.waitForGitHubCopilot(waitCtx, flow)
+	writeJSON(w, http.StatusOK, map[string]any{"provider_name": providerName, "verification_uri": pending.Device.VerificationURI, "user_code": pending.Device.UserCode, "expires_in": pending.Device.ExpiresIn, "interval": pending.Device.Interval})
+}
+
+func (h *OAuthHandler) waitForGitHubCopilot(ctx context.Context, flow *pendingGitHubCopilotFlow) {
+	githubToken, tokenResp, err := flow.login.Wait(ctx)
+	h.mu.Lock()
+	if h.pendingCopilot[flow.flowKey] == flow {
+		delete(h.pendingCopilot, flow.flowKey)
+	}
+	h.mu.Unlock()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		slog.Warn("copilot.oauth.wait", "provider", flow.providerName, "error", err)
+		return
+	}
+	saveCtx := store.WithTenantID(context.Background(), flow.tenantID)
+	if _, err := h.saveAndRegisterGitHubCopilot(saveCtx, flow.providerName, flow.displayName, flow.apiBase, flow.enterpriseDomain, githubToken, tokenResp); err != nil {
+		slog.Error("copilot.oauth.save", "provider", flow.providerName, "error", err)
+	}
+}
+
+func (h *OAuthHandler) saveAndRegisterGitHubCopilot(ctx context.Context, providerName, displayName, apiBase, enterpriseDomain, githubAccessToken string, tokenResp *oauth.GitHubCopilotTokenResponse) (uuid.UUID, error) {
+	ts := h.newGitHubCopilotTokenSource(ctx, providerName, displayName, apiBase)
+	providerID, err := ts.SaveLoginResult(ctx, githubAccessToken, tokenResp, enterpriseDomain)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	if h.providerReg != nil {
+		tid := oauthTenantID(ctx)
+		resolvedBase := apiBase
+		if h.provStore != nil {
+			providerCtx := store.WithTenantID(ctx, tid)
+			if providerData, err := h.provStore.GetProviderByName(providerCtx, providerName); err == nil {
+				if providerData.APIBase != "" {
+					resolvedBase = providerData.APIBase
+				}
+			}
+		}
+		h.providerReg.RegisterForTenant(tid, providers.NewGitHubCopilotProvider(providerName, ts, resolvedBase, ""))
+	}
+	if tokenResp != nil {
+		for _, model := range []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex"} {
+			oauth.EnableGitHubCopilotModel(tokenResp.Token, model, enterpriseDomain)
+		}
+	}
+	return providerID, nil
+}
+
+func (h *OAuthHandler) handleGitHubCopilotLogout(w http.ResponseWriter, r *http.Request) {
+	locale := extractLocale(r)
+	providerName := oauthProviderName(r)
+	if !isValidSlug(providerName) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidSlug, "provider")})
+		return
+	}
+	if err := h.ensureGitHubCopilotProviderName(r.Context(), providerName); err != nil {
+		writeOAuthProviderConflict(w, err)
+		return
+	}
+	ts := h.newGitHubCopilotTokenSource(r.Context(), providerName, "", "")
+	if err := ts.Delete(r.Context()); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if h.providerReg != nil {
+		tid := store.TenantIDFromContext(r.Context())
+		if tid == uuid.Nil {
+			tid = store.MasterTenantID
+		}
+		h.providerReg.UnregisterForTenant(tid, providerName)
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "logged out"})
+}

--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -61,6 +61,11 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 		return
 	}
 
+	if p.ProviderType == store.ProviderGitHubCopilotOAuth {
+		respond(githubCopilotModels())
+		return
+	}
+
 	// ACP agents don't need an API key — return hardcoded models
 	if p.ProviderType == store.ProviderACP {
 		respond(acpModels())

--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/oauth"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
@@ -62,7 +63,26 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 	}
 
 	if p.ProviderType == store.ProviderGitHubCopilotOAuth {
-		respond(githubCopilotModels())
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
+		ts := oauth.NewGitHubCopilotTokenSource(h.store, h.secretStore, p.Name).WithTenantID(p.TenantID)
+		token, tokenErr := ts.Token()
+		if tokenErr != nil {
+			slog.Warn("providers.models.github_copilot.token", "provider", p.Name, "error", tokenErr)
+			respond([]ModelInfo{})
+			return
+		}
+		enterpriseDomain := ""
+		if settings := store.ParseGitHubCopilotOAuthProviderSettings(p.Settings); settings != nil {
+			enterpriseDomain = settings.EnterpriseDomain
+		}
+		models, err := fetchGitHubCopilotModels(ctx, ts.APIBase(), token, enterpriseDomain)
+		if err != nil {
+			slog.Warn("providers.models.github_copilot", "provider", p.Name, "error", err)
+			respond([]ModelInfo{})
+			return
+		}
+		respond(withReasoningCapabilities(models))
 		return
 	}
 

--- a/internal/http/provider_models_catalog.go
+++ b/internal/http/provider_models_catalog.go
@@ -101,3 +101,20 @@ func chatGPTOAuthModels() []ModelInfo {
 		{ID: "gpt-5.1", Name: "GPT-5.1"},
 	})
 }
+
+// githubCopilotModels returns the curated, currently supported GitHub Copilot OAuth model set.
+// Initial implementation intentionally scopes to GPT-family models that can use the Responses transport.
+func githubCopilotModels() []ModelInfo {
+	return withReasoningCapabilities([]ModelInfo{
+		{ID: "gpt-5.4", Name: "GPT-5.4"},
+		{ID: "gpt-5.4-mini", Name: "GPT-5.4 Mini"},
+		{ID: "gpt-5.3-codex", Name: "GPT-5.3 Codex"},
+		{ID: "gpt-5.3-codex-spark", Name: "GPT-5.3 Codex Spark"},
+		{ID: "gpt-5.2-codex", Name: "GPT-5.2 Codex"},
+		{ID: "gpt-5.2", Name: "GPT-5.2"},
+		{ID: "gpt-5.1-codex", Name: "GPT-5.1 Codex"},
+		{ID: "gpt-5.1-codex-max", Name: "GPT-5.1 Codex Max"},
+		{ID: "gpt-5.1-codex-mini", Name: "GPT-5.1 Codex Mini"},
+		{ID: "gpt-5.1", Name: "GPT-5.1"},
+	})
+}

--- a/internal/http/provider_models_fetch.go
+++ b/internal/http/provider_models_fetch.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/oauth"
 )
 
 // fetchAnthropicModels calls the Anthropic models API.
@@ -124,6 +125,147 @@ func fetchOpenAIModels(ctx context.Context, apiBase, apiKey string) ([]ModelInfo
 		models = append(models, ModelInfo{ID: m.ID, Name: m.ID})
 	}
 	return models, nil
+}
+
+type gitHubCopilotModelRecord struct {
+	ID                 string   `json:"id"`
+	Name               string   `json:"name"`
+	Preview            bool     `json:"preview"`
+	ModelPickerEnabled *bool    `json:"model_picker_enabled"`
+	SupportedEndpoints []string `json:"supported_endpoints"`
+}
+
+type gitHubCopilotModelsEnvelope struct {
+	Data   []gitHubCopilotModelRecord `json:"data"`
+	Models []gitHubCopilotModelRecord `json:"models"`
+}
+
+func fetchGitHubCopilotModels(ctx context.Context, apiBase, token, enterpriseDomain string) ([]ModelInfo, error) {
+	candidates := make([]string, 0, 2)
+	if proxyBase := oauth.GetGitHubCopilotProxyBaseURL(token, enterpriseDomain); proxyBase != "" {
+		candidates = append(candidates, strings.TrimRight(proxyBase, "/")+"/models")
+	}
+	if trimmedAPIBase := strings.TrimRight(apiBase, "/"); trimmedAPIBase != "" {
+		candidates = append(candidates, trimmedAPIBase+"/models")
+	}
+	if len(candidates) == 0 {
+		candidates = append(candidates, oauth.DefaultGitHubCopilotProxyBase+"/models")
+	}
+
+	var lastErr error
+	for _, endpoint := range candidates {
+		models, err := fetchGitHubCopilotModelsFromEndpoint(ctx, endpoint, token)
+		if err == nil {
+			return models, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no GitHub Copilot model endpoint candidates available")
+	}
+	return nil, lastErr
+}
+
+func fetchGitHubCopilotModelsFromEndpoint(ctx context.Context, endpoint, token string) ([]ModelInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", oauth.GitHubCopilotUserAgent)
+	req.Header.Set("Editor-Version", oauth.GitHubCopilotEditorVersion)
+	req.Header.Set("Editor-Plugin-Version", oauth.GitHubCopilotPluginVersion)
+	req.Header.Set("Copilot-Integration-Id", oauth.GitHubCopilotIntegrationID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github copilot models API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	records, err := decodeGitHubCopilotModelRecords(body)
+	if err != nil {
+		return nil, err
+	}
+
+	models := make([]ModelInfo, 0, len(records))
+	for _, record := range records {
+		if !isGitHubCopilotPickerModel(record) {
+			continue
+		}
+		name := strings.TrimSpace(record.Name)
+		if name == "" {
+			name = record.ID
+		}
+		if record.Preview && !strings.Contains(strings.ToLower(name), "preview") {
+			name += " (Preview)"
+		}
+		models = append(models, ModelInfo{ID: record.ID, Name: name})
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("github copilot models endpoint returned no picker-visible models")
+	}
+	return dedupeModelInfos(models), nil
+}
+
+func decodeGitHubCopilotModelRecords(body []byte) ([]gitHubCopilotModelRecord, error) {
+	var envelope gitHubCopilotModelsEnvelope
+	if err := json.Unmarshal(body, &envelope); err == nil {
+		if len(envelope.Data) > 0 {
+			return envelope.Data, nil
+		}
+		if len(envelope.Models) > 0 {
+			return envelope.Models, nil
+		}
+	}
+
+	var direct []gitHubCopilotModelRecord
+	if err := json.Unmarshal(body, &direct); err == nil && len(direct) > 0 {
+		return direct, nil
+	}
+
+	return nil, fmt.Errorf("failed to decode GitHub Copilot models response")
+}
+
+func isGitHubCopilotPickerModel(record gitHubCopilotModelRecord) bool {
+	if strings.TrimSpace(record.ID) == "" {
+		return false
+	}
+	if record.ModelPickerEnabled != nil && !*record.ModelPickerEnabled {
+		return false
+	}
+	if len(record.SupportedEndpoints) == 0 {
+		return true
+	}
+	for _, endpoint := range record.SupportedEndpoints {
+		normalized := strings.ToLower(strings.TrimSpace(endpoint))
+		if strings.Contains(normalized, "chat") || strings.Contains(normalized, "response") {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupeModelInfos(models []ModelInfo) []ModelInfo {
+	seen := make(map[string]struct{}, len(models))
+	result := make([]ModelInfo, 0, len(models))
+	for _, model := range models {
+		if _, ok := seen[model.ID]; ok {
+			continue
+		}
+		seen[model.ID] = struct{}{}
+		result = append(result, model)
+	}
+	return result
 }
 
 // fetchOllamaModels calls Ollama's native /api/tags endpoint to get model metadata

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -195,6 +195,9 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 			codex.WithRoutingDefaults(oauthSettings.CodexPool.Strategy, oauthSettings.CodexPool.ExtraProviderNames)
 		}
 		h.providerReg.RegisterForTenant(p.TenantID, codex)
+	case store.ProviderGitHubCopilotOAuth:
+		ts := oauth.NewGitHubCopilotTokenSource(h.store, h.secretStore, p.Name).WithTenantID(p.TenantID)
+		h.providerReg.RegisterForTenant(p.TenantID, providers.NewGitHubCopilotProvider(p.Name, ts, apiBase, ""))
 	case store.ProviderAnthropicNative:
 		h.providerReg.RegisterForTenant(p.TenantID, providers.NewAnthropicProvider(p.APIKey,
 			providers.WithAnthropicBaseURL(apiBase)))

--- a/internal/oauth/github_copilot.go
+++ b/internal/oauth/github_copilot.go
@@ -1,0 +1,340 @@
+package oauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultGitHubCopilotProviderName = "github-copilot"
+	DefaultGitHubCopilotAPIBase      = "https://api.individual.githubcopilot.com"
+	GitHubCopilotUserAgent           = "GitHubCopilotChat/0.35.0"
+	GitHubCopilotEditorVersion       = "vscode/1.107.0"
+	GitHubCopilotPluginVersion       = "copilot-chat/0.35.0"
+	GitHubCopilotIntegrationID       = "vscode-chat"
+)
+
+var gitHubCopilotClientID = decodeGitHubCopilotClientID("SXYxLmI1MDdhMDhjODdlY2ZlOTg=")
+
+type GitHubCopilotDeviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	Interval        int    `json:"interval"`
+	ExpiresIn       int    `json:"expires_in"`
+}
+
+type GitHubCopilotDeviceTokenSuccessResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+}
+
+type GitHubCopilotDeviceTokenErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+	Interval         int    `json:"interval,omitempty"`
+}
+
+type GitHubCopilotTokenResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"`
+	RefreshIn int    `json:"refresh_in,omitempty"`
+	SKU       string `json:"sku,omitempty"`
+}
+
+type PendingGitHubCopilotLogin struct {
+	Domain string
+	Device GitHubCopilotDeviceCodeResponse
+}
+
+func decodeGitHubCopilotClientID(encoded string) string {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return ""
+	}
+	return string(decoded)
+}
+
+func gitHubCopilotHeaders() map[string]string {
+	return map[string]string{
+		"User-Agent":            GitHubCopilotUserAgent,
+		"Editor-Version":        GitHubCopilotEditorVersion,
+		"Editor-Plugin-Version": GitHubCopilotPluginVersion,
+		"Copilot-Integration-Id": GitHubCopilotIntegrationID,
+	}
+}
+
+func NormalizeGitHubCopilotDomain(input string) string {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return ""
+	}
+	if !strings.Contains(trimmed, "://") {
+		trimmed = "https://" + trimmed
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(u.Hostname())
+}
+
+func gitHubCopilotURLs(domain string) (deviceCodeURL, accessTokenURL, copilotTokenURL string) {
+	if domain == "" {
+		domain = "github.com"
+	}
+	return fmt.Sprintf("https://%s/login/device/code", domain),
+		fmt.Sprintf("https://%s/login/oauth/access_token", domain),
+		fmt.Sprintf("https://api.%s/copilot_internal/v2/token", domain)
+}
+
+func getGitHubCopilotBaseURLFromToken(token string) string {
+	match := strings.Split(token, "proxy-ep=")
+	if len(match) < 2 {
+		return ""
+	}
+	proxyHost := match[1]
+	if idx := strings.Index(proxyHost, ";"); idx >= 0 {
+		proxyHost = proxyHost[:idx]
+	}
+	proxyHost = strings.TrimSpace(proxyHost)
+	if proxyHost == "" {
+		return ""
+	}
+	apiHost := strings.TrimPrefix(proxyHost, "proxy.")
+	if apiHost == proxyHost {
+		apiHost = proxyHost
+	} else {
+		apiHost = "api." + apiHost
+	}
+	return "https://" + apiHost
+}
+
+func GetGitHubCopilotBaseURL(token, enterpriseDomain string) string {
+	if base := getGitHubCopilotBaseURLFromToken(token); base != "" {
+		return base
+	}
+	if domain := NormalizeGitHubCopilotDomain(enterpriseDomain); domain != "" {
+		return "https://copilot-api." + domain
+	}
+	return DefaultGitHubCopilotAPIBase
+}
+
+func fetchGitHubCopilotJSON(target string, init func(*http.Request)) (map[string]any, error) {
+	req, err := http.NewRequest(http.MethodPost, target, nil)
+	if err != nil {
+		return nil, err
+	}
+	if init != nil {
+		init(req)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%s %s: %s", resp.Status, target, string(body))
+	}
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return data, nil
+}
+
+func StartLoginGitHubCopilot(enterpriseDomain string) (*PendingGitHubCopilotLogin, error) {
+	domain := NormalizeGitHubCopilotDomain(enterpriseDomain)
+	if domain == "" {
+		domain = "github.com"
+	}
+	deviceCodeURL, _, _ := gitHubCopilotURLs(domain)
+	form := url.Values{
+		"client_id": {gitHubCopilotClientID},
+		"scope":     {"read:user"},
+	}
+	req, err := http.NewRequest(http.MethodPost, deviceCodeURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", GitHubCopilotUserAgent)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("device flow failed (%s): %s", resp.Status, string(body))
+	}
+	var device GitHubCopilotDeviceCodeResponse
+	if err := json.Unmarshal(body, &device); err != nil {
+		return nil, fmt.Errorf("parse device flow response: %w", err)
+	}
+	if device.DeviceCode == "" || device.UserCode == "" || device.VerificationURI == "" {
+		return nil, fmt.Errorf("invalid device flow response")
+	}
+	if device.Interval <= 0 {
+		device.Interval = 5
+	}
+	return &PendingGitHubCopilotLogin{Domain: domain, Device: device}, nil
+}
+
+func (p *PendingGitHubCopilotLogin) Wait(ctx context.Context) (string, *GitHubCopilotTokenResponse, error) {
+	githubToken, err := pollForGitHubCopilotAccessToken(ctx, p.Domain, p.Device.DeviceCode, p.Device.Interval, p.Device.ExpiresIn)
+	if err != nil {
+		return "", nil, err
+	}
+	tokenResp, err := RefreshGitHubCopilotToken(githubToken, p.Domain)
+	if err != nil {
+		return "", nil, err
+	}
+	return githubToken, tokenResp, nil
+}
+
+func pollForGitHubCopilotAccessToken(ctx context.Context, domain, deviceCode string, intervalSeconds, expiresIn int) (string, error) {
+	_, accessTokenURL, _ := gitHubCopilotURLs(domain)
+	if intervalSeconds <= 0 {
+		intervalSeconds = 5
+	}
+	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
+	interval := time.Duration(intervalSeconds) * time.Second
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(interval):
+		}
+
+		form := url.Values{
+			"client_id":   {gitHubCopilotClientID},
+			"device_code": {deviceCode},
+			"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+		}
+		req, err := http.NewRequest(http.MethodPost, accessTokenURL, strings.NewReader(form.Encode()))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("User-Agent", GitHubCopilotUserAgent)
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return "", readErr
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return "", fmt.Errorf("device token poll failed (%s): %s", resp.Status, string(body))
+		}
+		var success GitHubCopilotDeviceTokenSuccessResponse
+		if err := json.Unmarshal(body, &success); err == nil && success.AccessToken != "" {
+			return success.AccessToken, nil
+		}
+		var tokenErr GitHubCopilotDeviceTokenErrorResponse
+		if err := json.Unmarshal(body, &tokenErr); err != nil {
+			return "", fmt.Errorf("parse device token response: %w", err)
+		}
+		switch tokenErr.Error {
+		case "authorization_pending":
+			continue
+		case "slow_down":
+			if tokenErr.Interval > 0 {
+				interval = time.Duration(tokenErr.Interval) * time.Second
+			} else {
+				interval += 5 * time.Second
+			}
+			continue
+		default:
+			detail := strings.TrimSpace(tokenErr.ErrorDescription)
+			if detail != "" {
+				return "", fmt.Errorf("device flow failed: %s: %s", tokenErr.Error, detail)
+			}
+			return "", fmt.Errorf("device flow failed: %s", tokenErr.Error)
+		}
+	}
+	return "", fmt.Errorf("device flow timed out")
+}
+
+func RefreshGitHubCopilotToken(githubAccessToken, enterpriseDomain string) (*GitHubCopilotTokenResponse, error) {
+	domain := NormalizeGitHubCopilotDomain(enterpriseDomain)
+	if domain == "" {
+		domain = "github.com"
+	}
+	_, _, copilotTokenURL := gitHubCopilotURLs(domain)
+	req, err := http.NewRequest(http.MethodGet, copilotTokenURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+githubAccessToken)
+	for key, value := range gitHubCopilotHeaders() {
+		req.Header.Set(key, value)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("copilot token mint failed (%s): %s", resp.Status, string(body))
+	}
+	var tokenResp GitHubCopilotTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("parse Copilot token response: %w", err)
+	}
+	if tokenResp.Token == "" || tokenResp.ExpiresAt == 0 {
+		return nil, fmt.Errorf("invalid Copilot token response")
+	}
+	return &tokenResp, nil
+}
+
+func EnableGitHubCopilotModel(token, modelID, enterpriseDomain string) bool {
+	if strings.TrimSpace(modelID) == "" || strings.TrimSpace(token) == "" {
+		return false
+	}
+	baseURL := GetGitHubCopilotBaseURL(token, enterpriseDomain)
+	target := strings.TrimRight(baseURL, "/") + "/models/" + url.PathEscape(modelID) + "/policy"
+	body := strings.NewReader(`{"state":"enabled"}`)
+	req, err := http.NewRequest(http.MethodPost, target, body)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("openai-intent", "chat-policy")
+	req.Header.Set("x-interaction-type", "chat-policy")
+	for key, value := range gitHubCopilotHeaders() {
+		req.Header.Set(key, value)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}

--- a/internal/oauth/github_copilot.go
+++ b/internal/oauth/github_copilot.go
@@ -15,6 +15,7 @@ import (
 const (
 	DefaultGitHubCopilotProviderName = "github-copilot"
 	DefaultGitHubCopilotAPIBase      = "https://api.individual.githubcopilot.com"
+	DefaultGitHubCopilotProxyBase    = "https://proxy.individual.githubcopilot.com"
 	GitHubCopilotUserAgent           = "GitHubCopilotChat/0.35.0"
 	GitHubCopilotEditorVersion       = "vscode/1.107.0"
 	GitHubCopilotPluginVersion       = "copilot-chat/0.35.0"
@@ -96,7 +97,7 @@ func gitHubCopilotURLs(domain string) (deviceCodeURL, accessTokenURL, copilotTok
 		fmt.Sprintf("https://api.%s/copilot_internal/v2/token", domain)
 }
 
-func getGitHubCopilotBaseURLFromToken(token string) string {
+func getGitHubCopilotProxyHostFromToken(token string) string {
 	match := strings.Split(token, "proxy-ep=")
 	if len(match) < 2 {
 		return ""
@@ -106,6 +107,14 @@ func getGitHubCopilotBaseURLFromToken(token string) string {
 		proxyHost = proxyHost[:idx]
 	}
 	proxyHost = strings.TrimSpace(proxyHost)
+	if proxyHost == "" {
+		return ""
+	}
+	return proxyHost
+}
+
+func getGitHubCopilotBaseURLFromToken(token string) string {
+	proxyHost := getGitHubCopilotProxyHostFromToken(token)
 	if proxyHost == "" {
 		return ""
 	}
@@ -126,6 +135,16 @@ func GetGitHubCopilotBaseURL(token, enterpriseDomain string) string {
 		return "https://copilot-api." + domain
 	}
 	return DefaultGitHubCopilotAPIBase
+}
+
+func GetGitHubCopilotProxyBaseURL(token, enterpriseDomain string) string {
+	if host := getGitHubCopilotProxyHostFromToken(token); host != "" {
+		return "https://" + host
+	}
+	if domain := NormalizeGitHubCopilotDomain(enterpriseDomain); domain != "" {
+		return "https://proxy." + domain
+	}
+	return DefaultGitHubCopilotProxyBase
 }
 
 func fetchGitHubCopilotJSON(target string, init func(*http.Request)) (map[string]any, error) {

--- a/internal/oauth/github_copilot_test.go
+++ b/internal/oauth/github_copilot_test.go
@@ -1,0 +1,66 @@
+package oauth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+func TestGetGitHubCopilotBaseURLFromToken(t *testing.T) {
+	t.Parallel()
+	token := "abc;proxy-ep=proxy.individual.githubcopilot.com;foo=bar"
+	got := GetGitHubCopilotBaseURL(token, "")
+	if got != "https://api.individual.githubcopilot.com" {
+		t.Fatalf("GetGitHubCopilotBaseURL() = %q, want %q", got, "https://api.individual.githubcopilot.com")
+	}
+}
+
+func TestGetGitHubCopilotBaseURLEnterpriseFallback(t *testing.T) {
+	t.Parallel()
+	got := GetGitHubCopilotBaseURL("", "https://github.example.com")
+	if got != "https://copilot-api.github.example.com" {
+		t.Fatalf("GetGitHubCopilotBaseURL() = %q, want %q", got, "https://copilot-api.github.example.com")
+	}
+}
+
+func TestGitHubCopilotAccessTokenSecretKey(t *testing.T) {
+	t.Parallel()
+	if got := GitHubCopilotAccessTokenSecretKey(""); got != "oauth.github-copilot.github_token" {
+		t.Fatalf("default secret key = %q", got)
+	}
+	if got := GitHubCopilotAccessTokenSecretKey("team-copilot"); got != "oauth.team-copilot.github_token" {
+		t.Fatalf("custom secret key = %q", got)
+	}
+}
+
+func TestMarshalGitHubCopilotOAuthSettingsIntoPreservesUnknownKeys(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage(`{"foo":"bar","expires_at":1}`)
+	settings := store.GitHubCopilotOAuthProviderSettings{
+		ExpiresAt:        42,
+		EnterpriseDomain: "github.example.com",
+		CopilotPlan:      "individual",
+		BaseURL:          "https://api.individual.githubcopilot.com",
+	}
+	merged := marshalGitHubCopilotOAuthSettingsInto(raw, settings)
+	var decoded map[string]any
+	if err := json.Unmarshal(merged, &decoded); err != nil {
+		t.Fatalf("unmarshal merged settings: %v", err)
+	}
+	if decoded["foo"] != "bar" {
+		t.Fatalf("expected unknown key to survive, got %#v", decoded["foo"])
+	}
+	if decoded["enterprise_domain"] != "github.example.com" {
+		t.Fatalf("enterprise_domain = %#v", decoded["enterprise_domain"])
+	}
+	if decoded["copilot_plan"] != "individual" {
+		t.Fatalf("copilot_plan = %#v", decoded["copilot_plan"])
+	}
+	if decoded["base_url"] != "https://api.individual.githubcopilot.com" {
+		t.Fatalf("base_url = %#v", decoded["base_url"])
+	}
+	if decoded["expires_at"] != float64(42) {
+		t.Fatalf("expires_at = %#v", decoded["expires_at"])
+	}
+}

--- a/internal/oauth/github_copilot_token.go
+++ b/internal/oauth/github_copilot_token.go
@@ -1,0 +1,295 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+const gitHubCopilotRefreshMargin = 5 * time.Minute
+
+type GitHubCopilotTokenSource struct {
+	providerStore store.ProviderStore
+	secretsStore  store.ConfigSecretsStore
+	providerName  string
+	tenantID      uuid.UUID
+
+	providerDisplayName string
+	providerAPIBase     string
+
+	mu          sync.Mutex
+	cachedToken string
+	expiresAt   time.Time
+}
+
+func NewGitHubCopilotTokenSource(provStore store.ProviderStore, secretsStore store.ConfigSecretsStore, providerName string) *GitHubCopilotTokenSource {
+	if strings.TrimSpace(providerName) == "" {
+		providerName = DefaultGitHubCopilotProviderName
+	}
+	return &GitHubCopilotTokenSource{
+		providerStore: provStore,
+		secretsStore:  secretsStore,
+		providerName:  providerName,
+		tenantID:      store.MasterTenantID,
+	}
+}
+
+func (ts *GitHubCopilotTokenSource) WithTenantID(tenantID uuid.UUID) *GitHubCopilotTokenSource {
+	ts.tenantID = tenantID
+	return ts
+}
+
+func (ts *GitHubCopilotTokenSource) WithProviderMeta(displayName, apiBase string) *GitHubCopilotTokenSource {
+	if trimmed := strings.TrimSpace(displayName); trimmed != "" {
+		ts.providerDisplayName = trimmed
+	}
+	if trimmed := strings.TrimSpace(apiBase); trimmed != "" {
+		ts.providerAPIBase = trimmed
+	}
+	return ts
+}
+
+func (ts *GitHubCopilotTokenSource) APIBase() string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if strings.TrimSpace(ts.providerAPIBase) != "" {
+		return strings.TrimSpace(ts.providerAPIBase)
+	}
+	return DefaultGitHubCopilotAPIBase
+}
+
+func GitHubCopilotAccessTokenSecretKey(providerName string) string {
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" || providerName == DefaultGitHubCopilotProviderName {
+		return "oauth.github-copilot.github_token"
+	}
+	return fmt.Sprintf("oauth.%s.github_token", providerName)
+}
+
+func (ts *GitHubCopilotTokenSource) withTenantContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if store.TenantIDFromContext(ctx) == uuid.Nil {
+		ctx = store.WithTenantID(ctx, ts.tenantID)
+	}
+	return ctx
+}
+
+func (ts *GitHubCopilotTokenSource) loadProvider(ctx context.Context) (*store.LLMProviderData, error) {
+	p, err := ts.providerStore.GetProviderByName(ctx, ts.providerName)
+	if err != nil {
+		return nil, err
+	}
+	if p.ProviderType != store.ProviderGitHubCopilotOAuth {
+		return nil, &ProviderTypeConflictError{ProviderName: ts.providerName, ProviderType: p.ProviderType}
+	}
+	return p, nil
+}
+
+func (ts *GitHubCopilotTokenSource) Token() (string, error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if ts.cachedToken != "" && time.Until(ts.expiresAt) > gitHubCopilotRefreshMargin {
+		return ts.cachedToken, nil
+	}
+	ctx := store.WithTenantID(context.Background(), ts.tenantID)
+	if ts.cachedToken == "" {
+		provider, err := ts.loadProvider(ctx)
+		if err != nil {
+			return "", fmt.Errorf("load github copilot provider %q: %w", ts.providerName, err)
+		}
+		ts.cachedToken = provider.APIKey
+		if strings.TrimSpace(provider.APIBase) != "" {
+			ts.providerAPIBase = strings.TrimSpace(provider.APIBase)
+		}
+		if settings := parseGitHubCopilotOAuthSettings(provider.Settings); settings.ExpiresAt > 0 {
+			ts.expiresAt = time.Unix(settings.ExpiresAt, 0)
+		}
+	}
+	if time.Until(ts.expiresAt) < gitHubCopilotRefreshMargin {
+		if err := ts.refresh(ctx); err != nil {
+			if ts.cachedToken != "" {
+				return ts.cachedToken, nil
+			}
+			return "", err
+		}
+	}
+	return ts.cachedToken, nil
+}
+
+func (ts *GitHubCopilotTokenSource) refresh(ctx context.Context) error {
+	provider, err := ts.loadProvider(ctx)
+	if err != nil {
+		return err
+	}
+	settings := parseGitHubCopilotOAuthSettings(provider.Settings)
+	githubToken, err := ts.secretsStore.Get(ctx, GitHubCopilotAccessTokenSecretKey(ts.providerName))
+	if err != nil {
+		return fmt.Errorf("get GitHub Copilot login token: %w", err)
+	}
+	tokenResp, err := RefreshGitHubCopilotToken(githubToken, settings.EnterpriseDomain)
+	if err != nil {
+		return fmt.Errorf("refresh GitHub Copilot token: %w", err)
+	}
+	ts.cachedToken = tokenResp.Token
+	ts.expiresAt = time.Unix(tokenResp.ExpiresAt, 0)
+	apiBase := GetGitHubCopilotBaseURL(tokenResp.Token, settings.EnterpriseDomain)
+	ts.providerAPIBase = apiBase
+	merged := mergeGitHubCopilotOAuthSettings(settings, tokenResp, apiBase)
+	return ts.providerStore.UpdateProvider(ctx, provider.ID, map[string]any{
+		"api_key":  tokenResp.Token,
+		"api_base": apiBase,
+		"settings": marshalGitHubCopilotOAuthSettingsInto(provider.Settings, merged),
+		"enabled":  true,
+	})
+}
+
+func (ts *GitHubCopilotTokenSource) SaveLoginResult(ctx context.Context, githubAccessToken string, tokenResp *GitHubCopilotTokenResponse, enterpriseDomain string) (uuid.UUID, error) {
+	ctx = ts.withTenantContext(ctx)
+	apiBase := ts.providerAPIBase
+	if apiBase == "" {
+		apiBase = GetGitHubCopilotBaseURL(tokenResp.Token, enterpriseDomain)
+	}
+	ts.mu.Lock()
+	ts.cachedToken = tokenResp.Token
+	ts.expiresAt = time.Unix(tokenResp.ExpiresAt, 0)
+	ts.providerAPIBase = apiBase
+	ts.mu.Unlock()
+
+	settings := mergeGitHubCopilotOAuthSettings(store.GitHubCopilotOAuthProviderSettings{EnterpriseDomain: NormalizeGitHubCopilotDomain(enterpriseDomain)}, tokenResp, apiBase)
+	existing, err := ts.loadProvider(ctx)
+	if err == nil {
+		updates := map[string]any{
+			"api_key":  tokenResp.Token,
+			"api_base": apiBase,
+			"settings": marshalGitHubCopilotOAuthSettingsInto(existing.Settings, settings),
+			"enabled":  true,
+		}
+		if ts.providerDisplayName != "" {
+			updates["display_name"] = ts.providerDisplayName
+		}
+		if err := ts.providerStore.UpdateProvider(ctx, existing.ID, updates); err != nil {
+			return uuid.Nil, err
+		}
+		if err := ts.secretsStore.Set(ctx, GitHubCopilotAccessTokenSecretKey(ts.providerName), githubAccessToken); err != nil {
+			return uuid.Nil, err
+		}
+		return existing.ID, nil
+	}
+	if _, ok := err.(*ProviderTypeConflictError); ok {
+		return uuid.Nil, err
+	}
+	p := &store.LLMProviderData{
+		Name:         ts.providerName,
+		DisplayName:  ts.providerDisplayName,
+		ProviderType: store.ProviderGitHubCopilotOAuth,
+		APIBase:      apiBase,
+		APIKey:       tokenResp.Token,
+		Enabled:      true,
+		Settings:     marshalGitHubCopilotOAuthSettings(settings),
+	}
+	if err := ts.providerStore.CreateProvider(ctx, p); err != nil {
+		return uuid.Nil, err
+	}
+	if err := ts.secretsStore.Set(ctx, GitHubCopilotAccessTokenSecretKey(ts.providerName), githubAccessToken); err != nil {
+		return uuid.Nil, err
+	}
+	return p.ID, nil
+}
+
+func (ts *GitHubCopilotTokenSource) Delete(ctx context.Context) error {
+	ctx = ts.withTenantContext(ctx)
+	ts.mu.Lock()
+	ts.cachedToken = ""
+	ts.expiresAt = time.Time{}
+	ts.mu.Unlock()
+	_ = ts.secretsStore.Delete(ctx, GitHubCopilotAccessTokenSecretKey(ts.providerName))
+	p, err := ts.loadProvider(ctx)
+	if err != nil {
+		if _, ok := err.(*ProviderTypeConflictError); ok {
+			return err
+		}
+		return nil
+	}
+	return ts.providerStore.DeleteProvider(ctx, p.ID)
+}
+
+func (ts *GitHubCopilotTokenSource) Exists(ctx context.Context) bool {
+	ctx = ts.withTenantContext(ctx)
+	p, err := ts.loadProvider(ctx)
+	return err == nil && p.APIKey != ""
+}
+
+func parseGitHubCopilotOAuthSettings(raw json.RawMessage) store.GitHubCopilotOAuthProviderSettings {
+	if len(raw) == 0 {
+		return store.GitHubCopilotOAuthProviderSettings{}
+	}
+	var settings store.GitHubCopilotOAuthProviderSettings
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return store.GitHubCopilotOAuthProviderSettings{}
+	}
+	return settings
+}
+
+func mergeGitHubCopilotOAuthSettings(existing store.GitHubCopilotOAuthProviderSettings, tokenResp *GitHubCopilotTokenResponse, apiBase string) store.GitHubCopilotOAuthProviderSettings {
+	settings := existing
+	settings.ExpiresAt = tokenResp.ExpiresAt
+	if tokenResp.SKU != "" {
+		settings.CopilotPlan = tokenResp.SKU
+	}
+	if apiBase != "" {
+		settings.BaseURL = apiBase
+	}
+	return settings
+}
+
+func marshalGitHubCopilotOAuthSettings(settings store.GitHubCopilotOAuthProviderSettings) json.RawMessage {
+	data, _ := json.Marshal(settings)
+	return json.RawMessage(data)
+}
+
+func marshalGitHubCopilotOAuthSettingsInto(raw json.RawMessage, settings store.GitHubCopilotOAuthProviderSettings) json.RawMessage {
+	if len(raw) == 0 {
+		return marshalGitHubCopilotOAuthSettings(settings)
+	}
+	next := make(map[string]any)
+	if err := json.Unmarshal(raw, &next); err != nil {
+		return marshalGitHubCopilotOAuthSettings(settings)
+	}
+	next["expires_at"] = settings.ExpiresAt
+	if settings.Scopes != "" {
+		next["scopes"] = settings.Scopes
+	} else {
+		delete(next, "scopes")
+	}
+	if settings.EnterpriseDomain != "" {
+		next["enterprise_domain"] = settings.EnterpriseDomain
+	} else {
+		delete(next, "enterprise_domain")
+	}
+	if settings.GitHubLogin != "" {
+		next["github_login"] = settings.GitHubLogin
+	} else {
+		delete(next, "github_login")
+	}
+	if settings.CopilotPlan != "" {
+		next["copilot_plan"] = settings.CopilotPlan
+	} else {
+		delete(next, "copilot_plan")
+	}
+	if settings.BaseURL != "" {
+		next["base_url"] = settings.BaseURL
+	} else {
+		delete(next, "base_url")
+	}
+	data, _ := json.Marshal(next)
+	return json.RawMessage(data)
+}

--- a/internal/providers/codex_stream_state.go
+++ b/internal/providers/codex_stream_state.go
@@ -66,6 +66,15 @@ func (s *codexMessageStreamState) recordTextDelta(itemID string, outputIndex, co
 }
 
 func (s *codexMessageStreamState) recordFinalText(itemID string, outputIndex, contentIndex int, text string, result *ChatResponse, onChunk func(StreamChunk)) {
+	s.rememberFinalText(itemID, outputIndex, contentIndex, text)
+	msg := s.ensureMessage(itemID, "", outputIndex)
+	if !shouldEmitCodexPhase(msg.phase) {
+		return
+	}
+	msg.flushContiguous(result, onChunk)
+}
+
+func (s *codexMessageStreamState) rememberFinalText(itemID string, outputIndex, contentIndex int, text string) {
 	if text == "" {
 		return
 	}
@@ -73,11 +82,7 @@ func (s *codexMessageStreamState) recordFinalText(itemID string, outputIndex, co
 	part := msg.ensurePart(contentIndex)
 	prev := part.text
 	part.text = text
-	if !shouldEmitCodexPhase(msg.phase) {
-		return
-	}
 	part.reconcileCompleted(prev)
-	msg.flushContiguous(result, onChunk)
 }
 
 func (s *codexMessageStreamState) flushMessage(itemID string, result *ChatResponse, onChunk func(StreamChunk)) {
@@ -118,6 +123,23 @@ func (s *codexMessageStreamState) updateResultPhase(result *ChatResponse) {
 			return
 		}
 	}
+}
+
+func (s *codexMessageStreamState) bestCompletedMessage() *codexMessageState {
+	ordered := s.preferredMessages()
+	if len(ordered) == 0 {
+		return nil
+	}
+	best := ordered[0]
+	bestLen := best.normalizedTextLen()
+	for _, msg := range ordered[1:] {
+		msgLen := msg.normalizedTextLen()
+		if msgLen > bestLen || (msgLen == bestLen && msg.outputIndex > best.outputIndex) {
+			best = msg
+			bestLen = msgLen
+		}
+	}
+	return best
 }
 
 // preferredMessages returns messages ordered by outputIndex, preferring
@@ -196,6 +218,29 @@ func (m *codexMessageState) flushContiguous(result *ChatResponse, onChunk func(S
 		}
 		part.emitMissing(result, onChunk)
 	}
+}
+
+func (m *codexMessageState) normalizedText() string {
+	var b strings.Builder
+	var last string
+	for nextIndex := 0; ; nextIndex++ {
+		part, ok := m.parts[nextIndex]
+		if !ok {
+			return b.String()
+		}
+		if part.text == "" {
+			continue
+		}
+		if part.text == last {
+			continue
+		}
+		b.WriteString(part.text)
+		last = part.text
+	}
+}
+
+func (m *codexMessageState) normalizedTextLen() int {
+	return len(m.normalizedText())
 }
 
 func (p *codexTextPartState) emitMissing(result *ChatResponse, onChunk func(StreamChunk)) {

--- a/internal/providers/github_copilot.go
+++ b/internal/providers/github_copilot.go
@@ -268,10 +268,10 @@ func (p *GitHubCopilotProvider) processSSEEvent(event *codexSSEEvent, result *Ch
 	case "response.output_text.delta":
 		streamState.recordTextDelta(event.ItemID, event.OutputIndex, event.ContentIndex, event.Delta, result, onChunk)
 	case "response.output_text.done":
-		streamState.recordFinalText(event.ItemID, event.OutputIndex, event.ContentIndex, event.Text, result, onChunk)
+		streamState.rememberFinalText(event.ItemID, event.OutputIndex, event.ContentIndex, event.Text)
 	case "response.content_part.done":
 		if event.Part != nil && event.Part.Type == "output_text" {
-			streamState.recordFinalText(event.ItemID, event.OutputIndex, event.ContentIndex, event.Part.Text, result, onChunk)
+			streamState.rememberFinalText(event.ItemID, event.OutputIndex, event.ContentIndex, event.Part.Text)
 		}
 	case "response.function_call_arguments.delta":
 		if event.ItemID != "" {
@@ -287,7 +287,6 @@ func (p *GitHubCopilotProvider) processSSEEvent(event *codexSSEEvent, result *Ch
 			switch event.Item.Type {
 			case "message":
 				streamState.registerMessageItem(event.ItemID, event.OutputIndex, event.Item)
-				streamState.flushMessage(codexEventItemKey(event.ItemID, event.Item), result, onChunk)
 				streamState.updateResultPhase(result)
 			case "function_call":
 				acc := toolCalls[event.Item.ID]
@@ -315,7 +314,9 @@ func (p *GitHubCopilotProvider) processSSEEvent(event *codexSSEEvent, result *Ch
 		if event.Response != nil {
 			if result.Content == "" {
 				streamState.ingestCompletedResponse(event.Response)
-				streamState.flushCompletedResponse(result, onChunk)
+				if best := streamState.bestCompletedMessage(); best != nil {
+					appendCodexContent(result, best.normalizedText(), onChunk)
+				}
 				streamState.updateResultPhase(result)
 			}
 			if event.Response.Usage != nil {

--- a/internal/providers/github_copilot.go
+++ b/internal/providers/github_copilot.go
@@ -1,0 +1,333 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type gitHubCopilotAPIBaseSource interface {
+	APIBase() string
+}
+
+const (
+	gitHubCopilotUserAgent      = "GitHubCopilotChat/0.35.0"
+	gitHubCopilotEditorVersion  = "vscode/1.107.0"
+	gitHubCopilotPluginVersion  = "copilot-chat/0.35.0"
+	gitHubCopilotIntegrationID  = "vscode-chat"
+	defaultGitHubCopilotModel   = "gpt-5.4"
+	defaultGitHubCopilotAPIBase = "https://api.individual.githubcopilot.com"
+)
+
+// GitHubCopilotProvider implements Provider for the GitHub Copilot Responses API.
+// Initial support is intentionally scoped to GPT-family Copilot models that use the Responses transport.
+type GitHubCopilotProvider struct {
+	name         string
+	apiBase      string
+	defaultModel string
+	client       *http.Client
+	retryConfig  RetryConfig
+	tokenSource  TokenSource
+}
+
+func NewGitHubCopilotProvider(name string, tokenSource TokenSource, apiBase, defaultModel string) *GitHubCopilotProvider {
+	if apiBase == "" {
+		apiBase = defaultGitHubCopilotAPIBase
+	}
+	if defaultModel == "" {
+		defaultModel = defaultGitHubCopilotModel
+	}
+	return &GitHubCopilotProvider{
+		name:         name,
+		apiBase:      strings.TrimRight(apiBase, "/"),
+		defaultModel: defaultModel,
+		client:       &http.Client{Timeout: DefaultHTTPTimeout},
+		retryConfig:  DefaultRetryConfig(),
+		tokenSource:  tokenSource,
+	}
+}
+
+func (p *GitHubCopilotProvider) Name() string           { return p.name }
+func (p *GitHubCopilotProvider) DefaultModel() string   { return p.defaultModel }
+func (p *GitHubCopilotProvider) SupportsThinking() bool { return true }
+
+func (p *GitHubCopilotProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	return p.ChatStream(ctx, req, nil)
+}
+
+func (p *GitHubCopilotProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk func(StreamChunk)) (*ChatResponse, error) {
+	body := p.buildRequestBody(req, true)
+	respBody, err := RetryDo(ctx, p.retryConfig, func() (io.ReadCloser, error) {
+		return p.doRequest(ctx, body)
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer respBody.Close()
+
+	result := &ChatResponse{FinishReason: "stop"}
+	toolCalls := make(map[string]*codexToolCallAcc)
+	streamState := newCodexMessageStreamState()
+
+	scanner := bufio.NewScanner(respBody)
+	scanner.Buffer(make([]byte, 0, SSEScanBufInit), SSEScanBufMax)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data:")
+		data = strings.TrimPrefix(data, " ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var event codexSSEEvent
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			continue
+		}
+		p.processSSEEvent(&event, result, toolCalls, streamState, onChunk)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%s: stream read error: %w", p.name, err)
+	}
+	for _, acc := range toolCalls {
+		if acc.name == "" {
+			continue
+		}
+		args := make(map[string]any)
+		var parseErr string
+		if err := json.Unmarshal([]byte(acc.rawArgs), &args); err != nil && acc.rawArgs != "" {
+			parseErr = fmt.Sprintf("malformed JSON (%d chars): %v", len(acc.rawArgs), err)
+		}
+		result.ToolCalls = append(result.ToolCalls, ToolCall{ID: acc.callID, Name: acc.name, Arguments: args, ParseError: parseErr})
+	}
+	if len(result.ToolCalls) > 0 && result.FinishReason != "length" {
+		result.FinishReason = "tool_calls"
+	}
+	if onChunk != nil {
+		onChunk(StreamChunk{Done: true})
+	}
+	return result, nil
+}
+
+func (p *GitHubCopilotProvider) buildRequestBody(req ChatRequest, stream bool) map[string]any {
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+	var instructions string
+	var input []any
+	for _, m := range req.Messages {
+		switch m.Role {
+		case "system":
+			if instructions == "" {
+				instructions = m.Content
+			} else {
+				instructions += "\n\n" + m.Content
+			}
+		case "user":
+			if len(m.Images) > 0 {
+				var parts []map[string]any
+				for _, img := range m.Images {
+					parts = append(parts, map[string]any{"type": "input_image", "image_url": fmt.Sprintf("data:%s;base64,%s", img.MimeType, img.Data)})
+				}
+				if m.Content != "" {
+					parts = append(parts, map[string]any{"type": "input_text", "text": m.Content})
+				}
+				input = append(input, map[string]any{"role": "user", "content": parts})
+			} else {
+				input = append(input, map[string]any{"role": "user", "content": m.Content})
+			}
+		case "assistant":
+			if len(m.ToolCalls) > 0 {
+				for _, tc := range m.ToolCalls {
+					argsJSON, _ := json.Marshal(tc.Arguments)
+					callID := toFcID(tc.ID)
+					input = append(input, map[string]any{"type": "function_call", "id": callID, "call_id": callID, "name": tc.Name, "arguments": string(argsJSON)})
+				}
+			}
+			if m.Content != "" {
+				item := map[string]any{"type": "message", "role": "assistant", "content": []map[string]any{{"type": "output_text", "text": m.Content}}}
+				if m.Phase != "" {
+					item["phase"] = m.Phase
+				}
+				input = append(input, item)
+			}
+		case "tool":
+			input = append(input, map[string]any{"type": "function_call_output", "call_id": toFcID(m.ToolCallID), "output": m.Content})
+		}
+	}
+	if instructions == "" {
+		instructions = "You are a helpful assistant."
+	}
+	body := map[string]any{"model": model, "input": input, "stream": stream, "store": false, "instructions": instructions}
+	if len(req.Tools) > 0 {
+		var tools []map[string]any
+		for _, t := range req.Tools {
+			tools = append(tools, map[string]any{"type": "function", "name": t.Function.Name, "description": t.Function.Description, "parameters": NormalizeSchema("github_copilot", t.Function.Parameters)})
+		}
+		body["tools"] = tools
+	}
+	if level, ok := req.Options[OptThinkingLevel].(string); ok && level != "" && level != "off" {
+		body["reasoning"] = map[string]any{"effort": level}
+	}
+	return body
+}
+
+func (p *GitHubCopilotProvider) doRequest(ctx context.Context, body any) (io.ReadCloser, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: marshal request: %w", p.name, err)
+	}
+	apiBase := p.apiBase
+	if baseSource, ok := p.tokenSource.(gitHubCopilotAPIBaseSource); ok {
+		if dynamicBase := strings.TrimRight(baseSource.APIBase(), "/"); dynamicBase != "" {
+			apiBase = dynamicBase
+		}
+	}
+	target := apiBase + "/responses"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("%s: create request: %w", p.name, err)
+	}
+	token, err := p.tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("%s: get auth token: %w", p.name, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("OpenAI-Beta", "responses=v1")
+	httpReq.Header.Set("User-Agent", gitHubCopilotUserAgent)
+	httpReq.Header.Set("Editor-Version", gitHubCopilotEditorVersion)
+	httpReq.Header.Set("Editor-Plugin-Version", gitHubCopilotPluginVersion)
+	httpReq.Header.Set("Copilot-Integration-Id", gitHubCopilotIntegrationID)
+	for key, value := range buildGitHubCopilotDynamicHeaders(body) {
+		httpReq.Header.Set(key, value)
+	}
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("%s: request failed: %w", p.name, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		resp.Body.Close()
+		retryAfter := ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, &HTTPError{Status: resp.StatusCode, Body: fmt.Sprintf("%s: %s", p.name, string(respBody)), RetryAfter: retryAfter}
+	}
+	return resp.Body, nil
+}
+
+func buildGitHubCopilotDynamicHeaders(body any) map[string]string {
+	headers := map[string]string{
+		"Openai-Intent": "conversation-edits",
+		"X-Initiator":   "user",
+	}
+	payload, ok := body.(map[string]any)
+	if !ok {
+		return headers
+	}
+	input, _ := payload["input"].([]any)
+	if len(input) > 0 {
+		if last, ok := input[len(input)-1].(map[string]any); ok {
+			if role, _ := last["role"].(string); role != "" && role != "user" {
+				headers["X-Initiator"] = "agent"
+			}
+		}
+	}
+	for _, item := range input {
+		msg, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		content := msg["content"]
+		parts, ok := content.([]map[string]any)
+		if ok {
+			for _, part := range parts {
+				if part["type"] == "input_image" {
+					headers["Copilot-Vision-Request"] = "true"
+					return headers
+				}
+			}
+		}
+	}
+	return headers
+}
+
+func (p *GitHubCopilotProvider) processSSEEvent(event *codexSSEEvent, result *ChatResponse, toolCalls map[string]*codexToolCallAcc, streamState *codexMessageStreamState, onChunk func(StreamChunk)) {
+	switch event.Type {
+	case "response.output_item.added":
+		if event.Item != nil {
+			streamState.registerMessageItem(event.ItemID, event.OutputIndex, event.Item)
+		}
+	case "response.output_text.delta":
+		streamState.recordTextDelta(event.ItemID, event.OutputIndex, event.ContentIndex, event.Delta, result, onChunk)
+	case "response.output_text.done":
+		streamState.recordFinalText(event.ItemID, event.OutputIndex, event.ContentIndex, event.Text, result, onChunk)
+	case "response.content_part.done":
+		if event.Part != nil && event.Part.Type == "output_text" {
+			streamState.recordFinalText(event.ItemID, event.OutputIndex, event.ContentIndex, event.Part.Text, result, onChunk)
+		}
+	case "response.function_call_arguments.delta":
+		if event.ItemID != "" {
+			acc := toolCalls[event.ItemID]
+			if acc == nil {
+				acc = &codexToolCallAcc{}
+				toolCalls[event.ItemID] = acc
+			}
+			acc.rawArgs += event.Delta
+		}
+	case "response.output_item.done":
+		if event.Item != nil {
+			switch event.Item.Type {
+			case "message":
+				streamState.registerMessageItem(event.ItemID, event.OutputIndex, event.Item)
+				streamState.flushMessage(codexEventItemKey(event.ItemID, event.Item), result, onChunk)
+				streamState.updateResultPhase(result)
+			case "function_call":
+				acc := toolCalls[event.Item.ID]
+				if acc == nil {
+					acc = &codexToolCallAcc{}
+				}
+				acc.callID = event.Item.CallID
+				acc.name = event.Item.Name
+				if event.Item.Arguments != "" {
+					acc.rawArgs = event.Item.Arguments
+				}
+				toolCalls[event.Item.ID] = acc
+			case "reasoning":
+				for _, s := range event.Item.Summary {
+					if s.Text != "" {
+						result.Thinking += s.Text
+						if onChunk != nil {
+							onChunk(StreamChunk{Thinking: s.Text})
+						}
+					}
+				}
+			}
+		}
+	case "response.completed", "response.incomplete", "response.failed":
+		if event.Response != nil {
+			if result.Content == "" {
+				streamState.ingestCompletedResponse(event.Response)
+				streamState.flushCompletedResponse(result, onChunk)
+				streamState.updateResultPhase(result)
+			}
+			if event.Response.Usage != nil {
+				u := event.Response.Usage
+				result.Usage = &Usage{PromptTokens: u.InputTokens, CompletionTokens: u.OutputTokens, TotalTokens: u.TotalTokens}
+				if u.OutputTokensDetails != nil {
+					result.Usage.ThinkingTokens = u.OutputTokensDetails.ReasoningTokens
+				}
+			}
+			if event.Response.Status == "incomplete" {
+				result.FinishReason = "length"
+			}
+		}
+	}
+}

--- a/internal/providers/github_copilot_test.go
+++ b/internal/providers/github_copilot_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -60,5 +61,102 @@ func TestBuildGitHubCopilotDynamicHeadersAgent(t *testing.T) {
 	headers := buildGitHubCopilotDynamicHeaders(body)
 	if headers["X-Initiator"] != "agent" {
 		t.Fatalf("X-Initiator = %q", headers["X-Initiator"])
+	}
+}
+
+func TestGitHubCopilotProviderDedupesRepeatedMessageOutputs(t *testing.T) {
+	messageText := "Yo. I'm here, bro 🚀"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+
+		for i := 0; i < 4; i++ {
+			fmt.Fprintf(w, "data: %s\n\n", mustJSON(codexSSEEvent{
+				Type:       "response.output_item.done",
+				ItemID:     fmt.Sprintf("msg_%d", i),
+				OutputIndex: i,
+				Item: &codexItem{
+					ID:    fmt.Sprintf("msg_%d", i),
+					Type:  "message",
+					Role:  "assistant",
+					Phase: "final_answer",
+					Content: []codexContent{{Type: "output_text", Text: messageText}},
+				},
+			}))
+			flusher.Flush()
+		}
+		fmt.Fprintf(w, "data: %s\n\n", mustJSON(codexSSEEvent{
+			Type: "response.completed",
+			Response: &codexAPIResponse{
+				ID:     "resp-repeat",
+				Status: "completed",
+				Output: []codexItem{
+					{ID: "msg_0", Type: "message", Role: "assistant", Phase: "final_answer", Content: []codexContent{{Type: "output_text", Text: messageText}}},
+					{ID: "msg_1", Type: "message", Role: "assistant", Phase: "final_answer", Content: []codexContent{{Type: "output_text", Text: messageText}}},
+					{ID: "msg_2", Type: "message", Role: "assistant", Phase: "final_answer", Content: []codexContent{{Type: "output_text", Text: messageText}}},
+					{ID: "msg_3", Type: "message", Role: "assistant", Phase: "final_answer", Content: []codexContent{{Type: "output_text", Text: messageText}}},
+				},
+			},
+		}))
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	p := NewGitHubCopilotProvider("github-copilot", &staticGitHubCopilotTokenSource{token: "copilot-token", apiBase: server.URL}, server.URL, "gpt-5.4")
+	p.retryConfig.Attempts = 1
+
+	var chunks []string
+	resp, err := p.ChatStream(context.Background(), ChatRequest{Messages: []Message{{Role: "user", Content: "hello"}}}, func(chunk StreamChunk) {
+		if chunk.Content != "" {
+			chunks = append(chunks, chunk.Content)
+		}
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if resp.Content != messageText {
+		t.Fatalf("Content = %q, want %q", resp.Content, messageText)
+	}
+	if len(chunks) != 1 || chunks[0] != messageText {
+		t.Fatalf("chunks = %v, want single deduped chunk", chunks)
+	}
+}
+
+func TestGitHubCopilotProviderDedupesRepeatedCompletedParts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: %s\n\n", mustJSON(codexSSEEvent{
+			Type: "response.completed",
+			Response: &codexAPIResponse{
+				ID:     "resp-parts",
+				Status: "completed",
+				Output: []codexItem{{
+					ID:    "msg_final",
+					Type:  "message",
+					Role:  "assistant",
+					Phase: "final_answer",
+					Content: []codexContent{
+						{Type: "output_text", Text: "I meant to send one line. "},
+						{Type: "output_text", Text: "You got the same line four times. My bad."},
+						{Type: "output_text", Text: "You got the same line four times. My bad."},
+						{Type: "output_text", Text: "You got the same line four times. My bad."},
+					},
+				}},
+			},
+		}))
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	p := NewGitHubCopilotProvider("github-copilot", &staticGitHubCopilotTokenSource{token: "copilot-token", apiBase: server.URL}, server.URL, "gpt-5.4")
+	p.retryConfig.Attempts = 1
+
+	resp, err := p.Chat(context.Background(), ChatRequest{Messages: []Message{{Role: "user", Content: "hello"}}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	want := "I meant to send one line. You got the same line four times. My bad."
+	if resp.Content != want {
+		t.Fatalf("Content = %q, want %q", resp.Content, want)
 	}
 }

--- a/internal/providers/github_copilot_test.go
+++ b/internal/providers/github_copilot_test.go
@@ -1,0 +1,64 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type staticGitHubCopilotTokenSource struct {
+	token   string
+	apiBase string
+}
+
+func (s *staticGitHubCopilotTokenSource) Token() (string, error) { return s.token, nil }
+func (s *staticGitHubCopilotTokenSource) APIBase() string        { return s.apiBase }
+
+func TestGitHubCopilotProviderAddsDynamicHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer copilot-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("Copilot-Integration-Id"); got != "vscode-chat" {
+			t.Fatalf("Copilot-Integration-Id = %q", got)
+		}
+		if got := r.Header.Get("X-Initiator"); got != "user" {
+			t.Fatalf("X-Initiator = %q", got)
+		}
+		if got := r.Header.Get("Openai-Intent"); got != "conversation-edits" {
+			t.Fatalf("Openai-Intent = %q", got)
+		}
+		if got := r.URL.Path; got != "/responses" {
+			t.Fatalf("path = %q", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	p := NewGitHubCopilotProvider("github-copilot", &staticGitHubCopilotTokenSource{token: "copilot-token", apiBase: server.URL}, server.URL, "gpt-5.4")
+	p.retryConfig.Attempts = 1
+	resp, err := p.Chat(context.Background(), ChatRequest{Messages: []Message{{Role: "user", Content: "hello"}}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Fatalf("Content = %q", resp.Content)
+	}
+}
+
+func TestBuildGitHubCopilotDynamicHeadersAgent(t *testing.T) {
+	body := map[string]any{
+		"input": []any{
+			map[string]any{"role": "user", "content": "hello"},
+			map[string]any{"role": "assistant", "content": []map[string]any{{"type": "output_text", "text": "done"}}},
+		},
+	}
+	headers := buildGitHubCopilotDynamicHeaders(body)
+	if headers["X-Initiator"] != "agent" {
+		t.Fatalf("X-Initiator = %q", headers["X-Initiator"])
+	}
+}

--- a/internal/store/provider_store.go
+++ b/internal/store/provider_store.go
@@ -9,31 +9,32 @@ import (
 
 // Provider type constants.
 const (
-	ProviderAnthropicNative = "anthropic_native"
-	ProviderOpenAICompat    = "openai_compat"
-	ProviderGeminiNative    = "gemini_native"
-	ProviderOpenRouter      = "openrouter"
-	ProviderGroq            = "groq"
-	ProviderDeepSeek        = "deepseek"
-	ProviderMistral         = "mistral"
-	ProviderXAI             = "xai"
-	ProviderMiniMax         = "minimax_native"
-	ProviderCohere          = "cohere"
-	ProviderPerplexity      = "perplexity"
-	ProviderDashScope       = "dashscope"
-	ProviderBailian         = "bailian"
-	ProviderChatGPTOAuth    = "chatgpt_oauth"
-	ProviderClaudeCLI       = "claude_cli"
-	ProviderSuno            = "suno"
-	ProviderYesScale        = "yescale"
-	ProviderZai             = "zai"
-	ProviderZaiCoding       = "zai_coding"
-	ProviderOllama          = "ollama"       // local or self-hosted Ollama (no API key)
-	ProviderOllamaCloud     = "ollama_cloud" // Ollama Cloud (Bearer token required)
-	ProviderACP             = "acp"          // ACP (Agent Client Protocol) agent subprocess
-	ProviderNovita          = "novita"          // Novita AI (OpenAI-compatible endpoint)
-	ProviderBytePlus        = "byteplus"        // BytePlus ModelArk (Seed 2.0 models)
-	ProviderBytePlusCoding  = "byteplus_coding" // BytePlus ModelArk Coding Plan
+	ProviderAnthropicNative   = "anthropic_native"
+	ProviderOpenAICompat       = "openai_compat"
+	ProviderGeminiNative       = "gemini_native"
+	ProviderOpenRouter         = "openrouter"
+	ProviderGroq               = "groq"
+	ProviderDeepSeek           = "deepseek"
+	ProviderMistral            = "mistral"
+	ProviderXAI                = "xai"
+	ProviderMiniMax            = "minimax_native"
+	ProviderCohere             = "cohere"
+	ProviderPerplexity         = "perplexity"
+	ProviderDashScope          = "dashscope"
+	ProviderBailian            = "bailian"
+	ProviderChatGPTOAuth       = "chatgpt_oauth"
+	ProviderGitHubCopilotOAuth = "github_copilot_oauth"
+	ProviderClaudeCLI          = "claude_cli"
+	ProviderSuno               = "suno"
+	ProviderYesScale           = "yescale"
+	ProviderZai                = "zai"
+	ProviderZaiCoding          = "zai_coding"
+	ProviderOllama             = "ollama"       // local or self-hosted Ollama (no API key)
+	ProviderOllamaCloud        = "ollama_cloud" // Ollama Cloud (Bearer token required)
+	ProviderACP                = "acp"          // ACP (Agent Client Protocol) agent subprocess
+	ProviderNovita             = "novita"          // Novita AI (OpenAI-compatible endpoint)
+	ProviderBytePlus           = "byteplus"        // BytePlus ModelArk (Seed 2.0 models)
+	ProviderBytePlusCoding     = "byteplus_coding" // BytePlus ModelArk Coding Plan
 
 	// Novita AI defaults.
 	NovitaDefaultAPIBase = "https://api.novita.ai/openai"
@@ -61,6 +62,7 @@ var ValidProviderTypes = map[string]bool{
 	ProviderDashScope:       true,
 	ProviderBailian:         true,
 	ProviderChatGPTOAuth:    true,
+	ProviderGitHubCopilotOAuth: true,
 	ProviderClaudeCLI:       true,
 	ProviderSuno:            true,
 	ProviderYesScale:        true,
@@ -111,6 +113,16 @@ type ChatGPTOAuthProviderSettings struct {
 	CodexPool *ChatGPTOAuthRoutingConfig `json:"codex_pool,omitempty"`
 }
 
+// GitHubCopilotOAuthProviderSettings stores non-secret metadata for GitHub Copilot OAuth providers.
+type GitHubCopilotOAuthProviderSettings struct {
+	ExpiresAt        int64  `json:"expires_at,omitempty"`
+	Scopes           string `json:"scopes,omitempty"`
+	EnterpriseDomain string `json:"enterprise_domain,omitempty"`
+	GitHubLogin      string `json:"github_login,omitempty"`
+	CopilotPlan      string `json:"copilot_plan,omitempty"`
+	BaseURL          string `json:"base_url,omitempty"`
+}
+
 // ParseEmbeddingSettings extracts embedding config from a provider's settings JSONB.
 // Returns nil if not configured.
 func ParseEmbeddingSettings(settings json.RawMessage) *EmbeddingSettings {
@@ -140,6 +152,22 @@ func ParseChatGPTOAuthProviderSettings(settings json.RawMessage) *ChatGPTOAuthPr
 		return nil
 	}
 	s.CodexPool.OverrideMode = ""
+	return &s
+}
+
+// ParseGitHubCopilotOAuthProviderSettings extracts provider metadata for GitHub Copilot OAuth providers.
+// Returns nil when no meaningful metadata is present.
+func ParseGitHubCopilotOAuthProviderSettings(settings json.RawMessage) *GitHubCopilotOAuthProviderSettings {
+	if len(settings) == 0 {
+		return nil
+	}
+	var s GitHubCopilotOAuthProviderSettings
+	if json.Unmarshal(settings, &s) != nil {
+		return nil
+	}
+	if s.ExpiresAt == 0 && s.Scopes == "" && s.EnterpriseDomain == "" && s.GitHubLogin == "" && s.CopilotPlan == "" && s.BaseURL == "" {
+		return nil
+	}
 	return &s
 }
 
@@ -181,6 +209,7 @@ var NoEmbeddingTypes = map[string]bool{
 	ProviderACP:             true,
 	ProviderClaudeCLI:       true,
 	ProviderChatGPTOAuth:    true,
+	ProviderGitHubCopilotOAuth: true,
 	ProviderSuno:            true,
 }
 

--- a/ui/web/src/constants/providers.ts
+++ b/ui/web/src/constants/providers.ts
@@ -10,9 +10,11 @@ export interface ProviderTypeInfo {
 type ProviderAliasSource = string | { name?: string | null };
 
 export const DEFAULT_CODEX_OAUTH_ALIAS = "openai-codex";
+export const DEFAULT_GITHUB_COPILOT_OAUTH_ALIAS = "github-copilot";
 
 export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: "chatgpt_oauth", label: "ChatGPT Subscription (OAuth)", apiBase: "", placeholder: "" },
+  { value: "github_copilot_oauth", label: "GitHub Copilot (OAuth)", apiBase: "", placeholder: "" },
   { value: "anthropic_native", label: "Anthropic (Native)", apiBase: "", placeholder: "https://api.anthropic.com" },
   { value: "openai_compat", label: "OpenAI Compatible", apiBase: "", placeholder: "https://api.openai.com/v1" },
   { value: "gemini_native", label: "Google Gemini", apiBase: "https://generativelanguage.googleapis.com/v1beta/openai", placeholder: "" },

--- a/ui/web/src/hooks/use-clipboard.ts
+++ b/ui/web/src/hooks/use-clipboard.ts
@@ -2,13 +2,15 @@ import { useState, useCallback, useRef, useEffect } from "react";
 
 export function useClipboard(timeout = 2000) {
   const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => () => clearTimeout(timerRef.current), []);
+  useEffect(() => () => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+  }, []);
 
   const markCopied = useCallback(() => {
     setCopied(true);
-    clearTimeout(timerRef.current);
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => setCopied(false), timeout);
   }, [timeout]);
 

--- a/ui/web/src/pages/agents/agent-detail/file-sections/regenerate-dialog.tsx
+++ b/ui/web/src/pages/agents/agent-detail/file-sections/regenerate-dialog.tsx
@@ -33,10 +33,12 @@ export function RegenerateDialog({
   const [prompt, setPrompt] = useState("");
   const [phase, setPhase] = useState<Phase>("idle");
   const [errorMsg, setErrorMsg] = useState("");
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Cleanup auto-close timer on unmount
-  useEffect(() => () => { clearTimeout(closeTimerRef.current); }, []);
+  useEffect(() => () => {
+    if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current);
+  }, []);
 
   // Reset state when dialog opens
   useEffect(() => {

--- a/ui/web/src/pages/providers/hooks/use-chatgpt-oauth-provider-statuses.ts
+++ b/ui/web/src/pages/providers/hooks/use-chatgpt-oauth-provider-statuses.ts
@@ -19,7 +19,7 @@ export interface ChatGPTOAuthProviderStatus {
 export function useChatGPTOAuthProviderStatuses(providers: ProviderData[], enabled = true) {
   const http = useHttp();
   const oauthProviders = useMemo(
-    () => providers.filter((provider) => provider.provider_type === "chatgpt_oauth"),
+    () => providers.filter((provider) => provider.provider_type === "chatgpt_oauth" || provider.provider_type === "github_copilot_oauth"),
     [providers],
   );
   const providerKeys = oauthProviders.map((provider) => `${provider.name}:${provider.enabled ? "1" : "0"}`);
@@ -39,8 +39,11 @@ export function useChatGPTOAuthProviderStatuses(providers: ProviderData[], enabl
         }
 
         try {
+          const statusPath = provider.provider_type === "github_copilot_oauth"
+            ? `/v1/auth/copilot/${encodeURIComponent(provider.name)}/status`
+            : `/v1/auth/chatgpt/${encodeURIComponent(provider.name)}/status`;
           const status = await http.get<ChatGPTOAuthStatusResponse>(
-            `/v1/auth/chatgpt/${encodeURIComponent(provider.name)}/status`,
+            statusPath,
           );
           return {
             provider,

--- a/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
@@ -21,6 +21,7 @@ import { ConfigGroupHeader } from "@/components/shared/config-group-header";
 import { PROVIDER_TYPES } from "@/constants/providers";
 import { CLISection } from "../provider-cli-section";
 import { OAuthSection } from "../provider-oauth-section";
+import { GitHubCopilotOAuthSection } from "../provider-github-copilot-oauth-section";
 import type { ProviderData, ProviderInput } from "@/types/provider";
 
 interface ProviderAdvancedDialogProps {
@@ -52,7 +53,9 @@ export function ProviderAdvancedDialog({
 
   const isACP = provider.provider_type === "acp";
   const isCLI = provider.provider_type === "claude_cli";
-  const isOAuth = provider.provider_type === "chatgpt_oauth";
+  const isChatGPTOAuth = provider.provider_type === "chatgpt_oauth";
+  const isGitHubCopilotOAuth = provider.provider_type === "github_copilot_oauth";
+  const isOAuth = isChatGPTOAuth || isGitHubCopilotOAuth;
   const isStandard = !isACP && !isCLI && !isOAuth;
 
   const typeInfo = PROVIDER_TYPES.find((pt) => pt.value === provider.provider_type);
@@ -248,13 +251,22 @@ export function ProviderAdvancedDialog({
                 title={t("detail.oauthConfig")}
                 description={t("detail.oauthConfigDesc")}
               />
-              <OAuthSection
-                providerName={provider.name}
-                displayName={provider.display_name}
-                apiBase={provider.api_base}
-                authenticatedActionLabel={t("form.close")}
-                onSuccess={() => onOpenChange(false)}
-              />
+              {isChatGPTOAuth ? (
+                <OAuthSection
+                  providerName={provider.name}
+                  displayName={provider.display_name}
+                  apiBase={provider.api_base}
+                  authenticatedActionLabel={t("form.close")}
+                  onSuccess={() => onOpenChange(false)}
+                />
+              ) : (
+                <GitHubCopilotOAuthSection
+                  providerName={provider.name}
+                  displayName={provider.display_name}
+                  authenticatedActionLabel={t("form.close")}
+                  onSuccess={() => onOpenChange(false)}
+                />
+              )}
             </>
           )}
         </div>

--- a/ui/web/src/pages/providers/provider-detail/provider-header.tsx
+++ b/ui/web/src/pages/providers/provider-detail/provider-header.tsx
@@ -20,7 +20,7 @@ export function ProviderHeader({ provider, onBack, onAdvanced, onDelete }: Provi
   const typeInfo = PROVIDER_TYPES.find((pt) => pt.value === provider.provider_type);
   const typeLabel = typeInfo?.label ?? provider.provider_type;
   const displayTitle = provider.display_name || provider.name;
-  const subtitle = provider.provider_type === "chatgpt_oauth"
+  const subtitle = provider.provider_type === "chatgpt_oauth" || provider.provider_type === "github_copilot_oauth"
     ? t("card.oauthAlias", { name: provider.name })
     : provider.name;
 

--- a/ui/web/src/pages/providers/provider-detail/provider-overview-helpers.ts
+++ b/ui/web/src/pages/providers/provider-detail/provider-overview-helpers.ts
@@ -3,13 +3,14 @@ import type { ChatGPTOAuthRoutingConfig } from "@/types/agent";
 import { normalizeReasoningEffort, normalizeReasoningFallback } from "@/types/provider";
 
 // Provider types that don't use API keys
-export const NO_API_KEY_TYPES = new Set(["claude_cli", "acp", "chatgpt_oauth"]);
+export const NO_API_KEY_TYPES = new Set(["claude_cli", "acp", "chatgpt_oauth", "github_copilot_oauth"]);
 
 // Provider types that don't support embedding
 export const NO_EMBEDDING_TYPES = new Set([
   "claude_cli",
   "acp",
   "chatgpt_oauth",
+  "github_copilot_oauth",
   "suno",
   "anthropic_native",
 ]);

--- a/ui/web/src/pages/providers/provider-form-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-form-dialog.tsx
@@ -24,8 +24,14 @@ import {
 } from "@/components/ui/select";
 import type { ProviderData, ProviderInput } from "./hooks/use-providers";
 import { slugify } from "@/lib/slug";
-import { DEFAULT_CODEX_OAUTH_ALIAS, PROVIDER_TYPES, suggestUniqueProviderAlias } from "@/constants/providers";
+import {
+  DEFAULT_CODEX_OAUTH_ALIAS,
+  DEFAULT_GITHUB_COPILOT_OAUTH_ALIAS,
+  PROVIDER_TYPES,
+  suggestUniqueProviderAlias,
+} from "@/constants/providers";
 import { OAuthSection } from "./provider-oauth-section";
+import { GitHubCopilotOAuthSection } from "./provider-github-copilot-oauth-section";
 import { CLISection } from "./provider-cli-section";
 import { ACPSection } from "./provider-acp-section";
 import { Loader2 } from "lucide-react";
@@ -66,7 +72,9 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
   const name = watch("name");
 
   const hasClaudeCLI = existingProviders.some((p) => p.provider_type === "claude_cli");
-  const isOAuth = providerType === "chatgpt_oauth";
+  const isChatGPTOAuth = providerType === "chatgpt_oauth";
+  const isGitHubCopilotOAuth = providerType === "github_copilot_oauth";
+  const isOAuth = isChatGPTOAuth || isGitHubCopilotOAuth;
   const isCLI = providerType === "claude_cli";
   const isACP = providerType === "acp";
 
@@ -120,12 +128,15 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
     setValue("providerType", v, { shouldValidate: true });
     const preset = PROVIDER_TYPES.find((pt) => pt.value === v);
     setValue("apiBase", preset?.apiBase || "");
-    if (v === "chatgpt_oauth") {
-      if (!name || providerType !== "chatgpt_oauth") {
-        setValue("name", suggestUniqueProviderAlias(existingProviders));
+    if (v === "chatgpt_oauth" || v === "github_copilot_oauth") {
+      const baseAlias = v === "github_copilot_oauth"
+        ? DEFAULT_GITHUB_COPILOT_OAUTH_ALIAS
+        : DEFAULT_CODEX_OAUTH_ALIAS;
+      if (!name || providerType !== v) {
+        setValue("name", suggestUniqueProviderAlias(existingProviders, { baseAlias }));
       }
     } else {
-      if (name === DEFAULT_CODEX_OAUTH_ALIAS) setValue("name", "");
+      if (name === DEFAULT_CODEX_OAUTH_ALIAS || name === DEFAULT_GITHUB_COPILOT_OAUTH_ALIAS) setValue("name", "");
     }
   };
 
@@ -168,13 +179,22 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
                   />
                 </div>
               </div>
-              <OAuthSection
-                providerName={name}
-                displayName={watch("displayName") || ""}
-                apiBase={watch("apiBase") || ""}
-                authenticatedActionLabel={t("form.close")}
-                onSuccess={() => { queryClient.invalidateQueries({ queryKey: ["providers"] }); onOpenChange(false); }}
-              />
+              {isChatGPTOAuth ? (
+                <OAuthSection
+                  providerName={name}
+                  displayName={watch("displayName") || ""}
+                  apiBase={watch("apiBase") || ""}
+                  authenticatedActionLabel={t("form.close")}
+                  onSuccess={() => { queryClient.invalidateQueries({ queryKey: ["providers"] }); onOpenChange(false); }}
+                />
+              ) : (
+                <GitHubCopilotOAuthSection
+                  providerName={name}
+                  displayName={watch("displayName") || ""}
+                  authenticatedActionLabel={t("form.close")}
+                  onSuccess={() => { queryClient.invalidateQueries({ queryKey: ["providers"] }); onOpenChange(false); }}
+                />
+              )}
             </>
           ) : (
             <>

--- a/ui/web/src/pages/providers/provider-github-copilot-oauth-section.tsx
+++ b/ui/web/src/pages/providers/provider-github-copilot-oauth-section.tsx
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ExternalLink, Loader2, CheckCircle, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useHttp } from "@/hooks/use-ws";
+import { toast } from "@/stores/use-toast-store";
+import { isValidSlug } from "@/lib/slug";
+
+interface GitHubCopilotOAuthStatus {
+  authenticated: boolean;
+  pending?: boolean;
+  provider_name?: string;
+  verification_uri?: string;
+  user_code?: string;
+  error?: string;
+}
+
+interface GitHubCopilotOAuthStartResponse {
+  status?: string;
+  provider_name?: string;
+  verification_uri?: string;
+  user_code?: string;
+  interval?: number;
+  expires_in?: number;
+}
+
+interface GitHubCopilotOAuthSectionProps {
+  onSuccess: () => void;
+  authenticatedActionLabel?: string;
+  providerName?: string;
+  displayName?: string;
+}
+
+export function GitHubCopilotOAuthSection({
+  onSuccess,
+  authenticatedActionLabel = "Close",
+  providerName,
+  displayName,
+}: GitHubCopilotOAuthSectionProps) {
+  const http = useHttp();
+  const resolvedProviderName = providerName?.trim() ?? "";
+  const hasValidProvider = resolvedProviderName.length > 0 && isValidSlug(resolvedProviderName);
+  const [status, setStatus] = useState<GitHubCopilotOAuthStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [starting, setStarting] = useState(false);
+  const [enterpriseDomain, setEnterpriseDomain] = useState("");
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = () => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  };
+
+  const fetchStatus = useCallback(async () => {
+    if (!hasValidProvider) {
+      setStatus(null);
+      setLoading(false);
+      return null;
+    }
+    try {
+      const res = await http.get<GitHubCopilotOAuthStatus>(`/v1/auth/copilot/${encodeURIComponent(resolvedProviderName)}/status`);
+      setStatus(res);
+      return res;
+    } catch {
+      setStatus(null);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [hasValidProvider, http, resolvedProviderName]);
+
+  useEffect(() => {
+    fetchStatus();
+    return stopPolling;
+  }, [fetchStatus]);
+
+  useEffect(() => {
+    if (!status?.pending || status.authenticated) {
+      stopPolling();
+      return;
+    }
+    if (pollRef.current) return;
+    pollRef.current = setInterval(async () => {
+      const next = await fetchStatus();
+      if (next?.authenticated) {
+        stopPolling();
+      }
+    }, 2000);
+    return stopPolling;
+  }, [fetchStatus, status?.authenticated, status?.pending]);
+
+  const handleStart = async () => {
+    if (!hasValidProvider) return;
+    setStarting(true);
+    try {
+      const res = await http.post<GitHubCopilotOAuthStartResponse>(
+        `/v1/auth/copilot/${encodeURIComponent(resolvedProviderName)}/start`,
+        {
+          display_name: displayName?.trim() || undefined,
+          enterprise_domain: enterpriseDomain.trim() || undefined,
+        },
+      );
+      if (res.status === "already_authenticated") {
+        await fetchStatus();
+        onSuccess();
+        return;
+      }
+      if (res.verification_uri || res.user_code) {
+        setStatus({
+          authenticated: false,
+          pending: true,
+          provider_name: res.provider_name,
+          verification_uri: res.verification_uri,
+          user_code: res.user_code,
+        });
+      }
+    } catch (err) {
+      toast.error("GitHub Copilot sign-in failed", err instanceof Error ? err.message : "");
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    if (!hasValidProvider) return;
+    try {
+      await http.post(`/v1/auth/copilot/${encodeURIComponent(resolvedProviderName)}/logout`);
+      stopPolling();
+      setStatus({ authenticated: false });
+      toast.success("GitHub Copilot disconnected");
+    } catch (err) {
+      toast.error("Failed to disconnect GitHub Copilot", err instanceof Error ? err.message : "");
+    }
+  };
+
+  const copyCode = async () => {
+    if (!status?.user_code) return;
+    await navigator.clipboard.writeText(status.user_code);
+    toast.success("Code copied");
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Checking GitHub Copilot status…
+      </div>
+    );
+  }
+
+  if (status?.authenticated) {
+    return (
+      <div className="space-y-3 py-2">
+        <div className="flex items-center gap-2 rounded-md border border-green-500/30 bg-green-500/5 px-4 py-3 text-sm text-green-700 dark:text-green-400">
+          <CheckCircle className="h-5 w-5 shrink-0" />
+          <div>
+            <p className="font-medium">GitHub Copilot connected</p>
+            <p className="mt-0.5 text-xs opacity-80">Provider <code className="rounded bg-muted px-1 font-mono text-xs">{status.provider_name || resolvedProviderName}</code> is ready to use.</p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button size="sm" onClick={onSuccess}>{authenticatedActionLabel}</Button>
+          <Button variant="outline" size="sm" onClick={handleLogout}>Remove token</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!hasValidProvider) {
+    return (
+      <div className="rounded-md border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+        Enter a provider alias first. GitHub Copilot OAuth providers are created after sign-in completes.
+      </div>
+    );
+  }
+
+  if (status?.pending) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2 text-sm text-blue-700 dark:text-blue-400">
+          <Loader2 className="h-4 w-4 animate-spin" /> Waiting for GitHub approval…
+        </div>
+        <div className="rounded-md border bg-muted/40 p-3 space-y-3">
+          <div className="space-y-1">
+            <p className="text-sm font-medium">1. Open the GitHub device verification page</p>
+            <div className="flex flex-wrap gap-2">
+              <Button size="sm" variant="outline" asChild>
+                <a href={status.verification_uri || "https://github.com/login/device"} target="_blank" rel="noreferrer">
+                  <ExternalLink className="mr-1.5 h-3.5 w-3.5" /> Open verification page
+                </a>
+              </Button>
+            </div>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium">2. Enter this code</p>
+            <div className="flex items-center gap-2">
+              <Input readOnly value={status.user_code || ""} className="font-mono text-base tracking-[0.2em]" />
+              <Button size="icon" variant="outline" onClick={copyCode} aria-label="Copy code">
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border bg-muted/50 px-3 py-2 text-xs text-muted-foreground space-y-2">
+        <p className="text-sm text-foreground">Sign in with your GitHub account to mint a short-lived Copilot session token.</p>
+        <div className="space-y-2">
+          <label className="block text-xs font-medium text-foreground">GitHub Enterprise URL/domain (optional)</label>
+          <Input
+            placeholder="github.example.com"
+            value={enterpriseDomain}
+            onChange={(e) => setEnterpriseDomain(e.target.value)}
+            className="text-base md:text-sm"
+          />
+        </div>
+      </div>
+      <Button size="sm" onClick={handleStart} disabled={starting} className="gap-1.5">
+        {starting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ExternalLink className="h-3.5 w-3.5" />}
+        {starting ? "Starting device flow…" : "Sign in with GitHub Copilot"}
+      </Button>
+    </div>
+  );
+}

--- a/ui/web/src/pages/providers/provider-github-copilot-oauth-section.tsx
+++ b/ui/web/src/pages/providers/provider-github-copilot-oauth-section.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ExternalLink, Loader2, CheckCircle, Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useHttp } from "@/hooks/use-ws";
+import { queryKeys } from "@/lib/query-keys";
 import { toast } from "@/stores/use-toast-store";
 import { isValidSlug } from "@/lib/slug";
 
@@ -38,6 +40,7 @@ export function GitHubCopilotOAuthSection({
   displayName,
 }: GitHubCopilotOAuthSectionProps) {
   const http = useHttp();
+  const queryClient = useQueryClient();
   const resolvedProviderName = providerName?.trim() ?? "";
   const hasValidProvider = resolvedProviderName.length > 0 && isValidSlug(resolvedProviderName);
   const [status, setStatus] = useState<GitHubCopilotOAuthStatus | null>(null);
@@ -71,6 +74,10 @@ export function GitHubCopilotOAuthSection({
     }
   }, [hasValidProvider, http, resolvedProviderName]);
 
+  const invalidateProviders = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: queryKeys.providers.all });
+  }, [queryClient]);
+
   useEffect(() => {
     fetchStatus();
     return stopPolling;
@@ -86,10 +93,11 @@ export function GitHubCopilotOAuthSection({
       const next = await fetchStatus();
       if (next?.authenticated) {
         stopPolling();
+        await invalidateProviders();
       }
     }, 2000);
     return stopPolling;
-  }, [fetchStatus, status?.authenticated, status?.pending]);
+  }, [fetchStatus, invalidateProviders, status?.authenticated, status?.pending]);
 
   const handleStart = async () => {
     if (!hasValidProvider) return;
@@ -104,6 +112,7 @@ export function GitHubCopilotOAuthSection({
       );
       if (res.status === "already_authenticated") {
         await fetchStatus();
+        await invalidateProviders();
         onSuccess();
         return;
       }
@@ -129,6 +138,7 @@ export function GitHubCopilotOAuthSection({
       await http.post(`/v1/auth/copilot/${encodeURIComponent(resolvedProviderName)}/logout`);
       stopPolling();
       setStatus({ authenticated: false });
+      await invalidateProviders();
       toast.success("GitHub Copilot disconnected");
     } catch (err) {
       toast.error("Failed to disconnect GitHub Copilot", err instanceof Error ? err.message : "");

--- a/ui/web/src/pages/providers/provider-list-row.tsx
+++ b/ui/web/src/pages/providers/provider-list-row.tsx
@@ -52,7 +52,7 @@ export function ProviderListRow({
     label: provider.provider_type,
     variant: "outline" as const,
   };
-  const subtitle = provider.provider_type === "chatgpt_oauth"
+  const subtitle = provider.provider_type === "chatgpt_oauth" || provider.provider_type === "github_copilot_oauth"
     ? t("card.oauthAlias", { name: provider.name })
     : provider.display_name
       ? provider.name

--- a/ui/web/src/pages/providers/provider-utils.tsx
+++ b/ui/web/src/pages/providers/provider-utils.tsx
@@ -11,6 +11,7 @@ type BadgeVariant = "default" | "secondary" | "outline";
 const SPECIAL_VARIANTS: Record<string, BadgeVariant> = {
   anthropic_native: "default",
   chatgpt_oauth: "default",
+  github_copilot_oauth: "default",
   claude_cli: "outline",
   acp: "outline",
 };
@@ -121,6 +122,25 @@ export function ProviderApiKeyBadge({
       <span className="flex items-center gap-1 text-[11px] text-emerald-600 dark:text-emerald-400">
         <Link2 className="h-3 w-3" />{t("card.connected")}
       </span>
+    );
+  }
+  if (provider.provider_type === "github_copilot_oauth") {
+    if (provider.enabled === false) {
+      return (
+        <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+          <CircleSlash2 className="h-3 w-3" />{t("card.disabled")}
+        </span>
+      );
+    }
+    if (provider.api_key === "***") {
+      return (
+        <span className="flex items-center gap-1 text-[11px] text-emerald-600 dark:text-emerald-400">
+          <Link2 className="h-3 w-3" />GitHub connected
+        </span>
+      );
+    }
+    return (
+      <span className="text-[11px] text-muted-foreground/60">Sign in required</span>
     );
   }
   if (provider.provider_type === "claude_cli") {

--- a/ui/web/src/pages/setup/hooks/use-bootstrap-status.ts
+++ b/ui/web/src/pages/setup/hooks/use-bootstrap-status.ts
@@ -31,7 +31,7 @@ export function useBootstrapStatus() {
       provider.api_key === "***"
       || provider.provider_type === "claude_cli"
       || provider.provider_type === "ollama"
-      || (provider.provider_type === "chatgpt_oauth" && readyOAuthProviders.has(provider.name))
+      || ((provider.provider_type === "chatgpt_oauth" || provider.provider_type === "github_copilot_oauth") && readyOAuthProviders.has(provider.name))
     ));
     const hasAgent = agents.length > 0;
 

--- a/ui/web/src/pages/setup/setup-page.tsx
+++ b/ui/web/src/pages/setup/setup-page.tsx
@@ -123,7 +123,7 @@ export function SetupPage() {
     provider.api_key === "***"
     || provider.provider_type === "claude_cli"
     || provider.provider_type === "ollama"
-    || (provider.provider_type === "chatgpt_oauth" && readyOAuthProviders.has(provider.name))
+    || ((provider.provider_type === "chatgpt_oauth" || provider.provider_type === "github_copilot_oauth") && readyOAuthProviders.has(provider.name))
   )) ?? null;
   const activeAgent = createdAgent ?? agents[0] ?? null;
 

--- a/ui/web/src/pages/setup/step-provider.tsx
+++ b/ui/web/src/pages/setup/step-provider.tsx
@@ -18,6 +18,7 @@ import { PROVIDER_TYPES, suggestUniqueProviderAlias } from "@/constants/provider
 import { useProviders } from "@/pages/providers/hooks/use-providers";
 import { CLISection } from "@/pages/providers/provider-cli-section";
 import { OAuthSection } from "@/pages/providers/provider-oauth-section";
+import { GitHubCopilotOAuthSection } from "@/pages/providers/provider-github-copilot-oauth-section";
 import { slugify } from "@/lib/slug";
 import type { ProviderData, ProviderInput } from "@/types/provider";
 
@@ -43,7 +44,9 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  const isOAuth = providerType === "chatgpt_oauth";
+  const isChatGPTOAuth = providerType === "chatgpt_oauth";
+  const isGitHubCopilotOAuth = providerType === "github_copilot_oauth";
+  const isOAuth = isChatGPTOAuth || isGitHubCopilotOAuth;
   const isCLI = providerType === "claude_cli";
   // Local Ollama uses no API key — the server accepts any non-empty Bearer value internally
   const isOllama = providerType === "ollama";
@@ -51,10 +54,13 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
   const handleTypeChange = (value: string) => {
     setProviderType(value);
     const preset = PROVIDER_TYPES.find((t) => t.value === value);
-    setName(value === "chatgpt_oauth"
-      ? (providerType === "chatgpt_oauth"
+    setName(value === "chatgpt_oauth" || value === "github_copilot_oauth"
+      ? ((providerType === value)
         ? name
-        : suggestUniqueProviderAlias(providers, { excludeName: existingProvider?.name }))
+        : suggestUniqueProviderAlias(providers, {
+            excludeName: existingProvider?.name,
+            baseAlias: value === "github_copilot_oauth" ? "github-copilot" : "openai-codex",
+          }))
       : slugify(value));
     setApiBase(preset?.apiBase || "");
     setApiKey("");
@@ -78,7 +84,7 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
       for (let attempt = 0; attempt < 3; attempt++) {
         const res = await http.get<{ providers: ProviderData[] }>("/v1/providers");
         provider = res.providers?.find(
-          (p) => p.provider_type === "chatgpt_oauth" && p.name === name.trim(),
+          (p) => (p.provider_type === "chatgpt_oauth" || p.provider_type === "github_copilot_oauth") && p.name === name.trim(),
         );
         if (provider) break;
         if (attempt < 2) await new Promise((r) => setTimeout(r, 1000));
@@ -185,13 +191,22 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
                 />
               </div>
 
-              <OAuthSection
-                providerName={name}
-                displayName={oauthDisplayName}
-                apiBase={apiBase}
-                onSuccess={handleOAuthSuccess}
-                authenticatedActionLabel={t("model.continue")}
-              />
+              {isChatGPTOAuth ? (
+                <OAuthSection
+                  providerName={name}
+                  displayName={oauthDisplayName}
+                  apiBase={apiBase}
+                  onSuccess={handleOAuthSuccess}
+                  authenticatedActionLabel={t("model.continue")}
+                />
+              ) : (
+                <GitHubCopilotOAuthSection
+                  providerName={name}
+                  displayName={oauthDisplayName}
+                  onSuccess={handleOAuthSuccess}
+                  authenticatedActionLabel={t("model.continue")}
+                />
+              )}
             </>
           ) : isCLI ? (
             <CLISection open={true} />

--- a/ui/web/src/pages/teams/board/board-container.tsx
+++ b/ui/web/src/pages/teams/board/board-container.tsx
@@ -122,14 +122,14 @@ export const BoardContainer = memo(function BoardContainer({
   // Per-task debounce timers for fetch-one calls (300ms)
   const fetchTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   // Progress debounce timer (1s, global — batches all progress patches)
-  const progressTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const progressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingProgressRef = useRef(new Map<string, { percent: number; step: string }>());
 
   // Cleanup timers on unmount
   useEffect(() => {
     return () => {
       fetchTimersRef.current.forEach((t) => clearTimeout(t));
-      clearTimeout(progressTimerRef.current);
+      if (progressTimerRef.current !== null) clearTimeout(progressTimerRef.current);
     };
   }, []);
 
@@ -178,7 +178,7 @@ export const BoardContainer = memo(function BoardContainer({
       percent: p.progress_percent ?? 0,
       step: p.progress_step ?? "",
     });
-    clearTimeout(progressTimerRef.current);
+    if (progressTimerRef.current !== null) clearTimeout(progressTimerRef.current);
     progressTimerRef.current = setTimeout(() => {
       const patches = new Map(pendingProgressRef.current);
       pendingProgressRef.current.clear();


### PR DESCRIPTION
## Summary

Add a first-class GitHub Copilot OAuth provider to GoClaw, including device-flow authentication, token refresh/runtime support, web UI setup flows, live Copilot model discovery, and a follow-up fix for duplicated final assistant messages in Copilot streaming.

## What changed

- add backend support for a new `github_copilot_oauth` provider type
- implement GitHub device auth + Copilot token minting and refresh
- register the provider in gateway/provider setup paths
- add provider-specific HTTP OAuth endpoints and token source handling
- add web UI create/edit/setup support for GitHub Copilot OAuth providers
- fetch Copilot models dynamically from live `/models` endpoints instead of placeholders
- refresh provider queries in the UI immediately after Copilot auth/disconnect
- dedupe Copilot final message streaming to prevent repeated assistant output
- add regression tests for OAuth/token and Copilot streaming behavior

## Files of note

- `internal/oauth/github_copilot.go`
- `internal/oauth/github_copilot_token.go`
- `internal/http/oauth_github_copilot.go`
- `internal/http/provider_models.go`
- `internal/http/provider_models_fetch.go`
- `internal/providers/github_copilot.go`
- `ui/web/src/pages/providers/provider-github-copilot-oauth-section.tsx`
- `ui/web/src/pages/providers/provider-form-dialog.tsx`
- `ui/web/src/pages/setup/step-provider.tsx`

## Validation

- `go test ./internal/oauth ./internal/http`
- `go test ./internal/providers -run 'GitHubCopilot|CodexProviderChat(FallsBackToOutputItemMessageContent|FallsBackToCompletedResponseOutput|IgnoresCommentaryAndKeepsFinalAnswer|ConcatenatesMultipleOutputTextDoneParts|FallsBackToContentPartDone)'`
- `go build ./...`
- `cd ui/web && pnpm build`
- rebuilt and verified the temp test clone used for local Copilot testing
