### PR TITLE
feat(providers): add Qwen Code CLI provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ ARG ENABLE_PYTHON=false
 ARG ENABLE_NODE=false
 ARG ENABLE_FULL_SKILLS=false
 ARG ENABLE_CLAUDE_CLI=false
+ARG ENABLE_QWEN_CLI=true
 
 # Copy pinned Python deps (cleaned up after install).
 # requirements-base.txt: shared deps for ENABLE_PYTHON and ENABLE_FULL_SKILLS.
@@ -100,12 +101,16 @@ RUN set -eux; \
             pip3 install --no-cache-dir --break-system-packages \
                 -r /tmp/requirements-base.txt; \
         fi; \
-        if [ "$ENABLE_NODE" = "true" ] || [ "$ENABLE_CLAUDE_CLI" = "true" ]; then \
+        if [ "$ENABLE_NODE" = "true" ] || [ "$ENABLE_CLAUDE_CLI" = "true" ] || [ "$ENABLE_QWEN_CLI" = "true" ]; then \
             apk add --no-cache nodejs npm; \
         fi; \
     fi; \
     if [ "$ENABLE_CLAUDE_CLI" = "true" ]; then \
         npm install -g --cache /tmp/npm-cache @anthropic-ai/claude-code@^2.1.91; \
+        rm -rf /tmp/npm-cache; \
+    fi; \
+    if [ "$ENABLE_QWEN_CLI" = "true" ]; then \
+        npm install -g --cache /tmp/npm-cache @qwen-code/qwen-code@latest; \
         rm -rf /tmp/npm-cache; \
     fi; \
     rm -f /tmp/requirements-base.txt /tmp/requirements-skills.txt
@@ -143,16 +148,18 @@ RUN chmod +x /app/docker-entrypoint.sh && \
 # .runtime has split ownership: root owns the dir (so pkg-helper can write apk-packages),
 # while pip/npm subdirs are goclaw-owned (runtime installs by the app process).
 # Symlink .claude → data volume so Claude CLI credentials persist across container recreates.
+# Symlink .qwen → data volume so Qwen CLI credentials persist across container recreates.
 RUN mkdir -p /app/workspace /app/data/.runtime/pip /app/data/.runtime/npm-global/lib \
-        /app/data/.runtime/pip-cache /app/data/.claude /app/skills /app/tsnet-state /app/.goclaw \
+        /app/data/.runtime/pip-cache /app/data/.claude /app/data/.qwen /app/skills /app/tsnet-state /app/.goclaw \
     && ln -s /app/data/.claude /app/.claude \
+    && ln -s /app/data/.qwen /app/.qwen \
     && touch /app/data/.runtime/apk-packages \
     && chown -R goclaw:goclaw /app/workspace /app/skills /app/tsnet-state /app/.goclaw \
     && chown goclaw:goclaw /app/bundled-skills /app/data \
     && chown root:goclaw /app/data/.runtime /app/data/.runtime/apk-packages \
     && chmod 0750 /app/data/.runtime \
     && chmod 0640 /app/data/.runtime/apk-packages \
-    && chown -R goclaw:goclaw /app/data/.runtime/pip /app/data/.runtime/npm-global /app/data/.runtime/pip-cache /app/data/.claude
+    && chown -R goclaw:goclaw /app/data/.runtime/pip /app/data/.runtime/npm-global /app/data/.runtime/pip-cache /app/data/.claude /app/data/.qwen
 
 # Default environment
 ENV GOCLAW_CONFIG=/app/config.json \

--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -307,6 +307,26 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			slog.Info("registered provider from DB", "name", p.Name)
 			continue
 		}
+		// Qwen CLI provider — uses qwen binary, no API key needed (OAuth is handled by CLI).
+		if p.ProviderType == store.ProviderQwenCLI {
+			cliPath := p.APIBase // reuse APIBase field for CLI path
+			if cliPath == "" {
+				cliPath = "qwen"
+			}
+			if cliPath != "qwen" && !filepath.IsAbs(cliPath) {
+				slog.Warn("security.qwen_cli: invalid path from DB, using default", "path", cliPath)
+				cliPath = "qwen"
+			}
+			if _, err := exec.LookPath(cliPath); err != nil {
+				slog.Warn("qwen-cli: binary not found, skipping", "path", cliPath, "error", err)
+				continue
+			}
+			var cliOpts []providers.QwenCLIOption
+			cliOpts = append(cliOpts, providers.WithQwenCLIName(p.Name))
+			registry.RegisterForTenant(p.TenantID, providers.NewQwenCLIProvider(cliPath, cliOpts...))
+			slog.Info("registered provider from DB", "name", p.Name, "type", "qwen_cli")
+			continue
+		}
 		// ACP provider — no API key needed (agents manage their own auth).
 		if p.ProviderType == store.ProviderACP {
 			registerACPFromDB(registry, p)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -100,6 +100,24 @@ if [ -d /app/.claude-host ] && ! command -v claude >/dev/null 2>&1; then
   echo "WARNING: Claude credentials mounted but claude CLI not installed. Rebuild with: --build"
 fi
 
+# Copy Qwen Code credentials from host mount to goclaw-accessible location.
+# /app/.qwen is a symlink → /app/data/.qwen (writable volume, see Dockerfile).
+# Use su-exec to copy as goclaw user since container drops DAC_OVERRIDE capability.
+if [ -d /app/.qwen-host ] && [ "$(ls -A /app/.qwen-host 2>/dev/null)" ]; then
+  (mkdir -p /app/data/.qwen \
+    && if command -v su-exec >/dev/null 2>&1 && [ "$(id -u)" = "0" ]; then
+         su-exec goclaw cp -r /app/.qwen-host/. /app/data/.qwen/
+       else
+         cp -r /app/.qwen-host/. /app/data/.qwen/
+       fi \
+    && echo "Qwen Code credentials synced from host.") || echo "WARNING: Qwen credentials copy failed (non-fatal)"
+fi
+
+# Warn if Qwen credentials are mounted but Qwen Code binary is missing.
+if [ -d /app/.qwen-host ] && ! command -v qwen >/dev/null 2>&1; then
+  echo "WARNING: Qwen credentials mounted but Qwen Code CLI not installed."
+fi
+
 # Run command with privilege drop (su-exec in Docker, direct otherwise).
 run_as_goclaw() {
   if command -v su-exec >/dev/null 2>&1 && [ "$(id -u)" = "0" ]; then

--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -56,6 +56,12 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 		return
 	}
 
+	// Qwen CLI doesn't need an API key — return hardcoded models
+	if p.ProviderType == store.ProviderQwenCLI {
+		respond(qwenCLIModels())
+		return
+	}
+
 	if p.ProviderType == store.ProviderChatGPTOAuth {
 		respond(chatGPTOAuthModels())
 		return

--- a/internal/http/provider_models_catalog.go
+++ b/internal/http/provider_models_catalog.go
@@ -81,6 +81,13 @@ func claudeCLIModels() []ModelInfo {
 	}
 }
 
+// qwenCLIModels returns the model aliases accepted by the Qwen CLI.
+func qwenCLIModels() []ModelInfo {
+	return []ModelInfo{
+		{ID: "coder-model", Name: "Coder Model"},
+	}
+}
+
 // acpModels returns the model aliases for ACP-compatible coding agents.
 func acpModels() []ModelInfo {
 	return []ModelInfo{

--- a/internal/http/provider_verify.go
+++ b/internal/http/provider_verify.go
@@ -79,6 +79,25 @@ func (h *ProvidersHandler) handleVerifyProvider(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Qwen CLI: verify binary exists on the server (no LLM call needed)
+	if p.ProviderType == store.ProviderQwenCLI {
+		binary := p.APIBase
+		if binary == "" {
+			binary = "qwen"
+		}
+		// Validate binary against known allowlist
+		if binary != "qwen" && !filepath.IsAbs(binary) {
+			writeJSON(w, http.StatusOK, map[string]any{"valid": false, "error": "invalid binary path"})
+			return
+		}
+		if _, err := exec.LookPath(binary); err != nil {
+			writeJSON(w, http.StatusOK, map[string]any{"valid": false, "error": "binary not found: " + binary})
+		} else {
+			writeJSON(w, http.StatusOK, map[string]any{"valid": true})
+		}
+		return
+	}
+
 	if h.providerReg == nil {
 		writeJSON(w, http.StatusOK, map[string]any{"valid": false, "error": "no provider registry available"})
 		return
@@ -156,6 +175,45 @@ func (h *ProvidersHandler) handleClaudeCLIAuthStatus(w http.ResponseWriter, r *h
 		"email":             status.Email,
 		"subscription_type": status.SubscriptionType,
 		"in_docker":         inDocker,
+	})
+}
+
+// handleQwenCLIAuthStatus checks whether the Qwen CLI is authenticated on the server.
+//
+//	GET /v1/providers/qwen-cli/auth-status
+//	Response: {"logged_in": true, "auth_method": "Qwen OAuth", "type": "Free tier"}
+//	     or: {"logged_in": false, "error": "..."}
+func (h *ProvidersHandler) handleQwenCLIAuthStatus(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	cliPath := "qwen"
+	if existing, err := h.store.ListProviders(r.Context()); err == nil {
+		for _, p := range existing {
+			if p.ProviderType == "qwen_cli" && p.APIBase != "" {
+				cliPath = p.APIBase
+				break
+			}
+		}
+	}
+
+	inDocker := config.InDocker()
+
+	status, err := providers.CheckQwenAuthStatus(ctx, cliPath)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"logged_in": false,
+			"error":     err.Error(),
+			"in_docker": inDocker,
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"logged_in":   status.LoggedIn,
+		"auth_method": status.AuthMethod,
+		"type":        status.Type,
+		"in_docker":   inDocker,
 	})
 }
 

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -132,6 +132,9 @@ func (h *ProvidersHandler) RegisterRoutes(mux *http.ServeMux) {
 
 	// Claude CLI auth status (global — not per-provider)
 	mux.HandleFunc("GET /v1/providers/claude-cli/auth-status", h.auth(h.handleClaudeCLIAuthStatus))
+
+	// Qwen CLI auth status (global — not per-provider)
+	mux.HandleFunc("GET /v1/providers/qwen-cli/auth-status", h.auth(h.handleQwenCLIAuthStatus))
 }
 
 func (h *ProvidersHandler) auth(next http.HandlerFunc) http.HandlerFunc {

--- a/internal/providers/qwen_cli.go
+++ b/internal/providers/qwen_cli.go
@@ -1,0 +1,144 @@
+package providers
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+)
+
+// QwenCLIProvider implements Provider by shelling out to the `qwen` CLI binary.
+// It acts as a thin proxy: CLI manages session history, tool execution, and context.
+// GoClaw only forwards the latest user message and streams back the response.
+type QwenCLIProvider struct {
+	name         string     // provider name (default: "qwen-cli")
+	cliPath      string     // path to qwen binary (default: "qwen")
+	defaultModel string     // default: "coder-model"
+	baseWorkDir  string     // base dir for agent workspaces
+	approvalMode string     // approval mode (default: "yolo")
+	mu           sync.Mutex // protects workdir creation
+	sessionMu    sync.Map   // key: string, value: *sync.Mutex — per-session lock
+}
+
+// QwenCLIOption configures the provider.
+type QwenCLIOption func(*QwenCLIProvider)
+
+// WithQwenCLIName overrides the provider name (default: "qwen-cli").
+func WithQwenCLIName(name string) QwenCLIOption {
+	return func(p *QwenCLIProvider) {
+		if name != "" {
+			p.name = name
+		}
+	}
+}
+
+// WithQwenCLIModel sets the default model.
+func WithQwenCLIModel(model string) QwenCLIOption {
+	return func(p *QwenCLIProvider) {
+		if model != "" {
+			p.defaultModel = model
+		}
+	}
+}
+
+// WithQwenCLIWorkDir sets the base work directory.
+func WithQwenCLIWorkDir(dir string) QwenCLIOption {
+	return func(p *QwenCLIProvider) {
+		if dir != "" {
+			p.baseWorkDir = dir
+		}
+	}
+}
+
+// WithQwenCLIApprovalMode sets the approval mode (plan, default, auto-edit, yolo).
+func WithQwenCLIApprovalMode(mode string) QwenCLIOption {
+	return func(p *QwenCLIProvider) {
+		if mode != "" {
+			p.approvalMode = mode
+		}
+	}
+}
+
+// NewQwenCLIProvider creates a provider that invokes the qwen CLI.
+func NewQwenCLIProvider(cliPath string, opts ...QwenCLIOption) *QwenCLIProvider {
+	if cliPath == "" {
+		cliPath = "qwen"
+	}
+	p := &QwenCLIProvider{
+		name:         "qwen-cli",
+		cliPath:      cliPath,
+		defaultModel: "coder-model",
+		baseWorkDir:  defaultQwenCLIWorkDir(),
+		approvalMode: "yolo",
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+func (p *QwenCLIProvider) Name() string         { return p.name }
+func (p *QwenCLIProvider) DefaultModel() string { return p.defaultModel }
+
+// ProviderType returns the provider type for routing/capability detection.
+func (p *QwenCLIProvider) ProviderType() string { return "qwen_cli" }
+
+// Capabilities implements CapabilitiesAware for pipeline code-path selection.
+func (p *QwenCLIProvider) Capabilities() ProviderCapabilities {
+	return ProviderCapabilities{
+		Streaming:        true,
+		ToolCalling:      true,
+		StreamWithTools:  true,
+		Thinking:         true,
+		Vision:           false,
+		CacheControl:     false,
+		MaxContextWindow: 128_000,
+		TokenizerID:      "cl100k_base",
+	}
+}
+
+// Close cleans up resources. Implements io.Closer.
+func (p *QwenCLIProvider) Close() error {
+	return nil
+}
+
+// lockSession acquires a per-session mutex to prevent concurrent CLI calls on the same session.
+func (p *QwenCLIProvider) lockSession(sessionKey string) func() {
+	actual, _ := p.sessionMu.LoadOrStore(sessionKey, &sync.Mutex{})
+	m := actual.(*sync.Mutex)
+	m.Lock()
+	return m.Unlock
+}
+
+// ensureWorkDir creates and returns a stable work directory for the given session key.
+func (p *QwenCLIProvider) ensureWorkDir(sessionKey string) string {
+	safe := sanitizePathSegment(sessionKey)
+	dir := filepath.Join(p.baseWorkDir, safe)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		slog.Warn("qwen-cli: failed to create workdir", "dir", dir, "error", err)
+		return os.TempDir()
+	}
+	return dir
+}
+
+// writeQwenMD writes the system prompt to QWEN.md in the work directory.
+func (p *QwenCLIProvider) writeQwenMD(workDir, systemPrompt string) {
+	path := filepath.Join(workDir, "QWEN.md")
+	if existing, err := os.ReadFile(path); err == nil && string(existing) == systemPrompt {
+		return
+	}
+	if err := os.WriteFile(path, []byte(systemPrompt), 0600); err != nil {
+		slog.Warn("qwen-cli: failed to write QWEN.md", "path", path, "error", err)
+	}
+}
+
+// defaultQwenCLIWorkDir returns dataDir/qwen-cli-workspaces.
+func defaultQwenCLIWorkDir() string {
+	return filepath.Join(config.ResolvedDataDirFromEnv(), "qwen-cli-workspaces")
+}

--- a/internal/providers/qwen_cli_auth.go
+++ b/internal/providers/qwen_cli_auth.go
@@ -1,0 +1,69 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// QwenAuthStatus holds the parsed result of `qwen auth status`.
+type QwenAuthStatus struct {
+	LoggedIn   bool   `json:"loggedIn"`
+	AuthMethod string `json:"authMethod,omitempty"`
+	Type       string `json:"type,omitempty"`
+}
+
+// CheckQwenAuthStatus runs `qwen auth status` and returns the parsed status.
+func CheckQwenAuthStatus(ctx context.Context, cliPath string) (*QwenAuthStatus, error) {
+	if cliPath == "" {
+		cliPath = "qwen"
+	}
+
+	resolvedPath, err := exec.LookPath(cliPath)
+	if err != nil {
+		return nil, fmt.Errorf("qwen CLI binary not found at %q: %w", cliPath, err)
+	}
+
+	cmd := exec.CommandContext(ctx, resolvedPath, "auth", "status")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("qwen auth status failed: %w", err)
+	}
+
+	return parseQwenAuthStatus(string(output))
+}
+
+func parseQwenAuthStatus(output string) (*QwenAuthStatus, error) {
+	status := &QwenAuthStatus{}
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if strings.HasPrefix(line, "\u2713") || strings.HasPrefix(line, "✓") {
+			status.LoggedIn = true
+		}
+
+		if strings.Contains(line, "Authentication Method:") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				status.AuthMethod = strings.TrimSpace(parts[1])
+				status.LoggedIn = true
+			}
+		}
+
+		if strings.Contains(line, "Type:") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				status.Type = strings.TrimSpace(parts[1])
+			}
+		}
+	}
+
+	if strings.Contains(output, "Not logged in") || strings.Contains(output, "not authenticated") {
+		status.LoggedIn = false
+	}
+
+	return status, nil
+}

--- a/internal/providers/qwen_cli_chat.go
+++ b/internal/providers/qwen_cli_chat.go
@@ -1,0 +1,283 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Chat runs the CLI synchronously and returns the final response.
+func (p *QwenCLIProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	systemPrompt, userMsg, _ := extractFromMessages(req.Messages)
+	sessionKey := extractStringOpt(req.Options, OptSessionKey)
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+
+	unlock := p.lockSession(sessionKey)
+	defer unlock()
+
+	workDir := p.ensureWorkDir(sessionKey)
+	if systemPrompt != "" {
+		p.writeQwenMD(workDir, systemPrompt)
+	}
+
+	cliSessionID := deriveSessionUUID(sessionKey)
+	args := p.buildArgs(model, workDir, cliSessionID, "json")
+
+	cmd := exec.CommandContext(ctx, p.cliPath, args...)
+	cmd.Dir = workDir
+	cmd.Env = filterQwenCLIEnv(os.Environ())
+
+	// Qwen CLI reads prompt from stdin
+	cmd.Stdin = strings.NewReader(userMsg)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	slog.Debug("qwen-cli exec", "cmd", fmt.Sprintf("%s %s", p.cliPath, strings.Join(args, " ")), "workdir", workDir)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("qwen-cli: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return parseQwenJSONResponse(output)
+}
+
+// ChatStream runs the CLI with stream-json output, calling onChunk for each text delta.
+func (p *QwenCLIProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk func(StreamChunk)) (*ChatResponse, error) {
+	systemPrompt, userMsg, _ := extractFromMessages(req.Messages)
+	sessionKey := extractStringOpt(req.Options, OptSessionKey)
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+
+	slog.Debug("qwen-cli: acquiring session lock", "session_key", sessionKey)
+	unlock := p.lockSession(sessionKey)
+	slog.Debug("qwen-cli: session lock acquired", "session_key", sessionKey)
+	defer func() {
+		unlock()
+		slog.Debug("qwen-cli: session lock released", "session_key", sessionKey)
+	}()
+
+	workDir := p.ensureWorkDir(sessionKey)
+	if systemPrompt != "" {
+		p.writeQwenMD(workDir, systemPrompt)
+	}
+
+	cliSessionID := deriveSessionUUID(sessionKey)
+	args := p.buildArgs(model, workDir, cliSessionID, "stream-json")
+
+	cmd := exec.CommandContext(ctx, p.cliPath, args...)
+	cmd.WaitDelay = 5 * time.Second
+	cmd.Dir = workDir
+	cmd.Env = filterQwenCLIEnv(os.Environ())
+
+	// Qwen CLI reads prompt from stdin
+	cmd.Stdin = strings.NewReader(userMsg)
+
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("qwen-cli stdout pipe: %w", err)
+	}
+
+	fullCmd := fmt.Sprintf("%s %s", p.cliPath, strings.Join(args, " "))
+	slog.Debug("qwen-cli stream exec", "cmd", fullCmd, "workdir", workDir)
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("qwen-cli start: %w", err)
+	}
+
+	// Debug log file: only enabled when GOCLAW_DEBUG=1
+	var debugFile *os.File
+	if os.Getenv("GOCLAW_DEBUG") == "1" {
+		debugLogPath := filepath.Join(workDir, "qwen-cli-debug.log")
+		debugFile, _ = os.OpenFile(debugLogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if debugFile != nil {
+			fmt.Fprintf(debugFile, "=== CMD: %s\n=== WORKDIR: %s\n=== TIME: %s\n\n", fullCmd, workDir, time.Now().Format(time.RFC3339))
+			defer debugFile.Close()
+		}
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, StdioScanBufInit), StdioScanBufMax)
+
+	var finalResp ChatResponse
+	var contentBuf strings.Builder
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			break
+		}
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		if debugFile != nil {
+			fmt.Fprintf(debugFile, "%s\n", line)
+		}
+
+		var ev qwenStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			slog.Debug("qwen-cli: skip malformed stream line", "error", err)
+			continue
+		}
+
+		switch ev.Type {
+		case "assistant":
+			if ev.Message == nil {
+				continue
+			}
+			text, thinking := extractQwenStreamContent(ev.Message)
+			if text != "" {
+				contentBuf.WriteString(text)
+				onChunk(StreamChunk{Content: text})
+			}
+			if thinking != "" {
+				onChunk(StreamChunk{Thinking: thinking})
+			}
+
+		case "result":
+			if ev.Result != "" {
+				finalResp.Content = ev.Result
+			} else {
+				finalResp.Content = contentBuf.String()
+			}
+			finalResp.FinishReason = "stop"
+			if ev.Subtype == "error" {
+				finalResp.FinishReason = "error"
+			}
+			if ev.Usage != nil {
+				finalResp.Usage = &Usage{
+					PromptTokens:     ev.Usage.InputTokens,
+					CompletionTokens: ev.Usage.OutputTokens,
+					TotalTokens:      ev.Usage.TotalTokens,
+					CacheReadTokens:  ev.Usage.CacheReadInputTokens,
+				}
+			}
+		}
+	}
+
+	if ctx.Err() != nil {
+		// Kill the process to release Qwen CLI's internal session lock faster
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+		// Small delay to ensure Qwen CLI releases its session file lock
+		time.Sleep(100 * time.Millisecond)
+		return nil, ctx.Err()
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("qwen-cli: stream read error: %w", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if debugFile != nil {
+			fmt.Fprintf(debugFile, "\n=== STDERR:\n%s\n=== EXIT ERROR: %v\n", stderrBuf.String(), err)
+		}
+		if finalResp.Content != "" {
+			// Small delay to ensure Qwen CLI releases its session file lock
+			time.Sleep(100 * time.Millisecond)
+			return &finalResp, nil
+		}
+		return nil, fmt.Errorf("qwen-cli: %w (stderr: %s)", err, stderrBuf.String())
+	}
+
+	// Small delay to ensure Qwen CLI releases its session file lock before next request
+	time.Sleep(100 * time.Millisecond)
+
+	if finalResp.Content == "" {
+		finalResp.Content = contentBuf.String()
+		finalResp.FinishReason = "stop"
+	}
+
+	onChunk(StreamChunk{Done: true})
+	return &finalResp, nil
+}
+
+// buildArgs constructs CLI arguments for qwen.
+func (p *QwenCLIProvider) buildArgs(model, workDir string, cliSessionID uuid.UUID, outputFormat string) []string {
+	args := []string{
+		"-o", outputFormat,
+		"--approval-mode", p.approvalMode,
+	}
+
+	if model != "" && model != "coder-model" {
+		args = append(args, "-m", model)
+	}
+
+	sid := cliSessionID.String()
+	if qwenSessionFileExists(workDir, cliSessionID) {
+		args = append(args, "-r", sid)
+	} else {
+		args = append(args, "--session-id", sid)
+	}
+
+	return args
+}
+
+// qwenSessionFileExists checks if a Qwen CLI session file exists.
+// Qwen CLI stores sessions at: ~/.qwen/projects/<sanitizedCwd>/chats/<sessionId>.jsonl
+// where sanitizedCwd replaces all non-alphanumeric characters with hyphens.
+func qwenSessionFileExists(workDir string, sessionID uuid.UUID) bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		resolved = workDir
+	}
+	// Qwen CLI uses sanitizeCwd which replaces ALL non-alphanumeric chars with "-"
+	encoded := sanitizeQwenCwd(resolved)
+	sessionFile := filepath.Join(home, ".qwen", "projects", encoded, "chats", sessionID.String()+".jsonl")
+	_, err = os.Stat(sessionFile)
+	return err == nil
+}
+
+// sanitizeQwenCwd replicates Qwen CLI's sanitizeCwd function:
+// replaces all non-alphanumeric characters with hyphens.
+func sanitizeQwenCwd(cwd string) string {
+	var result strings.Builder
+	for _, r := range cwd {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			result.WriteRune(r)
+		} else {
+			result.WriteRune('-')
+		}
+	}
+	return result.String()
+}
+
+// filterQwenCLIEnv removes QWEN* env vars to prevent nested session conflicts.
+func filterQwenCLIEnv(environ []string) []string {
+	var filtered []string
+	for _, e := range environ {
+		key := e
+		if before, _, ok := strings.Cut(e, "="); ok {
+			key = before
+		}
+		if strings.HasPrefix(key, "QWEN") {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
+}

--- a/internal/providers/qwen_cli_chat.go
+++ b/internal/providers/qwen_cli_chat.go
@@ -35,13 +35,14 @@ func (p *QwenCLIProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespo
 
 	cliSessionID := deriveSessionUUID(sessionKey)
 	args := p.buildArgs(model, workDir, cliSessionID, "json")
+	// Use -p flag for non-interactive mode with explicit prompt
+	if userMsg != "" {
+		args = append(args, "-p", userMsg)
+	}
 
 	cmd := exec.CommandContext(ctx, p.cliPath, args...)
 	cmd.Dir = workDir
 	cmd.Env = filterQwenCLIEnv(os.Environ())
-
-	// Qwen CLI reads prompt from stdin
-	cmd.Stdin = strings.NewReader(userMsg)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -79,14 +80,15 @@ func (p *QwenCLIProvider) ChatStream(ctx context.Context, req ChatRequest, onChu
 
 	cliSessionID := deriveSessionUUID(sessionKey)
 	args := p.buildArgs(model, workDir, cliSessionID, "stream-json")
+	// Use -p flag for non-interactive mode with explicit prompt
+	if userMsg != "" {
+		args = append(args, "-p", userMsg)
+	}
 
 	cmd := exec.CommandContext(ctx, p.cliPath, args...)
 	cmd.WaitDelay = 5 * time.Second
 	cmd.Dir = workDir
 	cmd.Env = filterQwenCLIEnv(os.Environ())
-
-	// Qwen CLI reads prompt from stdin
-	cmd.Stdin = strings.NewReader(userMsg)
 
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf

--- a/internal/providers/qwen_cli_parse.go
+++ b/internal/providers/qwen_cli_parse.go
@@ -1,0 +1,144 @@
+package providers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func parseQwenJSONResponse(data []byte) (*ChatResponse, error) {
+	if resp := parseQwenJSONArray(data); resp != nil {
+		return resp, nil
+	}
+
+	for line := range bytes.SplitSeq(data, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		if resp := parseQwenSingleJSONResult(line); resp != nil {
+			return resp, nil
+		}
+	}
+
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return nil, fmt.Errorf("qwen-cli: empty response")
+	}
+	return &ChatResponse{
+		Content:      trimmed,
+		FinishReason: "stop",
+	}, nil
+}
+
+func parseQwenJSONArray(data []byte) *ChatResponse {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil
+	}
+
+	var events []json.RawMessage
+	if err := json.Unmarshal(trimmed, &events); err != nil {
+		return nil
+	}
+
+	var resultText string
+	var assistantText strings.Builder
+	var usage *Usage
+	finishReason := "stop"
+
+	for _, raw := range events {
+		var ev struct {
+			Type    string          `json:"type"`
+			Subtype string          `json:"subtype,omitempty"`
+			Result  string          `json:"result,omitempty"`
+			Message json.RawMessage `json:"message,omitempty"`
+			Usage   *qwenUsage      `json:"usage,omitempty"`
+		}
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			continue
+		}
+
+		switch ev.Type {
+		case "result":
+			resultText = ev.Result
+			if ev.Subtype == "error" {
+				finishReason = "error"
+			}
+			if ev.Usage != nil {
+				usage = &Usage{
+					PromptTokens:     ev.Usage.InputTokens,
+					CompletionTokens: ev.Usage.OutputTokens,
+					TotalTokens:      ev.Usage.TotalTokens,
+					CacheReadTokens:  ev.Usage.CacheReadInputTokens,
+				}
+			}
+
+		case "assistant":
+			if ev.Message != nil {
+				var msg qwenStreamMsg
+				if err := json.Unmarshal(ev.Message, &msg); err == nil {
+					for _, block := range msg.Content {
+						if block.Type == "text" {
+							assistantText.WriteString(block.Text)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	content := resultText
+	if content == "" {
+		content = assistantText.String()
+	}
+	if content == "" {
+		return nil
+	}
+
+	return &ChatResponse{
+		Content:      content,
+		FinishReason: finishReason,
+		Usage:        usage,
+	}
+}
+
+func parseQwenSingleJSONResult(line []byte) *ChatResponse {
+	var resp qwenJSONResponse
+	if err := json.Unmarshal(line, &resp); err != nil {
+		return nil
+	}
+	if resp.Type != "result" {
+		return nil
+	}
+	cr := &ChatResponse{
+		Content:      resp.Result,
+		FinishReason: "stop",
+	}
+	if resp.Subtype == "error" {
+		cr.FinishReason = "error"
+	}
+	if resp.Usage != nil {
+		cr.Usage = &Usage{
+			PromptTokens:     resp.Usage.InputTokens,
+			CompletionTokens: resp.Usage.OutputTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+			CacheReadTokens:  resp.Usage.CacheReadInputTokens,
+		}
+	}
+	return cr
+}
+
+func extractQwenStreamContent(msg *qwenStreamMsg) (text, thinking string) {
+	var textBuf, thinkBuf strings.Builder
+	for _, block := range msg.Content {
+		switch block.Type {
+		case "text":
+			textBuf.WriteString(block.Text)
+		case "thinking":
+			thinkBuf.WriteString(block.Thinking)
+		}
+	}
+	return textBuf.String(), thinkBuf.String()
+}

--- a/internal/providers/qwen_cli_types.go
+++ b/internal/providers/qwen_cli_types.go
@@ -1,0 +1,49 @@
+package providers
+
+// Qwen CLI JSON response types (internal).
+
+type qwenJSONResponse struct {
+	Type      string     `json:"type"`
+	Subtype   string     `json:"subtype"`
+	Result    string     `json:"result"`
+	SessionID string     `json:"session_id"`
+	Model     string     `json:"model"`
+	Usage     *qwenUsage `json:"usage"`
+	IsError   bool       `json:"is_error"`
+}
+
+type qwenUsage struct {
+	InputTokens          int `json:"input_tokens"`
+	OutputTokens         int `json:"output_tokens"`
+	TotalTokens          int `json:"total_tokens"`
+	CacheReadInputTokens int `json:"cache_read_input_tokens"`
+}
+
+type qwenStreamEvent struct {
+	Type      string         `json:"type"`
+	Subtype   string         `json:"subtype,omitempty"`
+	UUID      string         `json:"uuid,omitempty"`
+	SessionID string         `json:"session_id"`
+	Message   *qwenStreamMsg `json:"message,omitempty"`
+	Result    string         `json:"result,omitempty"`
+	Model     string         `json:"model,omitempty"`
+	Usage     *qwenUsage     `json:"usage,omitempty"`
+	IsError   bool           `json:"is_error,omitempty"`
+}
+
+type qwenStreamMsg struct {
+	ID         string             `json:"id"`
+	Type       string             `json:"type"`
+	Role       string             `json:"role"`
+	Model      string             `json:"model"`
+	Content    []qwenContentBlock `json:"content"`
+	StopReason *string            `json:"stop_reason"`
+	Usage      *qwenUsage         `json:"usage,omitempty"`
+}
+
+type qwenContentBlock struct {
+	Type      string `json:"type"`
+	Text      string `json:"text,omitempty"`
+	Thinking  string `json:"thinking,omitempty"`
+	Signature string `json:"signature,omitempty"`
+}

--- a/internal/store/provider_store.go
+++ b/internal/store/provider_store.go
@@ -23,6 +23,7 @@ const (
 	ProviderDashScope       = "dashscope"
 	ProviderBailian         = "bailian"
 	ProviderChatGPTOAuth    = "chatgpt_oauth"
+	ProviderQwenCLI         = "qwen_cli"
 	ProviderClaudeCLI       = "claude_cli"
 	ProviderSuno            = "suno"
 	ProviderYesScale        = "yescale"
@@ -61,6 +62,7 @@ var ValidProviderTypes = map[string]bool{
 	ProviderDashScope:       true,
 	ProviderBailian:         true,
 	ProviderChatGPTOAuth:    true,
+	ProviderQwenCLI:         true,
 	ProviderClaudeCLI:       true,
 	ProviderSuno:            true,
 	ProviderYesScale:        true,
@@ -179,6 +181,7 @@ func normalizeProviderReasoningConfig(raw *ProviderReasoningConfig) *ProviderRea
 var NoEmbeddingTypes = map[string]bool{
 	ProviderAnthropicNative: true, // uses x-api-key auth, not Bearer; no embedding models
 	ProviderACP:             true,
+	ProviderQwenCLI:         true,
 	ProviderClaudeCLI:       true,
 	ProviderChatGPTOAuth:    true,
 	ProviderSuno:            true,

--- a/ui/desktop/frontend/src/constants/providers.ts
+++ b/ui/desktop/frontend/src/constants/providers.ts
@@ -28,5 +28,6 @@ export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: 'ollama', label: 'Ollama (Local)', apiBase: 'http://localhost:11434/v1', needsKey: false },
   { value: 'ollama_cloud', label: 'Ollama Cloud', apiBase: 'https://ollama.com/v1', needsKey: true },
   { value: 'claude_cli', label: 'Claude CLI (Local)', apiBase: '', needsKey: false },
+  { value: 'qwen_cli', label: 'Qwen Code (Local)', apiBase: '', needsKey: false },
   { value: 'acp', label: 'ACP Agent (Subprocess)', apiBase: '', needsKey: false },
 ]

--- a/ui/web/src/constants/providers.ts
+++ b/ui/web/src/constants/providers.ts
@@ -35,6 +35,7 @@ export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: "ollama", label: "Ollama (Local)", apiBase: "http://localhost:11434/v1", placeholder: "" },
   { value: "ollama_cloud", label: "Ollama Cloud", apiBase: "https://ollama.com/v1", placeholder: "" },
   { value: "claude_cli", label: "Claude CLI (Local)", apiBase: "", placeholder: "" },
+  { value: "qwen_cli", label: "Qwen Code (Local)", apiBase: "", placeholder: "" },
   { value: "acp", label: "ACP Agent (Subprocess)", apiBase: "", placeholder: "claude" },
 ];
 

--- a/ui/web/src/i18n/locales/en/providers.json
+++ b/ui/web/src/i18n/locales/en/providers.json
@@ -179,6 +179,19 @@
     "runOnServer": "Run on the server terminal:",
     "recheckButton": "Re-check"
   },
+  "qwenCli": {
+    "description": "Qwen Code uses your local",
+    "descriptionSuffix": "binary. No API key needed.",
+    "checkingAuth": "Checking authentication...",
+    "authenticatedAs": "Authenticated via",
+    "switchAccount": "Switch account?",
+    "switchAccountInstructions": "Run on the server terminal:",
+    "switchAccountRecheck": "Then click",
+    "switchAccountRecheckSuffix": "to re-check.",
+    "notAuthenticated": "Not authenticated",
+    "runOnServer": "Run on the server terminal:",
+    "recheckButton": "Re-check"
+  },
   "detail": {
     "title": "Provider Details",
     "advanced": "Advanced",

--- a/ui/web/src/i18n/locales/vi/providers.json
+++ b/ui/web/src/i18n/locales/vi/providers.json
@@ -184,6 +184,19 @@
     "runOnServer": "Chạy trên terminal máy chủ:",
     "recheckButton": "Kiểm tra lại"
   },
+  "qwenCli": {
+    "description": "Qwen Code sử dụng tệp nhị phân",
+    "descriptionSuffix": "cục bộ của bạn. Không cần API key.",
+    "checkingAuth": "Đang kiểm tra xác thực...",
+    "authenticatedAs": "Đã xác thực qua",
+    "switchAccount": "Chuyển tài khoản?",
+    "switchAccountInstructions": "Chạy trên terminal máy chủ:",
+    "switchAccountRecheck": "Sau đó nhấp",
+    "switchAccountRecheckSuffix": "để kiểm tra lại.",
+    "notAuthenticated": "Chưa xác thực",
+    "runOnServer": "Chạy trên terminal máy chủ:",
+    "recheckButton": "Kiểm tra lại"
+  },
   "detail": {
     "advanced": "Nâng cao",
     "identity": "Danh tính",

--- a/ui/web/src/i18n/locales/zh/providers.json
+++ b/ui/web/src/i18n/locales/zh/providers.json
@@ -202,6 +202,19 @@
     "runOnServer": "在服务器终端运行：",
     "recheckButton": "重新检查"
   },
+  "qwenCli": {
+    "description": "Qwen Code 使用本地",
+    "descriptionSuffix": "二进制文件。无需 API 密钥。",
+    "checkingAuth": "正在检查认证...",
+    "authenticatedAs": "已通过",
+    "switchAccount": "切换账户？",
+    "switchAccountInstructions": "在服务器终端运行：",
+    "switchAccountRecheck": "然后点击",
+    "switchAccountRecheckSuffix": "重新检查。",
+    "notAuthenticated": "未认证",
+    "runOnServer": "在服务器终端运行：",
+    "recheckButton": "重新检查"
+  },
   "detail": {
     "advanced": "高级设置",
     "identity": "身份",

--- a/ui/web/src/pages/providers/provider-cli-section.tsx
+++ b/ui/web/src/pages/providers/provider-cli-section.tsx
@@ -8,24 +8,58 @@ interface CLIAuthStatus {
   logged_in: boolean;
   email?: string;
   subscription_type?: string;
+  auth_method?: string;
+  type?: string;
   error?: string;
   in_docker?: boolean;
 }
 
-export function CLISection({ open }: { open: boolean }) {
+type CLIType = "claude" | "qwen";
+
+interface CLISectionProps {
+  open: boolean;
+  cliType?: CLIType;
+}
+
+const CLI_CONFIG: Record<CLIType, {
+  binary: string;
+  endpoint: string;
+  translationPrefix: string;
+  authCommand: string;
+  logoutCommand: string;
+}> = {
+  claude: {
+    binary: "claude",
+    endpoint: "/v1/providers/claude-cli/auth-status",
+    translationPrefix: "cli",
+    authCommand: "claude auth login",
+    logoutCommand: "claude auth logout",
+  },
+  qwen: {
+    binary: "qwen",
+    endpoint: "/v1/providers/qwen-cli/auth-status",
+    translationPrefix: "qwenCli",
+    authCommand: "qwen auth",
+    logoutCommand: "rm ~/.qwen/oauth_creds.json && qwen auth",
+  },
+};
+
+export function CLISection({ open, cliType = "claude" }: CLISectionProps) {
   const { t } = useTranslation("providers");
   const http = useHttp();
   const [cliAuth, setCliAuth] = useState<CLIAuthStatus | null>(null);
   const [loading, setLoading] = useState(false);
 
+  const config = CLI_CONFIG[cliType];
+
   const checkAuth = useCallback(() => {
     setLoading(true);
     http
-      .get<CLIAuthStatus>("/v1/providers/claude-cli/auth-status")
+      .get<CLIAuthStatus>(config.endpoint)
       .then(setCliAuth)
       .catch(() => setCliAuth({ logged_in: false, error: "Failed to check auth status" }))
       .finally(() => setLoading(false));
-  }, [http]);
+  }, [http, config.endpoint]);
 
   useEffect(() => {
     if (open) {
@@ -35,15 +69,30 @@ export function CLISection({ open }: { open: boolean }) {
     }
   }, [open, checkAuth]);
 
+  const dockerPrefix = cliAuth?.in_docker ? "docker compose exec goclaw " : "";
+  const authCmd = `${dockerPrefix}${config.authCommand}`;
+  const switchCmd = `${dockerPrefix}${config.logoutCommand} && ${dockerPrefix}${config.authCommand}`;
+
+  // Get authentication display info based on CLI type
+  const getAuthDisplay = () => {
+    if (cliType === "qwen") {
+      const parts: string[] = [];
+      if (cliAuth?.auth_method) parts.push(cliAuth.auth_method);
+      if (cliAuth?.type) parts.push(cliAuth.type);
+      return parts.length > 0 ? parts.join(" - ") : "Authenticated";
+    }
+    return cliAuth?.email || "Authenticated";
+  };
+
   return (
     <div className="space-y-3">
       <p className="text-sm text-muted-foreground">
-        {t("cli.description")} <code className="rounded bg-muted px-1 py-0.5">claude</code> {t("cli.descriptionSuffix")}
+        {t(`${config.translationPrefix}.description`)} <code className="rounded bg-muted px-1 py-0.5">{config.binary}</code> {t(`${config.translationPrefix}.descriptionSuffix`)}
       </p>
       {loading ? (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          {t("cli.checkingAuth")}
+          {t(`${config.translationPrefix}.checkingAuth`)}
         </div>
       ) : cliAuth?.logged_in ? (
         <div className="space-y-2">
@@ -51,8 +100,8 @@ export function CLISection({ open }: { open: boolean }) {
             <div className="flex items-center gap-2">
               <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
               <p className="text-sm text-green-700 dark:text-green-300">
-                {t("cli.authenticatedAs")} <strong>{cliAuth.email}</strong>
-                {cliAuth.subscription_type && (
+                {t(`${config.translationPrefix}.authenticatedAs`)} <strong>{getAuthDisplay()}</strong>
+                {cliType === "claude" && cliAuth.subscription_type && (
                   <span className="ml-1 text-xs opacity-75">({cliAuth.subscription_type})</span>
                 )}
               </p>
@@ -68,15 +117,13 @@ export function CLISection({ open }: { open: boolean }) {
             </Button>
           </div>
           <details className="text-xs text-muted-foreground">
-            <summary className="cursor-pointer hover:text-foreground">{t("cli.switchAccount")}</summary>
+            <summary className="cursor-pointer hover:text-foreground">{t(`${config.translationPrefix}.switchAccount`)}</summary>
             <div className="mt-1.5 space-y-1 rounded-md border bg-muted/50 px-3 py-2">
-              <p>{t("cli.switchAccountInstructions")}</p>
+              <p>{t(`${config.translationPrefix}.switchAccountInstructions`)}</p>
               <code className="block rounded bg-muted px-2 py-1 font-mono">
-                {cliAuth?.in_docker
-                  ? "docker compose exec goclaw claude auth logout && docker compose exec goclaw claude auth login"
-                  : "claude auth logout && claude auth login"}
+                {switchCmd}
               </code>
-              <p>{t("cli.switchAccountRecheck")} <RefreshCw className="inline h-3 w-3" /> {t("cli.switchAccountRecheckSuffix")}</p>
+              <p>{t(`${config.translationPrefix}.switchAccountRecheck`)} <RefreshCw className="inline h-3 w-3" /> {t(`${config.translationPrefix}.switchAccountRecheckSuffix`)}</p>
             </div>
           </details>
         </div>
@@ -85,7 +132,7 @@ export function CLISection({ open }: { open: boolean }) {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-              <p className="text-sm font-medium text-amber-700 dark:text-amber-300">{t("cli.notAuthenticated")}</p>
+              <p className="text-sm font-medium text-amber-700 dark:text-amber-300">{t(`${config.translationPrefix}.notAuthenticated`)}</p>
             </div>
             <Button
               type="button"
@@ -95,14 +142,14 @@ export function CLISection({ open }: { open: boolean }) {
               onClick={checkAuth}
             >
               <RefreshCw className="h-3.5 w-3.5 mr-1" />
-              <span className="text-xs">{t("cli.recheckButton")}</span>
+              <span className="text-xs">{t(`${config.translationPrefix}.recheckButton`)}</span>
             </Button>
           </div>
           <p className="mt-1 text-sm text-amber-600 dark:text-amber-400">
-            {t("cli.runOnServer")}
+            {t(`${config.translationPrefix}.runOnServer`)}
           </p>
           <code className="mt-1 block rounded bg-amber-100 px-2 py-1 text-xs font-mono dark:bg-amber-900 dark:text-amber-300">
-            {cliAuth.in_docker ? "docker compose exec goclaw claude auth login" : "claude auth login"}
+            {authCmd}
           </code>
           {cliAuth.error && (
             <p className="mt-1 text-xs text-amber-500">{cliAuth.error}</p>

--- a/ui/web/src/pages/providers/provider-cli-section.tsx
+++ b/ui/web/src/pages/providers/provider-cli-section.tsx
@@ -69,7 +69,9 @@ export function CLISection({ open, cliType = "claude" }: CLISectionProps) {
     }
   }, [open, checkAuth]);
 
-  const dockerPrefix = cliAuth?.in_docker ? "docker compose exec goclaw " : "";
+  // Use -u goclaw to run as goclaw user, not root. Credentials are stored per-user,
+  // and goclaw process runs as goclaw user, so auth must also run as goclaw user.
+  const dockerPrefix = cliAuth?.in_docker ? "docker compose exec -u goclaw goclaw " : "";
   const authCmd = `${dockerPrefix}${config.authCommand}`;
   const switchCmd = `${dockerPrefix}${config.logoutCommand} && ${dockerPrefix}${config.authCommand}`;
 

--- a/ui/web/src/pages/providers/provider-detail/provider-overview-helpers.ts
+++ b/ui/web/src/pages/providers/provider-detail/provider-overview-helpers.ts
@@ -3,11 +3,12 @@ import type { ChatGPTOAuthRoutingConfig } from "@/types/agent";
 import { normalizeReasoningEffort, normalizeReasoningFallback } from "@/types/provider";
 
 // Provider types that don't use API keys
-export const NO_API_KEY_TYPES = new Set(["claude_cli", "acp", "chatgpt_oauth"]);
+export const NO_API_KEY_TYPES = new Set(["claude_cli", "qwen_cli", "acp", "chatgpt_oauth"]);
 
 // Provider types that don't support embedding
 export const NO_EMBEDDING_TYPES = new Set([
   "claude_cli",
+  "qwen_cli",
   "acp",
   "chatgpt_oauth",
   "suno",

--- a/ui/web/src/pages/providers/provider-form-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-form-dialog.tsx
@@ -67,8 +67,11 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
   const name = watch("name");
 
   const hasClaudeCLI = existingProviders.some((p) => p.provider_type === "claude_cli");
+  const hasQwenCLI = existingProviders.some((p) => p.provider_type === "qwen_cli");
   const isOAuth = providerType === "chatgpt_oauth";
-  const isCLI = providerType === "claude_cli";
+  const isClaudeCLI = providerType === "claude_cli";
+  const isQwenCLI = providerType === "qwen_cli";
+  const isCLI = isClaudeCLI || isQwenCLI;
   const isACP = providerType === "acp";
 
   // Reset form when dialog opens
@@ -141,6 +144,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
           <ProviderTypeSelect
             value={providerType}
             hasClaudeCLI={hasClaudeCLI}
+            hasQwenCLI={hasQwenCLI}
             alreadyAddedLabel={t("form.alreadyAdded")}
             providerTypeLabel={t("form.providerType")}
             onChange={handleProviderTypeChange}
@@ -206,7 +210,8 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
                 </div>
               </div>
 
-              {isCLI && <CLISection open={open} />}
+              {isClaudeCLI && <CLISection open={open} cliType="claude" />}
+              {isQwenCLI && <CLISection open={open} cliType="qwen" />}
 
               {isACP && (
                 <ACPSection
@@ -277,13 +282,20 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
   );
 }
 
-function ProviderTypeSelect({ value, hasClaudeCLI, alreadyAddedLabel, providerTypeLabel, onChange }: {
+function ProviderTypeSelect({ value, hasClaudeCLI, hasQwenCLI, alreadyAddedLabel, providerTypeLabel, onChange }: {
   value: string;
   hasClaudeCLI: boolean;
+  hasQwenCLI: boolean;
   alreadyAddedLabel: string;
   providerTypeLabel: string;
   onChange: (value: string) => void;
 }) {
+  const isDisabled = (pt: { value: string }) => {
+    if (pt.value === "claude_cli" && hasClaudeCLI) return true;
+    if (pt.value === "qwen_cli" && hasQwenCLI) return true;
+    return false;
+  };
+
   return (
     <div className="space-y-2">
       <Label>{providerTypeLabel}</Label>
@@ -296,10 +308,10 @@ function ProviderTypeSelect({ value, hasClaudeCLI, alreadyAddedLabel, providerTy
             <SelectItem
               key={pt.value}
               value={pt.value}
-              disabled={pt.value === "claude_cli" && hasClaudeCLI}
+              disabled={isDisabled(pt)}
             >
               {pt.label}
-              {pt.value === "claude_cli" && hasClaudeCLI && (
+              {isDisabled(pt) && (
                 <span className="ml-1 text-xs opacity-60">{alreadyAddedLabel}</span>
               )}
             </SelectItem>


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: What does this PR do and why? -->
Add qwen_cli provider type that shells out to the local `qwen` binary,
  mirroring the Claude CLI integration pattern.

  - Provider implementation with streaming support and session resumption
  - Session file detection at ~/.qwen/projects/<path>/chats/<id>.jsonl
  - OAuth auth status endpoint at /v1/providers/qwen-cli/auth-status
  - UI support: provider form, auth status section, i18n (en/vi/zh)
  - Container support: qwen binary pre-installed, credential sync in entrypoint
 
## Type
<!-- Check one -->
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->
dev

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [x] New user-facing strings added to all 3 locales (en/vi/zh)
- [x] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
  1. Add qwen_cli provider via UI
  2. Restart goclaw to register provider
  3. Create/update agent to use qwen provider
  4. Send chat message — verify first message succeeds
  5. Send second message — verify session resumes (no "Session Id already in use" error)
  6. Check auth status at GET /v1/providers/qwen-cli/auth-status
