### PR TITLE
fix(telegram): preserve Telegram topic routing for delayed notifications

### DIFF
--- a/internal/tasks/task_ticker.go
+++ b/internal/tasks/task_ticker.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	defaultRecoveryInterval    = 5 * time.Minute
-	defaultStaleThreshold      = 2 * time.Hour
-	defaultInReviewThreshold   = 4 * time.Hour
-	followupCooldown           = 5 * time.Minute
-	defaultFollowupInterval    = 30 * time.Minute
+	defaultRecoveryInterval  = 5 * time.Minute
+	defaultStaleThreshold    = 2 * time.Hour
+	defaultInReviewThreshold = 4 * time.Hour
+	followupCooldown         = 5 * time.Minute
+	defaultFollowupInterval  = 30 * time.Minute
 )
 
 // TaskTicker periodically recovers stale tasks and re-dispatches pending work.
@@ -242,7 +242,7 @@ func (t *TaskTicker) notifyLeaders(ctx context.Context, tasks []store.RecoveredT
 			fullTask = task
 			if fullTask != nil && fullTask.Metadata != nil {
 				if pk, ok := fullTask.Metadata["peer_kind"].(string); ok {
-				peerKind = pk
+					peerKind = pk
 				}
 			}
 		}
@@ -251,7 +251,7 @@ func (t *TaskTicker) notifyLeaders(ctx context.Context, tasks []store.RecoveredT
 			Channel:  channel,
 			SenderID: "ticker:system",
 			ChatID:   chatID,
-			Metadata: taskLocalKeyMetadata(fullTask),
+			Metadata: tools.TaskLocalKeyMetadata(fullTask),
 			AgentID:  lead.AgentKey,
 			UserID:   team.CreatedBy,
 			PeerKind: peerKind,
@@ -377,18 +377,8 @@ func followupOutboundMessage(task *store.TeamTaskData, content string) bus.Outbo
 		ChatID:  task.FollowupChatID,
 		Content: content,
 	}
-	message.Metadata = taskLocalKeyMetadata(task)
+	message.Metadata = tools.TaskLocalKeyMetadata(task)
 	return message
-}
-
-func taskLocalKeyMetadata(task *store.TeamTaskData) map[string]string {
-	if task == nil || task.Metadata == nil {
-		return nil
-	}
-	if localKey, ok := task.Metadata[tools.TaskMetaLocalKey].(string); ok && localKey != "" {
-		return map[string]string{tools.TaskMetaLocalKey: localKey}
-	}
-	return nil
 }
 
 // followupInterval parses the team's followup_interval_minutes setting.

--- a/internal/tasks/task_ticker.go
+++ b/internal/tasks/task_ticker.go
@@ -237,9 +237,13 @@ func (t *TaskTicker) notifyLeaders(ctx context.Context, tasks []store.RecoveredT
 
 		// Resolve PeerKind from first task's metadata for correct session routing (#266).
 		var peerKind string
-		if fullTask, err := t.teams.GetTask(ctx, scopeTasks[0].ID); err == nil && fullTask != nil && fullTask.Metadata != nil {
-			if pk, ok := fullTask.Metadata["peer_kind"].(string); ok {
+		var fullTask *store.TeamTaskData
+		if task, err := t.teams.GetTask(ctx, scopeTasks[0].ID); err == nil {
+			fullTask = task
+			if fullTask != nil && fullTask.Metadata != nil {
+				if pk, ok := fullTask.Metadata["peer_kind"].(string); ok {
 				peerKind = pk
+				}
 			}
 		}
 
@@ -247,6 +251,7 @@ func (t *TaskTicker) notifyLeaders(ctx context.Context, tasks []store.RecoveredT
 			Channel:  channel,
 			SenderID: "ticker:system",
 			ChatID:   chatID,
+			Metadata: taskLocalKeyMetadata(fullTask),
 			AgentID:  lead.AgentKey,
 			UserID:   team.CreatedBy,
 			PeerKind: peerKind,
@@ -334,11 +339,7 @@ func (t *TaskTicker) processTeamFollowups(ctx context.Context, tasks []store.Tea
 		}
 		content := fmt.Sprintf("Reminder (%s): %s", countLabel, task.FollowupMessage)
 
-		if !t.msgBus.TryPublishOutbound(bus.OutboundMessage{
-			Channel: task.FollowupChannel,
-			ChatID:  task.FollowupChatID,
-			Content: content,
-		}) {
+		if !t.msgBus.TryPublishOutbound(followupOutboundMessage(task, content)) {
 			slog.Warn("task_ticker: outbound buffer full, skipping followup", "task_id", task.ID)
 			continue
 		}
@@ -368,6 +369,26 @@ func (t *TaskTicker) processTeamFollowups(ctx context.Context, tasks []store.Tea
 			"team_id", task.TeamID,
 		)
 	}
+}
+
+func followupOutboundMessage(task *store.TeamTaskData, content string) bus.OutboundMessage {
+	message := bus.OutboundMessage{
+		Channel: task.FollowupChannel,
+		ChatID:  task.FollowupChatID,
+		Content: content,
+	}
+	message.Metadata = taskLocalKeyMetadata(task)
+	return message
+}
+
+func taskLocalKeyMetadata(task *store.TeamTaskData) map[string]string {
+	if task == nil || task.Metadata == nil {
+		return nil
+	}
+	if localKey, ok := task.Metadata[tools.TaskMetaLocalKey].(string); ok && localKey != "" {
+		return map[string]string{tools.TaskMetaLocalKey: localKey}
+	}
+	return nil
 }
 
 // followupInterval parses the team's followup_interval_minutes setting.

--- a/internal/tasks/task_ticker_test.go
+++ b/internal/tasks/task_ticker_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
 )
 
 // ─── minimal stub stores ───────────────────────────────────────────────────
@@ -459,4 +460,58 @@ func TestProcessFollowups_NoTasksIsNoop(t *testing.T) {
 	if ts.incrementCalls.Load() != 0 {
 		t.Errorf("IncrementFollowupCount calls = %d, want 0", ts.incrementCalls.Load())
 	}
+}
+
+func TestFollowupOutboundMessage_UsesLocalKey(t *testing.T) {
+	task := &store.TeamTaskData{
+		FollowupChannel: "telegram",
+		FollowupChatID:  "-100123456",
+		Metadata: map[string]any{
+			tools.TaskMetaLocalKey: "-100123456:topic:47",
+		},
+	}
+
+	got := followupOutboundMessage(task, "Reminder (1): ping")
+	if got.Metadata == nil {
+		t.Fatal("expected metadata to be populated")
+	}
+	if got.Metadata["local_key"] != "-100123456:topic:47" {
+		t.Fatalf("local_key = %q, want %q", got.Metadata["local_key"], "-100123456:topic:47")
+	}
+}
+
+func TestFollowupOutboundMessage_OmitsLocalKeyWhenMissing(t *testing.T) {
+	task := &store.TeamTaskData{
+		FollowupChannel: "telegram",
+		FollowupChatID:  "-100123456",
+	}
+
+	got := followupOutboundMessage(task, "Reminder (1): ping")
+	if got.Metadata != nil {
+		t.Fatalf("expected metadata to be nil, got %#v", got.Metadata)
+	}
+}
+
+func TestTaskLocalKeyMetadata(t *testing.T) {
+	t.Run("uses local key", func(t *testing.T) {
+		task := &store.TeamTaskData{
+			Metadata: map[string]any{
+				tools.TaskMetaLocalKey: "-100123456:topic:47",
+			},
+		}
+
+		got := taskLocalKeyMetadata(task)
+		if got == nil {
+			t.Fatal("expected metadata to be populated")
+		}
+		if got[tools.TaskMetaLocalKey] != "-100123456:topic:47" {
+			t.Fatalf("local_key = %q, want %q", got[tools.TaskMetaLocalKey], "-100123456:topic:47")
+		}
+	})
+
+	t.Run("omits local key when missing", func(t *testing.T) {
+		if got := taskLocalKeyMetadata(&store.TeamTaskData{}); got != nil {
+			t.Fatalf("expected metadata to be nil, got %#v", got)
+		}
+	})
 }

--- a/internal/tasks/task_ticker_test.go
+++ b/internal/tasks/task_ticker_test.go
@@ -491,27 +491,3 @@ func TestFollowupOutboundMessage_OmitsLocalKeyWhenMissing(t *testing.T) {
 		t.Fatalf("expected metadata to be nil, got %#v", got.Metadata)
 	}
 }
-
-func TestTaskLocalKeyMetadata(t *testing.T) {
-	t.Run("uses local key", func(t *testing.T) {
-		task := &store.TeamTaskData{
-			Metadata: map[string]any{
-				tools.TaskMetaLocalKey: "-100123456:topic:47",
-			},
-		}
-
-		got := taskLocalKeyMetadata(task)
-		if got == nil {
-			t.Fatal("expected metadata to be populated")
-		}
-		if got[tools.TaskMetaLocalKey] != "-100123456:topic:47" {
-			t.Fatalf("local_key = %q, want %q", got[tools.TaskMetaLocalKey], "-100123456:topic:47")
-		}
-	})
-
-	t.Run("omits local key when missing", func(t *testing.T) {
-		if got := taskLocalKeyMetadata(&store.TeamTaskData{}); got != nil {
-			t.Fatalf("expected metadata to be nil, got %#v", got)
-		}
-	})
-}

--- a/internal/tools/team_tasks_blocker.go
+++ b/internal/tools/team_tasks_blocker.go
@@ -77,6 +77,7 @@ func (t *TeamTasksTool) handleBlockerComment(
 				Channel:  task.Channel,
 				SenderID: "system:escalation",
 				ChatID:   task.ChatID,
+				Metadata: taskLocalKeyMetadata(task),
 				Content:  escalationMsg,
 				UserID:   store.UserIDFromContext(ctx),
 				PeerKind: blockerPeerKind,

--- a/internal/tools/team_tasks_blocker.go
+++ b/internal/tools/team_tasks_blocker.go
@@ -77,7 +77,7 @@ func (t *TeamTasksTool) handleBlockerComment(
 				Channel:  task.Channel,
 				SenderID: "system:escalation",
 				ChatID:   task.ChatID,
-				Metadata: taskLocalKeyMetadata(task),
+				Metadata: TaskLocalKeyMetadata(task),
 				Content:  escalationMsg,
 				UserID:   store.UserIDFromContext(ctx),
 				PeerKind: blockerPeerKind,

--- a/internal/tools/team_tool_helpers.go
+++ b/internal/tools/team_tool_helpers.go
@@ -27,11 +27,12 @@ func reviewOutboundMessage(task *store.TeamTaskData, content string) bus.Outboun
 		ChatID:  task.ChatID,
 		Content: content,
 	}
-	message.Metadata = taskLocalKeyMetadata(task)
+	message.Metadata = TaskLocalKeyMetadata(task)
 	return message
 }
 
-func taskLocalKeyMetadata(task *store.TeamTaskData) map[string]string {
+// TaskLocalKeyMetadata extracts local_key from task metadata for Telegram forum topic routing.
+func TaskLocalKeyMetadata(task *store.TeamTaskData) map[string]string {
 	if task == nil || task.Metadata == nil {
 		return nil
 	}

--- a/internal/tools/team_tool_helpers.go
+++ b/internal/tools/team_tool_helpers.go
@@ -21,6 +21,26 @@ func (m *TeamToolManager) broadcastTeamEvent(ctx context.Context, name string, p
 	bus.BroadcastForTenant(m.msgBus, name, store.TenantIDFromContext(ctx), payload)
 }
 
+func reviewOutboundMessage(task *store.TeamTaskData, content string) bus.OutboundMessage {
+	message := bus.OutboundMessage{
+		Channel: task.Channel,
+		ChatID:  task.ChatID,
+		Content: content,
+	}
+	message.Metadata = taskLocalKeyMetadata(task)
+	return message
+}
+
+func taskLocalKeyMetadata(task *store.TeamTaskData) map[string]string {
+	if task == nil || task.Metadata == nil {
+		return nil
+	}
+	if localKey, ok := task.Metadata[TaskMetaLocalKey].(string); ok && localKey != "" {
+		return map[string]string{TaskMetaLocalKey: localKey}
+	}
+	return nil
+}
+
 // resolveTeamRole returns the calling agent's role in the team.
 // Unlike requireLead(), this does NOT bypass for teammate channel —
 // workspace RBAC must respect actual roles even for teammate agents.
@@ -204,9 +224,5 @@ func (m *TeamToolManager) notifyChannelReview(task *store.TeamTaskData) {
 		return
 	}
 	content := fmt.Sprintf("🔔 Escalation: \"%s\" requires human review (task %s).", task.Subject, task.Identifier)
-	m.msgBus.PublishOutbound(bus.OutboundMessage{
-		Channel: task.Channel,
-		ChatID:  task.ChatID,
-		Content: content,
-	})
+	m.msgBus.PublishOutbound(reviewOutboundMessage(task, content))
 }

--- a/internal/tools/team_tool_helpers_test.go
+++ b/internal/tools/team_tool_helpers_test.go
@@ -44,7 +44,7 @@ func TestTaskLocalKeyMetadata(t *testing.T) {
 			},
 		}
 
-		got := taskLocalKeyMetadata(task)
+		got := TaskLocalKeyMetadata(task)
 		if got == nil {
 			t.Fatal("expected metadata to be populated")
 		}
@@ -54,7 +54,7 @@ func TestTaskLocalKeyMetadata(t *testing.T) {
 	})
 
 	t.Run("omits local key when missing", func(t *testing.T) {
-		if got := taskLocalKeyMetadata(&store.TeamTaskData{}); got != nil {
+		if got := TaskLocalKeyMetadata(&store.TeamTaskData{}); got != nil {
 			t.Fatalf("expected metadata to be nil, got %#v", got)
 		}
 	})

--- a/internal/tools/team_tool_helpers_test.go
+++ b/internal/tools/team_tool_helpers_test.go
@@ -1,0 +1,61 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+func TestReviewOutboundMessage_UsesLocalKey(t *testing.T) {
+	task := &store.TeamTaskData{
+		Channel: "telegram",
+		ChatID:  "-100123456",
+		Metadata: map[string]any{
+			TaskMetaLocalKey: "-100123456:topic:47",
+		},
+	}
+
+	got := reviewOutboundMessage(task, "review needed")
+	if got.Metadata == nil {
+		t.Fatal("expected metadata to be populated")
+	}
+	if got.Metadata["local_key"] != "-100123456:topic:47" {
+		t.Fatalf("local_key = %q, want %q", got.Metadata["local_key"], "-100123456:topic:47")
+	}
+}
+
+func TestReviewOutboundMessage_OmitsLocalKeyWhenMissing(t *testing.T) {
+	task := &store.TeamTaskData{
+		Channel: "telegram",
+		ChatID:  "-100123456",
+	}
+
+	got := reviewOutboundMessage(task, "review needed")
+	if got.Metadata != nil {
+		t.Fatalf("expected metadata to be nil, got %#v", got.Metadata)
+	}
+}
+
+func TestTaskLocalKeyMetadata(t *testing.T) {
+	t.Run("uses local key", func(t *testing.T) {
+		task := &store.TeamTaskData{
+			Metadata: map[string]any{
+				TaskMetaLocalKey: "-100123456:topic:47",
+			},
+		}
+
+		got := taskLocalKeyMetadata(task)
+		if got == nil {
+			t.Fatal("expected metadata to be populated")
+		}
+		if got[TaskMetaLocalKey] != "-100123456:topic:47" {
+			t.Fatalf("local_key = %q, want %q", got[TaskMetaLocalKey], "-100123456:topic:47")
+		}
+	})
+
+	t.Run("omits local key when missing", func(t *testing.T) {
+		if got := taskLocalKeyMetadata(&store.TeamTaskData{}); got != nil {
+			t.Fatalf("expected metadata to be nil, got %#v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Preserve Telegram topic routing for delayed notifications by carrying `local_key` through outbound metadata on follow-up, review, and blocker escalation messages. 

The old bug was that delayed sends only had the raw chat ID, so Telegram replies could land in the parent chat instead of the original forum topic/thread.

## Type
<!-- Check one -->
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->
dev

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
Validated the delayed-notification routing path with focused Go tests in `internal/tasks` and `internal/tools`. These cover `local_key` preservation for follow-up reminders, review notifications, and the shared routing metadata helper.
