### PR TITLE
feat: WhatsApp group agent overrides, pipeline block reply fix, and group management UI

### DIFF
--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -440,8 +440,10 @@ func processNormalMessage(
 		// block reply, suppress the final message to avoid duplicate delivery.
 		// Only applies when blockReply is enabled (otherwise nothing was delivered).
 		if blockReplyEnabled && outcome.Result.BlockReplies > 0 && outcome.Result.Content == outcome.Result.LastBlockReply && len(outcome.Result.Media) == 0 {
-			slog.Debug("inbound: dedup final message (matches last block reply)",
-				"channel", channel, "run_id", rID)
+			slog.Info("inbound: dedup final message (matches last block reply)",
+				"channel", channel, "run_id", rID,
+				"block_replies", outcome.Result.BlockReplies,
+				"content_len", len(outcome.Result.Content))
 			deps.MsgBus.PublishOutbound(bus.OutboundMessage{
 				Channel:  channel,
 				ChatID:   chatID,

--- a/internal/channels/dispatch.go
+++ b/internal/channels/dispatch.go
@@ -75,6 +75,7 @@ func (m *Manager) dispatchOutbound(ctx context.Context) {
 					"content_len", len(msg.Content),
 					"content_preview", Truncate(msg.Content, 160),
 					"error", err,
+					"has_media", len(msg.Media) > 0,
 				)
 				// Try to send a text-only error notification back to the chat.
 				// Only for media failures — text-only failures likely mean the chat

--- a/internal/channels/instance_loader.go
+++ b/internal/channels/instance_loader.go
@@ -162,6 +162,7 @@ func (l *InstanceLoader) Stop(ctx context.Context) {
 
 // coerceStringBools converts string "true"/"false" values to JSON booleans
 // in a raw config blob. Older UI versions saved select-based bool fields as strings.
+// Recurses into nested maps (e.g., WhatsApp group overrides).
 func coerceStringBools(data json.RawMessage) json.RawMessage {
 	if len(data) == 0 {
 		return data
@@ -170,10 +171,20 @@ func coerceStringBools(data json.RawMessage) json.RawMessage {
 	if json.Unmarshal(data, &m) != nil {
 		return data
 	}
+	if coerceMap(m) {
+		out, _ := json.Marshal(m)
+		return out
+	}
+	return data
+}
+
+// coerceMap recursively converts string "true"/"false" to JSON booleans in a map.
+func coerceMap(m map[string]any) bool {
 	changed := false
 	for k, v := range m {
-		if s, ok := v.(string); ok {
-			switch s {
+		switch tv := v.(type) {
+		case string:
+			switch tv {
 			case "true":
 				m[k] = true
 				changed = true
@@ -181,13 +192,13 @@ func coerceStringBools(data json.RawMessage) json.RawMessage {
 				m[k] = false
 				changed = true
 			}
+		case map[string]any:
+			if coerceMap(tv) {
+				changed = true
+			}
 		}
 	}
-	if !changed {
-		return data
-	}
-	out, _ := json.Marshal(m)
-	return out
+	return changed
 }
 
 // LoadedNames returns the set of channel names managed by the loader.

--- a/internal/channels/whatsapp/commands.go
+++ b/internal/channels/whatsapp/commands.go
@@ -1,0 +1,96 @@
+package whatsapp
+
+import (
+	"context"
+	"strings"
+
+	"go.mau.fi/whatsmeow/types"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
+)
+
+const menuHelpText = "Available commands:\n" +
+	"/reset — Reset conversation history\n" +
+	"/stop — Stop current running task\n" +
+	"/stopall — Stop all running tasks\n" +
+	"/menu — Show this help message\n" +
+	"\nJust send a message to chat with the AI."
+
+// handleCommand checks if the message is a known slash command and handles it.
+// Returns true if the message was handled (caller should stop processing).
+func (c *Channel) handleCommand(ctx context.Context, text, senderID, chatID, peerKind string, chatJID types.JID) bool {
+	if len(text) == 0 || text[0] != '/' {
+		return false
+	}
+
+	cmd := strings.SplitN(text, " ", 2)[0]
+	cmd = strings.ToLower(cmd)
+
+	switch cmd {
+	case "/reset":
+		c.Bus().PublishInbound(bus.InboundMessage{
+			Channel:  c.Name(),
+			SenderID: senderID,
+			ChatID:   chatID,
+			Content:  "/reset",
+			PeerKind: peerKind,
+			AgentID:  c.AgentID(),
+			UserID:   stripSenderUserID(senderID),
+			TenantID: c.TenantID(),
+			Metadata: map[string]string{
+				tools.MetaCommand: "reset",
+			},
+		})
+		c.sendText(chatJID, "Conversation history has been reset.")
+		return true
+
+	case "/stop":
+		c.Bus().PublishInbound(bus.InboundMessage{
+			Channel:  c.Name(),
+			SenderID: senderID,
+			ChatID:   chatID,
+			Content:  "/stop",
+			PeerKind: peerKind,
+			AgentID:  c.AgentID(),
+			UserID:   stripSenderUserID(senderID),
+			TenantID: c.TenantID(),
+			Metadata: map[string]string{
+				tools.MetaCommand: "stop",
+			},
+		})
+		// Feedback is sent by the consumer after cancel result is known.
+		return true
+
+	case "/stopall":
+		c.Bus().PublishInbound(bus.InboundMessage{
+			Channel:  c.Name(),
+			SenderID: senderID,
+			ChatID:   chatID,
+			Content:  "/stopall",
+			PeerKind: peerKind,
+			AgentID:  c.AgentID(),
+			UserID:   stripSenderUserID(senderID),
+			TenantID: c.TenantID(),
+			Metadata: map[string]string{
+				tools.MetaCommand: "stopall",
+			},
+		})
+		// Feedback is sent by the consumer after cancel result is known.
+		return true
+
+	case "/menu":
+		c.sendText(chatJID, menuHelpText)
+		return true
+	}
+
+	return false
+}
+
+// stripSenderUserID extracts the user ID portion before the '|' separator.
+func stripSenderUserID(senderID string) string {
+	if idx := strings.IndexByte(senderID, '|'); idx > 0 {
+		return senderID[:idx]
+	}
+	return senderID
+}

--- a/internal/channels/whatsapp/factory.go
+++ b/internal/channels/whatsapp/factory.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
@@ -67,6 +68,13 @@ func FactoryWithDB(db *sql.DB, pendingStore store.PendingMessageStore, dialect s
 			}
 			if json.Unmarshal(cfg, &wrapper) == nil {
 				waCfg.Groups = wrapper.Groups
+			}
+		}
+
+		if len(waCfg.Groups) > 0 {
+			slog.Info("whatsapp group overrides loaded", "name", name, "count", len(waCfg.Groups))
+			for jid, gc := range waCfg.Groups {
+				slog.Info("whatsapp group override", "jid", jid, "agent_id", gc.AgentID, "enabled", gc.Enabled)
 			}
 		}
 

--- a/internal/channels/whatsapp/factory.go
+++ b/internal/channels/whatsapp/factory.go
@@ -59,6 +59,17 @@ func FactoryWithDB(db *sql.DB, pendingStore store.PendingMessageStore, dialect s
 			HistoryLimit:   ic.HistoryLimit,
 			BlockReply:     ic.BlockReply,
 		}
+
+		// Parse per-group overrides from config JSONB.
+		if len(cfg) > 0 {
+			var wrapper struct {
+				Groups map[string]*config.WhatsAppGroupConfig `json:"groups"`
+			}
+			if json.Unmarshal(cfg, &wrapper) == nil {
+				waCfg.Groups = wrapper.Groups
+			}
+		}
+
 		// DB instances default to "pairing" for groups (secure by default).
 		if waCfg.GroupPolicy == "" {
 			waCfg.GroupPolicy = "pairing"

--- a/internal/channels/whatsapp/inbound.go
+++ b/internal/channels/whatsapp/inbound.go
@@ -159,7 +159,7 @@ func (c *Channel) handleIncomingMessage(evt *events.Message) {
 					slog.Info("whatsapp group message rejected: group disabled", "chat_id", chatID)
 					return
 				}
-				if grp.AgentID != "" {
+				if grp.AgentID != "" && grp.AgentID != "__default__" {
 					targetAgentID = grp.AgentID
 					slog.Info("whatsapp group agent override applied", "chat_id", chatID, "agent_id", targetAgentID)
 				}
@@ -167,6 +167,17 @@ func (c *Channel) handleIncomingMessage(evt *events.Message) {
 				slog.Info("whatsapp group no override found", "chat_id", chatID, "available_keys", groupKeys(c.config.Groups))
 			}
 		}
+	}
+
+	// Final routing summary log (unconditional — always fires for group messages).
+	if peerKind == "group" {
+		slog.Info("whatsapp routing resolved",
+			"chat_id", chatID,
+			"default_agent", c.AgentID(),
+			"final_agent", targetAgentID,
+			"override_applied", targetAgentID != c.AgentID(),
+			"groups_configured", len(c.config.Groups),
+		)
 	}
 
 	// Typing indicator.

--- a/internal/channels/whatsapp/inbound.go
+++ b/internal/channels/whatsapp/inbound.go
@@ -142,6 +142,26 @@ func (c *Channel) handleIncomingMessage(evt *events.Message) {
 			metadata["user_name"], "", peerKind, "user", "", "")
 	}
 
+	// Collect group as a contact for UI group discovery.
+	if cc := c.ContactCollector(); cc != nil && peerKind == "group" {
+		cc.EnsureContact(ctx, c.Type(), c.Name(), chatID, "", "", "", "group", "group", "", "")
+	}
+
+	// Resolve group-specific agent override.
+	targetAgentID := c.AgentID()
+	if peerKind == "group" && c.config.Groups != nil {
+		if grp, ok := c.config.Groups[chatID]; ok && grp != nil {
+			if grp.Enabled != nil && !*grp.Enabled {
+				slog.Debug("whatsapp group message rejected: group disabled", "chat_id", chatID)
+				return
+			}
+			if grp.AgentID != "" {
+				targetAgentID = grp.AgentID
+				slog.Debug("whatsapp group agent override", "chat_id", chatID, "agent_id", targetAgentID)
+			}
+		}
+	}
+
 	// Typing indicator.
 	if prevCancel, ok := c.typingCancel.LoadAndDelete(chatID); ok {
 		if fn, ok := prevCancel.(context.CancelFunc); ok {
@@ -166,7 +186,7 @@ func (c *Channel) handleIncomingMessage(evt *events.Message) {
 		Media:    mediaFiles,
 		PeerKind: peerKind,
 		UserID:   userID,
-		AgentID:  c.AgentID(),
+		AgentID:  targetAgentID,
 		TenantID: c.TenantID(),
 		Metadata: metadata,
 	})

--- a/internal/channels/whatsapp/inbound.go
+++ b/internal/channels/whatsapp/inbound.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/media"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
@@ -149,15 +150,21 @@ func (c *Channel) handleIncomingMessage(evt *events.Message) {
 
 	// Resolve group-specific agent override.
 	targetAgentID := c.AgentID()
-	if peerKind == "group" && c.config.Groups != nil {
-		if grp, ok := c.config.Groups[chatID]; ok && grp != nil {
-			if grp.Enabled != nil && !*grp.Enabled {
-				slog.Debug("whatsapp group message rejected: group disabled", "chat_id", chatID)
-				return
-			}
-			if grp.AgentID != "" {
-				targetAgentID = grp.AgentID
-				slog.Debug("whatsapp group agent override", "chat_id", chatID, "agent_id", targetAgentID)
+	if peerKind == "group" {
+		slog.Info("whatsapp group routing", "chat_id", chatID, "default_agent", targetAgentID,
+			"groups_count", len(c.config.Groups))
+		if c.config.Groups != nil {
+			if grp, ok := c.config.Groups[chatID]; ok && grp != nil {
+				if grp.Enabled != nil && !*grp.Enabled {
+					slog.Info("whatsapp group message rejected: group disabled", "chat_id", chatID)
+					return
+				}
+				if grp.AgentID != "" {
+					targetAgentID = grp.AgentID
+					slog.Info("whatsapp group agent override applied", "chat_id", chatID, "agent_id", targetAgentID)
+				}
+			} else {
+				slog.Info("whatsapp group no override found", "chat_id", chatID, "available_keys", groupKeys(c.config.Groups))
 			}
 		}
 	}
@@ -283,4 +290,13 @@ func (c *Channel) isMentioned(evt *events.Message) bool {
 		}
 	}
 	return false
+}
+
+// groupKeys returns the keys of the groups map for logging.
+func groupKeys(m map[string]*config.WhatsAppGroupConfig) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/internal/channels/whatsapp/inbound.go
+++ b/internal/channels/whatsapp/inbound.go
@@ -69,6 +69,11 @@ func (c *Channel) handleIncomingMessage(evt *events.Message) {
 
 	content := extractTextContent(evt.Message)
 
+	// Command interception: check for slash commands before the normal pipeline.
+	if handled := c.handleCommand(ctx, content, senderID, chatID, peerKind, chatJID); handled {
+		return
+	}
+
 	var mediaList []media.MediaInfo
 	mediaList = c.downloadMedia(evt)
 

--- a/internal/channels/whatsapp/outbound.go
+++ b/internal/channels/whatsapp/outbound.go
@@ -80,6 +80,21 @@ func (c *Channel) Send(_ context.Context, msg bus.OutboundMessage) error {
 	return nil
 }
 
+// sendText sends a plain text message directly to a WhatsApp JID.
+// Used for command feedback (e.g. /menu, /reset confirmation).
+func (c *Channel) sendText(chatJID types.JID, text string) {
+	if c.client == nil || !c.client.IsConnected() {
+		slog.Warn("whatsapp: cannot send text, not connected")
+		return
+	}
+	waMsg := &waE2E.Message{
+		Conversation: proto.String(text),
+	}
+	if _, err := c.client.SendMessage(c.ctx, chatJID, waMsg); err != nil {
+		slog.Error("whatsapp: failed to send command reply", "error", err, "chat", chatJID.String())
+	}
+}
+
 // buildMediaMessage uploads media to WhatsApp and returns the message proto.
 func (c *Channel) buildMediaMessage(data []byte, mime, caption string) (*waE2E.Message, error) {
 	switch {

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -133,6 +133,7 @@ type SlackConfig struct {
 
 // WhatsAppGroupConfig defines per-group overrides for a WhatsApp channel.
 type WhatsAppGroupConfig struct {
+	Name    string `json:"name,omitempty"`    // human-readable alias (e.g. "Channel Outlook")
 	AgentID string `json:"agent_id,omitempty"` // agent_key to route to (overrides channel default)
 	Enabled *bool  `json:"enabled,omitempty"`  // disable bot for this group (default: true)
 }

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -131,15 +131,22 @@ type SlackConfig struct {
 	MediaMaxBytes  int64               `json:"media_max_bytes,omitempty"` // max file download size in bytes (default 20MB)
 }
 
+// WhatsAppGroupConfig defines per-group overrides for a WhatsApp channel.
+type WhatsAppGroupConfig struct {
+	AgentID string `json:"agent_id,omitempty"` // agent_key to route to (overrides channel default)
+	Enabled *bool  `json:"enabled,omitempty"`  // disable bot for this group (default: true)
+}
+
 type WhatsAppConfig struct {
-	Enabled        bool                `json:"enabled"`
-	AuthDir        string              `json:"auth_dir,omitempty"`        // optional: SQLite auth dir override (desktop)
-	AllowFrom      FlexibleStringSlice `json:"allow_from"`
-	DMPolicy       string              `json:"dm_policy,omitempty"`       // "pairing" (default for DB instances), "open", "allowlist", "disabled"
-	GroupPolicy    string              `json:"group_policy,omitempty"`    // "pairing" (default for DB instances), "open" (default for config), "allowlist", "disabled"
-	RequireMention *bool               `json:"require_mention,omitempty"` // only respond in groups when bot is @mentioned (default false)
-	HistoryLimit   int                 `json:"history_limit,omitempty"`   // max pending group messages for context (default 200, 0=disabled)
-	BlockReply     *bool               `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
+	Enabled        bool                             `json:"enabled"`
+	AuthDir        string                           `json:"auth_dir,omitempty"`        // optional: SQLite auth dir override (desktop)
+	AllowFrom      FlexibleStringSlice              `json:"allow_from"`
+	DMPolicy       string                           `json:"dm_policy,omitempty"`       // "pairing" (default for DB instances), "open", "allowlist", "disabled"
+	GroupPolicy    string                           `json:"group_policy,omitempty"`    // "pairing" (default for DB instances), "open" (default for config), "allowlist", "disabled"
+	RequireMention *bool                            `json:"require_mention,omitempty"` // only respond in groups when bot is @mentioned (default false)
+	HistoryLimit   int                              `json:"history_limit,omitempty"`   // max pending group messages for context (default 200, 0=disabled)
+	BlockReply     *bool                            `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
+	Groups         map[string]*WhatsAppGroupConfig  `json:"groups,omitempty"`          // per-group overrides, keyed by group JID
 }
 
 type ZaloConfig struct {

--- a/internal/pipeline/observe_stage.go
+++ b/internal/pipeline/observe_stage.go
@@ -30,8 +30,10 @@ func (s *ObserveStage) Execute(_ context.Context, state *RunState) error {
 		return nil
 	}
 
-	// 2. Track block replies (every response with content counts as a block)
-	if resp.Content != "" {
+	// 2. Track block replies for intermediate responses only (with tool calls).
+	// Final answers (no tool calls) are delivered through the normal consumer path,
+	// not via block.reply — counting them here causes false dedup suppression.
+	if resp.Content != "" && len(resp.ToolCalls) > 0 {
 		state.Observe.BlockReplies++
 		state.Observe.LastBlockReply = resp.Content
 	}

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -796,12 +796,14 @@ func TestObserveStage_BlockReplies_IncrementedPerContentResponse(t *testing.T) {
 	stage := NewObserveStage(deps)
 	state := defaultState()
 
-	// first response with content
-	state.Think.LastResponse = &providers.ChatResponse{Content: "reply 1", FinishReason: "stop"}
+	// first intermediate response (with tool calls) — counts as block reply
+	state.Think.LastResponse = &providers.ChatResponse{Content: "reply 1", FinishReason: "stop",
+		ToolCalls: []providers.ToolCall{{ID: "1", Name: "tool"}}}
 	_ = stage.Execute(context.Background(), state)
 
-	// second response with content
-	state.Think.LastResponse = &providers.ChatResponse{Content: "reply 2", FinishReason: "stop"}
+	// second intermediate response — counts as block reply
+	state.Think.LastResponse = &providers.ChatResponse{Content: "reply 2", FinishReason: "stop",
+		ToolCalls: []providers.ToolCall{{ID: "2", Name: "tool"}}}
 	_ = stage.Execute(context.Background(), state)
 
 	if state.Observe.BlockReplies != 2 {
@@ -840,6 +842,28 @@ func TestObserveStage_EmptyContent_BlockRepliesNotIncremented(t *testing.T) {
 
 	if state.Observe.BlockReplies != 0 {
 		t.Errorf("BlockReplies = %d, want 0 when content empty", state.Observe.BlockReplies)
+	}
+}
+
+func TestObserveStage_FinalAnswer_NotCountedAsBlockReply(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{}
+	stage := NewObserveStage(deps)
+	state := defaultState()
+
+	// Final answer (no tool calls) — should NOT be counted as block reply
+	state.Think.LastResponse = &providers.ChatResponse{Content: "final answer", FinishReason: "stop"}
+
+	_ = stage.Execute(context.Background(), state)
+
+	if state.Observe.BlockReplies != 0 {
+		t.Errorf("BlockReplies = %d, want 0 for final answer (no tool calls)", state.Observe.BlockReplies)
+	}
+	if state.Observe.LastBlockReply != "" {
+		t.Errorf("LastBlockReply = %q, want empty for final answer", state.Observe.LastBlockReply)
+	}
+	if state.Observe.FinalContent != "final answer" {
+		t.Errorf("FinalContent = %q, want 'final answer'", state.Observe.FinalContent)
 	}
 }
 

--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -95,16 +95,7 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		resp.ToolCalls = s.deps.UniqueToolCallIDs(resp.ToolCalls, state.RunID, state.Iteration)
 	}
 
-	// 8. Emit block reply for ALL responses with content (including final answers).
-	// Non-streaming channels (WhatsApp, Discord, Zalo) need this for delivery.
-	// Must fire BEFORE the BreakLoop check — otherwise final answers (no tool calls)
-	// are never emitted, and the dedup logic in the consumer suppresses the final
-	// message because ObserveStage already counted it as a block reply.
-	if resp.Content != "" && s.deps.EmitBlockReply != nil {
-		s.deps.EmitBlockReply(resp.Content)
-	}
-
-	// 9. Flow control + message append.
+	// 8. Flow control + message append.
 	// Final answer (no tool calls): FinalizeStage builds the definitive assistant
 	// message with sanitization + MediaRefs, so skip AppendPending here to avoid
 	// a duplicate. Matches v2 behavior where loop breaks before appending.
@@ -123,6 +114,14 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		RawAssistantContent: resp.RawAssistantContent, // Anthropic thinking blocks passback
 	}
 	state.Messages.AppendPending(assistantMsg)
+
+	// 9. Emit block reply for intermediate assistant content during tool iterations.
+	// Non-streaming channels (Zalo, Discord, WhatsApp) need this for delivery.
+	// Only fires for intermediate responses (with tool calls) — final answers
+	// are delivered through the normal consumer path after FinalizeStage sanitization.
+	if resp.Content != "" && s.deps.EmitBlockReply != nil {
+		s.deps.EmitBlockReply(resp.Content)
+	}
 
 	return nil
 }

--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -95,7 +95,16 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		resp.ToolCalls = s.deps.UniqueToolCallIDs(resp.ToolCalls, state.RunID, state.Iteration)
 	}
 
-	// 8. Flow control + message append.
+	// 8. Emit block reply for ALL responses with content (including final answers).
+	// Non-streaming channels (WhatsApp, Discord, Zalo) need this for delivery.
+	// Must fire BEFORE the BreakLoop check — otherwise final answers (no tool calls)
+	// are never emitted, and the dedup logic in the consumer suppresses the final
+	// message because ObserveStage already counted it as a block reply.
+	if resp.Content != "" && s.deps.EmitBlockReply != nil {
+		s.deps.EmitBlockReply(resp.Content)
+	}
+
+	// 9. Flow control + message append.
 	// Final answer (no tool calls): FinalizeStage builds the definitive assistant
 	// message with sanitization + MediaRefs, so skip AppendPending here to avoid
 	// a duplicate. Matches v2 behavior where loop breaks before appending.
@@ -114,12 +123,6 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		RawAssistantContent: resp.RawAssistantContent, // Anthropic thinking blocks passback
 	}
 	state.Messages.AppendPending(assistantMsg)
-
-	// Emit block.reply for intermediate assistant content during tool iterations.
-	// Non-streaming channels (Zalo, Discord, WhatsApp) need this for delivery.
-	if resp.Content != "" && s.deps.EmitBlockReply != nil {
-		s.deps.EmitBlockReply(resp.Content)
-	}
 
 	return nil
 }

--- a/internal/store/pg/channel_instances.go
+++ b/internal/store/pg/channel_instances.go
@@ -218,6 +218,25 @@ func (s *PGChannelInstanceStore) Update(ctx context.Context, id uuid.UUID, updat
 		}
 		updates["credentials"] = credsBytes
 	}
+
+	// Marshal config to JSON bytes for JSONB column.
+	// The HTTP/WS handlers decode JSON into map[string]any, which may not
+	// serialize correctly to JSONB via database/sql parameter encoding.
+	if cfgVal, ok := updates["config"]; ok {
+		if cfgVal == nil {
+			updates["config"] = []byte("null")
+		} else {
+			switch cfgVal.(type) {
+			case json.RawMessage, []byte:
+				// Already raw JSON bytes — use as-is.
+			default:
+				if b, err := json.Marshal(cfgVal); err == nil {
+					updates["config"] = json.RawMessage(b)
+				}
+			}
+		}
+	}
+
 	updates["updated_at"] = time.Now()
 	if store.IsCrossTenant(ctx) {
 		return execMapUpdate(ctx, s.db, "channel_instances", id, updates)

--- a/internal/store/sqlitestore/channel_instances.go
+++ b/internal/store/sqlitestore/channel_instances.go
@@ -217,6 +217,25 @@ func (s *SQLiteChannelInstanceStore) Update(ctx context.Context, id uuid.UUID, u
 		}
 		updates["credentials"] = credsBytes
 	}
+
+	// Marshal config to JSON bytes for JSON column.
+	if cfgVal, ok := updates["config"]; ok {
+		if cfgVal == nil {
+			updates["config"] = []byte("null")
+		} else {
+			switch v := cfgVal.(type) {
+			case json.RawMessage:
+				// Already raw JSON bytes — use as-is.
+			case []byte:
+				// Already bytes — use as-is.
+			default:
+				if b, err := json.Marshal(cfgVal); err == nil {
+					updates["config"] = json.RawMessage(b)
+				}
+			}
+		}
+	}
+
 	updates["updated_at"] = time.Now()
 	if store.IsCrossTenant(ctx) {
 		return execMapUpdate(ctx, s.db, "channel_instances", id, updates)

--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -494,6 +494,8 @@
     "title": "WhatsApp Group Agents",
     "hint": "Assign a specific agent to handle each WhatsApp group. Groups without an override use the default channel agent.",
     "groupLabel": "Group: {{id}}",
+    "nameLabel": "Group Name",
+    "namePlaceholder": "e.g. Channel Outlook",
     "agentLabel": "Agent",
     "selectAgent": "Use channel default",
     "addGroupPlaceholder": "Group JID (e.g. 123456@g.us)",

--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -483,5 +483,17 @@
     "relinkDevice": "Re-link Device",
     "connectedSuccess": "✅ WhatsApp connected successfully!",
     "tabQrCode": "QR Code"
+  },
+  "whatsappGroupOverrides": {
+    "title": "WhatsApp Group Agents",
+    "hint": "Assign a specific agent to handle each WhatsApp group. Groups without an override use the default channel agent.",
+    "groupLabel": "Group: {{id}}",
+    "agentLabel": "Agent",
+    "selectAgent": "Use channel default",
+    "addGroupPlaceholder": "Group JID (e.g. 123456@g.us)",
+    "addGroup": "Add Group",
+    "knownGroups": "Discovered Groups",
+    "saveGroups": "Save Groups",
+    "saving": "Saving..."
   }
 }

--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -40,7 +40,13 @@
   "list": {
     "failureStreak": "{{count}} failures in a row",
     "openChannelDetail": "Open channel detail for the latest diagnosis",
-    "nextStep": "Next step"
+    "nextStep": "Next step",
+    "groupsCount": "{{count}} groups",
+    "showGroups": "Show groups",
+    "hideGroups": "Hide groups",
+    "defaultAgent": "Default",
+    "groupDisabled": "Disabled",
+    "noGroups": "No groups discovered yet. Groups appear after the bot receives messages in WhatsApp groups."
   },
   "failureKind": {
     "auth": "Auth",

--- a/ui/web/src/i18n/locales/vi/channels.json
+++ b/ui/web/src/i18n/locales/vi/channels.json
@@ -40,7 +40,13 @@
   "list": {
     "failureStreak": "{{count}} lỗi liên tiếp",
     "openChannelDetail": "Mở chi tiết channel để xem chẩn đoán mới nhất",
-    "nextStep": "Bước tiếp theo"
+    "nextStep": "Bước tiếp theo",
+    "groupsCount": "{{count}} nhóm",
+    "showGroups": "Hiện nhóm",
+    "hideGroups": "Ẩn nhóm",
+    "defaultAgent": "Mặc định",
+    "groupDisabled": "Đã tắt",
+    "noGroups": "Chưa phát hiện nhóm nào. Nhóm sẽ xuất hiện sau khi bot nhận tin nhắn trong nhóm WhatsApp."
   },
   "failureKind": {
     "auth": "Xác thực",

--- a/ui/web/src/i18n/locales/vi/channels.json
+++ b/ui/web/src/i18n/locales/vi/channels.json
@@ -409,6 +409,8 @@
     "title": "Agent nhóm WhatsApp",
     "hint": "Gán agent cụ thể để xử lý từng nhóm WhatsApp. Nhóm không có cấu hình sẽ dùng agent mặc định của channel.",
     "groupLabel": "Nhóm: {{id}}",
+    "nameLabel": "Tên nhóm",
+    "namePlaceholder": "vd: Channel Outlook",
     "agentLabel": "Agent",
     "selectAgent": "Dùng mặc định channel",
     "addGroupPlaceholder": "JID nhóm (vd: 123456@g.us)",

--- a/ui/web/src/i18n/locales/vi/channels.json
+++ b/ui/web/src/i18n/locales/vi/channels.json
@@ -398,5 +398,17 @@
     "relinkDevice": "Liên kết lại",
     "connectedSuccess": "✅ Kết nối WhatsApp thành công!",
     "tabQrCode": "Mã QR"
+  },
+  "whatsappGroupOverrides": {
+    "title": "Agent nhóm WhatsApp",
+    "hint": "Gán agent cụ thể để xử lý từng nhóm WhatsApp. Nhóm không có cấu hình sẽ dùng agent mặc định của channel.",
+    "groupLabel": "Nhóm: {{id}}",
+    "agentLabel": "Agent",
+    "selectAgent": "Dùng mặc định channel",
+    "addGroupPlaceholder": "JID nhóm (vd: 123456@g.us)",
+    "addGroup": "Thêm nhóm",
+    "knownGroups": "Nhóm đã phát hiện",
+    "saveGroups": "Lưu nhóm",
+    "saving": "Đang lưu..."
   }
 }

--- a/ui/web/src/i18n/locales/zh/channels.json
+++ b/ui/web/src/i18n/locales/zh/channels.json
@@ -409,6 +409,8 @@
     "title": "WhatsApp 群组 Agent",
     "hint": "为每个 WhatsApp 群组指定专门的 Agent 处理。未配置的群组使用 Channel 默认 Agent。",
     "groupLabel": "群组: {{id}}",
+    "nameLabel": "群组名称",
+    "namePlaceholder": "例如 Channel Outlook",
     "agentLabel": "Agent",
     "selectAgent": "使用 Channel 默认",
     "addGroupPlaceholder": "群组 JID（例如 123456@g.us）",

--- a/ui/web/src/i18n/locales/zh/channels.json
+++ b/ui/web/src/i18n/locales/zh/channels.json
@@ -40,7 +40,13 @@
   "list": {
     "failureStreak": "连续 {{count}} 次失败",
     "openChannelDetail": "打开 Channel 详情查看最新诊断",
-    "nextStep": "下一步"
+    "nextStep": "下一步",
+    "groupsCount": "{{count}} 个群组",
+    "showGroups": "显示群组",
+    "hideGroups": "隐藏群组",
+    "defaultAgent": "默认",
+    "groupDisabled": "已禁用",
+    "noGroups": "尚未发现群组。机器人接收 WhatsApp 群组消息后，群组会自动出现。"
   },
   "failureKind": {
     "auth": "认证",

--- a/ui/web/src/i18n/locales/zh/channels.json
+++ b/ui/web/src/i18n/locales/zh/channels.json
@@ -398,5 +398,17 @@
     "relinkDevice": "重新连接",
     "connectedSuccess": "✅ WhatsApp 连接成功！",
     "tabQrCode": "二维码"
+  },
+  "whatsappGroupOverrides": {
+    "title": "WhatsApp 群组 Agent",
+    "hint": "为每个 WhatsApp 群组指定专门的 Agent 处理。未配置的群组使用 Channel 默认 Agent。",
+    "groupLabel": "群组: {{id}}",
+    "agentLabel": "Agent",
+    "selectAgent": "使用 Channel 默认",
+    "addGroupPlaceholder": "群组 JID（例如 123456@g.us）",
+    "addGroup": "添加群组",
+    "knownGroups": "已发现的群组",
+    "saveGroups": "保存群组",
+    "saving": "保存中..."
   }
 }

--- a/ui/web/src/lib/query-keys.ts
+++ b/ui/web/src/lib/query-keys.ts
@@ -36,6 +36,7 @@ export const queryKeys = {
     all: ["channels"] as const,
     list: (params: Record<string, unknown>) => ["channels", params] as const,
     detail: (id: string) => ["channels", "detail", id] as const,
+    waGroups: () => ["channels", "wa-groups"] as const,
   },
   contacts: {
     all: ["contacts"] as const,

--- a/ui/web/src/pages/channels/channel-detail/channel-detail-page.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-detail-page.tsx
@@ -34,11 +34,11 @@ const baseChannelDetailTabs = new Set(["general", "credentials", "managers"]);
 
 export function resolveChannelDetailTab(
   requestedTab: string | null,
-  isTelegram: boolean,
+  showGroups: boolean,
 ) {
   if (!requestedTab) return DEFAULT_CHANNEL_DETAIL_TAB;
   if (requestedTab === "groups") {
-    return isTelegram ? "groups" : DEFAULT_CHANNEL_DETAIL_TAB;
+    return showGroups ? "groups" : DEFAULT_CHANNEL_DETAIL_TAB;
   }
   return baseChannelDetailTabs.has(requestedTab)
     ? requestedTab
@@ -60,6 +60,7 @@ export function ChannelDetailPage({
     listManagers,
     addManager,
     removeManager,
+    listContacts,
   } = useChannelDetail(instanceId);
   const { agents } = useAgents();
   const { channels } = useChannels();
@@ -80,6 +81,7 @@ export function ChannelDetailPage({
   })();
 
   const isTelegram = instance?.channel_type === "telegram";
+  const showGroupsTab = isTelegram || instance?.channel_type === "whatsapp";
   const supportsReauth = instance
     ? channelsWithAuth.has(instance.channel_type)
     : false;
@@ -89,8 +91,8 @@ export function ChannelDetailPage({
 
   useEffect(() => {
     if (!instance) return;
-    setActiveTab(resolveChannelDetailTab(searchParams.get("tab"), isTelegram));
-  }, [instance, isTelegram, searchParams]);
+    setActiveTab(resolveChannelDetailTab(searchParams.get("tab"), showGroupsTab));
+  }, [instance, showGroupsTab, searchParams]);
 
   useEffect(() => {
     if (!instance) return;
@@ -193,7 +195,7 @@ export function ChannelDetailPage({
               <TabsTrigger value="credentials">
                 {t("detail.tabs.credentials")}
               </TabsTrigger>
-              {isTelegram && (
+              {showGroupsTab && (
                 <TabsTrigger value="groups">
                   {t("detail.tabs.groups")}
                 </TabsTrigger>
@@ -218,12 +220,14 @@ export function ChannelDetailPage({
               />
             </TabsContent>
 
-            {isTelegram && (
+            {showGroupsTab && (
               <TabsContent value="groups" className="mt-4">
                 <ChannelGroupsTab
                   instance={instance}
                   onUpdate={updateInstance}
                   listManagerGroups={listManagerGroups}
+                  listContacts={listContacts}
+                  agents={agents}
                 />
               </TabsContent>
             )}

--- a/ui/web/src/pages/channels/channel-detail/channel-groups-tab.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-groups-tab.tsx
@@ -141,8 +141,8 @@ function WhatsAppGroupsContent({
   const { t } = useTranslation("channels");
   const config = (instance.config ?? {}) as Record<string, unknown>;
   const [groups, setGroups] = useState<
-    Record<string, { agent_id?: string; enabled?: boolean }>
-  >((config.groups as Record<string, { agent_id?: string; enabled?: boolean }>) ?? {});
+    Record<string, { name?: string; agent_id?: string; enabled?: boolean }>
+  >((config.groups as Record<string, { name?: string; agent_id?: string; enabled?: boolean }>) ?? {});
   const [saving, setSaving] = useState(false);
 
   const handleSave = async () => {

--- a/ui/web/src/pages/channels/channel-detail/channel-groups-tab.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-groups-tab.tsx
@@ -3,9 +3,12 @@ import { useTranslation } from "react-i18next";
 import { Save, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { ChannelInstanceData } from "@/types/channel";
+import type { ChannelContact } from "@/types/contact";
+import type { AgentData } from "@/types/agent";
 import { TelegramGroupOverrides } from "../telegram-group-overrides";
 import type { TelegramGroupConfigValues } from "../telegram-group-fields";
 import type { TelegramTopicConfigValues } from "../telegram-topic-overrides";
+import { WhatsAppGroupOverrides } from "../whatsapp-group-overrides";
 import type { GroupManagerGroupInfo } from "../hooks/use-channel-detail";
 
 interface GroupConfigWithTopics extends TelegramGroupConfigValues {
@@ -16,9 +19,49 @@ interface ChannelGroupsTabProps {
   instance: ChannelInstanceData;
   onUpdate: (updates: Record<string, unknown>) => Promise<void>;
   listManagerGroups: () => Promise<GroupManagerGroupInfo[]>;
+  listContacts: (search: string, channelType?: string) => Promise<ChannelContact[]>;
+  agents: AgentData[];
 }
 
-export function ChannelGroupsTab({ instance, onUpdate, listManagerGroups }: ChannelGroupsTabProps) {
+export function ChannelGroupsTab({
+  instance,
+  onUpdate,
+  listManagerGroups,
+  listContacts,
+  agents,
+}: ChannelGroupsTabProps) {
+  if (instance.channel_type === "whatsapp") {
+    return (
+      <WhatsAppGroupsContent
+        instance={instance}
+        onUpdate={onUpdate}
+        listContacts={listContacts}
+        agents={agents}
+      />
+    );
+  }
+
+  // Telegram (default)
+  return (
+    <TelegramGroupsContent
+      instance={instance}
+      onUpdate={onUpdate}
+      listManagerGroups={listManagerGroups}
+    />
+  );
+}
+
+// --- Telegram groups content (existing logic) ---
+
+function TelegramGroupsContent({
+  instance,
+  onUpdate,
+  listManagerGroups,
+}: {
+  instance: ChannelInstanceData;
+  onUpdate: (updates: Record<string, unknown>) => Promise<void>;
+  listManagerGroups: () => Promise<GroupManagerGroupInfo[]>;
+}) {
   const { t } = useTranslation("channels");
   const config = (instance.config ?? {}) as Record<string, unknown>;
   const [groups, setGroups] = useState<Record<string, GroupConfigWithTopics>>(
@@ -31,10 +74,14 @@ export function ChannelGroupsTab({ instance, onUpdate, listManagerGroups }: Chan
     try {
       const g = await listManagerGroups();
       setKnownGroups(g);
-    } catch { /* handled by http hook */ }
+    } catch {
+      /* handled by http hook */
+    }
   }, [listManagerGroups]);
 
-  useEffect(() => { loadKnownGroups(); }, [loadKnownGroups]);
+  useEffect(() => {
+    loadKnownGroups();
+  }, [loadKnownGroups]);
 
   const handleSave = async () => {
     const hasGroups = Object.keys(groups).length > 0;
@@ -46,8 +93,11 @@ export function ChannelGroupsTab({ instance, onUpdate, listManagerGroups }: Chan
 
     setSaving(true);
     try {
-      await onUpdate({ config: Object.keys(cleanConfig).length > 0 ? cleanConfig : null });
-    } catch { // toast shown by hook
+      await onUpdate({
+        config: Object.keys(cleanConfig).length > 0 ? cleanConfig : null,
+      });
+    } catch {
+      // toast shown by hook
     } finally {
       setSaving(false);
     }
@@ -55,12 +105,84 @@ export function ChannelGroupsTab({ instance, onUpdate, listManagerGroups }: Chan
 
   return (
     <div className="space-y-6">
-      <TelegramGroupOverrides groups={groups} onChange={(g) => setGroups(g)} knownGroups={knownGroups} />
+      <TelegramGroupOverrides
+        groups={groups}
+        onChange={(g) => setGroups(g)}
+        knownGroups={knownGroups}
+      />
 
       <div className="flex items-center justify-end gap-2">
         <Button onClick={handleSave} disabled={saving}>
-          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+          {saving ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Save className="h-4 w-4" />
+          )}
           {saving ? t("detail.groups.saving") : t("detail.groups.saveGroups")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// --- WhatsApp groups content ---
+
+function WhatsAppGroupsContent({
+  instance,
+  onUpdate,
+  listContacts,
+  agents,
+}: {
+  instance: ChannelInstanceData;
+  onUpdate: (updates: Record<string, unknown>) => Promise<void>;
+  listContacts: (search: string, channelType?: string) => Promise<ChannelContact[]>;
+  agents: AgentData[];
+}) {
+  const { t } = useTranslation("channels");
+  const config = (instance.config ?? {}) as Record<string, unknown>;
+  const [groups, setGroups] = useState<
+    Record<string, { agent_id?: string; enabled?: boolean }>
+  >((config.groups as Record<string, { agent_id?: string; enabled?: boolean }>) ?? {});
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    const hasGroups = Object.keys(groups).length > 0;
+    const updatedConfig = { ...config, groups: hasGroups ? groups : undefined };
+    const cleanConfig = Object.fromEntries(
+      Object.entries(updatedConfig).filter(([, v]) => v !== undefined),
+    );
+
+    setSaving(true);
+    try {
+      await onUpdate({
+        config: Object.keys(cleanConfig).length > 0 ? cleanConfig : null,
+      });
+    } catch {
+      // toast shown by hook
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <WhatsAppGroupOverrides
+        groups={groups}
+        onChange={setGroups}
+        listContacts={listContacts}
+        agents={agents}
+      />
+
+      <div className="flex items-center justify-end gap-2">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Save className="h-4 w-4" />
+          )}
+          {saving
+            ? t("whatsappGroupOverrides.saving")
+            : t("whatsappGroupOverrides.saveGroups")}
         </Button>
       </div>
     </div>

--- a/ui/web/src/pages/channels/channel-list-row.tsx
+++ b/ui/web/src/pages/channels/channel-list-row.tsx
@@ -1,4 +1,4 @@
-import { QrCode, Radio, Trash2 } from "lucide-react";
+import { QrCode, Radio, Trash2, ChevronDown, ChevronRight, Users } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -7,6 +7,8 @@ import type {
   ChannelInstanceData,
   ChannelRuntimeStatus,
 } from "@/types/channel";
+import type { AgentData } from "@/types/agent";
+import type { ChannelContact } from "@/types/contact";
 import {
   channelTypeLabels,
   getChannelCheckedLabel,
@@ -16,10 +18,35 @@ import {
 } from "./channels-status-view";
 import { channelsWithAuth } from "./channel-wizard-registry";
 
+interface WhatsAppGroupConfig {
+  agent_id?: string; // agent_key (slug), NOT agent.id
+  enabled?: boolean;
+}
+
+function getWhatsAppGroups(
+  config: Record<string, unknown> | null,
+): Record<string, WhatsAppGroupConfig> {
+  if (!config?.groups) return {};
+  return (config.groups as Record<string, WhatsAppGroupConfig>) ?? {};
+}
+
+function resolveAgentNameByKey(
+  agents: AgentData[],
+  agentKey?: string,
+): string {
+  if (!agentKey) return "";
+  const agent = agents.find((a) => a.agent_key === agentKey);
+  return agent?.display_name || agent?.agent_key || agentKey;
+}
+
 interface ChannelListRowProps {
   instance: ChannelInstanceData;
   status: ChannelRuntimeStatus | null;
   agentName: string;
+  agents: AgentData[];
+  waGroupContacts: ChannelContact[];
+  groupsExpanded: boolean;
+  onToggleGroups: () => void;
   onClick: () => void;
   onAuth?: () => void;
   onDelete?: () => void;
@@ -29,6 +56,10 @@ export function ChannelListRow({
   instance,
   status,
   agentName,
+  agents,
+  waGroupContacts,
+  groupsExpanded,
+  onToggleGroups,
   onClick,
   onAuth,
   onDelete,
@@ -55,6 +86,25 @@ export function ChannelListRow({
     t("list.openChannelDetail", {
       defaultValue: "Open channel detail for the latest diagnosis",
     });
+
+  const isWhatsApp = instance.channel_type === "whatsapp";
+
+  // Merge discovered contacts with configured overrides
+  const configGroups = isWhatsApp
+    ? getWhatsAppGroups(instance.config as Record<string, unknown> | null)
+    : {};
+
+  // Build merged group list: all contacts + any configured-only groups
+  const allGroupJids = new Set<string>();
+  for (const c of waGroupContacts) {
+    allGroupJids.add(c.sender_id);
+  }
+  for (const jid of Object.keys(configGroups)) {
+    allGroupJids.add(jid);
+  }
+
+  const hasGroups = allGroupJids.size > 0;
+  const sortedGroupJids = [...allGroupJids].sort();
 
   return (
     <div
@@ -151,6 +201,85 @@ export function ChannelListRow({
           )}
         </div>
       </div>
+
+      {/* WhatsApp groups section - always visible for WhatsApp instances */}
+      {isWhatsApp && (
+        <div className="border-t">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleGroups();
+            }}
+            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            {groupsExpanded ? (
+              <ChevronDown className="h-4 w-4 shrink-0" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0" />
+            )}
+            <Users className="h-4 w-4 shrink-0" />
+            <span>
+              {hasGroups
+                ? t("list.groupsCount", { count: allGroupJids.size })
+                : t("list.showGroups")}
+            </span>
+          </button>
+
+          {groupsExpanded && (
+            <div className="border-t px-4 pb-3 pt-1">
+              {hasGroups ? (
+                sortedGroupJids.map((jid) => {
+                  const config = configGroups[jid];
+                  const isOverride =
+                    config?.agent_id && config.agent_id !== "__default__";
+                  const groupAgentName = isOverride
+                    ? resolveAgentNameByKey(agents, config.agent_id)
+                    : agentName;
+                  const isDisabled = config?.enabled === false;
+
+                  return (
+                    <button
+                      key={jid}
+                      type="button"
+                      onClick={onClick}
+                      className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted/50"
+                    >
+                      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                        <Users className="h-3.5 w-3.5" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <span className="truncate font-mono text-xs text-muted-foreground">
+                          {jid}
+                        </span>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        {isDisabled && (
+                          <Badge variant="outline" className="text-xs text-muted-foreground">
+                            {t("list.groupDisabled")}
+                          </Badge>
+                        )}
+                        <Badge
+                          variant={isOverride ? "default" : "secondary"}
+                          className="text-xs-plus"
+                        >
+                          {isOverride
+                            ? groupAgentName
+                            : `${t("list.defaultAgent")} · ${groupAgentName}`}
+                        </Badge>
+                      </div>
+                    </button>
+                  );
+                })
+              ) : (
+                <p className="px-3 py-2 text-xs text-muted-foreground">
+                  {t("list.noGroups")}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/web/src/pages/channels/channel-list-row.tsx
+++ b/ui/web/src/pages/channels/channel-list-row.tsx
@@ -19,6 +19,7 @@ import {
 import { channelsWithAuth } from "./channel-wizard-registry";
 
 interface WhatsAppGroupConfig {
+  name?: string;    // human-readable alias
   agent_id?: string; // agent_key (slug), NOT agent.id
   enabled?: boolean;
 }
@@ -249,9 +250,16 @@ export function ChannelListRow({
                         <Users className="h-3.5 w-3.5" />
                       </div>
                       <div className="min-w-0 flex-1">
-                        <span className="truncate font-mono text-xs text-muted-foreground">
-                          {jid}
-                        </span>
+                        {config?.name ? (
+                          <div className="flex flex-col">
+                            <span className="truncate text-sm">{config.name}</span>
+                            <span className="truncate font-mono text-xs text-muted-foreground">{jid}</span>
+                          </div>
+                        ) : (
+                          <span className="truncate font-mono text-xs text-muted-foreground">
+                            {jid}
+                          </span>
+                        )}
                       </div>
                       <div className="flex shrink-0 items-center gap-2">
                         {isDisabled && (

--- a/ui/web/src/pages/channels/channels-page.tsx
+++ b/ui/web/src/pages/channels/channels-page.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, lazy, Suspense } from "react";
 import { useParams, useNavigate } from "react-router";
 import { Radio, Plus, RefreshCw } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
@@ -19,6 +20,9 @@ import { channelsWithAuth, reauthDialogs } from "./channel-wizard-registry";
 import { ChannelDetailPage } from "./channel-detail/channel-detail-page";
 import { ChannelListRow } from "./channel-list-row";
 import { useAgents } from "@/pages/agents/hooks/use-agents";
+import { useHttp } from "@/hooks/use-ws";
+import { queryKeys } from "@/lib/query-keys";
+import type { ChannelContact } from "@/types/contact";
 import { useMinLoading } from "@/hooks/use-min-loading";
 import { useDeferredLoading } from "@/hooks/use-deferred-loading";
 import { useDebouncedCallback } from "@/hooks/use-debounced-callback";
@@ -43,6 +47,7 @@ export function ChannelsPage() {
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [editInstance, setEditInstance] = useState<ChannelInstanceData | null>(null);
   const [qrTarget, setQrTarget] = useState<ChannelInstanceData | null>(null);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
 
   const pendingSearchRef = useRef("");
   const flushSearch = useDebouncedCallback(() => {
@@ -65,6 +70,35 @@ export function ChannelsPage() {
     offset: (page - 1) * pageSize,
   });
   const { agents } = useAgents();
+  const http = useHttp();
+
+  // Fetch WhatsApp group contacts for group display in channel list
+  const { data: waGroupContacts } = useQuery({
+    queryKey: queryKeys.channels.waGroups(),
+    queryFn: async () => {
+      const res = await http.get<{ contacts: ChannelContact[] }>("/v1/contacts", {
+        channel_type: "whatsapp",
+        peer_kind: "group",
+        contact_type: "group",
+        limit: "200",
+      });
+      return res.contacts ?? [];
+    },
+    staleTime: 60_000,
+  });
+
+  // Auto-expand WhatsApp groups on first load
+  const initializedRef = useRef(false);
+  if (!initializedRef.current && instances.length > 0) {
+    initializedRef.current = true;
+    const initial: Record<string, boolean> = {};
+    for (const inst of instances) {
+      if (inst.channel_type === "whatsapp") initial[inst.id] = true;
+    }
+    if (Object.keys(initial).length > 0) {
+      setExpandedGroups(initial);
+    }
+  }
 
   const loading = statusLoading || instancesLoading;
   const spinning = useMinLoading(loading);
@@ -174,6 +208,12 @@ export function ChannelsPage() {
                   instance={inst}
                   status={getStatus(inst)}
                   agentName={getAgentName(inst.agent_id)}
+                  agents={agents}
+                  waGroupContacts={inst.channel_type === "whatsapp" ? (waGroupContacts ?? []) : []}
+                  groupsExpanded={!!expandedGroups[inst.id]}
+                  onToggleGroups={() =>
+                    setExpandedGroups((prev) => ({ ...prev, [inst.id]: !prev[inst.id] }))
+                  }
                   onClick={() => navigate(`/channels/${inst.id}`)}
                   onAuth={channelsWithAuth.has(inst.channel_type) ? () => setQrTarget(inst) : undefined}
                   onDelete={!inst.is_default ? () => setDeleteTarget(inst) : undefined}

--- a/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
+++ b/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
@@ -129,7 +129,8 @@ export function WhatsAppGroupOverrides({
                     onValueChange={(val) =>
                       updateGroup(id, {
                         ...group,
-                        agent_id: val || undefined,
+                        agent_id:
+                          val === "__default__" || !val ? undefined : val,
                       })
                     }
                   >

--- a/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
+++ b/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
@@ -14,6 +14,7 @@ import type { ChannelContact } from "@/types/contact";
 import type { AgentData } from "@/types/agent";
 
 interface WhatsAppGroupConfigValues {
+  name?: string;
   agent_id?: string;
   enabled?: boolean;
 }
@@ -104,7 +105,11 @@ export function WhatsAppGroupOverrides({
                 ) : (
                   <ChevronRight className="h-4 w-4" />
                 )}
-                <span className="font-mono text-xs">{id}</span>
+                {group.name ? (
+                  <span className="text-sm">{group.name}</span>
+                ) : (
+                  <span className="font-mono text-xs">{id}</span>
+                )}
               </button>
               <Button
                 type="button"
@@ -119,6 +124,20 @@ export function WhatsAppGroupOverrides({
 
             {expanded[id] && (
               <div className="space-y-3 pl-2">
+                {/* Group name / alias */}
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    {t("whatsappGroupOverrides.nameLabel")}
+                  </label>
+                  <Input
+                    value={group.name ?? ""}
+                    onChange={(e) =>
+                      updateGroup(id, { ...group, name: e.target.value || undefined })
+                    }
+                    placeholder={t("whatsappGroupOverrides.namePlaceholder")}
+                    className="h-9 text-sm"
+                  />
+                </div>
                 {/* Agent selector */}
                 <div className="space-y-1.5">
                   <label className="text-xs font-medium text-muted-foreground">

--- a/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
+++ b/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
@@ -1,0 +1,208 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Plus, Trash2, ChevronDown, ChevronRight } from "lucide-react";
+import type { ChannelContact } from "@/types/contact";
+import type { AgentData } from "@/types/agent";
+
+interface WhatsAppGroupConfigValues {
+  agent_id?: string;
+  enabled?: boolean;
+}
+
+interface Props {
+  groups: Record<string, WhatsAppGroupConfigValues>;
+  onChange: (groups: Record<string, WhatsAppGroupConfigValues>) => void;
+  listContacts: (search: string, channelType?: string) => Promise<ChannelContact[]>;
+  agents: AgentData[];
+}
+
+export function WhatsAppGroupOverrides({
+  groups,
+  onChange,
+  listContacts,
+  agents,
+}: Props) {
+  const { t } = useTranslation("channels");
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [newGroupId, setNewGroupId] = useState("");
+  const [knownGroups, setKnownGroups] = useState<ChannelContact[]>([]);
+
+  const groupIds = Object.keys(groups);
+
+  const addGroup = (id?: string) => {
+    const gid = (id ?? newGroupId).trim();
+    if (!gid || groups[gid]) return;
+    onChange({ ...groups, [gid]: {} });
+    setExpanded((prev) => ({ ...prev, [gid]: true }));
+    if (!id) setNewGroupId("");
+  };
+
+  const removeGroup = (id: string) => {
+    const next = { ...groups };
+    delete next[id];
+    onChange(next);
+  };
+
+  const updateGroup = (id: string, config: WhatsAppGroupConfigValues) => {
+    onChange({ ...groups, [id]: config });
+  };
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  // Load discovered WhatsApp groups from contacts API
+  const loadKnownGroups = useCallback(async () => {
+    try {
+      const contacts = await listContacts("", "whatsapp");
+      const groupContacts = contacts.filter(
+        (c) => c.peer_kind === "group" && c.contact_type === "group",
+      );
+      setKnownGroups(groupContacts);
+    } catch {
+      /* handled by http hook */
+    }
+  }, [listContacts]);
+
+  useEffect(() => {
+    loadKnownGroups();
+  }, [loadKnownGroups]);
+
+  // Known groups not yet added as overrides
+  const availableGroups = knownGroups.filter((g) => !groups[g.sender_id]);
+
+  return (
+    <fieldset className="rounded-md border p-3 space-y-3">
+      <legend className="px-1 text-sm font-medium">
+        {t("whatsappGroupOverrides.title")}
+      </legend>
+      <p className="text-xs text-muted-foreground">
+        {t("whatsappGroupOverrides.hint")}
+      </p>
+
+      {groupIds.map((id) => {
+        const group = groups[id] ?? {};
+        return (
+          <div key={id} className="rounded-md border p-3 space-y-3">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                className="flex items-center gap-1 text-sm font-medium hover:underline"
+                onClick={() => toggle(id)}
+              >
+                {expanded[id] ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+                <span className="font-mono text-xs">{id}</span>
+              </button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                onClick={() => removeGroup(id)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+
+            {expanded[id] && (
+              <div className="space-y-3 pl-2">
+                {/* Agent selector */}
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    {t("whatsappGroupOverrides.agentLabel")}
+                  </label>
+                  <Select
+                    value={group.agent_id ?? ""}
+                    onValueChange={(val) =>
+                      updateGroup(id, {
+                        ...group,
+                        agent_id: val || undefined,
+                      })
+                    }
+                  >
+                    <SelectTrigger className="h-9">
+                      <SelectValue
+                        placeholder={t(
+                          "whatsappGroupOverrides.selectAgent",
+                        )}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__default__">
+                        {t("whatsappGroupOverrides.selectAgent")}
+                      </SelectItem>
+                      {agents.map((a) => (
+                        <SelectItem key={a.id} value={a.agent_key}>
+                          {a.display_name || a.agent_key}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {/* Discovered groups quick-add */}
+      {availableGroups.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-muted-foreground">
+            {t("whatsappGroupOverrides.knownGroups")}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {availableGroups.map((g) => (
+              <button
+                key={g.id}
+                type="button"
+                onClick={() => addGroup(g.sender_id)}
+                className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-muted/50 transition-colors"
+              >
+                <Plus className="h-3 w-3" />
+                <span className="font-mono">{g.sender_id}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Manual group JID input */}
+      <div className="flex items-center gap-2">
+        <Input
+          value={newGroupId}
+          onChange={(e) => setNewGroupId(e.target.value)}
+          placeholder={t("whatsappGroupOverrides.addGroupPlaceholder")}
+          className="h-8 flex-1 text-sm"
+          onKeyDown={(e) =>
+            e.key === "Enter" && (e.preventDefault(), addGroup())
+          }
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8"
+          onClick={() => addGroup()}
+          disabled={!newGroupId.trim()}
+        >
+          <Plus className="h-3.5 w-3.5 mr-1" />
+          {t("whatsappGroupOverrides.addGroup")}
+        </Button>
+      </div>
+    </fieldset>
+  );
+}


### PR DESCRIPTION
## Summary

- Add WhatsApp group agent override configuration with per-group agent routing and `__default__` sentinel handling
- Fix double WhatsApp message delivery caused by block reply emission for final answers — restrict block reply tracking in ObserveStage to intermediate tool-call responses only
- Add recursive config coercion for nested WhatsApp group overrides (string "true"/"false" → JSON booleans)
- Add WhatsApp group management UI to channel list with group display support
- Add human-readable names to WhatsApp group overrides and initialize project package manager

## Commits

| Commit | Description |
|--------|-------------|
| `ddd4f14e` | feat: add WhatsApp group agent override configuration support |
| `e66d978f` | update |
| `9665116f` | refactor: improve WhatsApp group agent routing, recursive config coercion, and pipeline block reply emission logic |
| `c9c1f030` | refactor: restrict block reply tracking to intermediate tool calls and add WhatsApp group management UI |
| `f0ac3bf9` | feat: add WhatsApp group management and display support to channel list |
| `120c45fa` | feat: add human-readable names to WhatsApp group overrides and initialize project package manager |

## Test plan

- [ ] Send a message to WhatsApp (single-turn, no tool calls) — should receive exactly one reply
- [ ] Send a message to WhatsApp that triggers tool use — should receive intermediate block replies + final answer, no duplicates
- [ ] Configure group agent override → verify routing uses the override agent for that group
- [ ] Set group agent to `__default__` → verify it falls back to channel default
- [ ] Verify WhatsApp groups tab in channel detail page shows group list with names
- [ ] Run `go test ./internal/pipeline/...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)