### PR TITLE
fix(facebook): preserve fb_mode in outbound routing + admin reply detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ compose.d/*
 /mise.*.toml
 /mise
 /.mise
+goclaw-patched-linux-amd64

--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -220,6 +220,7 @@ func processNormalMessage(
 			outMeta["reply_to_message_id"] = mid
 		}
 	}
+	// Channel routing keys — keep in sync with routingMetaKeys in channels/events.go.
 	for _, k := range []string{
 		tools.MetaMessageThreadID, "local_key", "placeholder_key", "group_id",
 		"feishu_reply_target_id",

--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -220,7 +220,11 @@ func processNormalMessage(
 			outMeta["reply_to_message_id"] = mid
 		}
 	}
-	for _, k := range []string{tools.MetaMessageThreadID, "local_key", "placeholder_key", "group_id", "feishu_reply_target_id"} {
+	for _, k := range []string{
+		tools.MetaMessageThreadID, "local_key", "placeholder_key", "group_id",
+		"feishu_reply_target_id",
+		"fb_mode", "sender_id", "page_id", "reply_to_comment_id",
+	} {
 		if v := msg.Metadata[k]; v != "" {
 			outMeta[k] = v
 		}

--- a/internal/channels/events.go
+++ b/internal/channels/events.go
@@ -346,6 +346,10 @@ func extractPayloadString(payload any, key string) string {
 	return ""
 }
 
+// routingMetaKeys enumerates the metadata keys that must survive the hop from
+// inbound RunContext.Metadata into outbound OutboundMessage.Metadata so that
+// replies, block replies, retries, and placeholder updates all land in the
+// correct thread / topic / subgroup routing bucket on each channel.
 var routingMetaKeys = []string{
 	"message_thread_id",      // telegram forum topics
 	"local_key",              // composite chat-id suffix
@@ -357,6 +361,8 @@ var routingMetaKeys = []string{
 	"reply_to_comment_id",    // facebook comment reply target
 }
 
+// copyRoutingMeta copies channel routing metadata from RunContext.Metadata
+// into a new map suitable for outbound messages.
 func copyRoutingMeta(src map[string]string) map[string]string {
 	out := make(map[string]string)
 	for _, k := range routingMetaKeys {

--- a/internal/channels/events.go
+++ b/internal/channels/events.go
@@ -346,19 +346,17 @@ func extractPayloadString(payload any, key string) string {
 	return ""
 }
 
-// routingMetaKeys enumerates the metadata keys that must survive the hop from
-// inbound RunContext.Metadata into outbound OutboundMessage.Metadata so that
-// replies, block replies, retries, and placeholder updates all land in the
-// correct thread / topic / subgroup routing bucket on each channel.
 var routingMetaKeys = []string{
 	"message_thread_id",      // telegram forum topics
 	"local_key",              // composite chat-id suffix
 	"group_id",               // legacy group identifier
-	"feishu_reply_target_id", // feishu/lark thread reply routing (issue #818)
+	"feishu_reply_target_id", // feishu/lark thread reply routing
+	"fb_mode",                // facebook messenger vs comment routing
+	"sender_id",              // facebook sender for first-inbox
+	"page_id",                // facebook page routing
+	"reply_to_comment_id",    // facebook comment reply target
 }
 
-// copyRoutingMeta copies channel routing metadata from RunContext.Metadata
-// into a new map suitable for outbound messages.
 func copyRoutingMeta(src map[string]string) map[string]string {
 	out := make(map[string]string)
 	for _, k := range routingMetaKeys {

--- a/internal/channels/facebook/facebook.go
+++ b/internal/channels/facebook/facebook.go
@@ -42,6 +42,14 @@ type Channel struct {
 	// firstInboxSent tracks which senders have already received a first-inbox DM (in-memory).
 	firstInboxSent sync.Map // senderID(string) → struct{}
 
+	// adminReplied tracks conversations where admin (page) sent a message recently.
+	// Bot skips auto-reply for these conversations to avoid duplicate responses.
+	adminReplied sync.Map // chatID(string) → time.Time
+
+	// botSentAt tracks when bot last sent a reply to each conversation.
+	// Used to distinguish bot replies from admin replies in Graph API checks.
+	botSentAt sync.Map // chatID(string) → time.Time
+
 	// postFetcher caches post content to enrich comment context.
 	postFetcher *PostFetcher
 
@@ -156,12 +164,44 @@ func (ch *Channel) Stop(_ context.Context) error {
 	return nil
 }
 
+// adminRepliedAfterBot checks if an admin (human) replied to this conversation
+// after the bot's last reply. Calls Graph API to get the last page message,
+// then compares its timestamp with our last bot-sent time. If the page message
+// is newer than our last send → admin replied → skip bot.
+func (ch *Channel) adminRepliedAfterBot(chatID string) bool {
+	lastPageMsg := ch.graphClient.LastPageMessageTime(ch.stopCtx, chatID)
+	if lastPageMsg.IsZero() {
+		return false // no page message found → no admin reply
+	}
+
+	// Check if we (bot) sent around that time
+	if val, ok := ch.botSentAt.Load(chatID); ok {
+		botTime := val.(time.Time)
+		// If page message is within 60s of bot send → it's our bot reply, not admin
+		if lastPageMsg.Sub(botTime).Abs() < 60*time.Second {
+			return false
+		}
+	}
+
+	// Page message exists and doesn't match our bot send time → admin replied
+	slog.Debug("facebook: admin reply detected via Graph API",
+		"chat_id", chatID, "page_msg_time", lastPageMsg.Format(time.RFC3339))
+	return true
+}
+
 // Send delivers an outbound message. Dispatches to comment reply or Messenger based on fb_mode metadata.
 func (ch *Channel) Send(ctx context.Context, msg bus.OutboundMessage) error {
 	mode := msg.Metadata["fb_mode"]
 
 	switch mode {
 	case "messenger":
+		// Skip bot reply if admin replied after bot's last send.
+		if ch.adminRepliedAfterBot(msg.ChatID) {
+			slog.Info("facebook: skipping bot reply (admin already responded)",
+				"chat_id", msg.ChatID)
+			return nil
+		}
+
 		text := FormatForMessenger(msg.Content)
 		parts := splitMessage(text, messengerMaxChars)
 		for _, part := range parts {
@@ -170,6 +210,8 @@ func (ch *Channel) Send(ctx context.Context, msg bus.OutboundMessage) error {
 				return err
 			}
 		}
+		// Record that bot sent a reply (to distinguish from admin in future checks).
+		ch.botSentAt.Store(msg.ChatID, time.Now())
 
 	default: // "comment"
 		commentID := msg.Metadata["reply_to_comment_id"]

--- a/internal/channels/facebook/facebook.go
+++ b/internal/channels/facebook/facebook.go
@@ -25,7 +25,7 @@ const (
 	dedupTTL           = 24 * time.Hour  // matches Facebook's max retry window
 	dedupCleanEvery    = 5 * time.Minute // how often to evict stale dedup entries
 	adminReplyCooldown = 5 * time.Minute
-	botEchoWindow      = 60 * time.Second
+	botEchoWindow      = 15 * time.Second
 )
 
 // Channel implements channels.Channel and channels.WebhookChannel for Facebook Fanpage.
@@ -286,7 +286,8 @@ func (ch *Channel) sendFirstInbox(ctx context.Context, senderID string) {
 	}
 }
 
-// runDedupCleaner evicts dedup entries older than dedupTTL every dedupCleanEvery.
+// runDedupCleaner evicts stale entries from dedup, adminReplied, and botSentAt
+// maps every dedupCleanEvery to prevent unbounded memory growth.
 func (ch *Channel) runDedupCleaner() {
 	ticker := time.NewTicker(dedupCleanEvery)
 	defer ticker.Stop()
@@ -299,6 +300,18 @@ func (ch *Channel) runDedupCleaner() {
 			ch.dedup.Range(func(k, v any) bool {
 				if t, ok := v.(time.Time); ok && now.Sub(t) > dedupTTL {
 					ch.dedup.Delete(k)
+				}
+				return true
+			})
+			ch.adminReplied.Range(func(k, v any) bool {
+				if t, ok := v.(time.Time); ok && now.Sub(t) > adminReplyCooldown {
+					ch.adminReplied.Delete(k)
+				}
+				return true
+			})
+			ch.botSentAt.Range(func(k, v any) bool {
+				if t, ok := v.(time.Time); ok && now.Sub(t) > botEchoWindow {
+					ch.botSentAt.Delete(k)
 				}
 				return true
 			})

--- a/internal/channels/facebook/facebook.go
+++ b/internal/channels/facebook/facebook.go
@@ -21,9 +21,11 @@ var (
 )
 
 const (
-	webhookPath     = "/channels/facebook/webhook"
-	dedupTTL        = 24 * time.Hour  // matches Facebook's max retry window
-	dedupCleanEvery = 5 * time.Minute // how often to evict stale dedup entries
+	webhookPath        = "/channels/facebook/webhook"
+	dedupTTL           = 24 * time.Hour  // matches Facebook's max retry window
+	dedupCleanEvery    = 5 * time.Minute // how often to evict stale dedup entries
+	adminReplyCooldown = 5 * time.Minute
+	botEchoWindow      = 60 * time.Second
 )
 
 // Channel implements channels.Channel and channels.WebhookChannel for Facebook Fanpage.
@@ -156,37 +158,42 @@ func (ch *Channel) Start(ctx context.Context) error {
 // Stop gracefully shuts down the channel.
 func (ch *Channel) Stop(_ context.Context) error {
 	globalRouter.unregister(ch.pageID)
-	ch.stopFn()           // cancel stopCtx → cancels inflight Graph API calls
-	close(ch.stopCh)      // stop background goroutines
+	ch.stopFn()      // cancel stopCtx → cancels inflight Graph API calls
+	close(ch.stopCh) // stop background goroutines
 	ch.SetRunning(false)
 	ch.MarkStopped("stopped")
 	slog.Info("facebook channel stopped", "page_id", ch.pageID, "name", ch.Name())
 	return nil
 }
 
-// adminRepliedAfterBot checks if an admin (human) replied to this conversation
-// after the bot's last reply. Calls Graph API to get the last page message,
-// then compares its timestamp with our last bot-sent time. If the page message
-// is newer than our last send → admin replied → skip bot.
-func (ch *Channel) adminRepliedAfterBot(chatID string) bool {
-	lastPageMsg := ch.graphClient.LastPageMessageTime(ch.stopCtx, chatID)
-	if lastPageMsg.IsZero() {
-		return false // no page message found → no admin reply
+func (ch *Channel) adminRepliedRecently(chatID string, now time.Time) bool {
+	val, ok := ch.adminReplied.Load(chatID)
+	if !ok {
+		return false
 	}
-
-	// Check if we (bot) sent around that time
-	if val, ok := ch.botSentAt.Load(chatID); ok {
-		botTime := val.(time.Time)
-		// If page message is within 60s of bot send → it's our bot reply, not admin
-		if lastPageMsg.Sub(botTime).Abs() < 60*time.Second {
-			return false
-		}
+	repliedAt, ok := val.(time.Time)
+	if !ok {
+		ch.adminReplied.Delete(chatID)
+		return false
 	}
+	if now.Sub(repliedAt) < adminReplyCooldown {
+		return true
+	}
+	ch.adminReplied.Delete(chatID)
+	return false
+}
 
-	// Page message exists and doesn't match our bot send time → admin replied
-	slog.Debug("facebook: admin reply detected via Graph API",
-		"chat_id", chatID, "page_msg_time", lastPageMsg.Format(time.RFC3339))
-	return true
+func (ch *Channel) isBotEcho(chatID string, eventAt time.Time) bool {
+	val, ok := ch.botSentAt.Load(chatID)
+	if !ok {
+		return false
+	}
+	sentAt, ok := val.(time.Time)
+	if !ok {
+		ch.botSentAt.Delete(chatID)
+		return false
+	}
+	return eventAt.Sub(sentAt).Abs() < botEchoWindow
 }
 
 // Send delivers an outbound message. Dispatches to comment reply or Messenger based on fb_mode metadata.
@@ -195,8 +202,7 @@ func (ch *Channel) Send(ctx context.Context, msg bus.OutboundMessage) error {
 
 	switch mode {
 	case "messenger":
-		// Skip bot reply if admin replied after bot's last send.
-		if ch.adminRepliedAfterBot(msg.ChatID) {
+		if ch.adminRepliedRecently(msg.ChatID, time.Now()) {
 			slog.Info("facebook: skipping bot reply (admin already responded)",
 				"chat_id", msg.ChatID)
 			return nil
@@ -204,14 +210,20 @@ func (ch *Channel) Send(ctx context.Context, msg bus.OutboundMessage) error {
 
 		text := FormatForMessenger(msg.Content)
 		parts := splitMessage(text, messengerMaxChars)
+		sentAt := time.Now()
+		ch.botSentAt.Store(msg.ChatID, sentAt)
+		sentAny := false
 		for _, part := range parts {
 			if _, err := ch.graphClient.SendMessage(ctx, msg.ChatID, part); err != nil {
+				if !sentAny {
+					ch.botSentAt.Delete(msg.ChatID)
+				}
 				ch.handleAPIError(err)
 				return err
 			}
+			sentAny = true
+			ch.botSentAt.Store(msg.ChatID, time.Now())
 		}
-		// Record that bot sent a reply (to distinguish from admin in future checks).
-		ch.botSentAt.Store(msg.ChatID, time.Now())
 
 	default: // "comment"
 		commentID := msg.Metadata["reply_to_comment_id"]
@@ -299,4 +311,3 @@ func (ch *Channel) isDup(key string) bool {
 	_, loaded := ch.dedup.LoadOrStore(key, time.Now())
 	return loaded
 }
-

--- a/internal/channels/facebook/graph_api.go
+++ b/internal/channels/facebook/graph_api.go
@@ -168,6 +168,43 @@ func (g *GraphClient) SendMessage(ctx context.Context, recipientID, message stri
 	return result.MessageID, nil
 }
 
+// LastPageMessageTime returns the timestamp of the most recent message sent by
+// the page in a conversation with recipientID. Returns zero time if none found.
+func (g *GraphClient) LastPageMessageTime(ctx context.Context, recipientID string) time.Time {
+	path := fmt.Sprintf("/me/conversations?user_id=%s&fields=messages.limit(3){from,created_time}", recipientID)
+	data, err := g.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		slog.Debug("facebook: last message check failed", "recipient", recipientID, "error", err)
+		return time.Time{}
+	}
+	var result struct {
+		Data []struct {
+			Messages struct {
+				Data []struct {
+					From struct {
+						ID string `json:"id"`
+					} `json:"from"`
+					CreatedTime string `json:"created_time"`
+				} `json:"data"`
+			} `json:"messages"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil || len(result.Data) == 0 {
+		return time.Time{}
+	}
+	// Find the most recent message from the page
+	for _, msg := range result.Data[0].Messages.Data {
+		if msg.From.ID == g.pageID {
+			t, err := time.Parse(time.RFC3339, msg.CreatedTime+"+0000")
+			if err != nil {
+				t, _ = time.Parse("2006-01-02T15:04:05+0000", msg.CreatedTime)
+			}
+			return t
+		}
+	}
+	return time.Time{}
+}
+
 // SendTypingOn sends a typing indicator to the recipient (auto-off after 3s).
 func (g *GraphClient) SendTypingOn(ctx context.Context, recipientID string) error {
 	body := map[string]any{

--- a/internal/channels/facebook/graph_api.go
+++ b/internal/channels/facebook/graph_api.go
@@ -168,43 +168,6 @@ func (g *GraphClient) SendMessage(ctx context.Context, recipientID, message stri
 	return result.MessageID, nil
 }
 
-// LastPageMessageTime returns the timestamp of the most recent message sent by
-// the page in a conversation with recipientID. Returns zero time if none found.
-func (g *GraphClient) LastPageMessageTime(ctx context.Context, recipientID string) time.Time {
-	path := fmt.Sprintf("/me/conversations?user_id=%s&fields=messages.limit(3){from,created_time}", recipientID)
-	data, err := g.doRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		slog.Debug("facebook: last message check failed", "recipient", recipientID, "error", err)
-		return time.Time{}
-	}
-	var result struct {
-		Data []struct {
-			Messages struct {
-				Data []struct {
-					From struct {
-						ID string `json:"id"`
-					} `json:"from"`
-					CreatedTime string `json:"created_time"`
-				} `json:"data"`
-			} `json:"messages"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(data, &result); err != nil || len(result.Data) == 0 {
-		return time.Time{}
-	}
-	// Find the most recent message from the page
-	for _, msg := range result.Data[0].Messages.Data {
-		if msg.From.ID == g.pageID {
-			t, err := time.Parse(time.RFC3339, msg.CreatedTime+"+0000")
-			if err != nil {
-				t, _ = time.Parse("2006-01-02T15:04:05+0000", msg.CreatedTime)
-			}
-			return t
-		}
-	}
-	return time.Time{}
-}
-
 // SendTypingOn sends a typing indicator to the recipient (auto-off after 3s).
 func (g *GraphClient) SendTypingOn(ctx context.Context, recipientID string) error {
 	body := map[string]any{
@@ -398,4 +361,3 @@ func IsRateLimitError(err error) bool {
 	}
 	return ge.code == 4 || ge.code == 17 || ge.code == 32 || ge.code == 613
 }
-

--- a/internal/channels/facebook/handlers_test.go
+++ b/internal/channels/facebook/handlers_test.go
@@ -337,6 +337,98 @@ func TestSend_MessengerMode(t *testing.T) {
 	}
 }
 
+// TestHandleMessagingEvent_PageEchoDoesNotTrackAdminReply verifies webhook
+// echoes for bot-sent messages do not arm the admin-reply cooldown.
+func TestHandleMessagingEvent_PageEchoDoesNotTrackAdminReply(t *testing.T) {
+	cfg := facebookInstanceConfig{}
+	cfg.Features.MessengerAutoReply = true
+	ch := newTestChannel(t, "111", cfg)
+
+	now := time.Now()
+	ch.botSentAt.Store("user-1", now)
+
+	ch.handleMessagingEvent(WebhookEntry{ID: "111"}, MessagingEvent{
+		Sender:    FBUser{ID: "111"},
+		Recipient: FBUser{ID: "user-1"},
+		Timestamp: now.UnixMilli(),
+		Message:   &IncomingMessage{MID: "echo-1", Text: "bot reply"},
+	})
+
+	if _, ok := ch.adminReplied.Load("user-1"); ok {
+		t.Fatal("bot echo should not be tracked as admin reply")
+	}
+}
+
+// TestSend_MessengerModeSkipsWhenAdminReplyTracked verifies bot replies are
+// suppressed when an admin reply was observed recently via webhook.
+func TestSend_MessengerModeSkipsWhenAdminReplyTracked(t *testing.T) {
+	var sends int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sends++
+		_, _ = w.Write([]byte(`{"message_id":"mid"}`))
+	}))
+	t.Cleanup(srv.Close)
+	swapGraphBase(t, srv.URL)
+
+	mb := bus.New()
+	ch, _ := New(facebookInstanceConfig{PageID: "111"}, facebookCreds{
+		PageAccessToken: "t", AppSecret: "s", VerifyToken: "v",
+	}, mb, nil)
+	ch.adminReplied.Store("user-1", time.Now())
+
+	err := ch.Send(t.Context(), bus.OutboundMessage{
+		ChatID:   "user-1",
+		Content:  "hello",
+		Metadata: map[string]string{"fb_mode": "messenger"},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sends != 0 {
+		t.Fatalf("sends = %d, want 0 when admin already replied", sends)
+	}
+}
+
+// TestSend_MessengerModeDoesNotConsultGraphHistory verifies historical page
+// messages do not suppress replies after process restart.
+func TestSend_MessengerModeDoesNotConsultGraphHistory(t *testing.T) {
+	var gets, posts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet:
+			gets++
+			_, _ = w.Write([]byte(`{"data":[{"messages":{"data":[{"from":{"id":"111"},"created_time":"2026-04-13T00:00:00+0000"}]}}]}`))
+		case r.Method == http.MethodPost:
+			posts++
+			_, _ = w.Write([]byte(`{"message_id":"mid"}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	swapGraphBase(t, srv.URL)
+
+	mb := bus.New()
+	ch, _ := New(facebookInstanceConfig{PageID: "111"}, facebookCreds{
+		PageAccessToken: "t", AppSecret: "s", VerifyToken: "v",
+	}, mb, nil)
+
+	err := ch.Send(t.Context(), bus.OutboundMessage{
+		ChatID:   "user-1",
+		Content:  "hello",
+		Metadata: map[string]string{"fb_mode": "messenger"},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if gets != 0 {
+		t.Fatalf("unexpected graph history check: gets = %d, want 0", gets)
+	}
+	if posts != 1 {
+		t.Fatalf("posts = %d, want 1", posts)
+	}
+}
+
 // TestSend_CommentModeMissingMetadata verifies the comment path errors when
 // reply_to_comment_id metadata is absent.
 func TestSend_CommentModeMissingMetadata(t *testing.T) {

--- a/internal/channels/facebook/messenger_handler.go
+++ b/internal/channels/facebook/messenger_handler.go
@@ -6,8 +6,6 @@ import (
 	"time"
 )
 
-const adminReplyCooldown = 5 * time.Minute
-
 // handleMessagingEvent processes a Messenger inbox event.
 func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent) {
 	// Feature gate.
@@ -25,7 +23,12 @@ func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent
 	// conversation during the cooldown window.
 	if event.Sender.ID == ch.pageID {
 		if event.Recipient.ID != "" {
-			ch.adminReplied.Store(event.Recipient.ID, time.Now())
+			eventAt := messagingEventTime(event.Timestamp)
+			if ch.isBotEcho(event.Recipient.ID, eventAt) {
+				slog.Debug("facebook: bot echo ignored", "chat_id", event.Recipient.ID)
+				return
+			}
+			ch.adminReplied.Store(event.Recipient.ID, eventAt)
 			slog.Debug("facebook: admin reply tracked", "chat_id", event.Recipient.ID)
 		}
 		return
@@ -51,13 +54,14 @@ func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent
 
 	// Check if admin already replied to this conversation recently.
 	senderID := event.Sender.ID
-	if val, ok := ch.adminReplied.Load(senderID); ok {
-		if repliedAt, ok := val.(time.Time); ok && time.Since(repliedAt) < adminReplyCooldown {
-			slog.Info("facebook: skipping auto-reply (admin replied recently)",
-				"chat_id", senderID, "admin_replied_at", repliedAt.Format(time.RFC3339))
-			return
+	if ch.adminRepliedRecently(senderID, time.Now()) {
+		if val, ok := ch.adminReplied.Load(senderID); ok {
+			if repliedAt, ok := val.(time.Time); ok {
+				slog.Info("facebook: skipping auto-reply (admin replied recently)",
+					"chat_id", senderID, "admin_replied_at", repliedAt.Format(time.RFC3339))
+			}
 		}
-		ch.adminReplied.Delete(senderID)
+		return
 	}
 
 	// Extract text content.
@@ -86,4 +90,15 @@ func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent
 	}
 
 	ch.HandleMessage(senderID, chatID, content, nil, metadata, "direct")
+}
+
+func messagingEventTime(ts int64) time.Time {
+	switch {
+	case ts > 1_000_000_000_000:
+		return time.UnixMilli(ts)
+	case ts > 0:
+		return time.Unix(ts, 0)
+	default:
+		return time.Now()
+	}
 }

--- a/internal/channels/facebook/messenger_handler.go
+++ b/internal/channels/facebook/messenger_handler.go
@@ -3,7 +3,10 @@ package facebook
 import (
 	"fmt"
 	"log/slog"
+	"time"
 )
+
+const adminReplyCooldown = 5 * time.Minute
 
 // handleMessagingEvent processes a Messenger inbox event.
 func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent) {
@@ -17,8 +20,14 @@ func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent
 		return
 	}
 
-	// Self-message prevention: skip messages sent by the page itself.
+	// Track admin (page) replies: when the page itself sends a message,
+	// record the recipient's chat ID so the bot skips auto-reply for that
+	// conversation during the cooldown window.
 	if event.Sender.ID == ch.pageID {
+		if event.Recipient.ID != "" {
+			ch.adminReplied.Store(event.Recipient.ID, time.Now())
+			slog.Debug("facebook: admin reply tracked", "chat_id", event.Recipient.ID)
+		}
 		return
 	}
 
@@ -40,6 +49,17 @@ func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent
 		return
 	}
 
+	// Check if admin already replied to this conversation recently.
+	senderID := event.Sender.ID
+	if val, ok := ch.adminReplied.Load(senderID); ok {
+		if repliedAt, ok := val.(time.Time); ok && time.Since(repliedAt) < adminReplyCooldown {
+			slog.Info("facebook: skipping auto-reply (admin replied recently)",
+				"chat_id", senderID, "admin_replied_at", repliedAt.Format(time.RFC3339))
+			return
+		}
+		ch.adminReplied.Delete(senderID)
+	}
+
 	// Extract text content.
 	var content string
 	switch {
@@ -52,7 +72,6 @@ func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent
 		return
 	}
 
-	senderID := event.Sender.ID
 	// Messenger sessions are 1:1: chatID = senderID (channel name scopes the session).
 	chatID := senderID
 

--- a/internal/channels/facebook/messenger_handler.go
+++ b/internal/channels/facebook/messenger_handler.go
@@ -55,12 +55,7 @@ func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent
 	// Check if admin already replied to this conversation recently.
 	senderID := event.Sender.ID
 	if ch.adminRepliedRecently(senderID, time.Now()) {
-		if val, ok := ch.adminReplied.Load(senderID); ok {
-			if repliedAt, ok := val.(time.Time); ok {
-				slog.Info("facebook: skipping auto-reply (admin replied recently)",
-					"chat_id", senderID, "admin_replied_at", repliedAt.Format(time.RFC3339))
-			}
-		}
+		slog.Info("facebook: skipping auto-reply (admin replied recently)", "chat_id", senderID)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Fix Messenger auto-reply not delivering: `fb_mode` metadata stripped during outbound message construction, causing `facebook.Send()` to fall into comment path
- Add admin reply detection: skip bot reply when admin already responded via Graph API check with bot-sent timestamp comparison

## Changes

- `cmd/gateway_consumer_normal.go`: Add `fb_mode`, `sender_id`, `page_id`, `reply_to_comment_id` to outbound metadata whitelist
- `internal/channels/events.go`: Same whitelist fix in `copyRoutingMeta()` and block reply path
- `internal/channels/facebook/facebook.go`: Add `adminRepliedAfterBot()` check before sending, track bot-sent timestamps
- `internal/channels/facebook/graph_api.go`: Add `LastPageMessageTime()` to query conversation history
- `internal/channels/facebook/messenger_handler.go`: Track admin echo replies, skip auto-reply during cooldown

## Test plan

- [ ] Send DM to FB page → bot replies via Messenger
- [ ] Admin replies manually → user sends again → bot skips (no duplicate)
- [ ] Bot reply → user sends again → bot replies normally (not blocked by own reply)
- [ ] Comment reply flow unaffected