### PR TITLE
fix(agent): use agentUUID instead of id for domain event AgentID

### DIFF
--- a/internal/agent/loop_finalize.go
+++ b/internal/agent/loop_finalize.go
@@ -201,7 +201,7 @@ func (l *Loop) finalizeRun(
 		l.domainBus.Publish(eventbus.DomainEvent{
 			Type:     eventbus.EventSessionCompleted,
 			TenantID: l.tenantID.String(),
-			AgentID:  l.id,
+			AgentID:  l.agentUUID.String(),
 			UserID:   req.UserID,
 			SourceID: req.SessionKey,
 			Payload: &eventbus.SessionCompletedPayload{

--- a/internal/agent/loop_pipeline_adapter.go
+++ b/internal/agent/loop_pipeline_adapter.go
@@ -147,7 +147,7 @@ func (l *Loop) buildPipelineDeps(req *RunRequest, bridgeRS *runState) pipeline.P
 				l.domainBus.Publish(eventbus.DomainEvent{
 					Type:     eventbus.EventSessionCompleted,
 					TenantID: l.tenantID.String(),
-					AgentID:  l.id,
+					AgentID:  l.agentUUID.String(),
 					UserID:   req.UserID,
 					SourceID: sessionKey,
 					Payload: &eventbus.SessionCompletedPayload{


### PR DESCRIPTION
Hi there! 👋

I noticed issue #809 where the episodic memory handler fails after a session completes because the <code>AgentID</code> field in the <code>session.completed</code> domain event contains an agent identifier string (like <code>"sofar"\u003c/code> or <code>"xiaoyan"\u003c/code>) instead of a valid UUID. PostgreSQL rightly rejects it with:

<pre>invalid input syntax for type uuid: "sofar" (SQLSTATE 22P02)</pre>

**Root cause**
Both <code>loop_finalize.go</code> and <code>loop_pipeline_adapter.go</code> were using <code>l.id</code> for the <code>AgentID</code> field. The <code>Loop</code> struct already carries <code>agentUUID uuid.UUID</code> specifically for context propagation, so switching to <code>l.agentUUID.String()</code> is the minimal and correct fix.

**Change**
- <code>internal/agent/loop_finalize.go</code>
- <code>internal/agent/loop_pipeline_adapter.go</code>

Credit to @PterX who pointed out the exact lines in the issue comments — this PR just turns that insight into a clean patch. 🙏

Let me know if you'd like me to add any additional regression tests or if there's a better place to enforce UUID validation at the boundary.

Fixes #809