### PR TITLE
fix(store): coerce null emoji/agent_description on agent update

### DIFF
--- a/internal/store/pg/agents.go
+++ b/internal/store/pg/agents.go
@@ -193,6 +193,12 @@ func (s *PGAgentStore) Update(ctx context.Context, id uuid.UUID, updates map[str
 	if v, ok := updates["skill_nudge_interval"]; ok && v == nil {
 		updates["skill_nudge_interval"] = 0
 	}
+	// NOT NULL text columns: null → empty string.
+	for _, col := range []string{"emoji", "agent_description"} {
+		if v, ok := updates[col]; ok && v == nil {
+			updates[col] = ""
+		}
+	}
 	// NOT NULL JSONB columns: null → empty object.
 	for _, col := range []string{"chatgpt_oauth_routing", "reasoning_config", "workspace_sharing", "shell_deny_groups", "kg_dedup_config"} {
 		if v, ok := updates[col]; ok && v == nil {

--- a/internal/store/pg/agents.go
+++ b/internal/store/pg/agents.go
@@ -194,7 +194,7 @@ func (s *PGAgentStore) Update(ctx context.Context, id uuid.UUID, updates map[str
 		updates["skill_nudge_interval"] = 0
 	}
 	// NOT NULL text columns: null → empty string.
-	for _, col := range []string{"emoji", "agent_description"} {
+	for _, col := range []string{"emoji", "agent_description", "thinking_level"} {
 		if v, ok := updates[col]; ok && v == nil {
 			updates[col] = ""
 		}

--- a/internal/store/sqlitestore/agents.go
+++ b/internal/store/sqlitestore/agents.go
@@ -138,7 +138,7 @@ func (s *SQLiteAgentStore) Update(ctx context.Context, id uuid.UUID, updates map
 		updates["skill_nudge_interval"] = 0
 	}
 	// NOT NULL text columns: null → empty string.
-	for _, col := range []string{"emoji", "agent_description"} {
+	for _, col := range []string{"emoji", "agent_description", "thinking_level"} {
 		if v, ok := updates[col]; ok && v == nil {
 			updates[col] = ""
 		}

--- a/internal/store/sqlitestore/agents.go
+++ b/internal/store/sqlitestore/agents.go
@@ -137,6 +137,12 @@ func (s *SQLiteAgentStore) Update(ctx context.Context, id uuid.UUID, updates map
 	if v, ok := updates["skill_nudge_interval"]; ok && v == nil {
 		updates["skill_nudge_interval"] = 0
 	}
+	// NOT NULL text columns: null → empty string.
+	for _, col := range []string{"emoji", "agent_description"} {
+		if v, ok := updates[col]; ok && v == nil {
+			updates[col] = ""
+		}
+	}
 
 	// Unset existing default before setting a new one (scoped to same tenant).
 	if v, ok := updates["is_default"]; ok {


### PR DESCRIPTION
## Summary
- Agent update fails with `null value in column "emoji" violates not-null constraint` when UI sends `emoji: null` or `agent_description: null`
- Adds null → `""` coercion for NOT NULL text columns in both PG and SQLite agent stores, matching existing pattern for `skill_nudge_interval` (null → 0)

## Test plan
- [ ] Update agent via Web UI without setting emoji → should succeed (previously 500)
- [ ] Update agent with explicit emoji → still works as before
- [ ] PG and SQLite builds compile cleanly