### PR TITLE
ci(release): build docker images on native arm64 runners

### DIFF
--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -86,28 +86,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Build and push Docker images tagged as beta
-  docker-images:
-    runs-on: ubuntu-latest
+  # Stage 1: Build per-arch beta images on native runners (no QEMU)
+  docker-images-build:
+    runs-on: ${{ matrix.platform.runs_on }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - variant: latest
-            suffix: ""
-            enable_otel: "false"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "false"
-          - variant: full
-            suffix: "-full"
-            enable_otel: "false"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "true"
+        variant:
+          - { name: latest, suffix: "",      enable_otel: "false", enable_embedui: "true", enable_python: "true", enable_full_skills: "false" }
+          - { name: full,   suffix: "-full", enable_otel: "false", enable_embedui: "true", enable_python: "true", enable_full_skills: "true"  }
+        platform:
+          - { name: "linux/amd64", runs_on: ubuntu-latest,    arch: amd64 }
+          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -131,24 +123,101 @@ jobs:
           images: |
             ${{ env.GHCR_IMAGE }}
             ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=${{ github.ref_name }},suffix=${{ matrix.suffix }}
-            type=raw,value=beta,enable=${{ matrix.suffix == '' }},suffix=
-            type=raw,value=beta${{ matrix.suffix }},enable=${{ matrix.suffix != '' }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform.name }}
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            ENABLE_OTEL=${{ matrix.enable_otel }}
-            ENABLE_EMBEDUI=${{ matrix.enable_embedui }}
-            ENABLE_PYTHON=${{ matrix.enable_python }}
-            ENABLE_FULL_SKILLS=${{ matrix.enable_full_skills }}
+            ENABLE_OTEL=${{ matrix.variant.enable_otel }}
+            ENABLE_EMBEDUI=${{ matrix.variant.enable_embedui }}
+            ENABLE_PYTHON=${{ matrix.variant.enable_python }}
+            ENABLE_FULL_SKILLS=${{ matrix.variant.enable_full_skills }}
             VERSION=${{ github.ref_name }}
-          cache-from: type=gha,scope=beta-${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=beta-${{ matrix.variant }}
+          cache-from: type=gha,scope=beta-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=beta-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stage 2: Merge per-arch digests into multi-arch manifests per variant
+  docker-images-merge:
+    needs: docker-images-build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - { name: latest, suffix: ""      }
+          - { name: full,   suffix: "-full" }
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ matrix.variant.name }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=raw,value=${{ github.ref_name }},suffix=${{ matrix.variant.suffix }}
+            type=raw,value=beta,enable=${{ matrix.variant.suffix == '' }},suffix=
+            type=raw,value=beta${{ matrix.variant.suffix }},enable=${{ matrix.variant.suffix != '' }}
+
+      - name: Create and push multi-arch manifest (GHCR)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Create and push multi-arch manifest (Docker Hub)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("digitop/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Inspect manifests
+        run: |
+          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            docker buildx imagetools inspect "$tag"
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,46 +146,24 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber
 
-  # Build and push Docker images to GHCR + Docker Hub
-  docker-images:
+  # Stage 1: Build per-arch images on native runners (no QEMU)
+  docker-images-build:
     needs: release
     if: needs.release.outputs.released == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runs_on }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          # Base: backend API-only, no web UI, no runtimes
-          - variant: base
-            suffix: "-base"
-            enable_otel: "false"
-            enable_embedui: "false"
-            enable_python: "false"
-            enable_full_skills: "false"
-          # Latest: backend + embedded web UI + Python
-          - variant: latest
-            suffix: ""
-            enable_otel: "false"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "false"
-          # Full: all runtimes + skills pre-installed
-          - variant: full
-            suffix: "-full"
-            enable_otel: "false"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "true"
-          # OTel: latest + OpenTelemetry tracing
-          - variant: otel
-            suffix: "-otel"
-            enable_otel: "true"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "false"
+        variant:
+          - { name: base,   suffix: "-base",  enable_otel: "false", enable_embedui: "false", enable_python: "false", enable_full_skills: "false" }
+          - { name: latest, suffix: "",       enable_otel: "false", enable_embedui: "true",  enable_python: "true",  enable_full_skills: "false" }
+          - { name: full,   suffix: "-full",  enable_otel: "false", enable_embedui: "true",  enable_python: "true",  enable_full_skills: "true"  }
+          - { name: otel,   suffix: "-otel",  enable_otel: "true",  enable_embedui: "true",  enable_python: "true",  enable_full_skills: "false" }
+        platform:
+          - { name: "linux/amd64", runs_on: ubuntu-latest,    arch: amd64 }
+          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -209,37 +187,121 @@ jobs:
           images: |
             ${{ env.GHCR_IMAGE }}
             ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=v${{ needs.release.outputs.version }},suffix=${{ matrix.suffix }}
-            type=raw,value=latest,enable=${{ matrix.suffix == '' }},suffix=
-            type=raw,value=${{ matrix.variant }},enable=${{ matrix.suffix != '' }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform.name }}
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            ENABLE_OTEL=${{ matrix.enable_otel }}
-            ENABLE_EMBEDUI=${{ matrix.enable_embedui }}
-            ENABLE_PYTHON=${{ matrix.enable_python }}
-            ENABLE_FULL_SKILLS=${{ matrix.enable_full_skills }}
+            ENABLE_OTEL=${{ matrix.variant.enable_otel }}
+            ENABLE_EMBEDUI=${{ matrix.variant.enable_embedui }}
+            ENABLE_PYTHON=${{ matrix.variant.enable_python }}
+            ENABLE_FULL_SKILLS=${{ matrix.variant.enable_full_skills }}
             VERSION=v${{ needs.release.outputs.version }}
-          cache-from: type=gha,scope=${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
+          cache-from: type=gha,scope=${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant.name }}-${{ matrix.platform.arch }}
 
-  # Build and push web UI Docker image
-  docker-web:
-    needs: release
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stage 2: Merge per-arch digests into multi-arch manifests per variant
+  docker-images-merge:
+    needs: [release, docker-images-build]
     if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - { name: base,   suffix: "-base"  }
+          - { name: latest, suffix: ""       }
+          - { name: full,   suffix: "-full"  }
+          - { name: otel,   suffix: "-otel"  }
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ matrix.variant.name }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=raw,value=v${{ needs.release.outputs.version }},suffix=${{ matrix.variant.suffix }}
+            type=raw,value=latest,enable=${{ matrix.variant.suffix == '' }},suffix=
+            type=raw,value=${{ matrix.variant.name }},enable=${{ matrix.variant.suffix != '' }}
+
+      - name: Create and push multi-arch manifest (GHCR)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Create and push multi-arch manifest (Docker Hub)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("${{ env.DOCKERHUB_IMAGE }}") or startswith("digitop/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Inspect manifests
+        run: |
+          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            docker buildx imagetools inspect "$tag"
+          done
+
+  # Stage 1: Build web UI image per-arch on native runners (no QEMU)
+  docker-web-build:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ${{ matrix.platform.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { name: "linux/amd64", runs_on: ubuntu-latest,    arch: amd64 }
+          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -263,24 +325,96 @@ jobs:
           images: |
             ${{ env.GHCR_IMAGE }}-web
             ${{ env.DOCKERHUB_IMAGE }}-web
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ui/web
+          platforms: ${{ matrix.platform.name }}
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }}-web,${{ env.DOCKERHUB_IMAGE }}-web",push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=web-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=web-${{ matrix.platform.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-web-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stage 2: Merge web UI per-arch digests into multi-arch manifest
+  docker-web-merge:
+    needs: [release, docker-web-build]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-web-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}-web
+            ${{ env.DOCKERHUB_IMAGE }}-web
           tags: |
             type=raw,value=v${{ needs.release.outputs.version }}
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: ui/web
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+      - name: Create and push multi-arch manifest (GHCR)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}-web@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Create and push multi-arch manifest (Docker Hub)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}-web@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("digitop/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Inspect manifests
+        run: |
+          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            docker buildx imagetools inspect "$tag"
+          done
 
   # Notify Discord on new release (runs even if docker jobs fail)
   notify-discord:
-    needs: [release, build-binaries, docker-images, docker-web]
+    needs: [release, build-binaries, docker-images-merge, docker-web-merge]
     if: always() && needs.release.outputs.released == 'true' && !cancelled()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Root cause

Run [24516158412](https://github.com/nextlevelbuilder/goclaw/actions/runs/24516158412) showed `docker-images (full)` and `docker-images (latest)` stalled for 6 hours before GHA cancelled them at the job timeout. The `base` (19 min) and `otel` (27 min) variants on the same workflow finished fine.

The bottleneck is QEMU emulating `linux/arm64` on an `amd64` runner. When `ENABLE_PYTHON=true`, the Alpine build layer runs pnpm + pip source-compiles pandas/numpy/lxml under QEMU — effectively single-threaded software emulation of a different ISA. This reliably hangs or takes 10× longer than native.

## Fix

Replace the single cross-arch buildx job with a 2-stage pipeline:

**Stage 1 — `*-build`** (per-variant × per-arch, native runners)
- `linux/amd64` jobs run on `ubuntu-latest` (existing free runner)
- `linux/arm64` jobs run on `ubuntu-24.04-arm` (GitHub-hosted ARM runner, **free for public repos**)
- Each job builds a single-platform image and pushes it by content digest (no tags yet)
- Digest files uploaded as artifacts (`digest-<variant>-<arch>`)

**Stage 2 — `*-merge`** (per-variant, fuses digests into multi-arch manifest)
- Downloads per-arch digest artifacts
- Runs `docker buildx imagetools create` twice — once for GHCR tags, once for Docker Hub tags — using GHCR digests as the source (content-addressable, accepted by both registries)
- No QEMU, no emulation at any point

Same pattern applied to:
- `release.yaml`: `docker-images` → `docker-images-build` + `docker-images-merge`; `docker-web` → `docker-web-build` + `docker-web-merge`
- `release-beta.yaml`: `docker-images` → `docker-images-build` + `docker-images-merge`

`notify-discord.needs` updated to reference `docker-images-merge` and `docker-web-merge`.

## Validation

- YAML syntax: validated with `python3 yaml.safe_load` (actionlint not installed locally — CI is the authoritative validator)
- Job key sets verified correct via Python
- No `setup-qemu-action` remaining in either file
- No combined `linux/amd64,linux/arm64` platform lines remaining
- Tag shapes unchanged: `:vX.Y.Z`, `:vX.Y.Z-full`, `:full`, `:latest`, `:beta`, `:beta-full`, etc.
- Both GHCR and Docker Hub receive all tags via separate `imagetools create` invocations

## Checklist

- [x] No changes outside the two workflow files
- [x] No Dockerfile or requirements-*.txt changes
- [x] `notify-discord` needs updated
- [x] `fail-fast: false` on all new matrices
- [x] Cache scopes updated to include arch suffix (avoids cross-contamination)