### PR TITLE
feat(sandbox): expose Workdir field in SandboxConfig

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,6 +224,7 @@ type SandboxConfig struct {
 	User           string `json:"user,omitempty"`             // container user (e.g. "1000:1000", "nobody")
 	TmpfsSizeMB    int    `json:"tmpfs_size_mb,omitempty"`    // default tmpfs size in MB (0 = Docker default)
 	MaxOutputBytes int    `json:"max_output_bytes,omitempty"` // limit exec output capture (default 1MB)
+	Workdir        string `json:"workdir,omitempty"`          // container workdir + workspace mount target (default "/workspace")
 
 	// Pruning (matching TS SandboxPruneSettings)
 	IdleHours        int `json:"idle_hours,omitempty"`         // prune containers idle > N hours (default 24)
@@ -296,6 +297,9 @@ func (sc *SandboxConfig) ToSandboxConfig() sandbox.Config {
 	}
 	if sc.MaxOutputBytes > 0 {
 		cfg.MaxOutputBytes = sc.MaxOutputBytes
+	}
+	if sc.Workdir != "" {
+		cfg.Workdir = sc.Workdir
 	}
 
 	// Pruning


### PR DESCRIPTION
## Tóm tắt
- Thêm field tuỳ chọn `workdir` (JSON) vào `config.SandboxConfig`, map thẳng qua field `sandbox.Config.Workdir` đã có sẵn.
- Cho phép mỗi agent (qua JSONB `sandbox_config` trong DB) override đường dẫn mount workspace bên trong container, thay vì bị khoá cứng ở `/workspace`.
- Backward compatible: agent nào không set `workdir` vẫn dùng default `/workspace` như cũ.

## Lý do
`sandbox.Config` (internal) vốn đã hỗ trợ custom `Workdir` — vừa làm working directory vừa làm điểm mount workspace bind-mount bên trong container. Nhưng `config.SandboxConfig` (JSONB lưu trong `agents.sandbox_config`) lại không expose field này ra. Hệ quả: bất kỳ agent nào có scripts hardcode đường dẫn khác `/workspace` (ví dụ tooling mong đợi `/shared`, `/srv`, `/data`, ...) đều không có cách nào để GoClaw mount workspace vào đúng vị trí — chỉ còn 2 workaround cồng kềnh: patch lại toàn bộ scripts, hoặc bake symlink vào sandbox image.

Patch 4 dòng này đóng được khe hở đó mà không thay đổi behavior với user hiện tại.

## Test plan
- [x] `go build ./internal/config/...`
- [x] `go vet ./internal/config/...`
- [x] Verified end-to-end với agent thật: set `sandbox_config.workdir = "/shared"`, agent workspace trỏ vào host dir, GoClaw spawn sandbox container với `-v <host>:/shared -w /shared` và scripts chạy đúng như mong đợi.
- [ ] Sandbox integration tests sẵn có vẫn green (không có behavior change khi `workdir` không set).