### PR TITLE
fix(providers): strip Gemma 4 reasoning leak

### DIFF
--- a/internal/providers/reasoning_resolution.go
+++ b/internal/providers/reasoning_resolution.go
@@ -32,9 +32,13 @@ func modelLeaksReasoning(model string) bool {
 	if m == "" {
 		return false
 	}
-	// Known leakers: Moonshot Kimi (any variant), DeepSeek-Reasoner family.
+	// Known leakers: Moonshot Kimi (any variant), DeepSeek-Reasoner family,
+	// and Gemma 4+ variants (for example "gemma4:8b" or "google/gemma-4-27b-it").
 	// Extend this list only after confirming the model does not honor effort="off".
-	return strings.Contains(m, "kimi") || strings.Contains(m, "deepseek-reasoner")
+	return strings.Contains(m, "kimi") ||
+		strings.Contains(m, "deepseek-reasoner") ||
+		strings.Contains(m, "gemma4") ||
+		strings.Contains(m, "gemma-4")
 }
 
 func ResolveReasoningDecision(provider Provider, model, requestedEffort, fallback, source string) (out ReasoningDecision) {

--- a/internal/providers/reasoning_strip_test.go
+++ b/internal/providers/reasoning_strip_test.go
@@ -17,6 +17,7 @@ func TestResolveReasoningDecisionStripsForLeakyModels(t *testing.T) {
 		{"kimi k2 default off", "kimi-k2", true, "off"},
 		{"kimi thinking preview", "moonshot/kimi-k2-thinking", true, "off"},
 		{"deepseek reasoner", "deepseek-reasoner", true, "off"},
+		{"gemma 4 family", "google/gemma-4-27b-it", true, "off"},
 		{"deepseek chat not flagged", "deepseek-chat", false, "off"},
 		{"gpt-5.4 not flagged", "gpt-5.4", false, "off"},
 		{"empty model", "", false, "off"},
@@ -52,7 +53,7 @@ func TestResolveReasoningDecisionNoStripWhenEffortActive(t *testing.T) {
 
 // TestModelLeaksReasoning spot-checks the model allowlist directly.
 func TestModelLeaksReasoning(t *testing.T) {
-	leaky := []string{"kimi-k2", "KIMI-K2-Thinking", "deepseek-reasoner"}
+	leaky := []string{"kimi-k2", "KIMI-K2-Thinking", "deepseek-reasoner", "google/gemma-4-27b-it", "gemma4:8b-it-q4_K_M"}
 	for _, m := range leaky {
 		if !modelLeaksReasoning(m) {
 			t.Errorf("modelLeaksReasoning(%q) = false, want true", m)


### PR DESCRIPTION
## Summary
Fixes Gemma 4+ reasoning leaks by treating those models as known reasoning leakers when `reasoning_effort` resolves to `off`, so the existing strip-thinking path suppresses internal thoughts before they reach users. This also adds regression coverage for the Gemma 4 family while keeping the Gemini tool-response `name` handling intact.

Fixes Issue #843 and #844.

## Type
<!-- Check one -->
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->
`dev`

## Checklist
- [x] `go build ./...` passes
- [ ] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [ ] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
`go test ./internal/providers -run "TestResolveReasoningDecisionStripsForLeakyModels|TestModelLeaksReasoning|TestBuildRequestBody_ToolMessageIncludesName|TestBuildRequestBody_ToolMessageNameLookupUsesRawID|TestBuildRequestBody_ToolMessageWithoutMatchingCallOmitsName" -count=1`

Verified the Gemma 4 reasoning allowlist change and the Gemini tool-response name handling path with targeted provider tests.
