### PR TITLE
feat: add delete-all chats action to web sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ compose.d/*
 /mise.*.toml
 /mise
 /.mise
+
+.agents/

--- a/internal/gateway/methods/sessions.go
+++ b/internal/gateway/methods/sessions.go
@@ -3,6 +3,8 @@ package methods
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
@@ -13,7 +15,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
 )
 
-// SessionsMethods handles sessions.list, sessions.preview, sessions.patch, sessions.delete, sessions.reset.
+// SessionsMethods handles sessions.list, sessions.preview, sessions.patch, sessions.delete, sessions.delete-bulk, sessions.reset.
 type SessionsMethods struct {
 	sessions store.SessionStore
 	eventBus bus.EventPublisher
@@ -29,6 +31,7 @@ func (m *SessionsMethods) Register(router *gateway.MethodRouter) {
 	router.Register(protocol.MethodSessionsPreview, m.handlePreview)
 	router.Register(protocol.MethodSessionsPatch, m.handlePatch)
 	router.Register(protocol.MethodSessionsDelete, m.handleDelete)
+	router.Register(protocol.MethodSessionsDeleteBulk, m.handleDeleteBulk)
 	router.Register(protocol.MethodSessionsReset, m.handleReset)
 }
 
@@ -73,6 +76,10 @@ func (m *SessionsMethods) handleList(ctx context.Context, client *gateway.Client
 
 type sessionKeyParams struct {
 	Key string `json:"key"`
+}
+
+type sessionsDeleteBulkParams struct {
+	Keys []string `json:"keys"`
 }
 
 func (m *SessionsMethods) handlePreview(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
@@ -201,6 +208,55 @@ func (m *SessionsMethods) handleDelete(ctx context.Context, client *gateway.Clie
 		"ok": true,
 	}))
 	emitAudit(m.eventBus, client, "session.deleted", "session", params.Key)
+}
+
+func (m *SessionsMethods) handleDeleteBulk(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	locale := store.LocaleFromContext(ctx)
+	var params sessionsDeleteBulkParams
+	if req.Params != nil {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, i18n.T(locale, i18n.MsgInvalidJSON)))
+			return
+		}
+	}
+
+	if len(params.Keys) == 0 {
+		client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+			"ok":    true,
+			"count": 0,
+		}))
+		return
+	}
+
+	deleted := 0
+	for _, key := range params.Keys {
+		parts := strings.SplitN(key, ":", 4)
+		if len(parts) < 4 || parts[0] != "agent" || parts[2] != "ws" {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, i18n.T(locale, i18n.MsgPermissionDenied, "session")))
+			return
+		}
+
+		sess := m.sessions.Get(ctx, key)
+		if sess == nil {
+			continue
+		}
+		if !canSeeAll(client.Role(), m.cfg.Gateway.OwnerIDs, client.UserID()) && sess.UserID != client.UserID() {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrUnauthorized, i18n.T(locale, i18n.MsgPermissionDenied, "session")))
+			return
+		}
+
+		if err := m.sessions.Delete(ctx, key); err != nil {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, fmt.Sprintf("bulk delete failed after %d deletions: %v", deleted, err)))
+			return
+		}
+		deleted++
+	}
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		"ok":    true,
+		"count": deleted,
+	}))
+	emitAudit(m.eventBus, client, "session.bulk_deleted", "session", fmt.Sprintf("count:%d", deleted))
 }
 
 func (m *SessionsMethods) handleReset(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {

--- a/pkg/protocol/methods.go
+++ b/pkg/protocol/methods.go
@@ -33,11 +33,12 @@ const (
 	MethodConfigSchema = "config.schema"
 
 	// Sessions
-	MethodSessionsList    = "sessions.list"
-	MethodSessionsPreview = "sessions.preview"
-	MethodSessionsPatch   = "sessions.patch"
-	MethodSessionsDelete  = "sessions.delete"
-	MethodSessionsReset   = "sessions.reset"
+	MethodSessionsList       = "sessions.list"
+	MethodSessionsPreview    = "sessions.preview"
+	MethodSessionsPatch      = "sessions.patch"
+	MethodSessionsDelete     = "sessions.delete"
+	MethodSessionsDeleteBulk = "sessions.delete-bulk"
+	MethodSessionsReset      = "sessions.reset"
 
 	// System
 	MethodConnect = "connect"
@@ -47,8 +48,8 @@ const (
 
 // Phase 2 - NEEDED methods
 const (
-	MethodSkillsList  = "skills.list"
-	MethodSkillsGet   = "skills.get"
+	MethodSkillsList   = "skills.list"
+	MethodSkillsGet    = "skills.get"
 	MethodSkillsUpdate = "skills.update"
 
 	MethodCronList   = "cron.list"
@@ -122,28 +123,28 @@ const (
 
 // Agent teams
 const (
-	MethodTeamsList     = "teams.list"
-	MethodTeamsCreate   = "teams.create"
-	MethodTeamsGet      = "teams.get"
-	MethodTeamsDelete   = "teams.delete"
-	MethodTeamsTaskList      = "teams.tasks.list"
-	MethodTeamsTaskGet       = "teams.tasks.get"
-	MethodTeamsTaskGetLight  = "teams.tasks.get-light"
-	MethodTeamsTaskApprove   = "teams.tasks.approve"
-	MethodTeamsTaskReject    = "teams.tasks.reject"
-	MethodTeamsTaskComment   = "teams.tasks.comment"
-	MethodTeamsTaskComments  = "teams.tasks.comments"
-	MethodTeamsTaskEvents    = "teams.tasks.events"
-	MethodTeamsTaskCreate    = "teams.tasks.create"
-	MethodTeamsTaskDelete     = "teams.tasks.delete"
-	MethodTeamsTaskDeleteBulk = "teams.tasks.delete-bulk"
-	MethodTeamsTaskAssign            = "teams.tasks.assign"
-	MethodTeamsTaskActiveBySession   = "teams.tasks.active-by-session"
-	MethodTeamsMembersAdd    = "teams.members.add"
-	MethodTeamsMembersRemove = "teams.members.remove"
-	MethodTeamsUpdate        = "teams.update"
-	MethodTeamsKnownUsers    = "teams.known_users"
-	MethodTeamsScopes        = "teams.scopes"
+	MethodTeamsList                = "teams.list"
+	MethodTeamsCreate              = "teams.create"
+	MethodTeamsGet                 = "teams.get"
+	MethodTeamsDelete              = "teams.delete"
+	MethodTeamsTaskList            = "teams.tasks.list"
+	MethodTeamsTaskGet             = "teams.tasks.get"
+	MethodTeamsTaskGetLight        = "teams.tasks.get-light"
+	MethodTeamsTaskApprove         = "teams.tasks.approve"
+	MethodTeamsTaskReject          = "teams.tasks.reject"
+	MethodTeamsTaskComment         = "teams.tasks.comment"
+	MethodTeamsTaskComments        = "teams.tasks.comments"
+	MethodTeamsTaskEvents          = "teams.tasks.events"
+	MethodTeamsTaskCreate          = "teams.tasks.create"
+	MethodTeamsTaskDelete          = "teams.tasks.delete"
+	MethodTeamsTaskDeleteBulk      = "teams.tasks.delete-bulk"
+	MethodTeamsTaskAssign          = "teams.tasks.assign"
+	MethodTeamsTaskActiveBySession = "teams.tasks.active-by-session"
+	MethodTeamsMembersAdd          = "teams.members.add"
+	MethodTeamsMembersRemove       = "teams.members.remove"
+	MethodTeamsUpdate              = "teams.update"
+	MethodTeamsKnownUsers          = "teams.known_users"
+	MethodTeamsScopes              = "teams.scopes"
 )
 
 // Team workspace
@@ -181,8 +182,8 @@ const (
 	MethodBrowserScreenshot = "browser.screenshot"
 
 	// Zalo Personal
-	MethodZaloPersonalQRStart   = "zalo.personal.qr.start"
-	MethodZaloPersonalContacts  = "zalo.personal.contacts"
+	MethodZaloPersonalQRStart  = "zalo.personal.qr.start"
+	MethodZaloPersonalContacts = "zalo.personal.contacts"
 
 	// WhatsApp
 	MethodWhatsAppQRStart = "whatsapp.qr.start"

--- a/ui/web/src/api/protocol.ts
+++ b/ui/web/src/api/protocol.ts
@@ -76,6 +76,7 @@ export const Methods = {
   SESSIONS_PREVIEW: "sessions.preview",
   SESSIONS_PATCH: "sessions.patch",
   SESSIONS_DELETE: "sessions.delete",
+  SESSIONS_DELETE_BULK: "sessions.delete-bulk",
   SESSIONS_RESET: "sessions.reset",
 
   // Phase 2 - NEEDED

--- a/ui/web/src/hooks/use-clipboard.ts
+++ b/ui/web/src/hooks/use-clipboard.ts
@@ -2,13 +2,19 @@ import { useState, useCallback, useRef, useEffect } from "react";
 
 export function useClipboard(timeout = 2000) {
   const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => () => clearTimeout(timerRef.current), []);
+  useEffect(() => () => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+  }, []);
 
   const markCopied = useCallback(() => {
     setCopied(true);
-    clearTimeout(timerRef.current);
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
     timerRef.current = setTimeout(() => setCopied(false), timeout);
   }, [timeout]);
 

--- a/ui/web/src/i18n/locales/en/chat.json
+++ b/ui/web/src/i18n/locales/en/chat.json
@@ -1,4 +1,9 @@
 {
+  "deleteAgentChatsConfirm": "This will permanently delete all visible chats for the selected agent.",
+  "deleteAgentChatsTitle": "Delete agent chats?",
+  "deleteAllChats": "Delete all chats",
+  "deleteAllChatsConfirm": "This will permanently delete all visible web chats across all agents.",
+  "deleteAllChatsTitle": "Delete all chats?",
   "deleteChat": "Delete chat",
   "deleteChatConfirm": "This will permanently delete this conversation and all its messages.",
   "newChat": "New Chat",

--- a/ui/web/src/i18n/locales/en/sessions.json
+++ b/ui/web/src/i18n/locales/en/sessions.json
@@ -35,6 +35,8 @@
     "messages": "messages"
   },
   "toast": {
+    "bulkDeleted": "Chats deleted",
+    "bulkDeleteFailed": "Failed to delete chats",
     "deleted": "Session deleted",
     "deleteFailed": "Failed to delete session",
     "reset": "Session reset",

--- a/ui/web/src/i18n/locales/vi/chat.json
+++ b/ui/web/src/i18n/locales/vi/chat.json
@@ -1,4 +1,9 @@
 {
+  "deleteAgentChatsConfirm": "Thao tác này sẽ xóa vĩnh viễn tất cả cuộc trò chuyện đang hiển thị của agent đã chọn.",
+  "deleteAgentChatsTitle": "Xóa các cuộc trò chuyện của agent?",
+  "deleteAllChats": "Xóa tất cả cuộc trò chuyện",
+  "deleteAllChatsConfirm": "Thao tác này sẽ xóa vĩnh viễn tất cả cuộc trò chuyện web đang hiển thị trên mọi agent.",
+  "deleteAllChatsTitle": "Xóa tất cả cuộc trò chuyện?",
   "empty": {
     "description": "Gửi tin nhắn để bắt đầu trò chuyện với agent.",
     "title": "Bắt đầu cuộc trò chuyện"

--- a/ui/web/src/i18n/locales/vi/sessions.json
+++ b/ui/web/src/i18n/locales/vi/sessions.json
@@ -35,6 +35,8 @@
     "messages": "tin nhắn"
   },
   "toast": {
+    "bulkDeleted": "Đã xóa các cuộc trò chuyện",
+    "bulkDeleteFailed": "Không thể xóa các cuộc trò chuyện",
     "deleted": "Đã xóa session",
     "deleteFailed": "Không thể xóa session",
     "reset": "Đã đặt lại session",

--- a/ui/web/src/i18n/locales/zh/chat.json
+++ b/ui/web/src/i18n/locales/zh/chat.json
@@ -1,4 +1,9 @@
 {
+  "deleteAgentChatsConfirm": "此操作将永久删除当前所选Agent下所有可见对话。",
+  "deleteAgentChatsTitle": "删除该Agent的所有对话？",
+  "deleteAllChats": "删除全部对话",
+  "deleteAllChatsConfirm": "此操作将永久删除所有Agent下当前可见的网页对话。",
+  "deleteAllChatsTitle": "删除全部对话？",
   "empty": {
     "description": "发送消息开始与Agent对话。",
     "title": "开始对话"

--- a/ui/web/src/i18n/locales/zh/sessions.json
+++ b/ui/web/src/i18n/locales/zh/sessions.json
@@ -35,6 +35,8 @@
     "messages": "条消息"
   },
   "toast": {
+    "bulkDeleted": "对话已删除",
+    "bulkDeleteFailed": "删除对话失败",
     "deleted": "Session已删除",
     "deleteFailed": "删除Session失败",
     "reset": "Session已重置",

--- a/ui/web/src/pages/agents/agent-detail/file-sections/regenerate-dialog.tsx
+++ b/ui/web/src/pages/agents/agent-detail/file-sections/regenerate-dialog.tsx
@@ -33,10 +33,14 @@ export function RegenerateDialog({
   const [prompt, setPrompt] = useState("");
   const [phase, setPhase] = useState<Phase>("idle");
   const [errorMsg, setErrorMsg] = useState("");
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Cleanup auto-close timer on unmount
-  useEffect(() => () => { clearTimeout(closeTimerRef.current); }, []);
+  useEffect(() => () => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current);
+    }
+  }, []);
 
   // Reset state when dialog opens
   useEffect(() => {
@@ -56,6 +60,9 @@ export function RegenerateDialog({
         setPhase("completed");
         onCompleted?.();
         // Auto-close after short delay
+        if (closeTimerRef.current !== null) {
+          clearTimeout(closeTimerRef.current);
+        }
         closeTimerRef.current = setTimeout(() => {
           onOpenChange(false);
           setPrompt("");

--- a/ui/web/src/pages/chat/chat-page.tsx
+++ b/ui/web/src/pages/chat/chat-page.tsx
@@ -52,6 +52,7 @@ export function ChatPage() {
     refresh: refreshSessions,
     buildNewSessionKey,
     deleteSession,
+    deleteAllSessions,
   } = useChatSessions(agentId);
 
   const {
@@ -94,7 +95,12 @@ export function ChatPage() {
   });
 
   const handleNewChat = useCallback(() => {
-    navigate(`/chat/${encodeURIComponent(buildNewSessionKey())}`);
+    const nextKey = buildNewSessionKey();
+    if (!nextKey) {
+      navigate("/chat");
+      return;
+    }
+    navigate(`/chat/${encodeURIComponent(nextKey)}`);
   }, [buildNewSessionKey, navigate]);
 
   const handleSessionSelect = useCallback(
@@ -117,6 +123,12 @@ export function ChatPage() {
       }
     }
   }, [deleteSession, sessionKey, sessions, handleSessionSelect, handleNewChat]);
+
+  const handleDeleteAllSessions = useCallback(async () => {
+    await deleteAllSessions();
+    setAgentIdFallback(agentId);
+    navigate("/chat");
+  }, [deleteAllSessions, agentId, navigate]);
 
   const handleAgentChange = useCallback(
     (newAgentId: string) => {
@@ -202,6 +214,7 @@ export function ChatPage() {
               activeSessionKey={sessionKey}
               onSessionSelect={handleSessionSelectMobile}
               onDeleteSession={handleDeleteSession}
+              onDeleteAllSessions={handleDeleteAllSessions}
               onNewChat={handleNewChatMobile}
             />
           </div>
@@ -215,6 +228,7 @@ export function ChatPage() {
           activeSessionKey={sessionKey}
           onSessionSelect={handleSessionSelect}
           onDeleteSession={handleDeleteSession}
+          onDeleteAllSessions={handleDeleteAllSessions}
           onNewChat={handleNewChat}
         />
       )}

--- a/ui/web/src/pages/chat/chat-sidebar.tsx
+++ b/ui/web/src/pages/chat/chat-sidebar.tsx
@@ -1,9 +1,17 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Plus } from "lucide-react";
+import { Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AgentSelector } from "@/components/chat/agent-selector";
 import { SessionSwitcher } from "@/components/chat/session-switcher";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import type { SessionInfo } from "@/types/session";
 
 interface ChatSidebarProps {
@@ -14,6 +22,7 @@ interface ChatSidebarProps {
   activeSessionKey: string;
   onSessionSelect: (key: string) => void;
   onDeleteSession?: (key: string) => void;
+  onDeleteAllSessions?: () => Promise<unknown>;
   onNewChat: () => void;
 }
 
@@ -25,25 +34,56 @@ export const ChatSidebar = memo(function ChatSidebar({
   activeSessionKey,
   onSessionSelect,
   onDeleteSession,
+  onDeleteAllSessions,
   onNewChat,
 }: ChatSidebarProps) {
   const { t } = useTranslation("chat");
+  const { t: tc } = useTranslation("common");
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const [isDeletingAll, setIsDeletingAll] = useState(false);
+  const deleteAllDisabled = sessionsLoading || sessions.length === 0 || isDeletingAll;
+  const hasAgentSelected = !!agentId;
+
+  const handleConfirmDeleteAll = async () => {
+    if (!onDeleteAllSessions || deleteAllDisabled) return;
+    try {
+      setIsDeletingAll(true);
+      await onDeleteAllSessions();
+      setBulkDeleteOpen(false);
+    } finally {
+      setIsDeletingAll(false);
+    }
+  };
+
   return (
-    <div className="flex h-full w-72 max-w-[85vw] flex-col border-r bg-background">
+    <>
+      <div className="flex h-full w-72 max-w-[85vw] flex-col border-r bg-background">
       {/* Agent selector */}
       <div className="border-b p-3">
         <AgentSelector value={agentId} onChange={onAgentChange} />
       </div>
 
       {/* New chat button */}
-      <div className="p-3">
+      <div className="flex gap-2 p-3">
         <Button
           variant="outline"
-          className="w-full justify-start gap-2"
+          className="flex-1 justify-start gap-2"
           onClick={onNewChat}
         >
           <Plus className="h-4 w-4" />
           {t("newChat")}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="shrink-0 text-muted-foreground hover:border-destructive/30 hover:bg-destructive/10 hover:text-destructive"
+          aria-label={t("deleteAllChats")}
+          title={t("deleteAllChats")}
+          disabled={deleteAllDisabled}
+          onClick={() => setBulkDeleteOpen(true)}
+        >
+          <Trash2 className="h-4 w-4" />
         </Button>
       </div>
 
@@ -57,6 +97,28 @@ export const ChatSidebar = memo(function ChatSidebar({
           loading={sessionsLoading}
         />
       </div>
-    </div>
+      </div>
+
+      <Dialog open={bulkDeleteOpen} onOpenChange={(open) => !isDeletingAll && setBulkDeleteOpen(open)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t(hasAgentSelected ? "deleteAgentChatsTitle" : "deleteAllChatsTitle")}
+            </DialogTitle>
+            <DialogDescription>
+              {t(hasAgentSelected ? "deleteAgentChatsConfirm" : "deleteAllChatsConfirm")}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBulkDeleteOpen(false)} disabled={isDeletingAll}>
+              {tc("cancel")}
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmDeleteAll} disabled={deleteAllDisabled}>
+              {tc("delete")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 });

--- a/ui/web/src/pages/chat/hooks/use-chat-sessions.ts
+++ b/ui/web/src/pages/chat/hooks/use-chat-sessions.ts
@@ -46,6 +46,7 @@ export function useChatSessions(agentId: string) {
   }, [loadSessions]);
 
   const buildNewSessionKey = useCallback(() => {
+	if (!agentId) return "";
     const convId = uniqueId();
     return `agent:${agentId}:ws:direct:${convId}`;
   }, [agentId]);
@@ -61,6 +62,21 @@ export function useChatSessions(agentId: string) {
       throw err;
     }
   }, [ws, connected, loadSessions]);
+
+  const deleteAllSessions = useCallback(async () => {
+    if (!connected) return 0;
+    try {
+      const res = await ws.call<{ count?: number }>(Methods.SESSIONS_DELETE_BULK, {
+        keys: sessions.map((session) => session.key),
+      });
+      await loadSessions();
+      toast.success(i18next.t("sessions:toast.bulkDeleted"));
+      return res.count ?? 0;
+    } catch (err) {
+      toast.error(i18next.t("sessions:toast.bulkDeleteFailed"), userFriendlyError(err));
+      throw err;
+    }
+  }, [ws, connected, loadSessions, sessions]);
 
   // Update session label in-place when backend generates a title.
   const handleSessionUpdated = useCallback((payload: unknown) => {
@@ -81,5 +97,6 @@ export function useChatSessions(agentId: string) {
     refresh: loadSessions,
     buildNewSessionKey,
     deleteSession,
+    deleteAllSessions,
   };
 }

--- a/ui/web/src/pages/teams/board/board-container.tsx
+++ b/ui/web/src/pages/teams/board/board-container.tsx
@@ -122,14 +122,16 @@ export const BoardContainer = memo(function BoardContainer({
   // Per-task debounce timers for fetch-one calls (300ms)
   const fetchTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   // Progress debounce timer (1s, global — batches all progress patches)
-  const progressTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const progressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingProgressRef = useRef(new Map<string, { percent: number; step: string }>());
 
   // Cleanup timers on unmount
   useEffect(() => {
     return () => {
       fetchTimersRef.current.forEach((t) => clearTimeout(t));
-      clearTimeout(progressTimerRef.current);
+      if (progressTimerRef.current !== null) {
+        clearTimeout(progressTimerRef.current);
+      }
     };
   }, []);
 
@@ -178,7 +180,9 @@ export const BoardContainer = memo(function BoardContainer({
       percent: p.progress_percent ?? 0,
       step: p.progress_step ?? "",
     });
-    clearTimeout(progressTimerRef.current);
+    if (progressTimerRef.current !== null) {
+      clearTimeout(progressTimerRef.current);
+    }
     progressTimerRef.current = setTimeout(() => {
       const patches = new Map(pendingProgressRef.current);
       pendingProgressRef.current.clear();


### PR DESCRIPTION
## Summary
- add a `sessions.delete-bulk` RPC for deleting the currently visible web chat sessions while preserving per-session delete side effects
- add a delete-all action to the web chat sidebar with confirmation, route reset behavior, and localized success/error copy
- fix the existing timer typing issues that were blocking the embedded web UI build

## Verification
- `pnpm --dir ui/web build`
- `make build-full`
- `go build ./...`
- `go build -tags sqliteonly ./...`