### PR TITLE
fix(pipeline): retry empty LLM responses instead of showing "..."

### DIFF
--- a/internal/agent/loop_pipeline_adapter.go
+++ b/internal/agent/loop_pipeline_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/nextlevelbuilder/goclaw/internal/eventbus"
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/memory"
 	"github.com/nextlevelbuilder/goclaw/internal/pipeline"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
@@ -142,9 +143,12 @@ func (l *Loop) buildPipelineDeps(req *RunRequest, bridgeRS *runState) pipeline.P
 		},
 
 		// Checkpoint + Finalize
-		FlushMessages:          cb.flushMessages,
-		SkillPostscript:        l.makeSkillPostscript(),
-		SanitizeContent:        cb.sanitizeContent,
+		FlushMessages: cb.flushMessages,
+		EmptyResponseFallback: func() string {
+			return i18n.T("en", i18n.MsgEmptyResponseFallback)
+		},
+		SkillPostscript: l.makeSkillPostscript(),
+		SanitizeContent: cb.sanitizeContent,
 		StripMessageDirectives: StripMessageDirectives,
 		DeduplicateMediaSuffix: deduplicateMediaSuffix,
 		IsSilentReply:          IsSilentReply,

--- a/internal/agent/loop_tracing.go
+++ b/internal/agent/loop_tracing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -151,6 +152,13 @@ func (l *Loop) emitLLMSpanEnd(ctx context.Context, spanID uuid.UUID, start time.
 		updates["status"] = store.SpanStatusError
 		updates["error"] = callErr.Error()
 	} else if resp != nil {
+		// Warn only when response is truly empty (no content + no tokens) — signals provider failure.
+		// Providers that don't report usage but return valid content (Ollama, local models) are fine.
+		if resp.Content == "" && len(resp.ToolCalls) == 0 && (resp.Usage == nil || resp.Usage.TotalTokens == 0) {
+			slog.Warn("empty LLM span: no content and no tokens",
+				"trace_id", traceID, "span_id", spanID,
+				"finish_reason", resp.FinishReason)
+		}
 		if resp.Usage != nil {
 			updates["input_tokens"] = resp.Usage.PromptTokens
 			updates["output_tokens"] = resp.Usage.CompletionTokens

--- a/internal/i18n/catalog_en.go
+++ b/internal/i18n/catalog_en.go
@@ -72,7 +72,8 @@ func init() {
 		MsgShuttingDown: "gateway is shutting down, please retry shortly",
 
 		// Provider
-		MsgProviderReqFailed: "%s: request failed: %s",
+		MsgProviderReqFailed:     "%s: request failed: %s",
+		MsgEmptyResponseFallback: "I couldn't generate a response. Please try again.",
 
 		// Unknown method
 		MsgUnknownMethod: "unknown method: %s",

--- a/internal/i18n/catalog_vi.go
+++ b/internal/i18n/catalog_vi.go
@@ -72,7 +72,8 @@ func init() {
 		MsgShuttingDown: "cổng đang tắt, vui lòng thử lại sau",
 
 		// Provider
-		MsgProviderReqFailed: "%s: yêu cầu thất bại: %s",
+		MsgProviderReqFailed:     "%s: yêu cầu thất bại: %s",
+		MsgEmptyResponseFallback: "Tôi không thể tạo phản hồi. Vui lòng thử lại.",
 
 		// Unknown method
 		MsgUnknownMethod: "phương thức không xác định: %s",

--- a/internal/i18n/catalog_zh.go
+++ b/internal/i18n/catalog_zh.go
@@ -72,7 +72,8 @@ func init() {
 		MsgShuttingDown: "网关正在关闭，请稍后重试",
 
 		// Provider
-		MsgProviderReqFailed: "%s：请求失败：%s",
+		MsgProviderReqFailed:     "%s：请求失败：%s",
+		MsgEmptyResponseFallback: "无法生成回复，请重试。",
 
 		// Unknown method
 		MsgUnknownMethod: "未知方法：%s",

--- a/internal/i18n/keys.go
+++ b/internal/i18n/keys.go
@@ -73,7 +73,8 @@ const (
 	MsgShuttingDown    = "error.shutting_down"     // "gateway is shutting down, please retry shortly"
 
 	// --- Provider ---
-	MsgProviderReqFailed = "error.provider_request_failed" // "%s: request failed: %s"
+	MsgProviderReqFailed      = "error.provider_request_failed"      // "%s: request failed: %s"
+	MsgEmptyResponseFallback  = "error.empty_response_fallback"      // "I couldn't generate a response. Please try again."
 
 	// --- Unknown method ---
 	MsgUnknownMethod = "error.unknown_method" // "unknown method: %s"

--- a/internal/pipeline/deps.go
+++ b/internal/pipeline/deps.go
@@ -80,6 +80,7 @@ type PipelineDeps struct {
 	FlushMessages func(ctx context.Context, sessionKey string, msgs []providers.Message) error
 
 	// Finalize callbacks (FinalizeStage)
+	EmptyResponseFallback    func() string                                                        // i18n fallback when LLM returns empty content (nil = "...")
 	SkillPostscript          func(ctx context.Context, content string, totalToolCalls int) string // skill evolution nudge (nil = disabled)
 	SanitizeContent          func(content string) string
 	StripMessageDirectives   func(content string) string

--- a/internal/pipeline/finalize_stage.go
+++ b/internal/pipeline/finalize_stage.go
@@ -41,7 +41,11 @@ func (s *FinalizeStage) Execute(ctx context.Context, state *RunState) error {
 
 	// 2b. Fallback for empty content (matching v2: channels need non-empty content to deliver).
 	if state.Observe.FinalContent == "" && !isSilent {
-		state.Observe.FinalContent = "..."
+		if s.deps.EmptyResponseFallback != nil {
+			state.Observe.FinalContent = s.deps.EmptyResponseFallback()
+		} else {
+			state.Observe.FinalContent = "..."
+		}
 	}
 
 	// 2c. Append content suffix (e.g. image markdown for WS) with dedup.

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -54,6 +54,7 @@ func TestThinkStage_NoToolCalls_ReturnsBreakLoop(t *testing.T) {
 			return &providers.ChatResponse{
 				Content:      "final answer",
 				FinishReason: "stop",
+				Usage:        &providers.Usage{PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110},
 			}, nil
 		},
 	}
@@ -190,6 +191,147 @@ func TestThinkStage_TruncationReset_OnSuccess(t *testing.T) {
 	}
 	if state.Think.TruncRetries != 0 {
 		t.Errorf("TruncRetries = %d after success, want 0", state.Think.TruncRetries)
+	}
+}
+
+func TestThinkStage_EmptyResponse_FirstRetry_AppendsContinueMessage(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			// Fully empty: no content, no thinking, no tool calls, no usage
+			return &providers.ChatResponse{
+				FinishReason: "stop",
+			}, nil
+		},
+	}
+	stage := NewThinkStage(deps)
+	state := defaultState()
+
+	err := stage.Execute(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if stage.Result() != Continue {
+		t.Errorf("Result() = %v, want Continue (retry)", stage.Result())
+	}
+	if state.Think.EmptyRetries != 1 {
+		t.Errorf("EmptyRetries = %d, want 1", state.Think.EmptyRetries)
+	}
+	// Should append system hint for retry (no assistant echo since content is empty)
+	pending := state.Messages.Pending()
+	if len(pending) != 1 {
+		t.Fatalf("pending len = %d, want 1 (system hint)", len(pending))
+	}
+	if pending[0].Role != "user" {
+		t.Errorf("hint role = %s, want user", pending[0].Role)
+	}
+}
+
+func TestThinkStage_ContentWithNilUsage_NoRetry(t *testing.T) {
+	t.Parallel()
+	// Providers like Ollama return content but no usage — should NOT retry.
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{
+				Content:      "valid response from Ollama",
+				FinishReason: "stop",
+				// Usage nil — but content present, so this is valid
+			}, nil
+		},
+	}
+	stage := NewThinkStage(deps)
+	state := defaultState()
+
+	err := stage.Execute(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if stage.Result() != BreakLoop {
+		t.Errorf("Result() = %v, want BreakLoop (valid final answer)", stage.Result())
+	}
+	if state.Think.EmptyRetries != 0 {
+		t.Errorf("EmptyRetries = %d, want 0 (content present, no retry)", state.Think.EmptyRetries)
+	}
+}
+
+func TestThinkStage_EmptyResponse_MaxRetries_ReturnsBreakLoop(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{
+				FinishReason: "stop",
+				Usage:        &providers.Usage{TotalTokens: 0},
+			}, nil
+		},
+	}
+	stage := NewThinkStage(deps)
+	state := defaultState()
+	state.Think.EmptyRetries = 1 // already had one retry
+
+	err := stage.Execute(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if stage.Result() != BreakLoop {
+		t.Errorf("Result() = %v, want BreakLoop (max retries exhausted)", stage.Result())
+	}
+	if state.Think.EmptyRetries != 2 {
+		t.Errorf("EmptyRetries = %d, want 2", state.Think.EmptyRetries)
+	}
+}
+
+func TestThinkStage_EmptyResponse_ResetOnSuccess(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{
+				Content:      "real answer",
+				FinishReason: "stop",
+				Usage:        &providers.Usage{PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120},
+			}, nil
+		},
+	}
+	stage := NewThinkStage(deps)
+	state := defaultState()
+	state.Think.EmptyRetries = 1 // had a retry before
+
+	err := stage.Execute(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if state.Think.EmptyRetries != 0 {
+		t.Errorf("EmptyRetries = %d after success, want 0", state.Think.EmptyRetries)
+	}
+}
+
+func TestThinkStage_EmptyResponse_WithToolCalls_SkipsRetry(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{
+				FinishReason: "tool_calls",
+				ToolCalls:    []providers.ToolCall{{ID: "tc1", Name: "exec"}},
+				// Usage nil but tool calls present → should NOT retry
+			}, nil
+		},
+	}
+	stage := NewThinkStage(deps)
+	state := defaultState()
+
+	err := stage.Execute(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if stage.Result() != Continue {
+		t.Errorf("Result() = %v, want Continue (tool execution)", stage.Result())
+	}
+	if state.Think.EmptyRetries != 0 {
+		t.Errorf("EmptyRetries = %d, want 0 (tool calls bypass zero-token check)", state.Think.EmptyRetries)
 	}
 }
 

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -335,6 +335,62 @@ func TestThinkStage_EmptyResponse_WithToolCalls_SkipsRetry(t *testing.T) {
 	}
 }
 
+func TestThinkStage_EmptyRetries_ResetByTruncation(t *testing.T) {
+	t.Parallel()
+	// Scenario: empty response (EmptyRetries=1) → truncation → empty response.
+	// The truncation in between should reset EmptyRetries to 0,
+	// so the second empty response starts at EmptyRetries=1, not 2.
+	callNum := 0
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			callNum++
+			switch callNum {
+			case 1:
+				// Empty response
+				return &providers.ChatResponse{FinishReason: "stop"}, nil
+			case 2:
+				// Truncated tool call
+				return &providers.ChatResponse{
+					FinishReason: "length",
+					ToolCalls:    []providers.ToolCall{{ID: "tc1", Name: "write_file"}},
+				}, nil
+			default:
+				// Empty response again
+				return &providers.ChatResponse{FinishReason: "stop"}, nil
+			}
+		},
+	}
+	stage := NewThinkStage(deps)
+	state := defaultState()
+
+	// Call 1: empty → EmptyRetries=1, Continue
+	_ = stage.Execute(context.Background(), state)
+	if state.Think.EmptyRetries != 1 {
+		t.Fatalf("after call 1: EmptyRetries = %d, want 1", state.Think.EmptyRetries)
+	}
+
+	// Call 2: truncation → EmptyRetries reset to 0, TruncRetries=1
+	stage2 := NewThinkStage(deps)
+	_ = stage2.Execute(context.Background(), state)
+	if state.Think.EmptyRetries != 0 {
+		t.Fatalf("after call 2 (truncation): EmptyRetries = %d, want 0", state.Think.EmptyRetries)
+	}
+	if state.Think.TruncRetries != 1 {
+		t.Fatalf("after call 2 (truncation): TruncRetries = %d, want 1", state.Think.TruncRetries)
+	}
+
+	// Call 3: empty again → EmptyRetries=1 (not 2), TruncRetries reset to 0
+	stage3 := NewThinkStage(deps)
+	_ = stage3.Execute(context.Background(), state)
+	if state.Think.EmptyRetries != 1 {
+		t.Errorf("after call 3: EmptyRetries = %d, want 1 (reset by truncation)", state.Think.EmptyRetries)
+	}
+	if state.Think.TruncRetries != 0 {
+		t.Errorf("after call 3: TruncRetries = %d, want 0 (reset by empty)", state.Think.TruncRetries)
+	}
+}
+
 func TestThinkStage_UsageAccumulation(t *testing.T) {
 	t.Parallel()
 	callCount := 0

--- a/internal/pipeline/substates.go
+++ b/internal/pipeline/substates.go
@@ -32,6 +32,7 @@ type ThinkState struct {
 	LastResponse    *providers.ChatResponse
 	TotalUsage      providers.Usage
 	TruncRetries    int  // consecutive truncation retries (max 3)
+	EmptyRetries    int  // consecutive zero-token response retries (max 2)
 	StreamingActive bool // true during active stream
 }
 

--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -77,6 +77,7 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 	parseErr := !truncated && toolCallsHaveParseErrors(resp.ToolCalls)
 	if truncated || parseErr {
 		state.Think.TruncRetries++
+		state.Think.EmptyRetries = 0 // reset: non-consecutive empty
 		if state.Think.TruncRetries >= maxTruncRetries {
 			s.result = AbortRun
 			return nil
@@ -99,6 +100,7 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		(resp.Usage == nil || resp.Usage.TotalTokens == 0)
 	if isEmptyResponse {
 		state.Think.EmptyRetries++
+		state.Think.TruncRetries = 0 // reset: non-consecutive truncation
 		slog.Warn("empty LLM response (no content, no tokens), retrying",
 			"attempt", state.Think.EmptyRetries,
 			"max", maxEmptyRetries,

--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -3,11 +3,13 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 )
 
 const maxTruncRetries = 3
+const maxEmptyRetries = 2
 
 // ThinkStage runs per iteration. Calls LLM, handles truncation retries,
 // accumulates usage, returns BreakLoop when response has no tool calls.
@@ -88,6 +90,32 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		return nil // Continue to next iteration for retry
 	}
 	state.Think.TruncRetries = 0 // reset on success
+
+	// 6b. Handle empty provider response: no content, no tool calls, no thinking,
+	// AND zero/nil token usage. All four conditions must be true — providers that
+	// don't report usage (Ollama, local models) but return valid content are fine.
+	isEmptyResponse := resp.Content == "" && resp.Thinking == "" &&
+		len(resp.ToolCalls) == 0 &&
+		(resp.Usage == nil || resp.Usage.TotalTokens == 0)
+	if isEmptyResponse {
+		state.Think.EmptyRetries++
+		slog.Warn("empty LLM response (no content, no tokens), retrying",
+			"attempt", state.Think.EmptyRetries,
+			"max", maxEmptyRetries,
+			"model", state.Model,
+			"iteration", state.Iteration,
+			"finish_reason", resp.FinishReason)
+		if state.Think.EmptyRetries >= maxEmptyRetries {
+			s.result = BreakLoop
+			return nil
+		}
+		state.Messages.AppendPending(providers.Message{
+			Role:    "user",
+			Content: "[System] Your previous response was empty. Please try again.",
+		})
+		return nil // Continue → next iteration retries
+	}
+	state.Think.EmptyRetries = 0 // reset on non-empty response
 
 	// 7. Uniquify tool call IDs (OpenAI returns 400 on duplicates across iterations).
 	// Skip if raw content present (Anthropic thinking passback) to avoid desync.


### PR DESCRIPTION
## Summary

- When a provider returns a fully empty response (no content, no thinking, no tool calls, no token usage), the pipeline now retries up to 2 times silently before falling through to a locale-aware fallback message
- Replaces the hardcoded `"..."` fallback in `finalize_stage.go` with an i18n callback (`MsgEmptyResponseFallback` in en/vi/zh)
- Adds observability warning in `loop_tracing.go` when a completed LLM span has empty content + zero tokens

### Detection criteria (conjunctive — all four must be true)

1. `resp.Content == ""`
2. `resp.Thinking == ""`
3. `len(resp.ToolCalls) == 0`
4. `resp.Usage == nil || resp.Usage.TotalTokens == 0`

This avoids false positives on providers that don't report usage (Ollama, local models) but return valid content.

### Files changed (11)

| File | Change |
|------|--------|
| `internal/pipeline/think_stage.go` | Empty response detection + retry (step 6b) |
| `internal/pipeline/substates.go` | `EmptyRetries` counter in ThinkState |
| `internal/pipeline/deps.go` | `EmptyResponseFallback` callback |
| `internal/pipeline/finalize_stage.go` | Uses callback instead of hardcoded `"..."` |
| `internal/agent/loop_pipeline_adapter.go` | Wires callback with i18n |
| `internal/agent/loop_tracing.go` | Warn on empty LLM spans |
| `internal/i18n/keys.go` + 3 catalogs | `MsgEmptyResponseFallback` in en/vi/zh |
| `internal/pipeline/stages_test.go` | 6 new tests |

Closes #930

## Test plan

- [x] `go build ./...` passes (PG)
- [x] `go build -tags sqliteonly ./...` passes (Desktop)
- [x] `go vet` clean on all changed packages
- [x] 6 new pipeline unit tests covering: first retry, max retries, reset on success, tool calls skip retry, content-with-nil-usage no retry
- [x] All 82 existing pipeline tests still pass