### PR TITLE
fix(sqlite): reset stale 'running' cron jobs on startup

### DIFF
--- a/internal/store/sqlitestore/cron_scheduler.go
+++ b/internal/store/sqlitestore/cron_scheduler.go
@@ -79,6 +79,15 @@ func (s *SQLiteCronStore) InvalidateCache() {
 // the original schedule anchor is not persisted. After the first execution cycle,
 // anchor-based scheduling in executeOneJob preserves spacing going forward.
 func (s *SQLiteCronStore) recomputeStaleJobs() {
+	// Reset stale 'running' status — jobs that were mid-execution when the app
+	// crashed will never self-recover, so mark them as interrupted on startup.
+	if res, err := s.db.ExecContext(s.baseCtx,
+		`UPDATE cron_jobs SET last_status = 'interrupted' WHERE last_status = 'running'`); err != nil {
+		slog.Warn("cron: failed to reset stale running jobs on startup", "error", err)
+	} else if n, _ := res.RowsAffected(); n > 0 {
+		slog.Info("cron: reset stale running jobs to interrupted", "count", n)
+	}
+
 	now := time.Now()
 	rows, err := s.db.QueryContext(s.baseCtx,
 		`SELECT id, schedule_kind, cron_expression, run_at, timezone, interval_ms


### PR DESCRIPTION
## Summary

- PG `recomputeStaleJobs` already resets jobs stuck in `last_status = 'running'` to `'interrupted'` on startup, but the SQLite implementation was missing this step
- Desktop app crashes leave cron jobs permanently stuck in `running` status, preventing them from ever executing again

One-line fix — mirrors the existing PG behavior exactly.

## Test plan

- [ ] Crash desktop app while a cron job is running → restart → verify job shows `interrupted` (not stuck `running`)
- [ ] Normal startup with no stale jobs — no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)