### PR TITLE
feat(pancake): add comment auto-react (like) on Facebook

### DIFF
--- a/internal/channels/pancake/api_client.go
+++ b/internal/channels/pancake/api_client.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -283,6 +284,52 @@ func (c *APIClient) newPageRequest(ctx context.Context, method, rawURL string, b
 	// Keep the header for compatibility; official docs require the query token.
 	req.Header.Set("Authorization", "Bearer "+c.pageAccessToken)
 	return req, nil
+}
+
+// ReactComment toggles the page's like on a comment via Pancake user API:
+// POST {userAPI}/pages/{pageID}/conversations/{convID}/messages/{msgID}/likes
+// with multipart body (action=like_toggle, user_likes=false). Server flips the
+// current state, so call once per fresh comment (dedup prevents double-toggle).
+func (c *APIClient) ReactComment(ctx context.Context, conversationID, messageID string) error {
+	if conversationID == "" || messageID == "" {
+		return fmt.Errorf("pancake: react-comment requires conversation_id and message_id")
+	}
+	if strings.ContainsAny(conversationID, "/?#") || strings.ContainsAny(messageID, "/?#") {
+		return fmt.Errorf("pancake: invalid character in conversation_id or message_id")
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("action", "like_toggle")
+	_ = mw.WriteField("user_likes", "false")
+	mw.Close()
+
+	url := fmt.Sprintf("%s/pages/%s/conversations/%s/messages/%s/likes",
+		c.userBaseURL, c.pageID, conversationID, messageID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &buf)
+	if err != nil {
+		return fmt.Errorf("pancake: build react-comment request: %w", err)
+	}
+	q := req.URL.Query()
+	q.Set("access_token", c.apiKey)
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("pancake: react-comment request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, _ := io.ReadAll(res.Body)
+	if res.StatusCode >= 400 {
+		snippet := string(body)
+		if len(snippet) > 300 {
+			snippet = snippet[:300]
+		}
+		return fmt.Errorf("pancake: react-comment HTTP %d: %s", res.StatusCode, snippet)
+	}
+	return nil
 }
 
 // isAuthError checks if an error is an authentication/authorization failure.

--- a/internal/channels/pancake/api_client_test.go
+++ b/internal/channels/pancake/api_client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // --- ReplyComment ---
@@ -225,5 +226,93 @@ func TestConfigParsing_Defaults(t *testing.T) {
 	}
 	if cfg.FirstInboxMessage != "" {
 		t.Errorf("FirstInboxMessage should default to empty, got %q", cfg.FirstInboxMessage)
+	}
+}
+
+// --- ReactComment (Pancake user API) ---
+
+func TestReactComment_Success(t *testing.T) {
+	done := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/likes") {
+			if got := r.URL.Query().Get("access_token"); got != "user-key" {
+				t.Errorf("access_token query = %q, want user-key", got)
+			}
+			if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "multipart/form-data") {
+				t.Errorf("Content-Type = %q, want multipart/form-data", ct)
+			}
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Errorf("ParseMultipartForm: %v", err)
+			}
+			if got := r.FormValue("action"); got != "like_toggle" {
+				t.Errorf("action = %q, want like_toggle", got)
+			}
+			if got := r.FormValue("user_likes"); got != "false" {
+				t.Errorf("user_likes = %q, want false", got)
+			}
+			select {
+			case done <- r.URL.Path:
+			default:
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"success":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := NewAPIClient("user-key", "page-token", "page123")
+	client.userBaseURL = srv.URL
+	client.httpClient = srv.Client()
+
+	err := client.ReactComment(context.Background(), "conv-1_msg-1", "conv-1_msg-1")
+	if err != nil {
+		t.Fatalf("ReactComment unexpected error: %v", err)
+	}
+	select {
+	case path := <-done:
+		want := "/pages/page123/conversations/conv-1_msg-1/messages/conv-1_msg-1/likes"
+		if path != want {
+			t.Errorf("path = %q, want %q", path, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("POST /likes was not called within 2s")
+	}
+}
+
+func TestReactComment_ErrorIncludesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"success":false,"message":"invalid access_token"}`))
+	}))
+	defer srv.Close()
+
+	client := NewAPIClient("bad-key", "page-token", "page123")
+	client.userBaseURL = srv.URL
+	client.httpClient = srv.Client()
+
+	err := client.ReactComment(context.Background(), "conv-1", "msg-1")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), "invalid access_token") {
+		t.Errorf("expected HTTP status + body in error, got: %v", err)
+	}
+}
+
+func TestReactComment_RejectsInvalidIDs(t *testing.T) {
+	client := NewAPIClient("key", "token", "page123")
+	cases := []struct{ conv, msg string }{
+		{"", "msg-1"},
+		{"conv-1", ""},
+		{"conv/1", "msg-1"},
+		{"conv-1", "msg?evil=1"},
+		{"conv#frag", "msg-1"},
+	}
+	for _, c := range cases {
+		if err := client.ReactComment(context.Background(), c.conv, c.msg); err == nil {
+			t.Errorf("expected error for conv=%q msg=%q, got nil", c.conv, c.msg)
+		}
 	}
 }

--- a/internal/channels/pancake/comment_handler.go
+++ b/internal/channels/pancake/comment_handler.go
@@ -1,9 +1,11 @@
 package pancake
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
 )
@@ -11,13 +13,13 @@ import (
 // handleCommentEvent processes a Pancake COMMENT webhook event.
 // Mirrors the inbox handler pattern with additional comment-specific guards.
 func (ch *Channel) handleCommentEvent(data MessagingData) {
-	// Feature gate.
-	if !ch.config.Features.CommentReply {
+	// Feature gate — exit only if BOTH reply and auto-react are disabled.
+	if !ch.config.Features.CommentReply && !ch.config.Features.AutoReact {
 		ch.commentReplyDisabledOnce.Do(func() {
-			slog.Info("pancake: comment ignored because comment_reply disabled",
+			slog.Info("pancake: comment ignored because comment_reply and auto_react are both disabled",
 				"page_id", ch.pageID,
 				"channel_name", ch.Name(),
-				"hint", "enable config.features.comment_reply to auto-reply page comments")
+				"hint", "enable config.features.comment_reply or config.features.auto_react")
 		})
 		return
 	}
@@ -54,6 +56,24 @@ func (ch *Channel) handleCommentEvent(data MessagingData) {
 			slog.Debug("pancake: duplicate comment skipped", "msg_id", data.Message.ID)
 			return
 		}
+	}
+
+	// Auto-react BEFORE keyword filter — fires on all valid non-duplicate comments.
+	// Independent of comment_reply: reacts even if reply is disabled.
+	if ch.config.Features.AutoReact && ch.platform == "facebook" &&
+		data.ConversationID != "" && data.Message.ID != "" {
+		select {
+		case ch.reactSem <- struct{}{}:
+			go ch.reactCommentAsync(data.ConversationID, data.Message.ID)
+		default:
+			slog.Debug("pancake: react semaphore full, dropping reaction",
+				"page_id", ch.pageID, "comment_id", data.Message.ID)
+		}
+	}
+
+	// Comment reply gate — independent of auto_react above.
+	if !ch.config.Features.CommentReply {
+		return
 	}
 
 	// Comment filter.
@@ -144,6 +164,23 @@ func (ch *Channel) buildCommentContent(data MessagingData) string {
 	}
 
 	return sb.String()
+}
+
+// reactCommentAsync likes the comment on Facebook asynchronously.
+// Respects channel shutdown via stopCtx with 5s cap; releases the semaphore slot on exit.
+func (ch *Channel) reactCommentAsync(conversationID, messageID string) {
+	defer func() { <-ch.reactSem }()
+
+	ctx, cancel := context.WithTimeout(ch.stopCtx, 5*time.Second)
+	defer cancel()
+
+	if err := ch.apiClient.ReactComment(ctx, conversationID, messageID); err != nil {
+		slog.Warn("pancake: auto-react comment failed",
+			"comment_id", messageID, "conv_id", conversationID, "page_id", ch.pageID, "err", err)
+		return
+	}
+	slog.Debug("pancake: auto-reacted to comment",
+		"comment_id", messageID, "page_id", ch.pageID)
 }
 
 // filterComment checks if the comment matches the configured filter.

--- a/internal/channels/pancake/comment_handler_test.go
+++ b/internal/channels/pancake/comment_handler_test.go
@@ -103,8 +103,8 @@ func TestHandleCommentEvent_FeatureDisabledLogsDiagnostic(t *testing.T) {
 	ch.handleCommentEvent(commentEvent("page-1", "conv-2", "user-2", "msg-2", "hello again"))
 
 	out := buf.String()
-	if count := strings.Count(out, "comment_reply disabled"); count != 1 {
-		t.Fatalf("expected exactly one diagnostic log for disabled comment reply, got %d logs:\n%s", count, out)
+	if count := strings.Count(out, "comment_reply and auto_react are both disabled"); count != 1 {
+		t.Fatalf("expected exactly one diagnostic log for disabled features, got %d logs:\n%s", count, out)
 	}
 	if !strings.Contains(out, "page-1") {
 		t.Fatalf("expected diagnostic log to include page_id, got:\n%s", out)
@@ -395,4 +395,177 @@ func TestHandleCommentEvent_ChatIDIsConversationID(t *testing.T) {
 // contains is a helper to check if a string contains a substring.
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
+}
+
+// --- AutoReact ---
+
+func TestHandleCommentEvent_AutoReactEnabled(t *testing.T) {
+	done := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/likes") {
+			parts := strings.Split(r.URL.Path, "/")
+			for i, p := range parts {
+				if p == "likes" && i > 0 {
+					select {
+					case done <- parts[i-1]:
+					default:
+					}
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"success":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := pancakeInstanceConfig{}
+	cfg.Features.CommentReply = true
+	cfg.Features.AutoReact = true
+
+	ch, _ := newTestChannel(t, "page-1", cfg)
+	ch.apiClient.userBaseURL = srv.URL
+	ch.apiClient.httpClient = srv.Client()
+
+	evt := commentEvent("page-1", "conv-abc", "user-1", "msg-xyz", "hello page!")
+	ch.handleCommentEvent(evt)
+
+	select {
+	case gotID := <-done:
+		if gotID != "msg-xyz" {
+			t.Errorf("expected message ID msg-xyz in path, got %q", gotID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReactComment was not called within 2s")
+	}
+}
+
+func TestHandleCommentEvent_AutoReactDisabled(t *testing.T) {
+	reacted := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/likes") {
+			select {
+			case reacted <- struct{}{}:
+			default:
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := pancakeInstanceConfig{}
+	cfg.Features.CommentReply = true
+
+	ch, _ := newTestChannel(t, "page-1", cfg)
+	ch.apiClient.userBaseURL = srv.URL
+	ch.apiClient.httpClient = srv.Client()
+
+	evt := commentEvent("page-1", "conv-1", "user-1", "123456789012345", "test comment")
+	ch.handleCommentEvent(evt)
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-reacted:
+		t.Error("ReactComment must NOT be called when AutoReact=false")
+	default:
+	}
+}
+
+func TestHandleCommentEvent_AutoReact_IndependentOfCommentReply(t *testing.T) {
+	done := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/likes") {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := pancakeInstanceConfig{}
+	cfg.Features.CommentReply = false
+	cfg.Features.AutoReact = true
+
+	ch, _ := newTestChannel(t, "page-1", cfg)
+	ch.apiClient.userBaseURL = srv.URL
+	ch.apiClient.httpClient = srv.Client()
+
+	evt := commentEvent("page-1", "conv-1", "user-1", "123456789012345", "hi!")
+	ch.handleCommentEvent(evt)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AutoReact must fire even when CommentReply=false")
+	}
+}
+
+func TestHandleCommentEvent_AutoReact_SkipNonFacebook(t *testing.T) {
+	reacted := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/likes") {
+			select {
+			case reacted <- struct{}{}:
+			default:
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := pancakeInstanceConfig{}
+	cfg.Features.AutoReact = true
+	cfg.Features.CommentReply = true
+
+	ch, _ := newTestChannel(t, "page-1", cfg)
+	ch.platform = "instagram"
+	ch.apiClient.userBaseURL = srv.URL
+	ch.apiClient.httpClient = srv.Client()
+
+	evt := commentEvent("page-1", "conv-1", "user-1", "123456789012345", "hi!")
+	evt.Platform = "instagram"
+	ch.handleCommentEvent(evt)
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-reacted:
+		t.Error("ReactComment must NOT be called for non-Facebook platforms")
+	default:
+	}
+}
+
+func TestHandleCommentEvent_AutoReact_EmptyMessageID(t *testing.T) {
+	reacted := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/likes") {
+			select {
+			case reacted <- struct{}{}:
+			default:
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := pancakeInstanceConfig{}
+	cfg.Features.AutoReact = true
+	cfg.Features.CommentReply = true
+
+	ch, _ := newTestChannel(t, "page-1", cfg)
+	ch.apiClient.userBaseURL = srv.URL
+	ch.apiClient.httpClient = srv.Client()
+
+	// Empty message ID → must not react (guards against malformed webhook)
+	evt := commentEvent("page-1", "conv-1", "user-1", "", "hi!")
+	ch.handleCommentEvent(evt)
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-reacted:
+		t.Error("ReactComment must NOT fire when message ID is empty")
+	default:
+	}
 }

--- a/internal/channels/pancake/pancake.go
+++ b/internal/channels/pancake/pancake.go
@@ -56,6 +56,9 @@ type Channel struct {
 	// arrive but the feature is disabled in channel config.
 	commentReplyDisabledOnce sync.Once
 
+	// reactSem bounds concurrent Facebook comment-like calls (cap 10).
+	reactSem chan struct{}
+
 	stopCh  chan struct{}
 	stopCtx context.Context
 	stopFn  context.CancelFunc
@@ -88,6 +91,7 @@ func New(cfg pancakeInstanceConfig, creds pancakeCreds,
 		platform:      cfg.Platform,
 		webhookSecret: creds.WebhookSecret,
 		postFetcher:   NewPostFetcher(apiClient, cfg.PostContextCacheTTL),
+		reactSem:      make(chan struct{}, 10),
 		stopCh:        make(chan struct{}),
 		stopCtx:       stopCtx,
 		stopFn:        stopFn,
@@ -151,6 +155,15 @@ func (ch *Channel) Start(ctx context.Context) error {
 		slog.Warn("security.pancake_webhook_no_secret",
 			"page_id", ch.pageID,
 			"note", "webhook_secret not configured; incoming webhook requests will not be authenticated")
+	}
+
+	// [F9] Warn if auto_react enabled without webhook signature verification.
+	// Without HMAC, any actor reaching the webhook endpoint can trigger Pancake API calls.
+	if ch.config.Features.AutoReact && ch.webhookSecret == "" {
+		slog.Warn("security.pancake_auto_react_without_hmac: auto_react is enabled but "+
+			"webhook_secret is not set; configure webhook_secret to prevent "+
+			"unauthenticated like-comment triggers",
+			"page_id", ch.pageID)
 	}
 
 	globalRouter.register(ch)

--- a/internal/channels/pancake/types.go
+++ b/internal/channels/pancake/types.go
@@ -22,7 +22,8 @@ type pancakeInstanceConfig struct {
 	Features struct {
 		InboxReply   bool `json:"inbox_reply"`
 		CommentReply bool `json:"comment_reply"`
-		FirstInbox   bool `json:"first_inbox"` // send one-time DM to commenter after comment reply
+		FirstInbox   bool `json:"first_inbox"`  // send one-time DM to commenter after comment reply
+		AutoReact    bool `json:"auto_react"`   // auto-like user comments on Facebook (platform=facebook only)
 	} `json:"features"`
 	CommentReplyOptions struct {
 		IncludePostContext bool     `json:"include_post_context"` // prepend post text to comment content


### PR DESCRIPTION
## Summary

- Add opt-in `features.auto_react: true` config for Pancake channel
- Automatically likes user comments on Facebook via Pancake `/likes` endpoint when webhook received
- Independent of `comment_reply` — reacts even if reply is disabled
- Platform-guarded: only fires when `ch.platform == "facebook"`

## Changes

| File | Change |
|------|--------|
| `types.go` | +`AutoReact bool` to `Features` struct |
| `api_client.go` | +`ReactComment()` — multipart POST to Pancake `/likes` with `like_toggle` |
| `comment_handler.go` | +`reactCommentAsync()` wired before keyword filter; updated feature gate |
| `pancake.go` | +`reactSem` (cap 10) semaphore field; startup HMAC warning when `auto_react=true` without `webhook_secret` |

## Architecture

```
Webhook COMMENT received
  └─ handleCommentEvent()
       ├─ [guards: skip own, skip staff, senderID, convID]
       ├─ [dedup]
       ├─ if AutoReact && platform=="facebook" && msgID != ""
       │    → reactSem (cap 10) → go reactCommentAsync(convID, msgID)
       ├─ if !CommentReply → return
       └─ [filter, echo check, HandleMessage]

reactCommentAsync:
  └─ context.WithTimeout(stopCtx, 5s)
  └─ ReactComment(ctx, convID, msgID)
       └─ POST /pages/{pageID}/conversations/{convID}/messages/{msgID}/likes
            ?access_token={api_key}
            body: multipart (action=like_toggle, user_likes=false)
```

## Test plan

- [x] `TestReactComment_Success` — verifies path, auth, multipart fields
- [x] `TestReactComment_ErrorIncludesBody` — 401 error body in message
- [x] `TestReactComment_RejectsInvalidIDs` — empty/URL-injection guards
- [x] `TestHandleCommentEvent_AutoReactEnabled` — fires and calls /likes
- [x] `TestHandleCommentEvent_AutoReactDisabled` — does NOT call /likes
- [x] `TestHandleCommentEvent_AutoReact_IndependentOfCommentReply` — fires without comment_reply
- [x] `TestHandleCommentEvent_AutoReact_SkipNonFacebook` — skips instagram
- [x] `TestHandleCommentEvent_AutoReact_EmptyMessageID` — skips empty msgID
- [x] All pancake tests pass with `-race`