### PR TITLE
fix: UI bug fixes — settings, cron, MCP, WS, events

### DIFF
--- a/internal/gateway/methods/teams_crud.go
+++ b/internal/gateway/methods/teams_crud.go
@@ -312,19 +312,23 @@ func (m *TeamsMethods) handleUpdate(ctx context.Context, client *gateway.Client,
 		EscalationActions     []string `json:"escalation_actions,omitempty"`
 		WorkspaceScope        string   `json:"workspace_scope,omitempty"`
 		WorkspaceQuotaMB      *int     `json:"workspace_quota_mb,omitempty"`
-		Notifications         *struct {
+		Notifications *struct {
 			Dispatched *bool  `json:"dispatched,omitempty"`
 			Progress   *bool  `json:"progress,omitempty"`
 			Failed     *bool  `json:"failed,omitempty"`
 			Completed  *bool  `json:"completed,omitempty"`
 			Commented  *bool  `json:"commented,omitempty"`
 			NewTask    *bool  `json:"new_task,omitempty"`
+			SlowTool   *bool  `json:"slow_tool,omitempty"`
 			Mode       string `json:"mode,omitempty"`
 		} `json:"notifications,omitempty"`
 		MemberRequests *struct {
 			Enabled      *bool `json:"enabled,omitempty"`
 			AutoDispatch *bool `json:"auto_dispatch,omitempty"`
 		} `json:"member_requests,omitempty"`
+		BlockerEscalation *struct {
+			Enabled *bool `json:"enabled,omitempty"`
+		} `json:"blocker_escalation,omitempty"`
 	}
 	raw, _ := json.Marshal(params.Settings)
 	var access teamAccessSettings

--- a/ui/web/src/api/ws-client.ts
+++ b/ui/web/src/api/ws-client.ts
@@ -91,6 +91,7 @@ export class WsClient {
 
   disconnect(): void {
     this.intentionalClose = true;
+    this.pairingInProgress = false;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/ui/web/src/api/ws-client.ts
+++ b/ui/web/src/api/ws-client.ts
@@ -21,6 +21,7 @@ export class WsClient {
   private reconnectAttempts = 0;
   private authenticated = false;
   private intentionalClose = false;
+  private pairingInProgress = false;
   private connectGeneration = 0;
 
   /** Server-assigned role from connect response. */
@@ -221,10 +222,14 @@ export class WsClient {
 
       // Browser pairing: server requires approval
       if (res?.status === "pending_pairing" && res.pairing_code && res.sender_id) {
-        this.onPairingRequired?.(res.pairing_code, res.sender_id);
+        if (!this.pairingInProgress) {
+          this.pairingInProgress = true;
+          this.onPairingRequired?.(res.pairing_code, res.sender_id);
+        }
         // Keep connection alive for polling browser.pairing.status
         return;
       }
+      this.pairingInProgress = false;
 
       // Server accepted connection but assigned viewer role → token is invalid
       if (this.getToken() && res?.role === "viewer") {
@@ -251,6 +256,7 @@ export class WsClient {
           this.onAuthFailure?.();
           return;
         }
+        this.intentionalClose = true;
         this.ws?.close();
       }
     }
@@ -329,11 +335,11 @@ export class WsClient {
   private scheduleReconnect(): void {
     if (this.reconnectTimer) return;
 
+    this.reconnectAttempts++;
     const delay = Math.min(
       this.baseReconnectDelay * Math.pow(2, this.reconnectAttempts),
       this.maxReconnectDelay,
     );
-    this.reconnectAttempts++;
 
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;

--- a/ui/web/src/components/graph/sigma-graph-container.tsx
+++ b/ui/web/src/components/graph/sigma-graph-container.tsx
@@ -166,7 +166,7 @@ export function SigmaGraphContainer({
         onSigmaReady?.(null);
       }
     };
-  }, [graph, edgeType, compact]);  
+  }, [graph, edgeType, compact, setSigmaRef]);
 
   // --- Update theme colors without re-init ---
   useEffect(() => {

--- a/ui/web/src/components/graph/sigma-graph-search.tsx
+++ b/ui/web/src/components/graph/sigma-graph-search.tsx
@@ -36,13 +36,15 @@ export function SigmaGraphSearch({ sigma, graph, onNodeSelect, placeholder = "Se
       }
       const lower = q.toLowerCase();
       const matches: SearchResult[] = [];
-      graph.forEachNode((node, attrs) => {
-        if (matches.length >= 10) return;
+      const nodes = graph.nodes();
+      for (let i = 0; i < nodes.length && matches.length < 10; i++) {
+        const node = nodes[i]!;
+        const attrs = graph.getNodeAttributes(node);
         const label = (attrs.label as string) || "";
         if (label.toLowerCase().includes(lower)) {
           matches.push({ id: node, label, color: attrs.color as string });
         }
-      });
+      }
       setResults(matches);
       setOpen(matches.length > 0);
       setActiveIndex(0);

--- a/ui/web/src/components/layout/app-layout.tsx
+++ b/ui/web/src/components/layout/app-layout.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Outlet, useLocation } from "react-router";
 import { WifiOff } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -28,6 +29,13 @@ export function AppLayout() {
   const setMobileSidebarOpen = useUiStore((s) => s.setMobileSidebarOpen);
   const connected = useAuthStore((s) => s.connected);
   const isMobile = useIsTablet();
+
+  // Close mobile sidebar on route change (e.g. programmatic navigation, back button)
+  useEffect(() => {
+    if (isMobile && mobileSidebarOpen) {
+      setMobileSidebarOpen(false);
+    }
+  }, [location.pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="flex h-dvh overflow-hidden safe-top">

--- a/ui/web/src/components/layout/sidebar.tsx
+++ b/ui/web/src/components/layout/sidebar.tsx
@@ -84,7 +84,7 @@ export function Sidebar({ collapsed, onNavItemClick }: SidebarProps) {
       <nav className="flex-1 space-y-4 overflow-y-auto px-2 py-4">
         <SidebarGroup label={t("groups.core")} collapsed={collapsed}>
           <SidebarItem to={ROUTES.OVERVIEW} icon={LayoutDashboard} label={t("nav.overview")} collapsed={collapsed} />
-          <SidebarItem to="/chat" icon={MessageSquare} label={t("nav.chat")} collapsed={collapsed} />
+          <SidebarItem to={ROUTES.CHAT} icon={MessageSquare} label={t("nav.chat")} collapsed={collapsed} />
           <SidebarItem to={ROUTES.AGENTS} icon={Bot} label={t("nav.agents")} collapsed={collapsed} />
           <SidebarItem to={ROUTES.TEAMS} icon={Users} label={t("nav.agentTeams")} collapsed={collapsed} />
         </SidebarGroup>

--- a/ui/web/src/components/providers/ws-provider.tsx
+++ b/ui/web/src/components/providers/ws-provider.tsx
@@ -76,6 +76,7 @@ export function WsProvider({ children }: { children: React.ReactNode }) {
             });
         }
         if (state === "disconnected") {
+          store.setRole("");
           store.setTenant("", "", "", false);
           store.setAvailableTenants([]);
           store.setTenantSelected(false);

--- a/ui/web/src/components/shared/search-input.tsx
+++ b/ui/web/src/components/shared/search-input.tsx
@@ -2,7 +2,7 @@ import { Search } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { useDebounce } from "@/hooks/use-debounce";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 interface SearchInputProps {
   value: string;
@@ -22,10 +22,12 @@ export function SearchInput({
   const { t } = useTranslation("common");
   const [local, setLocal] = useState(value);
   const debounced = useDebounce(local, delay);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
 
   useEffect(() => {
-    onChange(debounced);
-  }, [debounced, onChange]);
+    onChangeRef.current(debounced);
+  }, [debounced]);
 
   useEffect(() => {
     setLocal(value);

--- a/ui/web/src/pages/activity/hooks/use-activity.ts
+++ b/ui/web/src/pages/activity/hooks/use-activity.ts
@@ -42,8 +42,8 @@ export function useActivity() {
         if (filters?.action) params.action = filters.action;
         if (filters?.entity_type) params.entity_type = filters.entity_type;
         if (filters?.actor_id) params.actor_id = filters.actor_id;
-        if (filters?.limit) params.limit = String(filters.limit);
-        if (filters?.offset) params.offset = String(filters.offset);
+        if (filters?.limit !== undefined) params.limit = String(filters.limit);
+        if (filters?.offset !== undefined) params.offset = String(filters.offset);
 
         const res = await http.get<ActivityListResponse>("/v1/activity", params);
         setLogs(res.logs ?? []);

--- a/ui/web/src/pages/agents/hooks/use-agents.ts
+++ b/ui/web/src/pages/agents/hooks/use-agents.ts
@@ -47,9 +47,9 @@ export function useAgents() {
         max_tool_iterations: 0,
         workspace: "",
         restrict_to_workspace: false,
-        agent_type: "open" as const,
+        agent_type: (a as unknown as { agentType?: string }).agentType === "predefined" ? "predefined" as const : "open" as const,
         is_default: false,
-        status: a.isRunning ? "running" : "idle",
+        status: a.isRunning ? "active" : "inactive",
       }));
     },
     staleTime: 60_000,

--- a/ui/web/src/pages/channels/channel-detail/channel-advanced-dialog.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-advanced-dialog.tsx
@@ -65,7 +65,7 @@ export function ChannelAdvancedDialog({
     if (!open) return;
     setValues(deriveInitialValues(instance));
      
-  }, [open]);
+  }, [open, instance]);
 
   const handleChange = useCallback((key: string, value: unknown) => {
     setValues((prev) => ({ ...prev, [key]: value }));

--- a/ui/web/src/pages/channels/channel-detail/channel-detail-dialogs.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-detail-dialogs.tsx
@@ -67,7 +67,7 @@ export function ChannelDetailDialogs({
           confirmValue={instance.display_name || instance.name}
           confirmLabel={t("delete.confirmLabel")}
           onConfirm={async () => {
-            onDelete({
+            await onDelete({
               id: instance.id,
               name: instance.display_name || instance.name,
             });

--- a/ui/web/src/pages/chat/chat-page.tsx
+++ b/ui/web/src/pages/chat/chat-page.tsx
@@ -125,7 +125,7 @@ export function ChatPage() {
         navigate("/chat");
       }
     },
-    [navigate, sessionKey],
+    [navigate],
   );
 
   const handleSend = useCallback(

--- a/ui/web/src/pages/config/sections/behavior-section.tsx
+++ b/ui/web/src/pages/config/sections/behavior-section.tsx
@@ -83,9 +83,13 @@ export function BehaviorSection({ config, onPatch, saving }: Props) {
     (v: T) => { setter(v); setDirty(true); };
 
   const handleSave = () => {
+    // Strip masked/secret values to avoid overwriting real secrets with "***"
+    const gwClean = Object.fromEntries(
+      Object.entries(gw).filter(([, v]) => typeof v !== "string" || v !== "***"),
+    );
     onPatch({
       gateway: {
-        ...gw,
+        ...gwClean,
         tool_status: ux.tool_status,
         block_reply: ux.block_reply,
         max_message_chars: rate.max_message_chars,

--- a/ui/web/src/pages/cron/cron-detail/cron-advanced-dialog.tsx
+++ b/ui/web/src/pages/cron/cron-detail/cron-advanced-dialog.tsx
@@ -87,7 +87,7 @@ export function CronAdvancedDialog({ open, onOpenChange, job, onUpdate }: CronAd
     reset(deriveDefaults(job));
     fetchTargets();
      
-  }, [open]);
+  }, [open, job, reset, fetchTargets]);
 
   const handleSave = async () => {
     if (!onUpdate) {

--- a/ui/web/src/pages/cron/cron-detail/cron-overview-tab.tsx
+++ b/ui/web/src/pages/cron/cron-detail/cron-overview-tab.tsx
@@ -96,18 +96,20 @@ export function CronOverviewTab({ job, onUpdate }: CronOverviewTabProps) {
       } else {
         schedule = { kind: "at" as const, atMs: job.schedule.atMs ?? Date.now() + 60000, tz: timezone !== "UTC" ? timezone : "" };
       }
-      await onUpdate(job.id, {
+      const patch: import("../hooks/use-cron").CronJobPatch = {
         schedule,
         message: message.trim(),
         agentId: agentId.trim() || "",
-        enabled,
         deliver,
         deliverChannel: deliver ? channel.trim() || undefined : undefined,
         deliverTo: deliver ? to.trim() || undefined : undefined,
         wakeHeartbeat,
         deleteAfterRun,
         stateless,
-      });
+      };
+      // Only include enabled in patch if it actually changed to avoid unintended toggles
+      if (enabled !== job.enabled) patch.enabled = enabled;
+      await onUpdate(job.id, patch);
       setEditingMessage(false);
     } catch {
       // toast shown by hook

--- a/ui/web/src/pages/events/events-page.tsx
+++ b/ui/web/src/pages/events/events-page.tsx
@@ -58,7 +58,7 @@ export function EventsPage() {
       if (!teamId) return t("global");
       return teamMap.get(teamId) ?? teamId.slice(0, 8);
     },
-    [teamMap],
+    [teamMap, t],
   );
 
   // Unique teams from events for filter dropdown
@@ -118,7 +118,7 @@ export function EventsPage() {
           e.event.startsWith("team.member."),
       );
     }
-    return userFilteredEvents.filter((e) => e.event.startsWith(categoryFilter));
+    return chatFilteredEvents.filter((e) => e.event.startsWith(categoryFilter));
   }, [chatFilteredEvents, categoryFilter]);
 
   // Auto-scroll to bottom when new events arrive

--- a/ui/web/src/pages/mcp/mcp-form-dialog.tsx
+++ b/ui/web/src/pages/mcp/mcp-form-dialog.tsx
@@ -89,7 +89,7 @@ export function MCPFormDialog({ open, onOpenChange, server, onSubmit, onTest }: 
         url: server?.url ?? "",
         headers: server?.headers ?? {},
         env: server?.env ?? {},
-        toolPrefix: (server?.tool_prefix ?? "").replace(/^mcp_/, ""),
+        toolPrefix: server?.tool_prefix ?? "",
         timeout: server?.timeout_sec ?? 60,
         enabled: server?.enabled ?? true,
         requireUserCreds: server?.settings?.require_user_credentials ?? false,
@@ -160,7 +160,7 @@ export function MCPFormDialog({ open, onOpenChange, server, onSubmit, onTest }: 
       });
       onOpenChange(false);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : t("form.saving"));
+      setError(err instanceof Error ? err.message : t("form.errors.saveFailed", "Save failed"));
     } finally {
       setLoading(false);
     }

--- a/ui/web/src/pages/memory/hooks/use-episodic.ts
+++ b/ui/web/src/pages/memory/hooks/use-episodic.ts
@@ -13,8 +13,8 @@ export function useEpisodicSummaries(agentId: string, opts: { userId?: string; l
   const params = useMemo(() => {
     const p: Record<string, string> = {};
     if (opts.userId) p.user_id = opts.userId;
-    if (opts.limit) p.limit = String(opts.limit);
-    if (opts.offset) p.offset = String(opts.offset);
+    if (opts.limit !== undefined) p.limit = String(opts.limit);
+    if (opts.offset !== undefined) p.offset = String(opts.offset);
     return p;
   }, [opts.userId, opts.limit, opts.offset]);
 

--- a/ui/web/src/pages/pending-messages/pending-messages-page.tsx
+++ b/ui/web/src/pages/pending-messages/pending-messages-page.tsx
@@ -38,6 +38,10 @@ export function PendingMessagesPage() {
 
   useEffect(() => {
     loadGroups();
+    return () => {
+      if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+      if (timeoutRef.current) { clearTimeout(timeoutRef.current); timeoutRef.current = null; }
+    };
   }, [loadGroups]);
 
   // Clear spinner as soon as the compacting group's has_summary becomes true

--- a/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
@@ -76,7 +76,7 @@ export function ProviderAdvancedDialog({
     setAcpPermMode(s.acpPermMode);
     setAcpWorkDir(s.acpWorkDir);
      
-  }, [open]);
+  }, [open, provider]);
 
   const [saving, setSaving] = useState(false);
 

--- a/ui/web/src/pages/sessions/session-detail-page.tsx
+++ b/ui/web/src/pages/sessions/session-detail-page.tsx
@@ -253,7 +253,6 @@ export function SessionDetailPage({
         onConfirm={async () => {
           await onDelete(session.key);
           setConfirmDelete(false);
-          onBack();
         }}
       />
 

--- a/ui/web/src/pages/sessions/session-message-blocks.tsx
+++ b/ui/web/src/pages/sessions/session-message-blocks.tsx
@@ -52,7 +52,12 @@ export function SummaryBlock({ text }: { text: string }) {
 
   useLayoutEffect(() => {
     if (contentRef.current) {
-      setNeedsTruncation(contentRef.current.scrollHeight > SUMMARY_MAX_HEIGHT);
+      // Temporarily remove max-height to measure true content height
+      const el = contentRef.current;
+      const prev = el.style.maxHeight;
+      el.style.maxHeight = "none";
+      setNeedsTruncation(el.scrollHeight > SUMMARY_MAX_HEIGHT);
+      el.style.maxHeight = prev;
     }
   }, [text]);
 
@@ -62,7 +67,7 @@ export function SummaryBlock({ text }: { text: string }) {
       <div
         ref={contentRef}
         className="mt-1 overflow-hidden transition-[max-height] duration-200"
-        style={{ maxHeight: expanded ? contentRef.current?.scrollHeight : SUMMARY_MAX_HEIGHT }}
+        style={{ maxHeight: expanded ? (contentRef.current?.scrollHeight ?? "none") : SUMMARY_MAX_HEIGHT }}
       >
         {text}
       </div>

--- a/ui/web/src/pages/skills/skill-table-row.tsx
+++ b/ui/web/src/pages/skills/skill-table-row.tsx
@@ -46,7 +46,7 @@ export function SkillTableRow({
           <button
             type="button"
             className="font-medium text-left hover:underline cursor-pointer"
-            onClick={() => onView(skill.slug ?? skill.name)}
+            onClick={() => onView(skill.name)}
           >
             {skill.name}
           </button>

--- a/ui/web/src/pages/storage/hooks/use-storage.ts
+++ b/ui/web/src/pages/storage/hooks/use-storage.ts
@@ -36,6 +36,8 @@ export function useStorage() {
       const res = await http.get<StorageListResponse>("/v1/storage/files");
       setFiles(res.files ?? []);
       setBaseDir(res.baseDir ?? "");
+    } catch (err) {
+      toast.error(i18next.t("storage:toast.loadFailed", "Failed to load files"), userFriendlyError(err));
     } finally {
       if (!opts?.silent) setLoading(false);
     }

--- a/ui/web/src/pages/teams/team-settings-tab.tsx
+++ b/ui/web/src/pages/teams/team-settings-tab.tsx
@@ -126,7 +126,7 @@ export function TeamSettingsTab({ teamId, team, onSaved }: TeamSettingsTabProps)
     } finally {
       setSaving(false);
     }
-  }, [teamId, form, escalationMode, escalationActions, updateTeamSettings, onSaved]);
+  }, [teamId, form, initial, escalationMode, escalationActions, updateTeamSettings, onSaved]);
 
   const channelOptions = CHANNEL_TYPES.map((c) => ({ value: c.value, label: c.label }));
 

--- a/ui/web/src/pages/teams/team-settings-tab.tsx
+++ b/ui/web/src/pages/teams/team-settings-tab.tsx
@@ -94,6 +94,8 @@ export function TeamSettingsTab({ teamId, team, onSaved }: TeamSettingsTabProps)
     try {
       const data = form.getValues();
       const settings: TeamAccessSettings = {};
+      // Preserve version from existing settings to prevent v2→v1 downgrade
+      if (initial.version !== undefined) settings.version = initial.version;
       if (data.allowUserIds.length > 0) settings.allow_user_ids = data.allowUserIds;
       if (data.denyUserIds.length > 0) settings.deny_user_ids = data.denyUserIds;
       if (data.allowChannels.length > 0) settings.allow_channels = data.allowChannels;
@@ -109,16 +111,14 @@ export function TeamSettingsTab({ teamId, team, onSaved }: TeamSettingsTabProps)
         new_task: data.notifyNewTask,
       };
       settings.notifications = notifications;
-      if (data.memberRequestsEnabled) {
-        settings.member_requests = { enabled: true, auto_dispatch: data.memberRequestsAutoDispatch };
-      }
+      settings.member_requests = { enabled: data.memberRequestsEnabled, auto_dispatch: data.memberRequestsAutoDispatch };
       if (escalationMode) {
         settings.escalation_mode = escalationMode;
         if (escalationActions.length > 0) settings.escalation_actions = escalationActions;
       }
       settings.blocker_escalation = { enabled: data.blockerEscalationEnabled };
-      if (data.followupInterval !== 30) settings.followup_interval_minutes = data.followupInterval;
-      if (data.followupMaxReminders !== 0) settings.followup_max_reminders = data.followupMaxReminders;
+      settings.followup_interval_minutes = data.followupInterval;
+      settings.followup_max_reminders = data.followupMaxReminders;
       settings.workspace_scope = data.workspaceScope || "isolated";
       await updateTeamSettings(teamId, settings);
       onSaved();

--- a/ui/web/src/pages/vault/hooks/use-vault.ts
+++ b/ui/web/src/pages/vault/hooks/use-vault.ts
@@ -28,8 +28,8 @@ export function useVaultDocuments(agentId: string, opts: VaultListOpts) {
     if (opts.scope) p.scope = opts.scope;
     if (opts.docType) p.doc_type = opts.docType;
     if (opts.teamId) p.team_id = opts.teamId;
-    if (opts.limit) p.limit = String(opts.limit);
-    if (opts.offset) p.offset = String(opts.offset);
+    if (opts.limit !== undefined) p.limit = String(opts.limit);
+    if (opts.offset !== undefined) p.offset = String(opts.offset);
     return p;
   }, [agentId, opts.scope, opts.docType, opts.teamId, opts.limit, opts.offset]);
 

--- a/ui/web/src/pages/vault/vault-search-dialog.tsx
+++ b/ui/web/src/pages/vault/vault-search-dialog.tsx
@@ -25,6 +25,12 @@ export function VaultSearchDialog({ agentId, open, onOpenChange, onSelectResult 
   const [results, setResults] = useState<VaultSearchResult[]>([]);
   const [searching, setSearching] = useState(false);
 
+  // Clear stale results when dialog closes
+  const handleOpenChange = useCallback((v: boolean) => {
+    if (!v) { setQuery(""); setResults([]); }
+    onOpenChange(v);
+  }, [onOpenChange]);
+
   const handleSearch = useCallback(async () => {
     if (!query.trim()) return;
     setSearching(true);
@@ -39,7 +45,7 @@ export function VaultSearchDialog({ agentId, open, onOpenChange, onSelectResult 
   }, [query, search]);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-lg max-sm:inset-0">
         <DialogHeader>
           <DialogTitle>{t("search")}</DialogTitle>

--- a/ui/web/src/pages/vault/vault-search-dialog.tsx
+++ b/ui/web/src/pages/vault/vault-search-dialog.tsx
@@ -79,7 +79,7 @@ export function VaultSearchDialog({ agentId, open, onOpenChange, onSelectResult 
                   className="w-full text-left p-2 rounded hover:bg-muted/50 flex items-center justify-between gap-2"
                   onClick={() => {
                     onSelectResult(r.document);
-                    onOpenChange(false);
+                    handleOpenChange(false);
                   }}
                 >
                   <div className="min-w-0">


### PR DESCRIPTION
## Summary

Comprehensive UI bug fix pass covering 28 files across the web dashboard:

**Critical (5):**
- Team settings save now preserves `version` field (prevents v2→v1 Super Team downgrade)
- Backend `teamAccessSettings` whitelist now includes `blocker_escalation` and `notifications.slow_tool` (previously silently stripped on save)
- Cron overview tab only sends `enabled` in patch when actually changed (prevents unintended job toggles)
- MCP form no longer strips `mcp_` prefix from `tool_prefix` on edit (was silently breaking all agent tool references)
- WS client prevents duplicate pairing modals on reconnect via `pairingInProgress` guard

**Medium (20):**
- Events page category filter was reading from wrong filtered source (`userFilteredEvents` → `chatFilteredEvents`)
- Config behavior section was spreading masked `"***"` token back to server, corrupting gateway auth
- Agent WS fallback mapped status to `"running"/"idle"` instead of `"active"/"inactive"`, breaking TeamCreateDialog filters
- `offset=0` silently dropped in activity/vault/episodic hooks (truthiness check on number)
- Channel/provider/cron dialog `useEffect` deps missing `instance`/`provider`/`job` — stale forms
- Mobile sidebar not closing on programmatic navigation (back button, `navigate()`)
- WS `role` not cleared on disconnect; non-revocation auth failures caused infinite reconnect loop
- `SearchInput` `onChange` ref instability caused spurious search calls on every parent re-render
- Pending messages poll/timeout intervals not cleaned up on component unmount
- `SummaryBlock` "Show more" button never appeared (CSS `max-height` clamped `scrollHeight` measurement)
- Session delete double-navigate pushed spurious history entry
- Channel delete `onConfirm` not awaiting async `onDelete`
- Skill view button passed `slug` instead of `name` to backend lookup
- Storage `listFiles` silently swallowed API errors with no user feedback
- Graph search `forEachNode` early-return didn't stop iteration on large graphs

**Low (5):**
- Removed unused `sessionKey` from `handleAgentChange` deps
- Sidebar Chat link now uses `ROUTES.CHAT` constant instead of hardcoded string
- WS reconnect backoff off-by-one (first retry always used minimum delay)
- Cron advanced dialog useEffect missing `job`/`reset`/`fetchTargets` deps
- Vault search dialog now clears stale results on close

## Test plan

- [x] Frontend type-check passes (`pnpm exec tsc --noEmit` — only pre-existing graphology/sigma type errors)
- [x] Docker build + deploy successful (`gup`)
- [x] Backend Go struct change verified (teams_crud.go `teamAccessSettings` whitelist)
- [ ] Manual: verify team settings save preserves v2 version
- [ ] Manual: verify MCP server edit preserves `mcp_` prefix in `tool_prefix`
- [ ] Manual: verify cron job save doesn't toggle enabled state
- [ ] Manual: verify events page combined category+chat filter works correctly