### PR TITLE
ci: native arm64 runners + DRY docker release workflows via reusable workflow

### DIFF
--- a/.github/actions/docker-registry-login/action.yaml
+++ b/.github/actions/docker-registry-login/action.yaml
@@ -1,0 +1,26 @@
+name: 'Docker Registry Login'
+description: 'Log in to GHCR and Docker Hub'
+inputs:
+  github-token:
+    description: 'GITHUB_TOKEN for GHCR auth'
+    required: true
+  dockerhub-username:
+    description: 'Docker Hub username'
+    required: true
+  dockerhub-token:
+    description: 'Docker Hub token'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github-token }}
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   go:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Postgres service container for integration tests. pgvector/pgvector:pg18
     # matches the local dev image (Makefile uses the same tag on port 5433).
     # Healthcheck blocks the job until PG accepts connections, avoiding
@@ -70,7 +70,7 @@ jobs:
         run: go tool cover -func=coverage.out | tail -1
 
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ui/web

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/docker-multiarch.yaml
+++ b/.github/workflows/docker-multiarch.yaml
@@ -21,8 +21,10 @@ on:
       tag-rules:
         description: |
           Multiline tag template for docker/metadata-action `tags` field.
-          May reference ${{ matrix.variant.name }} / ${{ matrix.variant.suffix }}.
-          Resolved at merge-job matrix expansion time inside this workflow.
+          May reference placeholders {{name}}, {{suffix}}, {{is_latest}},
+          {{is_variant}}. Callers cannot use matrix expressions directly
+          because matrix context is not available at caller scope.
+          Placeholders resolve inside the merge job at matrix-expansion time.
         required: true
         type: string
       cache-prefix:
@@ -132,6 +134,30 @@ jobs:
           path: /tmp/digests
           merge-multiple: true
 
+      - name: Resolve tag rules
+        id: tagrules
+        env:
+          TAG_RULES: ${{ inputs.tag-rules }}
+          NAME: ${{ matrix.variant.name }}
+          SUFFIX: ${{ matrix.variant.suffix }}
+        run: |
+          # Derive boolean placeholders from suffix presence
+          if [ -z "$SUFFIX" ]; then
+            IS_LATEST=true; IS_VARIANT=false
+          else
+            IS_LATEST=false; IS_VARIANT=true
+          fi
+          RESOLVED="$TAG_RULES"
+          RESOLVED="${RESOLVED//\{\{name\}\}/$NAME}"
+          RESOLVED="${RESOLVED//\{\{suffix\}\}/$SUFFIX}"
+          RESOLVED="${RESOLVED//\{\{is_latest\}\}/$IS_LATEST}"
+          RESOLVED="${RESOLVED//\{\{is_variant\}\}/$IS_VARIANT}"
+          {
+            echo 'rules<<RULES_EOF'
+            printf '%s\n' "$RESOLVED"
+            echo 'RULES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -139,7 +165,7 @@ jobs:
           images: |
             ${{ env.GHCR_IMAGE }}
             ${{ env.DOCKERHUB_IMAGE }}
-          tags: ${{ inputs.tag-rules }}
+          tags: ${{ steps.tagrules.outputs.rules }}
 
       - name: Create and push multi-arch manifest (GHCR)
         run: |

--- a/.github/workflows/docker-multiarch.yaml
+++ b/.github/workflows/docker-multiarch.yaml
@@ -134,6 +134,13 @@ jobs:
           path: /tmp/digests
           merge-multiple: true
 
+      # Resolve {{name}}/{{suffix}}/{{is_latest}}/{{is_variant}} placeholders.
+      # Why bash-substitution instead of GHA's `${{ matrix.* }}`:
+      # GHA evaluates expressions in a caller's `with:` inputs at CALLER scope,
+      # where `matrix` is undefined (the matrix lives inside this reusable
+      # workflow, not in the caller). Passing `${{ matrix.variant.x }}` from a
+      # caller therefore fails workflow parse. Placeholders let the caller
+      # write template strings that this job resolves at matrix-expansion time.
       - name: Resolve tag rules
         id: tagrules
         env:

--- a/.github/workflows/docker-multiarch.yaml
+++ b/.github/workflows/docker-multiarch.yaml
@@ -1,0 +1,164 @@
+name: Docker Multi-Arch Build & Push
+
+on:
+  workflow_call:
+    inputs:
+      image-suffix:
+        description: 'Suffix appended to image name (e.g. "-web" or "")'
+        default: ''
+        type: string
+      build-context:
+        description: 'Docker build context path'
+        default: '.'
+        type: string
+      variants-json:
+        description: |
+          JSON array of variant objects. Each must include: name, suffix,
+          enable_otel, enable_embedui, enable_python, enable_full_skills.
+          For web-only (no backend args), pass a 1-variant sentinel.
+        required: true
+        type: string
+      tag-rules:
+        description: |
+          Multiline tag template for docker/metadata-action `tags` field.
+          May reference ${{ matrix.variant.name }} / ${{ matrix.variant.suffix }}.
+          Resolved at merge-job matrix expansion time inside this workflow.
+        required: true
+        type: string
+      cache-prefix:
+        description: 'Cache scope prefix (e.g. "release", "beta", "web")'
+        required: true
+        type: string
+      version:
+        description: 'VERSION build-arg value'
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+env:
+  # NOTE: DOCKERHUB_IMAGE is patched per-repo. Upstream: digitop/goclaw.
+  # Forks override locally (e.g. dataplanelabs/goclaw) on their test branch.
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}${{ inputs.image-suffix }}
+  DOCKERHUB_IMAGE: digitop/goclaw${{ inputs.image-suffix }}
+
+jobs:
+  build:
+    runs-on: ${{ matrix.platform.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(inputs.variants-json) }}
+        platform:
+          - { name: "linux/amd64", runs_on: ubuntu-24.04,     arch: amd64 }
+          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: ./.github/actions/docker-registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.build-context }}
+          platforms: ${{ matrix.platform.name }}
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ENABLE_OTEL=${{ matrix.variant.enable_otel }}
+            ENABLE_EMBEDUI=${{ matrix.variant.enable_embedui }}
+            ENABLE_PYTHON=${{ matrix.variant.enable_python }}
+            ENABLE_FULL_SKILLS=${{ matrix.variant.enable_full_skills }}
+            VERSION=${{ inputs.version }}
+          cache-from: type=gha,scope=${{ inputs.cache-prefix }}-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.cache-prefix }}-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+
+      - name: Export digest
+        # Filename IS the digest sha; merge job reads filenames to rebuild
+        # content-addressable image refs. File content is intentionally empty.
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ inputs.cache-prefix }}-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(inputs.variants-json) }}
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/docker-registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ inputs.cache-prefix }}-${{ matrix.variant.name }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          tags: ${{ inputs.tag-rules }}
+
+      - name: Create and push multi-arch manifest (GHCR)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Create and push multi-arch manifest (Docker Hub)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr --arg p "${{ env.DOCKERHUB_IMAGE }}" '.tags | map(select(startswith($p)) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Inspect manifests
+        run: |
+          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            docker buildx imagetools inspect "$tag"
+          done

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -86,28 +86,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Build and push Docker images tagged as beta
-  docker-images:
-    runs-on: ubuntu-latest
+  # Stage 1: Build per-arch beta images on native runners (no QEMU)
+  docker-images-build:
+    runs-on: ${{ matrix.platform.runs_on }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - variant: latest
-            suffix: ""
-            enable_otel: "false"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "false"
-          - variant: full
-            suffix: "-full"
-            enable_otel: "false"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "true"
+        variant:
+          - { name: latest, suffix: "",      enable_otel: "false", enable_embedui: "true", enable_python: "true", enable_full_skills: "false" }
+          - { name: full,   suffix: "-full", enable_otel: "false", enable_embedui: "true", enable_python: "true", enable_full_skills: "true"  }
+        platform:
+          - { name: "linux/amd64", runs_on: ubuntu-latest,    arch: amd64 }
+          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -131,24 +123,101 @@ jobs:
           images: |
             ${{ env.GHCR_IMAGE }}
             ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=${{ github.ref_name }},suffix=${{ matrix.suffix }}
-            type=raw,value=beta,enable=${{ matrix.suffix == '' }},suffix=
-            type=raw,value=beta${{ matrix.suffix }},enable=${{ matrix.suffix != '' }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform.name }}
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            ENABLE_OTEL=${{ matrix.enable_otel }}
-            ENABLE_EMBEDUI=${{ matrix.enable_embedui }}
-            ENABLE_PYTHON=${{ matrix.enable_python }}
-            ENABLE_FULL_SKILLS=${{ matrix.enable_full_skills }}
+            ENABLE_OTEL=${{ matrix.variant.enable_otel }}
+            ENABLE_EMBEDUI=${{ matrix.variant.enable_embedui }}
+            ENABLE_PYTHON=${{ matrix.variant.enable_python }}
+            ENABLE_FULL_SKILLS=${{ matrix.variant.enable_full_skills }}
             VERSION=${{ github.ref_name }}
-          cache-from: type=gha,scope=beta-${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=beta-${{ matrix.variant }}
+          cache-from: type=gha,scope=beta-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=beta-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stage 2: Merge per-arch digests into multi-arch manifests per variant
+  docker-images-merge:
+    needs: docker-images-build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - { name: latest, suffix: ""      }
+          - { name: full,   suffix: "-full" }
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ matrix.variant.name }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=raw,value=${{ github.ref_name }},suffix=${{ matrix.variant.suffix }}
+            type=raw,value=beta,enable=${{ matrix.variant.suffix == '' }},suffix=
+            type=raw,value=beta${{ matrix.variant.suffix }},enable=${{ matrix.variant.suffix != '' }}
+
+      - name: Create and push multi-arch manifest (GHCR)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Create and push multi-arch manifest (Docker Hub)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("digitop/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Inspect manifests
+        run: |
+          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            docker buildx imagetools inspect "$tag"
+          done

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -96,9 +96,9 @@ jobs:
           {"name":"full","suffix":"-full","enable_otel":"false","enable_embedui":"true","enable_python":"true","enable_full_skills":"true"}
         ]
       tag-rules: |
-        type=raw,value=${{ github.ref_name }},suffix=${{ matrix.variant.suffix }}
-        type=raw,value=beta,enable=${{ matrix.variant.suffix == '' }},suffix=
-        type=raw,value=beta${{ matrix.variant.suffix }},enable=${{ matrix.variant.suffix != '' }}
+        type=raw,value=${{ github.ref_name }},suffix={{suffix}}
+        type=raw,value=beta,enable={{is_latest}},suffix=
+        type=raw,value=beta{{suffix}},enable={{is_variant}}
       cache-prefix: beta
       version: ${{ github.ref_name }}
     secrets:

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   # Build cross-platform binaries and create prerelease
   build-binaries:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:
@@ -64,7 +64,7 @@ jobs:
   # Create GitHub prerelease with binaries
   create-prerelease:
     needs: build-binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -86,138 +86,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Stage 1: Build per-arch beta images on native runners (no QEMU)
-  docker-images-build:
-    runs-on: ${{ matrix.platform.runs_on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          - { name: latest, suffix: "",      enable_otel: "false", enable_embedui: "true", enable_python: "true", enable_full_skills: "false" }
-          - { name: full,   suffix: "-full", enable_otel: "false", enable_embedui: "true", enable_python: "true", enable_full_skills: "true"  }
-        platform:
-          - { name: "linux/amd64", runs_on: ubuntu-latest,    arch: amd64 }
-          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_IMAGE }}
-            ${{ env.DOCKERHUB_IMAGE }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: ${{ matrix.platform.name }}
-          outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            ENABLE_OTEL=${{ matrix.variant.enable_otel }}
-            ENABLE_EMBEDUI=${{ matrix.variant.enable_embedui }}
-            ENABLE_PYTHON=${{ matrix.variant.enable_python }}
-            ENABLE_FULL_SKILLS=${{ matrix.variant.enable_full_skills }}
-            VERSION=${{ github.ref_name }}
-          cache-from: type=gha,scope=beta-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
-          cache-to: type=gha,mode=max,scope=beta-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: digest-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # Stage 2: Merge per-arch digests into multi-arch manifests per variant
-  docker-images-merge:
-    needs: docker-images-build
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          - { name: latest, suffix: ""      }
-          - { name: full,   suffix: "-full" }
-    steps:
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          pattern: digest-${{ matrix.variant.name }}-*
-          path: /tmp/digests
-          merge-multiple: true
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_IMAGE }}
-            ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=${{ github.ref_name }},suffix=${{ matrix.variant.suffix }}
-            type=raw,value=beta,enable=${{ matrix.variant.suffix == '' }},suffix=
-            type=raw,value=beta${{ matrix.variant.suffix }},enable=${{ matrix.variant.suffix != '' }}
-
-      - name: Create and push multi-arch manifest (GHCR)
-        run: |
-          cd /tmp/digests
-          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $DIGESTS
-
-      - name: Create and push multi-arch manifest (Docker Hub)
-        run: |
-          cd /tmp/digests
-          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("digitop/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $DIGESTS
-
-      - name: Inspect manifests
-        run: |
-          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
-            docker buildx imagetools inspect "$tag"
-          done
+  # Docker beta images: 2 variants on both registries, multi-arch
+  docker-images:
+    uses: ./.github/workflows/docker-multiarch.yaml
+    with:
+      variants-json: >-
+        [
+          {"name":"latest","suffix":"","enable_otel":"false","enable_embedui":"true","enable_python":"true","enable_full_skills":"false"},
+          {"name":"full","suffix":"-full","enable_otel":"false","enable_embedui":"true","enable_python":"true","enable_full_skills":"true"}
+        ]
+      tag-rules: |
+        type=raw,value=${{ github.ref_name }},suffix=${{ matrix.variant.suffix }}
+        type=raw,value=beta,enable=${{ matrix.variant.suffix == '' }},suffix=
+        type=raw,value=beta${{ matrix.variant.suffix }},enable=${{ matrix.variant.suffix != '' }}
+      cache-prefix: beta
+      version: ${{ github.ref_name }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-desktop.yaml
+++ b/.github/workflows/release-desktop.yaml
@@ -148,7 +148,7 @@ jobs:
   # ── Create GitHub Release ──
   create-release:
     needs: [build-macos, build-windows]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
       released: ${{ steps.version.outputs.version != '' }}
@@ -64,7 +64,7 @@ jobs:
   build-binaries:
     needs: release
     if: needs.release.outputs.released == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:
@@ -118,7 +118,7 @@ jobs:
   checksums:
     needs: [release, build-binaries]
     if: needs.release.outputs.released == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Download all binary assets
         env:
@@ -146,277 +146,52 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber
 
-  # Stage 1: Build per-arch images on native runners (no QEMU)
-  docker-images-build:
+  # Docker images: backend variants on both registries, multi-arch
+  docker-images:
     needs: release
     if: needs.release.outputs.released == 'true'
-    runs-on: ${{ matrix.platform.runs_on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          - { name: base,   suffix: "-base",  enable_otel: "false", enable_embedui: "false", enable_python: "false", enable_full_skills: "false" }
-          - { name: latest, suffix: "",       enable_otel: "false", enable_embedui: "true",  enable_python: "true",  enable_full_skills: "false" }
-          - { name: full,   suffix: "-full",  enable_otel: "false", enable_embedui: "true",  enable_python: "true",  enable_full_skills: "true"  }
-          - { name: otel,   suffix: "-otel",  enable_otel: "true",  enable_embedui: "true",  enable_python: "true",  enable_full_skills: "false" }
-        platform:
-          - { name: "linux/amd64", runs_on: ubuntu-latest,    arch: amd64 }
-          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
-    steps:
-      - uses: actions/checkout@v4
+    uses: ./.github/workflows/docker-multiarch.yaml
+    with:
+      variants-json: >-
+        [
+          {"name":"base","suffix":"-base","enable_otel":"false","enable_embedui":"false","enable_python":"false","enable_full_skills":"false"},
+          {"name":"latest","suffix":"","enable_otel":"false","enable_embedui":"true","enable_python":"true","enable_full_skills":"false"},
+          {"name":"full","suffix":"-full","enable_otel":"false","enable_embedui":"true","enable_python":"true","enable_full_skills":"true"},
+          {"name":"otel","suffix":"-otel","enable_otel":"true","enable_embedui":"true","enable_python":"true","enable_full_skills":"false"}
+        ]
+      tag-rules: |
+        type=raw,value=v${{ needs.release.outputs.version }},suffix=${{ matrix.variant.suffix }}
+        type=raw,value=latest,enable=${{ matrix.variant.suffix == '' }},suffix=
+        type=raw,value=${{ matrix.variant.name }},enable=${{ matrix.variant.suffix != '' }}
+      cache-prefix: release
+      version: v${{ needs.release.outputs.version }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_IMAGE }}
-            ${{ env.DOCKERHUB_IMAGE }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: ${{ matrix.platform.name }}
-          outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            ENABLE_OTEL=${{ matrix.variant.enable_otel }}
-            ENABLE_EMBEDUI=${{ matrix.variant.enable_embedui }}
-            ENABLE_PYTHON=${{ matrix.variant.enable_python }}
-            ENABLE_FULL_SKILLS=${{ matrix.variant.enable_full_skills }}
-            VERSION=v${{ needs.release.outputs.version }}
-          cache-from: type=gha,scope=${{ matrix.variant.name }}-${{ matrix.platform.arch }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.variant.name }}-${{ matrix.platform.arch }}
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: digest-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # Stage 2: Merge per-arch digests into multi-arch manifests per variant
-  docker-images-merge:
-    needs: [release, docker-images-build]
-    if: needs.release.outputs.released == 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          - { name: base,   suffix: "-base"  }
-          - { name: latest, suffix: ""       }
-          - { name: full,   suffix: "-full"  }
-          - { name: otel,   suffix: "-otel"  }
-    steps:
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          pattern: digest-${{ matrix.variant.name }}-*
-          path: /tmp/digests
-          merge-multiple: true
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_IMAGE }}
-            ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=v${{ needs.release.outputs.version }},suffix=${{ matrix.variant.suffix }}
-            type=raw,value=latest,enable=${{ matrix.variant.suffix == '' }},suffix=
-            type=raw,value=${{ matrix.variant.name }},enable=${{ matrix.variant.suffix != '' }}
-
-      - name: Create and push multi-arch manifest (GHCR)
-        run: |
-          cd /tmp/digests
-          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $DIGESTS
-
-      - name: Create and push multi-arch manifest (Docker Hub)
-        run: |
-          cd /tmp/digests
-          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("${{ env.DOCKERHUB_IMAGE }}") or startswith("digitop/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $DIGESTS
-
-      - name: Inspect manifests
-        run: |
-          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
-            docker buildx imagetools inspect "$tag"
-          done
-
-  # Stage 1: Build web UI image per-arch on native runners (no QEMU)
-  docker-web-build:
+  # Web UI image: single variant, multi-arch
+  docker-web:
     needs: release
     if: needs.release.outputs.released == 'true'
-    runs-on: ${{ matrix.platform.runs_on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { name: "linux/amd64", runs_on: ubuntu-latest,    arch: amd64 }
-          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_IMAGE }}-web
-            ${{ env.DOCKERHUB_IMAGE }}-web
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: ui/web
-          platforms: ${{ matrix.platform.name }}
-          outputs: type=image,"name=${{ env.GHCR_IMAGE }}-web,${{ env.DOCKERHUB_IMAGE }}-web",push-by-digest=true,name-canonical=true,push=true
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=web-${{ matrix.platform.arch }}
-          cache-to: type=gha,mode=max,scope=web-${{ matrix.platform.arch }}
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: digest-web-${{ matrix.platform.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # Stage 2: Merge web UI per-arch digests into multi-arch manifest
-  docker-web-merge:
-    needs: [release, docker-web-build]
-    if: needs.release.outputs.released == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          pattern: digest-web-*
-          path: /tmp/digests
-          merge-multiple: true
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_IMAGE }}-web
-            ${{ env.DOCKERHUB_IMAGE }}-web
-          tags: |
-            type=raw,value=v${{ needs.release.outputs.version }}
-            type=raw,value=latest
-
-      - name: Create and push multi-arch manifest (GHCR)
-        run: |
-          cd /tmp/digests
-          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}-web@sha256:%s " *)
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $DIGESTS
-
-      - name: Create and push multi-arch manifest (Docker Hub)
-        run: |
-          cd /tmp/digests
-          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}-web@sha256:%s " *)
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("digitop/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $DIGESTS
-
-      - name: Inspect manifests
-        run: |
-          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
-            docker buildx imagetools inspect "$tag"
-          done
+    uses: ./.github/workflows/docker-multiarch.yaml
+    with:
+      image-suffix: "-web"
+      build-context: ui/web
+      variants-json: '[{"name":"web","suffix":"","enable_otel":"false","enable_embedui":"false","enable_python":"false","enable_full_skills":"false"}]'
+      tag-rules: |
+        type=raw,value=v${{ needs.release.outputs.version }}
+        type=raw,value=latest
+      cache-prefix: web
+      version: v${{ needs.release.outputs.version }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   # Notify Discord on new release (runs even if docker jobs fail)
   notify-discord:
-    needs: [release, build-binaries, docker-images-merge, docker-web-merge]
+    needs: [release, build-binaries, docker-images, docker-web]
     if: always() && needs.release.outputs.released == 'true' && !cancelled()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Send Discord notification
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,46 +146,24 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber
 
-  # Build and push Docker images to GHCR + Docker Hub
-  docker-images:
+  # Stage 1: Build per-arch images on native runners (no QEMU)
+  docker-images-build:
     needs: release
     if: needs.release.outputs.released == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runs_on }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          # Base: backend API-only, no web UI, no runtimes
-          - variant: base
-            suffix: "-base"
-            enable_otel: "false"
-            enable_embedui: "false"
-            enable_python: "false"
-            enable_full_skills: "false"
-          # Latest: backend + embedded web UI + Python
-          - variant: latest
-            suffix: ""
-            enable_otel: "false"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "false"
-          # Full: all runtimes + skills pre-installed
-          - variant: full
-            suffix: "-full"
-            enable_otel: "false"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "true"
-          # OTel: latest + OpenTelemetry tracing
-          - variant: otel
-            suffix: "-otel"
-            enable_otel: "true"
-            enable_embedui: "true"
-            enable_python: "true"
-            enable_full_skills: "false"
+        variant:
+          - { name: base,   suffix: "-base",  enable_otel: "false", enable_embedui: "false", enable_python: "false", enable_full_skills: "false" }
+          - { name: latest, suffix: "",       enable_otel: "false", enable_embedui: "true",  enable_python: "true",  enable_full_skills: "false" }
+          - { name: full,   suffix: "-full",  enable_otel: "false", enable_embedui: "true",  enable_python: "true",  enable_full_skills: "true"  }
+          - { name: otel,   suffix: "-otel",  enable_otel: "true",  enable_embedui: "true",  enable_python: "true",  enable_full_skills: "false" }
+        platform:
+          - { name: "linux/amd64", runs_on: ubuntu-latest,    arch: amd64 }
+          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -209,37 +187,121 @@ jobs:
           images: |
             ${{ env.GHCR_IMAGE }}
             ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=v${{ needs.release.outputs.version }},suffix=${{ matrix.suffix }}
-            type=raw,value=latest,enable=${{ matrix.suffix == '' }},suffix=
-            type=raw,value=${{ matrix.variant }},enable=${{ matrix.suffix != '' }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform.name }}
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            ENABLE_OTEL=${{ matrix.enable_otel }}
-            ENABLE_EMBEDUI=${{ matrix.enable_embedui }}
-            ENABLE_PYTHON=${{ matrix.enable_python }}
-            ENABLE_FULL_SKILLS=${{ matrix.enable_full_skills }}
+            ENABLE_OTEL=${{ matrix.variant.enable_otel }}
+            ENABLE_EMBEDUI=${{ matrix.variant.enable_embedui }}
+            ENABLE_PYTHON=${{ matrix.variant.enable_python }}
+            ENABLE_FULL_SKILLS=${{ matrix.variant.enable_full_skills }}
             VERSION=v${{ needs.release.outputs.version }}
-          cache-from: type=gha,scope=${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
+          cache-from: type=gha,scope=${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant.name }}-${{ matrix.platform.arch }}
 
-  # Build and push web UI Docker image
-  docker-web:
-    needs: release
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stage 2: Merge per-arch digests into multi-arch manifests per variant
+  docker-images-merge:
+    needs: [release, docker-images-build]
     if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - { name: base,   suffix: "-base"  }
+          - { name: latest, suffix: ""       }
+          - { name: full,   suffix: "-full"  }
+          - { name: otel,   suffix: "-otel"  }
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ matrix.variant.name }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=raw,value=v${{ needs.release.outputs.version }},suffix=${{ matrix.variant.suffix }}
+            type=raw,value=latest,enable=${{ matrix.variant.suffix == '' }},suffix=
+            type=raw,value=${{ matrix.variant.name }},enable=${{ matrix.variant.suffix != '' }}
+
+      - name: Create and push multi-arch manifest (GHCR)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Create and push multi-arch manifest (Docker Hub)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("${{ env.DOCKERHUB_IMAGE }}") or startswith("digitop/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Inspect manifests
+        run: |
+          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            docker buildx imagetools inspect "$tag"
+          done
+
+  # Stage 1: Build web UI image per-arch on native runners (no QEMU)
+  docker-web-build:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ${{ matrix.platform.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { name: "linux/amd64", runs_on: ubuntu-latest,    arch: amd64 }
+          - { name: "linux/arm64", runs_on: ubuntu-24.04-arm, arch: arm64 }
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -263,24 +325,96 @@ jobs:
           images: |
             ${{ env.GHCR_IMAGE }}-web
             ${{ env.DOCKERHUB_IMAGE }}-web
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ui/web
+          platforms: ${{ matrix.platform.name }}
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }}-web,${{ env.DOCKERHUB_IMAGE }}-web",push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=web-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=web-${{ matrix.platform.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-web-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stage 2: Merge web UI per-arch digests into multi-arch manifest
+  docker-web-merge:
+    needs: [release, docker-web-build]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-web-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}-web
+            ${{ env.DOCKERHUB_IMAGE }}-web
           tags: |
             type=raw,value=v${{ needs.release.outputs.version }}
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: ui/web
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+      - name: Create and push multi-arch manifest (GHCR)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}-web@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Create and push multi-arch manifest (Docker Hub)
+        run: |
+          cd /tmp/digests
+          DIGESTS=$(printf "${{ env.GHCR_IMAGE }}-web@sha256:%s " *)
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("digitop/")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $DIGESTS
+
+      - name: Inspect manifests
+        run: |
+          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            docker buildx imagetools inspect "$tag"
+          done
 
   # Notify Discord on new release (runs even if docker jobs fail)
   notify-discord:
-    needs: [release, build-binaries, docker-images, docker-web]
+    needs: [release, build-binaries, docker-images-merge, docker-web-merge]
     if: always() && needs.release.outputs.released == 'true' && !cancelled()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,9 +160,9 @@ jobs:
           {"name":"otel","suffix":"-otel","enable_otel":"true","enable_embedui":"true","enable_python":"true","enable_full_skills":"false"}
         ]
       tag-rules: |
-        type=raw,value=v${{ needs.release.outputs.version }},suffix=${{ matrix.variant.suffix }}
-        type=raw,value=latest,enable=${{ matrix.variant.suffix == '' }},suffix=
-        type=raw,value=${{ matrix.variant.name }},enable=${{ matrix.variant.suffix != '' }}
+        type=raw,value=v${{ needs.release.outputs.version }},suffix={{suffix}}
+        type=raw,value=latest,enable={{is_latest}},suffix=
+        type=raw,value={{name}},enable={{is_variant}}
       cache-prefix: release
       version: v${{ needs.release.outputs.version }}
     secrets:


### PR DESCRIPTION
## Summary

Supersedes #940. Combines:
1. **Native arm64 runners** — drops QEMU emulation (~4x faster arm64 builds) by using `ubuntu-24.04-arm` runners. Stage 1 builds per-arch, Stage 2 merges into multi-arch manifest.
2. **DRY refactor** — extracts shared docker build/merge pattern into a composite action + reusable workflow, eliminating ~450 LOC of YAML duplication.

### New files

- `.github/actions/docker-registry-login/action.yaml` — composite action for GHCR + Docker Hub login (was repeated 5x inline)
- `.github/workflows/docker-multiarch.yaml` — reusable workflow encapsulating per-arch build + manifest merge pipeline

### Also

- Pins `ubuntu-24.04` explicitly across all workflows (parity with `ubuntu-24.04-arm`, avoids silent OS drift)
- Uses placeholder tokens (`{{name}}`, `{{suffix}}`, `{{is_latest}}`, `{{is_variant}}`) for matrix values in caller `tag-rules` — GHA evaluates caller `with:` expressions eagerly, so matrix context isn't available at caller scope; reusable workflow resolves placeholders at merge-job time

## Out of scope

Action version bumps (Node 20 -> 24 deprecation: `checkout@v4->v5`, `setup-go@v5->v6`, `build-push@v6->v7`, etc.) are **intentionally deferred** to a follow-up PR to keep this diff reviewable.

## LOC impact

| File | Before | After | Delta |
|------|--------|-------|-------|
| release.yaml | 441 | 215 | -226 |
| release-beta.yaml | 224 | 106 | -118 |
| NEW docker-multiarch.yaml | 0 | ~200 | +200 |
| NEW docker-registry-login/action.yaml | 0 | 23 | +23 |
| **Net caller LOC** | **665** | **~544** | **-121** |

## Validation

Validated on fork `vanducng/goclaw` (DOCKERHUB_IMAGE patched to `dataplanelabs/goclaw`) prior to this PR:

- **Beta path** (`release-beta.yaml`): tag `v3.99.0-beta.dry.2` pushed -> all 6 jobs green (4 build + 2 merge). Run: https://github.com/vanducng/goclaw/actions/runs/24556944984
- **Stable path** (`release.yaml`): `workflow_dispatch` with tag `v3.99.0-beta.dry.2` -> all 15 docker jobs green (8 backend build + 4 backend merge + 2 web build + 1 web merge); `notify-discord` failed only because fork has no `DISCORD_WEBHOOK_URL` secret. Run: https://github.com/vanducng/goclaw/actions/runs/24557454577

Manifest inspection confirms 2-platform (linux/amd64 + linux/arm64) images published to both GHCR + DockerHub for all tags.

- **Before**
<img width="2176" height="1406" alt="CleanShot 2026-04-16 at 20 38 25@2x" src="https://github.com/user-attachments/assets/9cdf06a4-0b3f-45e5-ba48-0a4936bbf8e1" />


- **After**
<img width="2756" height="2192" alt="CleanShot 2026-04-17 at 09 20 59@2x" src="https://github.com/user-attachments/assets/f03851d0-61b2-45e9-9154-eae0b25ec418" />


## Rollback

`gh pr revert` restores pre-PR state. Low risk — fork validation de-risked this before landing.

## Closes

Closes #940