### PR TITLE
fix(docker): exclude node deps and dist from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,5 +19,8 @@ tmp/
 ui/desktop/
 ui/simple-saas/
 !ui/web/
+ui/web/node_modules/
+ui/web/dist/
 plans/
 skills-store/
+**/node_modules/


### PR DESCRIPTION
## Summary
- Root `.dockerignore` does not exclude local dep/dist folders; `COPY ui/web/ .` in `Dockerfile` ships stale local installs into the web-builder stage.
- Stale artifacts (e.g. leftover `rollup@4.57.1` from older `vite@6`) override `pnpm install --frozen-lockfile`, breaking Alpine musl builds with: `Cannot find module @rollup/rollup-linux-arm64-musl`.
- Add explicit ignores for `ui/web` dep/dist folders and a catch-all for any nested dep folder.

## Why
- Deterministic Docker builds regardless of local dev state (matches CI behavior).
- Faster build context transfer — hundreds of MB skipped.
- CI unaffected (checkout is already clean); only local `docker compose build` was breaking.

## Repro
1. `cd ui/web && pnpm install` (any older lockfile state works).
2. Later update lockfile to vite@8 + rolldown.
3. `docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.selfservice.yml build` — fails at `pnpm build` with missing `@rollup/rollup-linux-arm64-musl`.

## Test plan
- [x] `docker compose ... build --no-cache goclaw` succeeds on macOS arm64.
- [x] `docker compose ... up -d` brings up `postgres`, `goclaw-ui`, `goclaw` cleanly.
- [ ] Confirm CI still green (no behavior change expected for CI).