### PR TITLE
fix(skills): add missing AS alias for COALESCE in embedding search query

### DIFF
--- a/internal/store/pg/skills_embedding.go
+++ b/internal/store/pg/skills_embedding.go
@@ -29,7 +29,7 @@ func (s *PGSkillStore) SearchByEmbedding(ctx context.Context, embedding []float3
 	tenantCond := buildSkillEmbeddingTenantCond(tc)
 	orderN := nextParam
 	limitN := orderN + 1
-	q := fmt.Sprintf(`SELECT name, slug, COALESCE(description, ''), version, file_path,
+	q := fmt.Sprintf(`SELECT name, slug, COALESCE(description, '') AS description, version, file_path,
 			1 - (embedding <=> $1::vector) AS score
 		FROM skills
 		WHERE status = 'active' AND enabled = true AND embedding IS NOT NULL


### PR DESCRIPTION
## Summary
- `SearchByEmbedding` query uses `COALESCE(description, '')` without an `AS description` alias
- PostgreSQL names the column `coalesce`, but `sqlx` scan struct expects `db:"description"`
- Results in `missing destination name coalesce` error, falling back to BM25 search
- The `BackfillEmbeddings` query (line 84) already has the correct alias

## Fix
Add `AS description` alias to match the scan struct tag.

## Test plan
- [x] Verified PostgreSQL returns correct column name with alias
- [x] Build succeeds
- [x] Skill search no longer falls back to BM25

🤖 Generated with [Claude Code](https://claude.com/claude-code)