### PR TITLE
fix(providers): use DB name for Anthropic/ClaudeCLI in HTTP onboarding

### DIFF
--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -162,8 +162,10 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 		if cliPath == "" {
 			cliPath = "claude"
 		}
-		var cliOpts []providers.ClaudeCLIOption
-		cliOpts = append(cliOpts, providers.WithClaudeCLISecurityHooks("", true))
+		cliOpts := []providers.ClaudeCLIOption{
+			providers.WithClaudeCLIName(p.Name),
+			providers.WithClaudeCLISecurityHooks("", true),
+		}
 		if h.gatewayAddr != "" {
 			mcpData := providers.BuildCLIMCPConfigData(nil, h.gatewayAddr, pkgGatewayToken)
 			mcpData.AgentMCPLookup = h.mcpLookup
@@ -197,6 +199,7 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 		h.providerReg.RegisterForTenant(p.TenantID, codex)
 	case store.ProviderAnthropicNative:
 		h.providerReg.RegisterForTenant(p.TenantID, providers.NewAnthropicProvider(p.APIKey,
+			providers.WithAnthropicName(p.Name),
 			providers.WithAnthropicBaseURL(apiBase)))
 	case store.ProviderDashScope:
 		h.providerReg.RegisterForTenant(p.TenantID, providers.NewDashScopeProvider(p.Name, p.APIKey, apiBase, ""))

--- a/internal/http/providers_test.go
+++ b/internal/http/providers_test.go
@@ -57,6 +57,66 @@ func TestProvidersHandlerRegisterInMemoryAppliesCodexPoolDefaults(t *testing.T) 
 	}
 }
 
+// TestProvidersHandlerRegisterInMemoryUsesDBNameForAnthropic guards the onboarding verify flow:
+// when an Anthropic provider is created via HTTP with a custom name, the in-memory registry
+// must key the provider by that DB name — not the hardcoded "anthropic" default. Otherwise
+// handleVerifyProvider's GetForTenant(p.TenantID, p.Name) lookup fails with "provider not registered".
+// See commit 7fcf0327 for the matching fix on the startup path (cmd/gateway_providers.go).
+func TestProvidersHandlerRegisterInMemoryUsesDBNameForAnthropic(t *testing.T) {
+	providerReg := providers.NewRegistry(nil)
+	handler := NewProvidersHandler(newMockProviderStore(), newMockSecretsStore(), providerReg, "")
+
+	provider := &store.LLMProviderData{
+		BaseModel:    store.BaseModel{ID: uuid.New()},
+		TenantID:     uuid.New(),
+		Name:         "my-anthropic",
+		ProviderType: store.ProviderAnthropicNative,
+		APIKey:       "sk-ant-test",
+		Enabled:      true,
+	}
+
+	handler.registerInMemory(provider)
+
+	got, err := providerReg.GetForTenant(provider.TenantID, provider.Name)
+	if err != nil {
+		t.Fatalf("GetForTenant(%q) error = %v, want provider registered under DB name", provider.Name, err)
+	}
+	if got.Name() != provider.Name {
+		t.Fatalf("Name() = %q, want %q", got.Name(), provider.Name)
+	}
+
+	// Negative: the hardcoded default "anthropic" must NOT be registered when the user chose a different name.
+	if _, err := providerReg.GetForTenant(provider.TenantID, "anthropic"); err == nil {
+		t.Fatal("GetForTenant(\"anthropic\") succeeded, want not-found — provider should only live under its DB name")
+	}
+}
+
+// TestProvidersHandlerRegisterInMemoryUsesDBNameForClaudeCLI mirrors the Anthropic guard for Claude CLI.
+// Custom-named CLI providers must be registered under their DB name to be locatable via verify.
+func TestProvidersHandlerRegisterInMemoryUsesDBNameForClaudeCLI(t *testing.T) {
+	providerReg := providers.NewRegistry(nil)
+	handler := NewProvidersHandler(newMockProviderStore(), newMockSecretsStore(), providerReg, "")
+
+	provider := &store.LLMProviderData{
+		BaseModel:    store.BaseModel{ID: uuid.New()},
+		TenantID:     uuid.New(),
+		Name:         "claude-max",
+		ProviderType: store.ProviderClaudeCLI,
+		APIBase:      "claude",
+		Enabled:      true,
+	}
+
+	handler.registerInMemory(provider)
+
+	got, err := providerReg.GetForTenant(provider.TenantID, provider.Name)
+	if err != nil {
+		t.Fatalf("GetForTenant(%q) error = %v, want provider registered under DB name", provider.Name, err)
+	}
+	if got.Name() != provider.Name {
+		t.Fatalf("Name() = %q, want %q", got.Name(), provider.Name)
+	}
+}
+
 func setupProvidersAdminToken(t *testing.T) string {
 	t.Helper()
 	token := "system-admin-key"

--- a/internal/http/providers_test.go
+++ b/internal/http/providers_test.go
@@ -115,6 +115,11 @@ func TestProvidersHandlerRegisterInMemoryUsesDBNameForClaudeCLI(t *testing.T) {
 	if got.Name() != provider.Name {
 		t.Fatalf("Name() = %q, want %q", got.Name(), provider.Name)
 	}
+
+	// Negative: the hardcoded default "claude-cli" must NOT be registered when the user chose a different name.
+	if _, err := providerReg.GetForTenant(provider.TenantID, "claude-cli"); err == nil {
+		t.Fatal("GetForTenant(\"claude-cli\") succeeded, want not-found — provider should only live under its DB name")
+	}
 }
 
 func setupProvidersAdminToken(t *testing.T) string {


### PR DESCRIPTION
## Summary

- HTTP onboarding registered Anthropic / Claude CLI providers under their hardcoded default name ("anthropic", "claude-cli") instead of the user's chosen DB name. Verify (`handleVerifyProvider`) then failed with `provider not registered: <custom-name>` for any custom-named provider.
- Root cause: incomplete refactor in 7fcf0327 — the `WithAnthropicName` / `WithClaudeCLIName` options were added only to the startup path (`cmd/gateway_providers.go`), not to `internal/http/providers.go:registerInMemory`.
- Fix: pass `WithAnthropicName(p.Name)` / `WithClaudeCLIName(p.Name)` in the HTTP onboarding path, mirroring the startup path exactly.

## Test plan

- [x] `go build ./...` (PG) clean
- [x] `go build -tags sqliteonly ./...` (desktop) clean
- [x] `go vet ./internal/http/...` clean
- [x] `go test -race ./internal/http/... ./internal/providers/...` passes
- [x] Regression tests added:
  - `TestProvidersHandlerRegisterInMemoryUsesDBNameForAnthropic` — custom-named provider is locatable under DB name; hardcoded "anthropic" key is NOT present
  - `TestProvidersHandlerRegisterInMemoryUsesDBNameForClaudeCLI` — same for Claude CLI

## Follow-ups (not blocking)

- HTTP onboarding still skips `WithAnthropicRegistry(modelReg)` (startup path has it at `cmd/gateway_providers.go:349`) — affects forward-compat model resolution / token counting only, not verify.
- HTTP onboarding CLI branch skips the `filepath.IsAbs` + `exec.LookPath` binary validation present in the startup path.

## Notes

- Scout: `plans/reports/scout-260417-1301-onboarding-anthropic-model-verify.md`
- Pre-landing review: `plans/reports/code-reviewer-260417-1427-anthropic-claudecli-onboarding-name-parity.md`