### PR TITLE
fix(zalo): OA bot wire type mismatch + poll client + context propagation

### DIFF
--- a/internal/channels/zalo/zalo.go
+++ b/internal/channels/zalo/zalo.go
@@ -116,7 +116,7 @@ func (c *Channel) Stop(_ context.Context) error {
 }
 
 // Send delivers an outbound message to a Zalo chat.
-func (c *Channel) Send(_ context.Context, msg bus.OutboundMessage) error {
+func (c *Channel) Send(ctx context.Context, msg bus.OutboundMessage) error {
 	if !c.IsRunning() {
 		return fmt.Errorf("zalo bot not running")
 	}
@@ -132,13 +132,13 @@ func (c *Channel) Send(_ context.Context, msg bus.OutboundMessage) error {
 			if end > 0 {
 				photoURL := msg.Content[start+7 : start+end]
 				caption := strings.TrimSpace(msg.Content[:start] + msg.Content[start+end+1:])
-				return c.sendPhoto(msg.ChatID, photoURL, caption)
+				return c.sendPhoto(ctx, msg.ChatID, photoURL, caption)
 			}
 		}
 	}
 
 	// Send as text, chunking if over 2000 chars
-	return c.sendChunkedText(msg.ChatID, msg.Content)
+	return c.sendChunkedText(ctx, msg.ChatID, msg.Content)
 }
 
 // --- Polling ---
@@ -263,7 +263,7 @@ func (c *Channel) handleImageMessage(msg *zaloMessage) {
 	}
 
 	if photoURL != "" {
-		localPath, err := c.downloadMedia(photoURL)
+		localPath, err := c.downloadMedia(ctx, photoURL)
 		if err != nil {
 			slog.Warn("zalo photo download failed, passing URL as fallback",
 				"photo_url", photoURL, "error", err)
@@ -325,7 +325,7 @@ func (c *Channel) sendPairingReply(ctx context.Context, senderID, chatID string)
 		senderID, code, code,
 	)
 
-	if err := c.sendMessage(chatID, replyText); err != nil {
+	if err := c.sendMessage(ctx, chatID, replyText); err != nil {
 		slog.Warn("failed to send zalo pairing reply", "error", err)
 	} else {
 		c.MarkPairingNotifSent(senderID)
@@ -339,8 +339,12 @@ const maxMediaBytes = 10 * 1024 * 1024 // 10MB
 
 // downloadMedia fetches a photo from a Zalo CDN URL and saves it as a local temp file.
 // Zalo CDN URLs are auth-restricted and expire, so we must download immediately.
-func (c *Channel) downloadMedia(url string) (string, error) {
-	resp, err := c.client.Get(url)
+func (c *Channel) downloadMedia(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetch: %w", err)
 	}
@@ -384,9 +388,9 @@ func (c *Channel) downloadMedia(url string) (string, error) {
 
 // --- Chunked text sending ---
 
-func (c *Channel) sendChunkedText(chatID, text string) error {
+func (c *Channel) sendChunkedText(ctx context.Context, chatID, text string) error {
 	for _, chunk := range channels.ChunkMarkdown(text, maxTextLength) {
-		if err := c.sendMessage(chatID, chunk); err != nil {
+		if err := c.sendMessage(ctx, chatID, chunk); err != nil {
 			return err
 		}
 	}
@@ -517,17 +521,17 @@ func (c *Channel) getUpdates(ctx context.Context, timeout int) (*zaloUpdate, err
 	return &update, nil
 }
 
-func (c *Channel) sendMessage(chatID, text string) error {
+func (c *Channel) sendMessage(ctx context.Context, chatID, text string) error {
 	params := map[string]any{
 		"chat_id": chatID,
 		"text":    text,
 	}
 
-	_, err := c.callAPI(context.Background(), "sendMessage", params)
+	_, err := c.callAPI(ctx, "sendMessage", params)
 	return err
 }
 
-func (c *Channel) sendPhoto(chatID, photoURL, caption string) error {
+func (c *Channel) sendPhoto(ctx context.Context, chatID, photoURL, caption string) error {
 	params := map[string]any{
 		"chat_id": chatID,
 		"photo":   photoURL,
@@ -536,6 +540,6 @@ func (c *Channel) sendPhoto(chatID, photoURL, caption string) error {
 		params["caption"] = caption
 	}
 
-	_, err := c.callAPI(context.Background(), "sendPhoto", params)
+	_, err := c.callAPI(ctx, "sendPhoto", params)
 	return err
 }

--- a/internal/channels/zalo/zalo.go
+++ b/internal/channels/zalo/zalo.go
@@ -24,11 +24,12 @@ import (
 )
 
 const (
-	defaultPollTimeout = 30
-	maxTextLength      = 2000
-	defaultMediaMaxMB  = 5
-	pollErrorBackoff   = 5 * time.Second
-	pairingDebounce    = 60 * time.Second
+	defaultPollTimeout  = 30
+	maxTextLength       = 2000
+	defaultMediaMaxMB   = 5
+	pollErrorBackoff    = 5 * time.Second
+	pairingDebounce     = 60 * time.Second
+	pollTimeoutHeadroom = 7 * time.Second // network jitter buffer for long-poll
 )
 
 // apiBase is the Zalo Bot API root. Declared as a variable so tests can
@@ -43,8 +44,8 @@ type Channel struct {
 	mediaMaxMB int
 	blockReply *bool
 	stopCh     chan struct{}
-	client     *http.Client
-	// pairingService, pairingDebounce are inherited from channels.BaseChannel.
+	client     *http.Client // general API calls (sendMessage, sendPhoto, getMe)
+	pollClient *http.Client // long-poll getUpdates (no global timeout)
 }
 
 // New creates a new Zalo channel.
@@ -74,6 +75,12 @@ func New(cfg config.ZaloConfig, msgBus *bus.MessageBus, pairingSvc store.Pairing
 		blockReply:  cfg.BlockReply,
 		stopCh:      make(chan struct{}),
 		client:      &http.Client{Timeout: 60 * time.Second},
+		pollClient: &http.Client{
+			Timeout: 0, // no global timeout; per-call context handles it
+			Transport: &http.Transport{
+				IdleConnTimeout: 90 * time.Second,
+			},
+		},
 	}
 	ch.SetPairingService(pairingSvc)
 	return ch, nil
@@ -87,11 +94,11 @@ func (c *Channel) Start(ctx context.Context) error {
 	slog.Info("starting zalo bot (polling mode)")
 
 	// Validate token
-	info, err := c.getMe()
+	info, err := c.getMe(ctx)
 	if err != nil {
 		return fmt.Errorf("zalo getMe failed: %w", err)
 	}
-	slog.Info("zalo bot connected", "bot_id", info.ID, "bot_name", info.Name)
+	slog.Info("zalo bot connected", "bot_id", info.ID, "bot_name", info.DisplayName)
 
 	c.SetRunning(true)
 
@@ -150,7 +157,7 @@ func (c *Channel) pollLoop(ctx context.Context) {
 		default:
 		}
 
-		updates, err := c.getUpdates(defaultPollTimeout)
+		update, err := c.getUpdates(ctx, defaultPollTimeout)
 		if err != nil {
 			// 408 = no updates (timeout), not an error
 			if !strings.Contains(err.Error(), "408") {
@@ -166,9 +173,7 @@ func (c *Channel) pollLoop(ctx context.Context) {
 			continue
 		}
 
-		for _, update := range updates {
-			c.processUpdate(update)
-		}
+		c.processUpdate(*update)
 	}
 }
 
@@ -212,6 +217,7 @@ func (c *Channel) handleTextMessage(msg *zaloMessage) {
 
 	slog.Debug("zalo text message received",
 		"sender_id", senderID,
+		"sender_name", msg.From.DisplayName,
 		"chat_id", chatID,
 		"preview", channels.Truncate(content, 50),
 	)
@@ -397,8 +403,10 @@ type zaloAPIResponse struct {
 }
 
 type zaloBotInfo struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	AccountName string `json:"account_name"`
+	AccountType string `json:"account_type"`
 }
 
 type zaloMessage struct {
@@ -413,13 +421,14 @@ type zaloMessage struct {
 }
 
 type zaloFrom struct {
-	ID       string `json:"id"`
-	Username string `json:"username"`
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	IsBot       bool   `json:"is_bot"`
 }
 
 type zaloChat struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
+	ID       string `json:"id"`
+	ChatType string `json:"chat_type"`
 }
 
 type zaloUpdate struct {
@@ -427,7 +436,11 @@ type zaloUpdate struct {
 	Message   *zaloMessage `json:"message,omitempty"`
 }
 
-func (c *Channel) callAPI(method string, body any) (json.RawMessage, error) {
+func (c *Channel) callAPI(ctx context.Context, method string, body any) (json.RawMessage, error) {
+	return c.doAPICall(ctx, c.client, method, body)
+}
+
+func (c *Channel) doAPICall(ctx context.Context, httpClient *http.Client, method string, body any) (json.RawMessage, error) {
 	url := fmt.Sprintf("%s/bot%s/%s", apiBase, c.token, method)
 
 	var reqBody io.Reader
@@ -439,7 +452,7 @@ func (c *Channel) callAPI(method string, body any) (json.RawMessage, error) {
 		reqBody = bytes.NewReader(data)
 	}
 
-	req, err := http.NewRequest("POST", url, reqBody)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
@@ -447,7 +460,7 @@ func (c *Channel) callAPI(method string, body any) (json.RawMessage, error) {
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("api call %s: %w", method, err)
 	}
@@ -470,8 +483,8 @@ func (c *Channel) callAPI(method string, body any) (json.RawMessage, error) {
 	return apiResp.Result, nil
 }
 
-func (c *Channel) getMe() (*zaloBotInfo, error) {
-	result, err := c.callAPI("getMe", nil)
+func (c *Channel) getMe(ctx context.Context) (*zaloBotInfo, error) {
+	result, err := c.callAPI(ctx, "getMe", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -483,21 +496,25 @@ func (c *Channel) getMe() (*zaloBotInfo, error) {
 	return &info, nil
 }
 
-func (c *Channel) getUpdates(timeout int) ([]zaloUpdate, error) {
+func (c *Channel) getUpdates(ctx context.Context, timeout int) (*zaloUpdate, error) {
 	params := map[string]any{
 		"timeout": timeout,
 	}
 
-	result, err := c.callAPI("getUpdates", params)
+	callTimeout := time.Duration(timeout)*time.Second + pollTimeoutHeadroom
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	result, err := c.doAPICall(ctx, c.pollClient, "getUpdates", params)
 	if err != nil {
 		return nil, err
 	}
 
-	var updates []zaloUpdate
-	if err := json.Unmarshal(result, &updates); err != nil {
-		return nil, fmt.Errorf("unmarshal updates: %w", err)
+	var update zaloUpdate
+	if err := json.Unmarshal(result, &update); err != nil {
+		return nil, fmt.Errorf("unmarshal update: %w", err)
 	}
-	return updates, nil
+	return &update, nil
 }
 
 func (c *Channel) sendMessage(chatID, text string) error {
@@ -506,7 +523,7 @@ func (c *Channel) sendMessage(chatID, text string) error {
 		"text":    text,
 	}
 
-	_, err := c.callAPI("sendMessage", params)
+	_, err := c.callAPI(context.Background(), "sendMessage", params)
 	return err
 }
 
@@ -519,6 +536,6 @@ func (c *Channel) sendPhoto(chatID, photoURL, caption string) error {
 		params["caption"] = caption
 	}
 
-	_, err := c.callAPI("sendPhoto", params)
+	_, err := c.callAPI(context.Background(), "sendPhoto", params)
 	return err
 }

--- a/internal/channels/zalo/zalo_test.go
+++ b/internal/channels/zalo/zalo_test.go
@@ -193,7 +193,7 @@ func TestSendMessage_PostsBodyWithParams(t *testing.T) {
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
-	if err := ch.sendMessage("user-1", "hello"); err != nil {
+	if err := ch.sendMessage(context.Background(), "user-1", "hello"); err != nil {
 		t.Fatalf("sendMessage: %v", err)
 	}
 	if got["chat_id"] != "user-1" {
@@ -218,10 +218,10 @@ func TestSendPhoto_OmitsEmptyCaption(t *testing.T) {
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
-	if err := ch.sendPhoto("chat-1", "https://cdn.example.test/a.jpg", ""); err != nil {
+	if err := ch.sendPhoto(context.Background(), "chat-1", "https://cdn.example.test/a.jpg", ""); err != nil {
 		t.Fatalf("sendPhoto: %v", err)
 	}
-	if err := ch.sendPhoto("chat-1", "https://cdn.example.test/b.jpg", "caption"); err != nil {
+	if err := ch.sendPhoto(context.Background(), "chat-1", "https://cdn.example.test/b.jpg", "caption"); err != nil {
 		t.Fatalf("sendPhoto (w/ caption): %v", err)
 	}
 	if len(gotBodies) != 2 {
@@ -248,7 +248,7 @@ func TestSendChunkedText_ChunksLongContent(t *testing.T) {
 	ch := newTestChannel(t, srv.URL)
 	// Build text larger than maxTextLength (2000) to force chunking.
 	long := strings.Repeat("a", maxTextLength*2+10)
-	if err := ch.sendChunkedText("chat-x", long); err != nil {
+	if err := ch.sendChunkedText(context.Background(), "chat-x", long); err != nil {
 		t.Fatalf("sendChunkedText: %v", err)
 	}
 	if got := atomic.LoadInt32(&callCount); got < 2 {
@@ -265,7 +265,7 @@ func TestSendChunkedText_PropagatesFirstError(t *testing.T) {
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
-	err := ch.sendChunkedText("chat-x", "short enough")
+	err := ch.sendChunkedText(context.Background(), "chat-x", "short enough")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -449,7 +449,7 @@ func TestDownloadMedia_SuccessWritesTempFile(t *testing.T) {
 
 	mb := bus.New()
 	ch, _ := New(config.ZaloConfig{Token: "t"}, mb, nil)
-	path, err := ch.downloadMedia(srv.URL + "/photo")
+	path, err := ch.downloadMedia(context.Background(), srv.URL+"/photo")
 	if err != nil {
 		t.Fatalf("downloadMedia: %v", err)
 	}
@@ -475,7 +475,7 @@ func TestDownloadMedia_HTTPErrorReturnsError(t *testing.T) {
 	defer srv.Close()
 
 	ch, _ := New(config.ZaloConfig{Token: "t"}, bus.New(), nil)
-	if _, err := ch.downloadMedia(srv.URL); err == nil {
+	if _, err := ch.downloadMedia(context.Background(), srv.URL); err == nil {
 		t.Fatal("expected error on 404, got nil")
 	}
 }
@@ -490,7 +490,7 @@ func TestDownloadMedia_EmptyResponseReturnsError(t *testing.T) {
 	defer srv.Close()
 
 	ch, _ := New(config.ZaloConfig{Token: "t"}, bus.New(), nil)
-	if _, err := ch.downloadMedia(srv.URL); err == nil {
+	if _, err := ch.downloadMedia(context.Background(), srv.URL); err == nil {
 		t.Fatal("expected empty-response error, got nil")
 	}
 }
@@ -505,7 +505,7 @@ func TestDownloadMedia_FallbackJPEGExtension(t *testing.T) {
 	defer srv.Close()
 
 	ch, _ := New(config.ZaloConfig{Token: "t"}, bus.New(), nil)
-	path, err := ch.downloadMedia(srv.URL)
+	path, err := ch.downloadMedia(context.Background(), srv.URL)
 	if err != nil {
 		t.Fatalf("downloadMedia: %v", err)
 	}

--- a/internal/channels/zalo/zalo_test.go
+++ b/internal/channels/zalo/zalo_test.go
@@ -53,13 +53,13 @@ func TestCallAPI_SuccessRoutesOKResponse(t *testing.T) {
 		gotCT = r.Header.Get("Content-Type")
 		raw, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(raw, &gotBody)
-		_, _ = w.Write([]byte(`{"ok":true,"result":{"id":"bot-1","name":"Zalobot"}}`))
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"id":"bot-1","display_name":"Zalobot","account_name":"bot.test","account_type":"BASIC"}}`))
 	}))
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
 
-	raw, err := ch.callAPI("getMe", nil)
+	raw, err := ch.callAPI(context.Background(), "getMe", nil)
 	if err != nil {
 		t.Fatalf("callAPI: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestCallAPI_ErrorResponseSurfaces(t *testing.T) {
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
-	_, err := ch.callAPI("getMe", nil)
+	_, err := ch.callAPI(context.Background(), "getMe", nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -106,7 +106,7 @@ func TestCallAPI_MalformedJSONReturnsError(t *testing.T) {
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
-	_, err := ch.callAPI("getMe", nil)
+	_, err := ch.callAPI(context.Background(), "getMe", nil)
 	if err == nil {
 		t.Fatal("expected unmarshal error, got nil")
 	}
@@ -115,16 +115,16 @@ func TestCallAPI_MalformedJSONReturnsError(t *testing.T) {
 // TestGetMe_ParsesBotInfo verifies getMe returns the zaloBotInfo struct.
 func TestGetMe_ParsesBotInfo(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"ok":true,"result":{"id":"bot-xyz","name":"TestBot"}}`))
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"id":"bot-xyz","display_name":"TestBot","account_name":"bot.test","account_type":"BASIC"}}`))
 	}))
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
-	info, err := ch.getMe()
+	info, err := ch.getMe(context.Background())
 	if err != nil {
 		t.Fatalf("getMe: %v", err)
 	}
-	if info.ID != "bot-xyz" || info.Name != "TestBot" {
+	if info.ID != "bot-xyz" || info.DisplayName != "TestBot" {
 		t.Errorf("info = %+v, want bot-xyz/TestBot", info)
 	}
 }
@@ -137,31 +137,34 @@ func TestGetMe_UnmarshalError(t *testing.T) {
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
-	if _, err := ch.getMe(); err == nil {
+	if _, err := ch.getMe(context.Background()); err == nil {
 		t.Fatal("expected unmarshal error, got nil")
 	}
 }
 
-// TestGetUpdates_ParsesUpdateArray verifies getUpdates decodes the updates array.
-func TestGetUpdates_ParsesUpdateArray(t *testing.T) {
+// TestGetUpdates_ParsesSingleUpdate verifies getUpdates decodes a single update object.
+func TestGetUpdates_ParsesSingleUpdate(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"ok":true,"result":[{"event_name":"message.text.received","message":{"message_id":"m1","text":"hi","from":{"id":"user1"},"chat":{"id":"user1"}}}]}`))
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"event_name":"message.text.received","message":{"message_id":"m1","text":"hi","from":{"id":"user1","display_name":"Tester","is_bot":false},"chat":{"id":"user1","chat_type":"private"}}}}`))
 	}))
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
-	updates, err := ch.getUpdates(10)
+	update, err := ch.getUpdates(context.Background(), 10)
 	if err != nil {
 		t.Fatalf("getUpdates: %v", err)
 	}
-	if len(updates) != 1 {
-		t.Fatalf("updates len = %d, want 1", len(updates))
+	if update.EventName != "message.text.received" {
+		t.Errorf("EventName = %q", update.EventName)
 	}
-	if updates[0].EventName != "message.text.received" {
-		t.Errorf("EventName = %q", updates[0].EventName)
+	if update.Message == nil || update.Message.Text != "hi" {
+		t.Errorf("Message = %+v", update.Message)
 	}
-	if updates[0].Message == nil || updates[0].Message.Text != "hi" {
-		t.Errorf("Message = %+v", updates[0].Message)
+	if update.Message.From.DisplayName != "Tester" {
+		t.Errorf("From.DisplayName = %q, want Tester", update.Message.From.DisplayName)
+	}
+	if update.Message.Chat.ChatType != "private" {
+		t.Errorf("Chat.ChatType = %q, want private", update.Message.Chat.ChatType)
 	}
 }
 
@@ -173,7 +176,7 @@ func TestGetUpdates_UnmarshalError(t *testing.T) {
 	defer srv.Close()
 
 	ch := newTestChannel(t, srv.URL)
-	if _, err := ch.getUpdates(5); err == nil {
+	if _, err := ch.getUpdates(context.Background(), 5); err == nil {
 		t.Fatal("expected unmarshal error, got nil")
 	}
 }
@@ -398,8 +401,8 @@ func TestProcessUpdate_DispatchesByEventName(t *testing.T) {
 		Message: &zaloMessage{
 			MessageID: "m1",
 			Text:      "hello",
-			From:      zaloFrom{ID: "u1"},
-			Chat:      zaloChat{ID: "u1"},
+			From:      zaloFrom{ID: "u1", DisplayName: "Tester"},
+			Chat:      zaloChat{ID: "u1", ChatType: "private"},
 		},
 	})
 }
@@ -530,5 +533,59 @@ func TestZaloAPIResponse_Roundtrip(t *testing.T) {
 	}
 	if !got.OK {
 		t.Error("OK field lost in round-trip")
+	}
+}
+
+// TestGetUpdates_RejectsArrayFormat is a regression test ensuring the old
+// array-based response format (which was never correct for this API)
+// fails gracefully now that getUpdates expects a single object.
+func TestGetUpdates_RejectsArrayFormat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"result":[{"event_name":"message.text.received"}]}`))
+	}))
+	defer srv.Close()
+
+	ch := newTestChannel(t, srv.URL)
+	_, err := ch.getUpdates(context.Background(), 2)
+	if err == nil {
+		t.Fatal("expected unmarshal error for array format, got nil")
+	}
+}
+
+// TestGetUpdates_NullResultReturnsZeroValue verifies that when the API returns
+// result:null (ok=true, no pending update), getUpdates returns a zero-value
+// update rather than an error.
+func TestGetUpdates_NullResultReturnsZeroValue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"result":null}`))
+	}))
+	defer srv.Close()
+
+	ch := newTestChannel(t, srv.URL)
+	update, err := ch.getUpdates(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("getUpdates with null result: %v", err)
+	}
+	if update.EventName != "" {
+		t.Errorf("EventName = %q, want empty for null result", update.EventName)
+	}
+}
+
+// TestDoAPICall_PropagatesContext verifies that doAPICall respects context
+// cancellation — a cancelled context should cause the request to fail.
+func TestDoAPICall_PropagatesContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"ok":true,"result":{}}`))
+	}))
+	defer srv.Close()
+
+	ch := newTestChannel(t, srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := ch.callAPI(ctx, "getMe", nil)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
 	}
 }


### PR DESCRIPTION
## Summary
- Align wire types with actual Zalo Bot API (`display_name`, `chat_type`, `is_bot`, `account_name`, `account_type`)
- Fix `getUpdates` deserialization: single object instead of array
- Add dedicated `pollClient` with no global timeout for long-poll; per-call `context.WithTimeout` with 7s headroom
- Propagate `context.Context` through `sendMessage`, `sendPhoto`, `downloadMedia` for graceful shutdown

Resolves #922

## Test plan
- [x] `go build ./...` (PG)
- [x] `go build -tags sqliteonly ./...` (Desktop)
- [x] `go vet ./internal/channels/zalo/`
- [x] `go test -count=1 ./internal/channels/zalo/` — 35 tests pass
- [x] Regression tests: array format rejection, null result, context cancellation