### PR TITLE
feat(vertex): add ADC-only native Vertex provider support

### DIFF
--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -140,6 +140,19 @@ func registerProviders(registry *providers.Registry, cfg *config.Config, modelRe
 		slog.Info("registered provider", "name", "ollama-cloud")
 	}
 
+	// Google Vertex AI provider (native token source: explicit token or ADC).
+	if cfg.Providers.Vertex.APIBase != "" {
+		base := cfg.Providers.Vertex.APIBase
+		ts, err := providers.NewVertexTokenSource()
+		if err != nil {
+			slog.Warn("vertex provider disabled", "error", err)
+		} else {
+			prov := providers.NewVertexProvider("vertex", base, "google/gemini-2.5-flash", ts)
+			registry.Register(prov)
+			slog.Info("registered provider", "name", "vertex")
+		}
+	}
+
 	// Novita AI — OpenAI-compatible endpoint.
 	if cfg.Providers.Novita.APIKey != "" {
 		base := cfg.Providers.Novita.APIBase
@@ -324,9 +337,6 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			continue
 		}
 
-		if p.APIKey == "" {
-			continue
-		}
 		// Fall back to config/env api_base when DB provider has none set.
 		if p.APIBase == "" && cfg != nil {
 			if base := cfg.Providers.APIBaseForType(p.ProviderType); base != "" {
@@ -405,7 +415,22 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			prov := providers.NewOpenAIProvider(p.Name, p.APIKey, base, store.BytePlusDefaultModel)
 			prov.WithProviderType(p.ProviderType)
 			registry.RegisterForTenant(p.TenantID, prov)
+		case store.ProviderVertex:
+			base := p.APIBase
+			if base == "" {
+				slog.Warn("vertex provider skipped: missing api_base", "name", p.Name)
+				continue
+			}
+			ts, err := providers.NewVertexTokenSource()
+			if err != nil {
+				slog.Warn("vertex provider skipped: token source unavailable", "name", p.Name, "error", err)
+				continue
+			}
+			registry.RegisterForTenant(p.TenantID, providers.NewVertexProvider(p.Name, base, "google/gemini-2.5-flash", ts))
 		default:
+			if p.APIKey == "" {
+				continue
+			}
 			prov := providers.NewOpenAIProvider(p.Name, p.APIKey, p.APIBase, "")
 			prov.WithProviderType(p.ProviderType)
 			if p.ProviderType == store.ProviderMiniMax {

--- a/cmd/providers_cmd.go
+++ b/cmd/providers_cmd.go
@@ -125,6 +125,7 @@ func runProvidersAdd() {
 		{"OpenAI", "openai"},
 		{"OpenRouter", "openrouter"},
 		{"DashScope (Alibaba)", "dashscope"},
+		{"Google Vertex AI", "vertex"},
 		{"OpenAI-compatible", "openai-compat"},
 	}
 	providerType, err := promptSelect("Provider type", typeOptions, 0)
@@ -140,17 +141,20 @@ func runProvidersAdd() {
 		return
 	}
 
-	// Step 3: API key
-	apiKey, err := promptPassword("API key", "will be encrypted at rest")
-	if err != nil || apiKey == "" {
-		fmt.Println("Cancelled.")
-		return
+	// Step 3: API key (Vertex uses ADC only, so no key prompt).
+	apiKey := ""
+	if providerType != "vertex" {
+		apiKey, err = promptPassword("API key", "will be encrypted at rest")
+		if err != nil || apiKey == "" {
+			fmt.Println("Cancelled.")
+			return
+		}
 	}
 
 	// Step 4: Base URL (pre-fill per type, editable)
 	defaultURL := defaultBaseURL(providerType)
 	baseURL := ""
-	if providerType == "openai-compat" {
+	if providerType == "openai-compat" || providerType == "vertex" {
 		baseURL, err = promptString("Base URL", "e.g. https://api.example.com/v1", defaultURL)
 		if err != nil {
 			fmt.Println("Cancelled.")
@@ -161,8 +165,10 @@ func runProvidersAdd() {
 	body := map[string]any{
 		"name":          name,
 		"provider_type": providerType,
-		"api_key":       apiKey,
 		"enabled":       true,
+	}
+	if apiKey != "" {
+		body["api_key"] = apiKey
 	}
 	if baseURL != "" {
 		body["base_url"] = baseURL
@@ -318,6 +324,8 @@ func defaultBaseURL(providerType string) string {
 		return "https://openrouter.ai/api/v1"
 	case "dashscope":
 		return "https://dashscope.aliyuncs.com/compatible-mode/v1"
+	case "vertex":
+		return "https://aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/global/endpoints/openapi"
 	default:
 		return ""
 	}

--- a/docker-compose.vertex.yml
+++ b/docker-compose.vertex.yml
@@ -1,0 +1,8 @@
+services:
+  goclaw:
+    environment:
+      # ADC credential path inside container.
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcp/vertex-sa.json
+    volumes:
+      # Host path -> container path (read-only). Prefer keeping this file outside the repo.
+      - ${HOME}/secrets/gcp/vertex-sa.json:/run/secrets/gcp/vertex-sa.json:ro

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa // indirect
@@ -145,7 +146,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go4.org/mem v0.0.0-20240501181205-ae6ca9944745 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/oauth2 v0.34.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
 9fans.net/go v0.0.8-0.20250307142834-96bdba94b63f h1:1C7nZuxUMNz7eiQALRfiqNOm04+m3edWlRff/BYHf0Q=
 9fans.net/go v0.0.8-0.20250307142834-96bdba94b63f/go.mod h1:hHyrZRryGqVdqrknjq5OWDLGCTJ2NeEvtrpR96mjraM=
+cloud.google.com/go v0.121.6 h1:waZiuajrI28iAf40cWgycWNgaXPO06dupuS+sgibK6c=
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 filippo.io/mkcert v1.4.4 h1:8eVbbwfVlaqUM7OwuftKc2nuYOoTDQWqsoXmzoXZdbc=
@@ -578,6 +581,8 @@ golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
 golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -24,25 +24,25 @@ type ChannelsConfig struct {
 }
 
 type TelegramConfig struct {
-	Enabled        bool                `json:"enabled"`
-	Token          string              `json:"token"`
-	Proxy          string              `json:"proxy,omitempty"`
-	APIServer      string              `json:"api_server,omitempty"` // custom Telegram Bot API server URL (e.g. "http://localhost:8081")
-	AllowFrom      FlexibleStringSlice `json:"allow_from"`
-	DMPolicy       string              `json:"dm_policy,omitempty"`       // "pairing" (default), "allowlist", "open", "disabled"
-	GroupPolicy    string              `json:"group_policy,omitempty"`    // "open" (default), "allowlist", "disabled"
-	RequireMention *bool               `json:"require_mention,omitempty"` // require @bot mention in groups (default true)
-	MentionMode    string              `json:"mention_mode,omitempty"`    // "strict" (default) = only respond when mentioned; "yield" = respond unless another bot is mentioned
-	HistoryLimit   int                 `json:"history_limit,omitempty"`   // max pending group messages for context (default 50, 0=disabled)
-	DMStream         *bool               `json:"dm_stream,omitempty"`          // enable streaming for DMs (default false) — edits placeholder progressively
-	GroupStream      *bool               `json:"group_stream,omitempty"`      // enable streaming for groups (default false) — sends new message, edits progressively
-	DraftTransport   *bool               `json:"draft_transport,omitempty"`   // use sendMessageDraft for DM streaming (default true) — stealth preview, no notifications per edit
-	ReasoningStream  *bool               `json:"reasoning_stream,omitempty"`  // show reasoning as separate message when provider emits thinking events (default true)
-	ReactionLevel    string              `json:"reaction_level,omitempty"`    // "off" (default), "minimal", "full" — status emoji reactions
-	MediaMaxBytes  int64               `json:"media_max_bytes,omitempty"` // max media download size in bytes (default 20MB)
-	LinkPreview    *bool               `json:"link_preview,omitempty"`    // enable URL previews in messages (default true)
-	BlockReply     *bool               `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
-	ForceIPv4      bool                `json:"force_ipv4,omitempty"`      // force IPv4 for all Telegram API requests (use when IPv6 routing is broken)
+	Enabled         bool                `json:"enabled"`
+	Token           string              `json:"token"`
+	Proxy           string              `json:"proxy,omitempty"`
+	APIServer       string              `json:"api_server,omitempty"` // custom Telegram Bot API server URL (e.g. "http://localhost:8081")
+	AllowFrom       FlexibleStringSlice `json:"allow_from"`
+	DMPolicy        string              `json:"dm_policy,omitempty"`        // "pairing" (default), "allowlist", "open", "disabled"
+	GroupPolicy     string              `json:"group_policy,omitempty"`     // "open" (default), "allowlist", "disabled"
+	RequireMention  *bool               `json:"require_mention,omitempty"`  // require @bot mention in groups (default true)
+	MentionMode     string              `json:"mention_mode,omitempty"`     // "strict" (default) = only respond when mentioned; "yield" = respond unless another bot is mentioned
+	HistoryLimit    int                 `json:"history_limit,omitempty"`    // max pending group messages for context (default 50, 0=disabled)
+	DMStream        *bool               `json:"dm_stream,omitempty"`        // enable streaming for DMs (default false) — edits placeholder progressively
+	GroupStream     *bool               `json:"group_stream,omitempty"`     // enable streaming for groups (default false) — sends new message, edits progressively
+	DraftTransport  *bool               `json:"draft_transport,omitempty"`  // use sendMessageDraft for DM streaming (default true) — stealth preview, no notifications per edit
+	ReasoningStream *bool               `json:"reasoning_stream,omitempty"` // show reasoning as separate message when provider emits thinking events (default true)
+	ReactionLevel   string              `json:"reaction_level,omitempty"`   // "off" (default), "minimal", "full" — status emoji reactions
+	MediaMaxBytes   int64               `json:"media_max_bytes,omitempty"`  // max media download size in bytes (default 20MB)
+	LinkPreview     *bool               `json:"link_preview,omitempty"`     // enable URL previews in messages (default true)
+	BlockReply      *bool               `json:"block_reply,omitempty"`      // override gateway block_reply (nil = inherit)
+	ForceIPv4       bool                `json:"force_ipv4,omitempty"`       // force IPv4 for all Telegram API requests (use when IPv6 routing is broken)
 
 	// Optional STT (Speech-to-Text) pipeline for voice/audio inbound messages.
 	// When stt_proxy_url is set, audio/voice messages are transcribed before being forwarded to the agent.
@@ -133,7 +133,7 @@ type SlackConfig struct {
 
 type WhatsAppConfig struct {
 	Enabled        bool                `json:"enabled"`
-	AuthDir        string              `json:"auth_dir,omitempty"`        // optional: SQLite auth dir override (desktop)
+	AuthDir        string              `json:"auth_dir,omitempty"` // optional: SQLite auth dir override (desktop)
 	AllowFrom      FlexibleStringSlice `json:"allow_from"`
 	DMPolicy       string              `json:"dm_policy,omitempty"`       // "pairing" (default for DB instances), "open", "allowlist", "disabled"
 	GroupPolicy    string              `json:"group_policy,omitempty"`    // "pairing" (default for DB instances), "open" (default for config), "allowlist", "disabled"
@@ -196,28 +196,29 @@ type FeishuConfig struct {
 
 // ProvidersConfig maps provider name to its config.
 type ProvidersConfig struct {
-	Anthropic  ProviderConfig  `json:"anthropic"`
-	OpenAI     ProviderConfig  `json:"openai"`
-	OpenRouter ProviderConfig  `json:"openrouter"`
-	Groq       ProviderConfig  `json:"groq"`
-	Gemini     ProviderConfig  `json:"gemini"`
-	DeepSeek   ProviderConfig  `json:"deepseek"`
-	Mistral    ProviderConfig  `json:"mistral"`
-	XAI        ProviderConfig  `json:"xai"`
-	MiniMax    ProviderConfig  `json:"minimax"`
-	Cohere     ProviderConfig  `json:"cohere"`
-	Perplexity ProviderConfig  `json:"perplexity"`
-	DashScope  ProviderConfig  `json:"dashscope"`
-	Bailian    ProviderConfig  `json:"bailian"`
-	Zai         ProviderConfig  `json:"zai"`
-	ZaiCoding   ProviderConfig  `json:"zai_coding"`
-	Ollama      OllamaConfig    `json:"ollama"`       // local Ollama instance (no API key needed)
-	OllamaCloud ProviderConfig  `json:"ollama_cloud"` // Ollama Cloud (API key required)
-	ClaudeCLI   ClaudeCLIConfig `json:"claude_cli"`
-	ACP         ACPConfig       `json:"acp"`
+	Anthropic      ProviderConfig  `json:"anthropic"`
+	OpenAI         ProviderConfig  `json:"openai"`
+	OpenRouter     ProviderConfig  `json:"openrouter"`
+	Groq           ProviderConfig  `json:"groq"`
+	Gemini         ProviderConfig  `json:"gemini"`
+	DeepSeek       ProviderConfig  `json:"deepseek"`
+	Mistral        ProviderConfig  `json:"mistral"`
+	XAI            ProviderConfig  `json:"xai"`
+	MiniMax        ProviderConfig  `json:"minimax"`
+	Cohere         ProviderConfig  `json:"cohere"`
+	Perplexity     ProviderConfig  `json:"perplexity"`
+	DashScope      ProviderConfig  `json:"dashscope"`
+	Bailian        ProviderConfig  `json:"bailian"`
+	Zai            ProviderConfig  `json:"zai"`
+	ZaiCoding      ProviderConfig  `json:"zai_coding"`
+	Ollama         OllamaConfig    `json:"ollama"`       // local Ollama instance (no API key needed)
+	OllamaCloud    ProviderConfig  `json:"ollama_cloud"` // Ollama Cloud (API key required)
+	ClaudeCLI      ClaudeCLIConfig `json:"claude_cli"`
+	ACP            ACPConfig       `json:"acp"`
 	Novita         ProviderConfig  `json:"novita"`          // Novita AI (OpenAI-compatible endpoint)
 	BytePlus       ProviderConfig  `json:"byteplus"`        // BytePlus ModelArk (Seed 2.0)
 	BytePlusCoding ProviderConfig  `json:"byteplus_coding"` // BytePlus ModelArk Coding Plan
+	Vertex         ProviderConfig  `json:"vertex"`          // Google Vertex AI OpenAI-compatible endpoint
 }
 
 // OllamaConfig configures a local (or self-hosted) Ollama instance.
@@ -292,6 +293,8 @@ func (p *ProvidersConfig) APIBaseForType(providerType string) string {
 		return p.BytePlus.APIBase
 	case "byteplus_coding":
 		return p.BytePlusCoding.APIBase
+	case "vertex":
+		return p.Vertex.APIBase
 	default:
 		return ""
 	}
@@ -321,7 +324,8 @@ func (c *Config) HasAnyProvider() bool {
 		p.ACP.Binary != "" ||
 		p.Novita.APIKey != "" ||
 		p.BytePlus.APIKey != "" ||
-		p.BytePlusCoding.APIKey != ""
+		p.BytePlusCoding.APIKey != "" ||
+		p.Vertex.APIBase != ""
 }
 
 // QuotaWindow defines request limits per time window. Zero means unlimited.
@@ -346,16 +350,16 @@ type QuotaConfig struct {
 
 // GatewayConfig controls the gateway server.
 type GatewayConfig struct {
-	Host              string       `json:"host"`
-	Port              int          `json:"port"`
-	Token             string       `json:"token,omitempty"`               // bearer token for WS/HTTP auth
-	OwnerIDs          []string     `json:"owner_ids,omitempty"`           // sender IDs considered "owner"
-	AllowedOrigins    []string     `json:"allowed_origins,omitempty"`     // WebSocket CORS whitelist (empty = allow all)
-	MaxMessageChars   int          `json:"max_message_chars,omitempty"`   // max user message characters (default 32000)
-	RateLimitRPM      int          `json:"rate_limit_rpm,omitempty"`      // rate limit: requests per minute per user (default 20, 0 = disabled)
-	InjectionAction   string       `json:"injection_action,omitempty"`    // prompt injection action: "log", "warn" (default), "block", "off"
-	InboundDebounceMs int          `json:"inbound_debounce_ms,omitempty"` // merge rapid messages from same sender (default 1000ms, -1 = disabled)
-	Quota             *QuotaConfig `json:"quota,omitempty"`               // per-user/group request quotas
+	Host                    string       `json:"host"`
+	Port                    int          `json:"port"`
+	Token                   string       `json:"token,omitempty"`                      // bearer token for WS/HTTP auth
+	OwnerIDs                []string     `json:"owner_ids,omitempty"`                  // sender IDs considered "owner"
+	AllowedOrigins          []string     `json:"allowed_origins,omitempty"`            // WebSocket CORS whitelist (empty = allow all)
+	MaxMessageChars         int          `json:"max_message_chars,omitempty"`          // max user message characters (default 32000)
+	RateLimitRPM            int          `json:"rate_limit_rpm,omitempty"`             // rate limit: requests per minute per user (default 20, 0 = disabled)
+	InjectionAction         string       `json:"injection_action,omitempty"`           // prompt injection action: "log", "warn" (default), "block", "off"
+	InboundDebounceMs       int          `json:"inbound_debounce_ms,omitempty"`        // merge rapid messages from same sender (default 1000ms, -1 = disabled)
+	Quota                   *QuotaConfig `json:"quota,omitempty"`                      // per-user/group request quotas
 	BlockReply              *bool        `json:"block_reply,omitempty"`                // deliver intermediate text during tool iterations (default false)
 	ToolStatus              *bool        `json:"tool_status,omitempty"`                // show tool name in streaming preview during tool execution (default true)
 	TaskRecoveryIntervalSec int          `json:"task_recovery_interval_sec,omitempty"` // team task recovery ticker interval in seconds (default 300 = 5min)
@@ -413,9 +417,9 @@ type WebFetchPolicyConfig struct {
 
 // BrowserToolConfig controls the browser automation tool.
 type BrowserToolConfig struct {
-	Enabled         bool   `json:"enabled"`                    // enable the browser tool (default false)
-	Headless        bool   `json:"headless,omitempty"`         // run Chrome in headless mode (ignored when RemoteURL is set)
-	RemoteURL       string `json:"remote_url,omitempty"`       // CDP endpoint for remote Chrome sidecar, e.g. "ws://chrome:9222"
+	Enabled         bool   `json:"enabled"`                     // enable the browser tool (default false)
+	Headless        bool   `json:"headless,omitempty"`          // run Chrome in headless mode (ignored when RemoteURL is set)
+	RemoteURL       string `json:"remote_url,omitempty"`        // CDP endpoint for remote Chrome sidecar, e.g. "ws://chrome:9222"
 	ActionTimeoutMs int    `json:"action_timeout_ms,omitempty"` // per-action timeout in ms (default 30000)
 	IdleTimeoutMs   int    `json:"idle_timeout_ms,omitempty"`   // idle page auto-close in ms (default 600000, 0=disabled)
 	MaxPages        int    `json:"max_pages,omitempty"`         // max open pages per tenant (default 5)
@@ -423,12 +427,12 @@ type BrowserToolConfig struct {
 
 // ToolPolicySpec defines a tool policy at any level (global, per-agent, per-provider).
 type ToolPolicySpec struct {
-	Profile    string                     `json:"profile,omitempty"`
-	Allow      []string                   `json:"allow,omitempty"`
-	Deny       []string                   `json:"deny,omitempty"`
-	AlsoAllow  []string                   `json:"alsoAllow,omitempty"`
-	ByProvider map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
-	ToolCallPrefix string `json:"toolCallPrefix,omitempty"` // prefix to strip from model's tool call names before registry lookup
+	Profile        string                     `json:"profile,omitempty"`
+	Allow          []string                   `json:"allow,omitempty"`
+	Deny           []string                   `json:"deny,omitempty"`
+	AlsoAllow      []string                   `json:"alsoAllow,omitempty"`
+	ByProvider     map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
+	ToolCallPrefix string                     `json:"toolCallPrefix,omitempty"` // prefix to strip from model's tool call names before registry lookup
 }
 
 type WebToolsConfig struct {

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -112,6 +112,7 @@ func (c *Config) applyEnvOverrides() {
 	envStr("GOCLAW_OLLAMA_HOST", &c.Providers.Ollama.Host)
 	envStr("GOCLAW_OLLAMA_CLOUD_API_KEY", &c.Providers.OllamaCloud.APIKey)
 	envStr("GOCLAW_OLLAMA_CLOUD_API_BASE", &c.Providers.OllamaCloud.APIBase)
+	envStr("GOCLAW_VERTEX_API_BASE", &c.Providers.Vertex.APIBase)
 	envStr("GOCLAW_GATEWAY_TOKEN", &c.Gateway.Token)
 	envStr("GOCLAW_TELEGRAM_TOKEN", &c.Channels.Telegram.Token)
 	envStr("GOCLAW_DISCORD_TOKEN", &c.Channels.Discord.Token)
@@ -279,7 +280,6 @@ func (c *Config) applyEnvOverrides() {
 		c.Tools.Browser.Enabled = true
 	}
 }
-
 
 // Save writes the config to a JSON file.
 func Save(path string, cfg *Config) error {

--- a/internal/http/openapi_spec.json
+++ b/internal/http/openapi_spec.json
@@ -933,7 +933,7 @@
         "properties": {
           "name": { "type": "string", "description": "Unique provider slug" },
           "display_name": { "type": "string" },
-          "provider_type": { "type": "string", "enum": ["anthropic_native", "openai_compat", "gemini_native", "openrouter", "groq", "deepseek", "mistral", "xai", "minimax_native", "cohere", "perplexity", "dashscope", "bailian", "chatgpt_oauth", "claude_cli", "suno", "yescale", "zai", "zai_coding", "ollama", "ollama_cloud", "acp"] },
+          "provider_type": { "type": "string", "enum": ["anthropic_native", "openai_compat", "gemini_native", "openrouter", "groq", "deepseek", "mistral", "xai", "minimax_native", "cohere", "perplexity", "dashscope", "bailian", "chatgpt_oauth", "claude_cli", "suno", "yescale", "zai", "zai_coding", "ollama", "ollama_cloud", "acp", "vertex"] },
           "api_base": { "type": "string" },
           "api_key": { "type": "string" },
           "enabled": { "type": "boolean", "default": true },

--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -15,8 +15,8 @@ import (
 
 // ModelInfo is a normalized model entry returned by the list-models endpoint.
 type ModelInfo struct {
-	ID        string                        `json:"id"`
-	Name      string                        `json:"name,omitempty"`
+	ID        string                         `json:"id"`
+	Name      string                         `json:"name,omitempty"`
 	Reasoning *providers.ReasoningCapability `json:"reasoning,omitempty"`
 }
 
@@ -86,7 +86,7 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if p.APIKey == "" {
+	if p.APIKey == "" && p.ProviderType != store.ProviderVertex {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "API key")})
 		return
 	}
@@ -101,6 +101,18 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 		models, err = fetchAnthropicModels(ctx, p.APIKey, h.resolveAPIBase(p))
 	case "gemini_native":
 		models, err = fetchGeminiModels(ctx, p.APIKey)
+	case store.ProviderVertex:
+		apiBase := strings.TrimRight(h.resolveAPIBase(p), "/")
+		if apiBase == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "api_base")})
+			return
+		}
+		ts, tsErr := providers.NewVertexTokenSource()
+		if tsErr != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": tsErr.Error()})
+			return
+		}
+		models, err = fetchOpenAIModelsWithTokenSource(ctx, apiBase, ts)
 	case "bailian":
 		models = bailianModels()
 	case "dashscope":

--- a/internal/http/provider_models_fetch.go
+++ b/internal/http/provider_models_fetch.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
 )
 
 // fetchAnthropicModels calls the Anthropic models API.
@@ -124,6 +125,14 @@ func fetchOpenAIModels(ctx context.Context, apiBase, apiKey string) ([]ModelInfo
 		models = append(models, ModelInfo{ID: m.ID, Name: m.ID})
 	}
 	return models, nil
+}
+
+func fetchOpenAIModelsWithTokenSource(ctx context.Context, apiBase string, ts providers.TokenSource) ([]ModelInfo, error) {
+	token, err := ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("token source error: %w", err)
+	}
+	return fetchOpenAIModels(ctx, apiBase, token)
 }
 
 // fetchOllamaModels calls Ollama's native /api/tags endpoint to get model metadata

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -183,6 +183,19 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 		h.providerReg.RegisterForTenant(p.TenantID, providers.NewOpenAIProvider(p.Name, "ollama", config.DockerLocalhost(host), "llama3.3"))
 		return
 	}
+	if p.ProviderType == store.ProviderVertex {
+		if p.APIBase == "" {
+			slog.Warn("providers.register.vertex", "name", p.Name, "error", "missing api_base")
+			return
+		}
+		ts, err := providers.NewVertexTokenSource()
+		if err != nil {
+			slog.Warn("providers.register.vertex", "name", p.Name, "error", err)
+			return
+		}
+		h.providerReg.RegisterForTenant(p.TenantID, providers.NewVertexProvider(p.Name, h.resolveAPIBase(p), "google/gemini-2.5-flash", ts))
+		return
+	}
 	if p.APIKey == "" {
 		return
 	}
@@ -286,6 +299,16 @@ func validateProviderURL(rawURL string, providerType string) error {
 	return nil
 }
 
+func validateVertexProviderPolicy(p *store.LLMProviderData) error {
+	if p.ProviderType != store.ProviderVertex {
+		return nil
+	}
+	if strings.TrimSpace(p.APIKey) != "" {
+		return fmt.Errorf("vertex provider does not accept api_key; use ADC on server runtime")
+	}
+	return nil
+}
+
 // --- Provider CRUD ---
 
 func (h *ProvidersHandler) handleListProviders(w http.ResponseWriter, r *http.Request) {
@@ -322,6 +345,10 @@ func (h *ProvidersHandler) handleCreateProvider(w http.ResponseWriter, r *http.R
 	}
 	if !store.ValidProviderTypes[p.ProviderType] {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidRequest, "unsupported provider_type")})
+		return
+	}
+	if err := validateVertexProviderPolicy(&p); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
 
@@ -457,6 +484,10 @@ func (h *ProvidersHandler) handleUpdateProvider(w http.ResponseWriter, r *http.R
 			return
 		}
 		candidate.Settings = rawSettings
+	}
+	if err := validateVertexProviderPolicy(&candidate); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
 	}
 
 	// Re-validate URLs against the (possibly new) provider type.

--- a/internal/http/providers_test.go
+++ b/internal/http/providers_test.go
@@ -187,3 +187,63 @@ func TestProvidersHandlerUpdateRejectsIncompatibleEmbeddingDimensions(t *testing
 		t.Fatalf("embedding dimensions = %+v, want 1536 preserved", es)
 	}
 }
+
+func TestProvidersHandlerCreateRejectsVertexAPIKey(t *testing.T) {
+	token := setupProvidersAdminToken(t)
+	providerStore := newMockProviderStore()
+	handler := NewProvidersHandler(providerStore, newMockSecretsStore(), nil, "")
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	body := `{
+		"name": "vertex-main",
+		"provider_type": "vertex",
+		"api_base": "https://aiplatform.googleapis.com/v1/projects/p/locations/global/endpoints/openapi",
+		"api_key": "should-not-be-accepted",
+		"enabled": true
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d, body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "does not accept api_key") {
+		t.Fatalf("response body = %q, want vertex api_key rejection", w.Body.String())
+	}
+}
+
+func TestProvidersHandlerUpdateRejectsVertexAPIKey(t *testing.T) {
+	token := setupProvidersAdminToken(t)
+	providerStore := newMockProviderStore()
+	provider := &store.LLMProviderData{
+		BaseModel:    store.BaseModel{ID: uuid.New()},
+		Name:         "vertex-main",
+		ProviderType: store.ProviderVertex,
+		APIBase:      "https://aiplatform.googleapis.com/v1/projects/p/locations/global/endpoints/openapi",
+		Enabled:      true,
+	}
+	if err := providerStore.CreateProvider(context.Background(), provider); err != nil {
+		t.Fatalf("CreateProvider() error = %v", err)
+	}
+
+	handler := NewProvidersHandler(providerStore, newMockSecretsStore(), nil, "")
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	body := `{"api_key":"should-not-be-accepted"}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/providers/"+provider.ID.String(), bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d, body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "does not accept api_key") {
+		t.Fatalf("response body = %q, want vertex api_key rejection", w.Body.String())
+	}
+}

--- a/internal/providers/vertex.go
+++ b/internal/providers/vertex.go
@@ -1,0 +1,264 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// VertexProvider is a native provider for Google Vertex AI's OpenAI-compatible chat API.
+// It keeps request/response shape aligned with OpenAI Chat Completions while using
+// Google access tokens (ADC or explicit bearer token) for authentication.
+type VertexProvider struct {
+	name         string
+	apiBase      string
+	defaultModel string
+	tokenSource  TokenSource
+	client       *http.Client
+	retryConfig  RetryConfig
+	middlewares  RequestMiddleware
+	base         *OpenAIProvider
+}
+
+func NewVertexProvider(name, apiBase, defaultModel string, tokenSource TokenSource) *VertexProvider {
+	baseURL := strings.TrimRight(apiBase, "/")
+	if name == "" {
+		name = "vertex"
+	}
+	if defaultModel == "" {
+		defaultModel = "google/gemini-2.5-flash"
+	}
+	openaiBase := NewOpenAIProvider(name, "", baseURL, defaultModel)
+	openaiBase.WithProviderType("vertex")
+
+	return &VertexProvider{
+		name:         name,
+		apiBase:      baseURL,
+		defaultModel: defaultModel,
+		tokenSource:  tokenSource,
+		client:       &http.Client{Timeout: DefaultHTTPTimeout},
+		retryConfig:  DefaultRetryConfig(),
+		middlewares:  ComposeMiddlewares(FastModeMiddleware, ServiceTierMiddleware, CacheMiddleware),
+		base:         openaiBase,
+	}
+}
+
+func (p *VertexProvider) Name() string           { return p.name }
+func (p *VertexProvider) DefaultModel() string   { return p.defaultModel }
+func (p *VertexProvider) SupportsThinking() bool { return true }
+
+func (p *VertexProvider) Capabilities() ProviderCapabilities {
+	return ProviderCapabilities{
+		Streaming:        true,
+		ToolCalling:      true,
+		StreamWithTools:  true,
+		Thinking:         true,
+		Vision:           true,
+		CacheControl:     false,
+		MaxContextWindow: 1_000_000,
+		TokenizerID:      "o200k_base",
+	}
+}
+
+func (p *VertexProvider) middlewareConfig(model string, req ChatRequest) MiddlewareConfig {
+	return MiddlewareConfig{
+		Provider: p.name,
+		Model:    model,
+		Caps:     p.Capabilities(),
+		AuthType: "oauth",
+		APIBase:  p.apiBase,
+		Options:  req.Options,
+	}
+}
+
+func (p *VertexProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	model := p.base.resolveModel(req.Model)
+	body := p.base.buildRequestBody(model, req, false)
+	body = ApplyMiddlewares(body, p.middlewares, p.middlewareConfig(model, req))
+
+	chatFn := func() (*ChatResponse, error) {
+		respBody, err := p.doRequest(ctx, body)
+		if err != nil {
+			return nil, err
+		}
+		defer respBody.Close()
+
+		var oaiResp openAIResponse
+		if err := json.NewDecoder(respBody).Decode(&oaiResp); err != nil {
+			return nil, fmt.Errorf("%s: decode response: %w", p.name, err)
+		}
+		return p.base.parseResponse(&oaiResp), nil
+	}
+
+	resp, err := RetryDo(ctx, p.retryConfig, chatFn)
+	if err != nil {
+		if clamped := clampMaxTokensFromError(err, body); clamped {
+			slog.Info("vertex: max_tokens clamped, retrying", "model", model, "limit", clampedLimit(body))
+			resp, err = RetryDo(ctx, p.retryConfig, chatFn)
+		}
+	}
+	if resp != nil {
+		if strip, _ := req.Options[OptStripThinking].(bool); strip {
+			resp.Thinking = ""
+		}
+	}
+	return resp, err
+}
+
+func (p *VertexProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk func(StreamChunk)) (*ChatResponse, error) {
+	model := p.base.resolveModel(req.Model)
+	stripThinking, _ := req.Options[OptStripThinking].(bool)
+	body := p.base.buildRequestBody(model, req, true)
+	body = ApplyMiddlewares(body, p.middlewares, p.middlewareConfig(model, req))
+
+	respBody, err := RetryDo(ctx, p.retryConfig, func() (io.ReadCloser, error) {
+		return p.doRequest(ctx, body)
+	})
+	if err != nil {
+		if clamped := clampMaxTokensFromError(err, body); clamped {
+			slog.Info("vertex: max_tokens clamped, retrying stream", "model", model, "limit", clampedLimit(body))
+			respBody, err = RetryDo(ctx, p.retryConfig, func() (io.ReadCloser, error) {
+				return p.doRequest(ctx, body)
+			})
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer respBody.Close()
+
+	result := &ChatResponse{FinishReason: "stop"}
+	accumulators := make(map[int]*toolCallAccumulator)
+
+	sse := NewSSEScanner(respBody)
+	for sse.Next() {
+		data := sse.Data()
+
+		var chunk openAIStreamChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+		if chunk.Usage != nil {
+			result.Usage = &Usage{
+				PromptTokens:     chunk.Usage.PromptTokens,
+				CompletionTokens: chunk.Usage.CompletionTokens,
+				TotalTokens:      chunk.Usage.TotalTokens,
+			}
+			if chunk.Usage.PromptTokensDetails != nil {
+				result.Usage.CacheReadTokens = chunk.Usage.PromptTokensDetails.CachedTokens
+			}
+			if chunk.Usage.CompletionTokensDetails != nil && chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
+				result.Usage.ThinkingTokens = chunk.Usage.CompletionTokensDetails.ReasoningTokens
+			}
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+
+		delta := chunk.Choices[0].Delta
+		reasoning := delta.ReasoningContent
+		if reasoning == "" {
+			reasoning = delta.Reasoning
+		}
+		if reasoning != "" && !stripThinking {
+			result.Thinking += reasoning
+			if onChunk != nil {
+				onChunk(StreamChunk{Thinking: reasoning})
+			}
+		}
+		if delta.Content != "" {
+			result.Content += delta.Content
+			if onChunk != nil {
+				onChunk(StreamChunk{Content: delta.Content})
+			}
+		}
+		for _, tc := range delta.ToolCalls {
+			acc, ok := accumulators[tc.Index]
+			if !ok {
+				acc = &toolCallAccumulator{
+					ToolCall: ToolCall{ID: tc.ID, Name: strings.TrimSpace(tc.Function.Name)},
+				}
+				accumulators[tc.Index] = acc
+			}
+			if tc.Function.Name != "" {
+				acc.Name = strings.TrimSpace(tc.Function.Name)
+			}
+			acc.rawArgs += tc.Function.Arguments
+			if tc.Function.ThoughtSignature != "" {
+				acc.thoughtSig = tc.Function.ThoughtSignature
+			}
+		}
+		if chunk.Choices[0].FinishReason != "" {
+			result.FinishReason = chunk.Choices[0].FinishReason
+		}
+	}
+
+	if err := sse.Err(); err != nil {
+		return nil, fmt.Errorf("%s: stream read error: %w", p.name, err)
+	}
+	for i := 0; i < len(accumulators); i++ {
+		acc := accumulators[i]
+		args := make(map[string]any)
+		if err := json.Unmarshal([]byte(acc.rawArgs), &args); err != nil && acc.rawArgs != "" {
+			slog.Warn("vertex_stream: failed to parse tool call arguments",
+				"tool", acc.Name, "raw_len", len(acc.rawArgs), "error", err)
+			acc.ParseError = fmt.Sprintf("malformed JSON (%d chars): %v", len(acc.rawArgs), err)
+		}
+		acc.Arguments = args
+		if acc.thoughtSig != "" {
+			acc.Metadata = map[string]string{"thought_signature": acc.thoughtSig}
+		}
+		result.ToolCalls = append(result.ToolCalls, acc.ToolCall)
+	}
+	if len(result.ToolCalls) > 0 && result.FinishReason != "length" {
+		result.FinishReason = "tool_calls"
+	}
+	if onChunk != nil {
+		onChunk(StreamChunk{Done: true})
+	}
+	return result, nil
+}
+
+func (p *VertexProvider) doRequest(ctx context.Context, body any) (io.ReadCloser, error) {
+	if p.tokenSource == nil {
+		return nil, fmt.Errorf("%s: missing token source", p.name)
+	}
+
+	token, err := p.tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("%s: get access token: %w", p.name, err)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: marshal request: %w", p.name, err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.apiBase+"/chat/completions", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("%s: create request: %w", p.name, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("%s: request failed: %w", p.name, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		resp.Body.Close()
+		retryAfter := ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, &HTTPError{
+			Status:     resp.StatusCode,
+			Body:       fmt.Sprintf("%s: %s", p.name, string(respBody)),
+			RetryAfter: retryAfter,
+		}
+	}
+	return resp.Body, nil
+}

--- a/internal/providers/vertex_test.go
+++ b/internal/providers/vertex_test.go
@@ -1,0 +1,52 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testTokenSource struct {
+	token string
+}
+
+func (s *testTokenSource) Token() (string, error) {
+	return s.token, nil
+}
+
+func TestVertexProviderChat_UsesBearerToken(t *testing.T) {
+	var gotAuth string
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{"content": "ok"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	ts := &testTokenSource{token: "vertex-access-token"}
+	p := NewVertexProvider("vertex", server.URL, "google/gemini-2.5-flash", ts)
+	resp, err := p.Chat(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat error: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Fatalf("unexpected content: %q", resp.Content)
+	}
+	if gotAuth != "Bearer vertex-access-token" {
+		t.Fatalf("unexpected auth header: %q", gotAuth)
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("unexpected path: %q", gotPath)
+	}
+}

--- a/internal/providers/vertex_token_source.go
+++ b/internal/providers/vertex_token_source.go
@@ -1,0 +1,38 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const vertexCloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+type oauth2TokenSourceAdapter struct {
+	ts oauth2.TokenSource
+}
+
+func (a *oauth2TokenSourceAdapter) Token() (string, error) {
+	tok, err := a.ts.Token()
+	if err != nil {
+		return "", err
+	}
+	if tok == nil || tok.AccessToken == "" {
+		return "", fmt.Errorf("vertex: empty access token")
+	}
+	return tok.AccessToken, nil
+}
+
+// NewVertexTokenSource returns an ADC-backed token source for Vertex authentication.
+func NewVertexTokenSource() (TokenSource, error) {
+	creds, err := google.FindDefaultCredentials(context.Background(), vertexCloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("vertex: ADC unavailable: %w", err)
+	}
+	if creds == nil || creds.TokenSource == nil {
+		return nil, fmt.Errorf("vertex: ADC returned no token source")
+	}
+	return &oauth2TokenSourceAdapter{ts: creds.TokenSource}, nil
+}

--- a/internal/store/provider_store.go
+++ b/internal/store/provider_store.go
@@ -28,12 +28,13 @@ const (
 	ProviderYesScale        = "yescale"
 	ProviderZai             = "zai"
 	ProviderZaiCoding       = "zai_coding"
-	ProviderOllama          = "ollama"       // local or self-hosted Ollama (no API key)
-	ProviderOllamaCloud     = "ollama_cloud" // Ollama Cloud (Bearer token required)
-	ProviderACP             = "acp"          // ACP (Agent Client Protocol) agent subprocess
+	ProviderOllama          = "ollama"          // local or self-hosted Ollama (no API key)
+	ProviderOllamaCloud     = "ollama_cloud"    // Ollama Cloud (Bearer token required)
+	ProviderACP             = "acp"             // ACP (Agent Client Protocol) agent subprocess
 	ProviderNovita          = "novita"          // Novita AI (OpenAI-compatible endpoint)
 	ProviderBytePlus        = "byteplus"        // BytePlus ModelArk (Seed 2.0 models)
 	ProviderBytePlusCoding  = "byteplus_coding" // BytePlus ModelArk Coding Plan
+	ProviderVertex          = "vertex"          // Google Vertex AI OpenAI-compatible endpoint
 
 	// Novita AI defaults.
 	NovitaDefaultAPIBase = "https://api.novita.ai/openai"
@@ -72,6 +73,7 @@ var ValidProviderTypes = map[string]bool{
 	ProviderNovita:          true,
 	ProviderBytePlus:        true,
 	ProviderBytePlusCoding:  true,
+	ProviderVertex:          true,
 }
 
 // LLMProviderData represents an LLM provider configuration.

--- a/ui/web/src/constants/providers.ts
+++ b/ui/web/src/constants/providers.ts
@@ -32,6 +32,7 @@ export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: "zai_coding", label: "Z.ai Coding Plan", apiBase: "https://api.z.ai/api/coding/paas/v4", placeholder: "" },
   { value: "byteplus", label: "BytePlus ModelArk", apiBase: "https://ark.ap-southeast.bytepluses.com/api/v3", placeholder: "" },
   { value: "byteplus_coding", label: "BytePlus Coding Plan", apiBase: "https://ark.ap-southeast.bytepluses.com/api/coding/v3", placeholder: "" },
+  { value: "vertex", label: "Google Vertex AI", apiBase: "https://aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/global/endpoints/openapi", placeholder: "" },
   { value: "ollama", label: "Ollama (Local)", apiBase: "http://localhost:11434/v1", placeholder: "" },
   { value: "ollama_cloud", label: "Ollama Cloud", apiBase: "https://ollama.com/v1", placeholder: "" },
   { value: "claude_cli", label: "Claude CLI (Local)", apiBase: "", placeholder: "" },

--- a/ui/web/src/pages/providers/provider-form-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-form-dialog.tsx
@@ -70,6 +70,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
   const isOAuth = providerType === "chatgpt_oauth";
   const isCLI = providerType === "claude_cli";
   const isACP = providerType === "acp";
+  const isVertex = providerType === "vertex";
 
   // Reset form when dialog opens
   useEffect(() => {
@@ -109,7 +110,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
       if (Object.keys(settings).length > 0) payload.settings = settings;
     }
 
-    if (data.apiKey && data.apiKey !== "***") {
+    if (data.providerType !== "vertex" && data.apiKey && data.apiKey !== "***") {
       payload.api_key = data.apiKey;
     }
 
@@ -229,6 +230,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
                   errors={errors}
                   providerType={providerType}
                   control={control}
+                  isVertex={isVertex}
                 />
               )}
 

--- a/ui/web/src/pages/providers/provider-standard-form-fields.tsx
+++ b/ui/web/src/pages/providers/provider-standard-form-fields.tsx
@@ -12,6 +12,7 @@ interface ProviderStandardFormFieldsProps {
   errors: FieldErrors<ProviderCreateFormData>;
   providerType: string;
   control: Control<ProviderCreateFormData>;
+  isVertex?: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ export function ProviderStandardFormFields({
   errors,
   providerType,
   control,
+  isVertex = false,
 }: ProviderStandardFormFieldsProps) {
   const { t } = useTranslation("providers");
 
@@ -42,16 +44,27 @@ export function ProviderStandardFormFields({
         />
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="apiKey">{t("form.apiKey")}</Label>
-        <Input
-          id="apiKey"
-          type="password"
-          {...register("apiKey")}
-          placeholder={t("form.apiKeyPlaceholder")}
-          className="text-base md:text-sm"
-        />
-      </div>
+      {isVertex && (
+        <div className="space-y-2">
+          <Label>Vertex auth mode</Label>
+          <p className="text-xs text-muted-foreground">
+            ADC only. Configure Google credentials on the server runtime (no API key in UI).
+          </p>
+        </div>
+      )}
+
+      {!isVertex && (
+        <div className="space-y-2">
+          <Label htmlFor="apiKey">{t("form.apiKey")}</Label>
+          <Input
+            id="apiKey"
+            type="password"
+            {...register("apiKey")}
+            placeholder={t("form.apiKeyPlaceholder")}
+            className="text-base md:text-sm"
+          />
+        </div>
+      )}
 
       <div className="flex items-center justify-between">
         <Label htmlFor="enabled">{t("form.enabled")}</Label>

--- a/ui/web/src/pages/setup/step-provider.tsx
+++ b/ui/web/src/pages/setup/step-provider.tsx
@@ -47,6 +47,7 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
   const isCLI = providerType === "claude_cli";
   // Local Ollama uses no API key — the server accepts any non-empty Bearer value internally
   const isOllama = providerType === "ollama";
+  const isVertex = providerType === "vertex";
 
   const handleTypeChange = (value: string) => {
     setProviderType(value);
@@ -97,7 +98,7 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
 
   const handleSubmit = async () => {
     if (isOAuth) return;
-    if (!isEditing && !isCLI && !isOllama && !apiKey.trim()) { setError(t("provider.errors.apiKeyRequired")); return; }
+    if (!isEditing && !isCLI && !isOllama && !isVertex && !apiKey.trim()) { setError(t("provider.errors.apiKeyRequired")); return; }
     setLoading(true);
     setError("");
     try {
@@ -108,7 +109,7 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
           api_base: apiBase.trim() || undefined,
         };
         // Only include api_key if user entered a new one
-        if (apiKey.trim()) patch.api_key = apiKey.trim();
+        if (!isVertex && apiKey.trim()) patch.api_key = apiKey.trim();
         await updateProvider(existingProvider!.id, patch as Partial<ProviderInput>);
         onComplete({ ...existingProvider!, ...patch } as ProviderData);
       } else {
@@ -116,7 +117,7 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
           name: name.trim(),
           provider_type: providerType,
           api_base: apiBase.trim() || undefined,
-          api_key: isCLI || isOllama || isOAuth ? undefined : apiKey.trim(),
+          api_key: isCLI || isOllama || isOAuth || isVertex ? undefined : apiKey.trim(),
           enabled: true,
         }) as ProviderData;
         onComplete(provider);
@@ -139,6 +140,8 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
                 ? t("provider.descriptionOauth")
                 : isCLI
                 ? t("provider.descriptionCli")
+                : isVertex
+                ? "Connect Vertex AI using server-side Google ADC credentials."
                 : t("provider.description")}
             </p>
           </div>
@@ -197,18 +200,25 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
             <CLISection open={true} />
           ) : (
             <>
-              <div className="space-y-2">
-                <Label className="inline-flex items-center gap-1.5">
-                  {t("provider.apiKey")}
-                  <InfoTip text={t("provider.apiKeyHint")} />
-                </Label>
-                <Input
-                  type="password"
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                  placeholder="sk-..."
-                />
-              </div>
+              {!isVertex && (
+                <div className="space-y-2">
+                  <Label className="inline-flex items-center gap-1.5">
+                    {t("provider.apiKey")}
+                    <InfoTip text={t("provider.apiKeyHint")} />
+                  </Label>
+                  <Input
+                    type="password"
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder="sk-..."
+                  />
+                </div>
+              )}
+              {isVertex && (
+                <p className="text-xs text-muted-foreground">
+                  Vertex runs in ADC-only mode. Configure Google credentials on server runtime.
+                </p>
+              )}
 
               <div className="space-y-2">
                 <Label className="inline-flex items-center gap-1.5">
@@ -228,7 +238,7 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
 
           {!isOAuth && (
             <div className="flex justify-end">
-              <Button onClick={handleSubmit} disabled={loading || (!isEditing && !isCLI && !isOllama && !apiKey.trim())}>
+              <Button onClick={handleSubmit} disabled={loading || (!isEditing && !isCLI && !isOllama && !isVertex && !apiKey.trim())}>
                 {loading
                   ? isEditing ? t("provider.updating", "Updating...") : t("provider.creating")
                   : isEditing ? t("provider.update", "Update") : t("provider.create")}


### PR DESCRIPTION
## Summary
- add native vertex provider with Google ADC-backed token source and streaming/tool-call support
- expose Vertex in provider setup flows and enforce ADC-only policy (reject api_key for vertex)
- add Docker compose overlay for Vertex ADC mount (docker-compose.vertex.yml)

## Test plan
- go test ./internal/providers ./internal/http ./cmd ./internal/store ./internal/config
- verify setup/provider UI flow for Google Vertex AI no longer requires API key
- WITH_VERTEX=1 make -n up