### PR TITLE
fix(media): add claude-cli as fallback provider for read_image and read_document

### DIFF
--- a/internal/tools/read_document.go
+++ b/internal/tools/read_document.go
@@ -51,12 +51,13 @@ const documentMaxBytes = 20 * 1024 * 1024
 // documentProviderPriority is the order in which providers are tried for document analysis.
 // Gemini has best native PDF support (50MB, 258 tokens/page).
 // "alibaba" is included as an alias for dashscope (common DB registration name).
-var documentProviderPriority = []string{"gemini", "anthropic", "openrouter", "dashscope"}
+var documentProviderPriority = []string{"gemini", "anthropic", "claude-cli", "openrouter", "dashscope"}
 
 // documentModelDefaults maps provider names to preferred document-capable models.
 var documentModelDefaults = map[string]string{
 	"gemini":     "gemini-2.5-flash",
 	"openrouter": "google/gemini-2.5-flash",
+	"claude-cli": "",
 	"dashscope":  "qwen-vl-max",
 }
 

--- a/internal/tools/read_document_resolve.go
+++ b/internal/tools/read_document_resolve.go
@@ -95,8 +95,9 @@ func (t *ReadDocumentTool) callProvider(ctx context.Context, cp credentialProvid
 		},
 		Model: model,
 		Options: map[string]any{
-			"max_tokens":  16384,
-			"temperature": 0.2,
+			"max_tokens":    16384,
+			"temperature":   0.2,
+			"disable_tools": true,
 		},
 	})
 	if err != nil {

--- a/internal/tools/read_image.go
+++ b/internal/tools/read_image.go
@@ -30,13 +30,14 @@ func MediaImagesFromCtx(ctx context.Context) []providers.ImageContent {
 // --- ReadImageTool ---
 
 // visionProviderPriority is the order in which providers are tried for vision.
-var visionProviderPriority = []string{"openrouter", "gemini", "anthropic", "dashscope"}
+var visionProviderPriority = []string{"openrouter", "gemini", "anthropic", "claude-cli", "dashscope"}
 
 // visionModelDefaults maps provider names to preferred vision models.
 var visionModelDefaults = map[string]string{
 	"openrouter": "google/gemini-2.5-flash-image",
 	"gemini":     "gemini-2.5-flash",
 	"anthropic":  "",
+	"claude-cli": "",
 	"dashscope":  "qwen3-vl",
 }
 
@@ -146,8 +147,9 @@ func (t *ReadImageTool) callProvider(ctx context.Context, cp credentialProvider,
 		},
 		Model: model,
 		Options: map[string]any{
-			"max_tokens":  1024,
-			"temperature": 0.3,
+			"max_tokens":      1024,
+			"temperature":     0.3,
+			"disable_tools":   true,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Problem

`read_image` and `read_document` fail with "No vision provider configured" when only `claude-cli` is available, because the media provider fallback chains don't include it.

Closes #801

## Root Cause

`claude-cli` is registered under that name in the provider registry, but `visionProviderPriority` and `documentProviderPriority` only list `anthropic` (which requires a separate API key). `registry.Get(ctx, "anthropic")` fails, and the chain comes up empty.

## Fix

- **`internal/tools/read_image.go`** — Add `claude-cli` to `visionProviderPriority` (after `anthropic`) and `visionModelDefaults`. Add `disable_tools: true` to Chat() options to skip MCP loading for one-shot vision calls.
- **`internal/tools/read_document.go`** — Add `claude-cli` to `documentProviderPriority` and `documentModelDefaults`.
- **`internal/tools/read_document_resolve.go`** — Add `disable_tools: true` to Chat() options.

## Testing

Verified on a claude-cli-only installation. `read_image` successfully analyzes images via Claude CLI's native stream-json vision support.