### PR TITLE
feat(channels) WeChat intergration porting from ts official lib

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/channels/feishu"
 	slackchannel "github.com/nextlevelbuilder/goclaw/internal/channels/slack"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/telegram"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/wechat"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/whatsapp"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo"
 	zalopersonal "github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal"
@@ -459,6 +460,7 @@ func runGateway() {
 		instanceLoader.RegisterFactory(channels.TypeSlack, slackchannel.FactoryWithPendingStore(pgStores.PendingMessages))
 		instanceLoader.RegisterFactory(channels.TypeFacebook, facebook.Factory)
 		instanceLoader.RegisterFactory(channels.TypePancake, pancake.Factory)
+		instanceLoader.RegisterFactory(channels.TypeWeChat, wechat.Factory)
 		if err := instanceLoader.LoadAll(context.Background()); err != nil {
 			slog.Error("failed to load channel instances from DB", "error", err)
 		}

--- a/cmd/gateway_channels_setup.go
+++ b/cmd/gateway_channels_setup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/channels/feishu"
 	slackchannel "github.com/nextlevelbuilder/goclaw/internal/channels/slack"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/telegram"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/wechat"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/whatsapp"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo"
 	zalopersonal "github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal"
@@ -142,6 +143,18 @@ func registerConfigChannels(cfg *config.Config, channelMgr *channels.Manager, ms
 			}
 		}
 	}
+
+	if cfg.Channels.WeChat.Enabled {
+		if cfg.Channels.WeChat.Token == "" {
+			recordMissingConfig(channels.TypeWeChat, "Set channels.wechat.token in config.")
+		} else if wc, err := wechat.New(cfg.Channels.WeChat, msgBus, pgStores.Pairing); err != nil {
+			channelMgr.RecordFailure(channels.TypeWeChat, "", err)
+			slog.Error("failed to initialize wechat channel", "error", err)
+		} else {
+			channelMgr.RegisterChannel(channels.TypeWeChat, wc)
+			slog.Info("wechat channel enabled (config)")
+		}
+	}
 }
 
 // wireChannelRPCMethods registers WS RPC methods for channels, instances, agent links, and teams.
@@ -155,6 +168,7 @@ func wireChannelRPCMethods(server *gateway.Server, pgStores *store.Stores, chann
 		zalomethods.NewQRMethods(pgStores.ChannelInstances, msgBus).Register(server.Router())
 		zalomethods.NewContactsMethods(pgStores.ChannelInstances).Register(server.Router())
 		whatsapp.NewQRMethods(pgStores.ChannelInstances, channelMgr).Register(server.Router())
+		wechat.NewQRMethods(pgStores.ChannelInstances, msgBus).Register(server.Router())
 	}
 
 	// Register agent links WS RPC methods
@@ -270,4 +284,3 @@ func wireChannelEventSubscribers(
 		})
 	}
 }
-

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -80,6 +80,7 @@ const (
 	TypeWhatsApp     = "whatsapp"
 	TypeZaloOA       = "zalo_oa"
 	TypeZaloPersonal = "zalo_personal"
+	TypeWeChat       = "wechat"
 )
 
 // Channel defines the interface that all channel implementations must satisfy.

--- a/internal/channels/wechat/api.go
+++ b/internal/channels/wechat/api.go
@@ -1,0 +1,254 @@
+package wechat
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	channelVersion = "goclaw-wechat/1.0.0"
+
+	defaultLongPollTimeoutMs = 35000
+	defaultAPITimeoutMs      = 15000
+	defaultConfigTimeoutMs   = 10000
+)
+
+// APIClient communicates with the Weixin iLink Bot API.
+type APIClient struct {
+	BaseURL    string
+	Token      string
+	HTTPClient *http.Client
+}
+
+// NewAPIClient creates a new API client.
+func NewAPIClient(baseURL, token string) *APIClient {
+	return &APIClient{
+		BaseURL: baseURL,
+		Token:   token,
+		HTTPClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+func buildBaseInfo() *BaseInfo {
+	return &BaseInfo{ChannelVersion: channelVersion}
+}
+
+func ensureTrailingSlash(u string) string {
+	if strings.HasSuffix(u, "/") {
+		return u
+	}
+	return u + "/"
+}
+
+// randomWechatUin generates X-WECHAT-UIN header: random uint32 -> decimal -> base64.
+func randomWechatUin() string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	uint32Val := binary.BigEndian.Uint32(b)
+	decimal := fmt.Sprintf("%d", uint32Val)
+	return base64.StdEncoding.EncodeToString([]byte(decimal))
+}
+
+func (c *APIClient) buildHeaders(bodyLen int) http.Header {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set("AuthorizationType", "ilink_bot_token")
+	h.Set("Content-Length", fmt.Sprintf("%d", bodyLen))
+	h.Set("X-WECHAT-UIN", randomWechatUin())
+	if c.Token != "" {
+		h.Set("Authorization", "Bearer "+strings.TrimSpace(c.Token))
+	}
+	return h
+}
+
+// apiPost sends a POST request and returns the response body.
+func (c *APIClient) apiPost(ctx context.Context, endpoint string, body []byte, timeoutMs int) ([]byte, error) {
+	base := ensureTrailingSlash(c.BaseURL)
+	u, err := url.JoinPath(base, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("build URL: %w", err)
+	}
+
+	timeout := time.Duration(timeoutMs) * time.Millisecond
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	for k, vs := range c.buildHeaders(len(body)) {
+		for _, v := range vs {
+			req.Header.Set(k, v)
+		}
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API %s %d: %s", endpoint, resp.StatusCode, string(respBody))
+	}
+	return respBody, nil
+}
+
+// apiGet sends a GET request and returns the response body.
+func (c *APIClient) apiGet(ctx context.Context, reqPath string, query url.Values, timeoutMs int) ([]byte, error) {
+	base, err := url.Parse(ensureTrailingSlash(c.BaseURL))
+	if err != nil {
+		return nil, fmt.Errorf("parse base URL: %w", err)
+	}
+	u := base.JoinPath(reqPath)
+	u.RawQuery = query.Encode()
+
+	timeout := time.Duration(timeoutMs) * time.Millisecond
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	for k, vs := range c.buildHeaders(0) {
+		for _, v := range vs {
+			req.Header.Set(k, v)
+		}
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API %s %d: %s", reqPath, resp.StatusCode, string(respBody))
+	}
+	return respBody, nil
+}
+
+// GetUpdates performs a long-poll getUpdates request.
+// On context deadline (normal for long-poll), returns an empty response with ret=0.
+func (c *APIClient) GetUpdates(ctx context.Context, getUpdatesBuf string, timeoutMs int) (*GetUpdatesResp, error) {
+	if timeoutMs <= 0 {
+		timeoutMs = defaultLongPollTimeoutMs
+	}
+
+	reqBody := GetUpdatesReq{
+		GetUpdatesBuf: getUpdatesBuf,
+		BaseInfo:      buildBaseInfo(),
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal getUpdates: %w", err)
+	}
+
+	respBody, err := c.apiPost(ctx, "ilink/bot/getupdates", body, timeoutMs)
+	if err != nil {
+		if ctx.Err() != nil {
+			slog.Debug("wechat getUpdates: client-side timeout, returning empty response")
+			return &GetUpdatesResp{Ret: 0, GetUpdatesBuf: getUpdatesBuf}, nil
+		}
+		return nil, err
+	}
+
+	var resp GetUpdatesResp
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal getUpdates: %w", err)
+	}
+	return &resp, nil
+}
+
+// SendMessage sends a single message downstream.
+func (c *APIClient) SendMessage(ctx context.Context, req *SendMessageReq) error {
+	if req.BaseInfo == nil {
+		req.BaseInfo = buildBaseInfo()
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal sendMessage: %w", err)
+	}
+	_, err = c.apiPost(ctx, "ilink/bot/sendmessage", body, defaultAPITimeoutMs)
+	return err
+}
+
+// GetUploadURL gets a pre-signed CDN upload URL.
+func (c *APIClient) GetUploadURL(ctx context.Context, req *GetUploadURLReq) (*GetUploadURLResp, error) {
+	if req.BaseInfo == nil {
+		req.BaseInfo = buildBaseInfo()
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal getUploadUrl: %w", err)
+	}
+	respBody, err := c.apiPost(ctx, "ilink/bot/getuploadurl", body, defaultAPITimeoutMs)
+	if err != nil {
+		return nil, err
+	}
+	var resp GetUploadURLResp
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal getUploadUrl: %w", err)
+	}
+	return &resp, nil
+}
+
+// GetConfig fetches bot config (includes typing_ticket).
+func (c *APIClient) GetConfig(ctx context.Context, ilinkUserID, contextToken string) (*GetConfigResp, error) {
+	reqBody := GetConfigReq{
+		ILinkUserID:  ilinkUserID,
+		ContextToken: contextToken,
+		BaseInfo:     buildBaseInfo(),
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal getConfig: %w", err)
+	}
+	respBody, err := c.apiPost(ctx, "ilink/bot/getconfig", body, defaultConfigTimeoutMs)
+	if err != nil {
+		return nil, err
+	}
+	var resp GetConfigResp
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal getConfig: %w", err)
+	}
+	return &resp, nil
+}
+
+// SendTyping sends a typing indicator.
+func (c *APIClient) SendTyping(ctx context.Context, req *SendTypingReq) error {
+	if req.BaseInfo == nil {
+		req.BaseInfo = buildBaseInfo()
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal sendTyping: %w", err)
+	}
+	_, err = c.apiPost(ctx, "ilink/bot/sendtyping", body, defaultConfigTimeoutMs)
+	return err
+}

--- a/internal/channels/wechat/cdn.go
+++ b/internal/channels/wechat/cdn.go
@@ -1,0 +1,308 @@
+package wechat
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// UploadedFileInfo holds the result of uploading a file to the CDN.
+type UploadedFileInfo struct {
+	FileKey                     string
+	DownloadEncryptedQueryParam string
+	AesKeyHex                   string // hex-encoded AES key
+	FileSize                    int64  // plaintext size
+	FileSizeCiphertext          int64  // ciphertext size
+}
+
+// buildCdnDownloadURL constructs a CDN download URL.
+func buildCdnDownloadURL(encryptedQueryParam, cdnBaseURL string) string {
+	return fmt.Sprintf("%s/download?encrypted_query_param=%s",
+		cdnBaseURL, url.QueryEscape(encryptedQueryParam))
+}
+
+// buildCdnUploadURL constructs a CDN upload URL.
+func buildCdnUploadURL(cdnBaseURL, uploadParam, filekey string) string {
+	return fmt.Sprintf("%s/upload?encrypted_query_param=%s&filekey=%s",
+		cdnBaseURL, url.QueryEscape(uploadParam), url.QueryEscape(filekey))
+}
+
+const uploadMaxRetries = 3
+
+// uploadBufferToCdn encrypts and uploads a buffer to the Weixin CDN.
+func uploadBufferToCdn(ctx context.Context, plaintext, aesKey []byte, uploadFullURL, uploadParam, filekey, cdnBaseURL, label string) (string, error) {
+	ciphertext, err := encryptAesEcb(plaintext, aesKey)
+	if err != nil {
+		return "", fmt.Errorf("%s: encrypt: %w", label, err)
+	}
+
+	var cdnURL string
+	trimmedFull := strings.TrimSpace(uploadFullURL)
+	if trimmedFull != "" {
+		cdnURL = trimmedFull
+	} else if uploadParam != "" {
+		cdnURL = buildCdnUploadURL(cdnBaseURL, uploadParam, filekey)
+	} else {
+		return "", fmt.Errorf("%s: CDN upload URL missing", label)
+	}
+
+	slog.Debug("wechat cdn upload", "label", label, "size", len(ciphertext))
+
+	var downloadParam string
+	var lastErr error
+	client := &http.Client{Timeout: 60 * time.Second}
+
+	for attempt := 1; attempt <= uploadMaxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, cdnURL, bytes.NewReader(ciphertext))
+		if err != nil {
+			return "", fmt.Errorf("%s: create request: %w", label, err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt < uploadMaxRetries {
+				slog.Error("wechat cdn upload failed, retrying", "label", label, "attempt", attempt, "error", err)
+				continue
+			}
+			break
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			errMsg := resp.Header.Get("x-error-message")
+			return "", fmt.Errorf("%s: CDN client error %d: %s", label, resp.StatusCode, errMsg)
+		}
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("%s: CDN server error %d", label, resp.StatusCode)
+			if attempt < uploadMaxRetries {
+				slog.Error("wechat cdn upload failed, retrying", "label", label, "attempt", attempt, "status", resp.StatusCode)
+				continue
+			}
+			break
+		}
+
+		downloadParam = resp.Header.Get("x-encrypted-param")
+		if downloadParam == "" {
+			lastErr = fmt.Errorf("%s: CDN response missing x-encrypted-param header", label)
+			if attempt < uploadMaxRetries {
+				continue
+			}
+			break
+		}
+		return downloadParam, nil
+	}
+
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", fmt.Errorf("%s: CDN upload failed after %d attempts", label, uploadMaxRetries)
+}
+
+// uploadMediaToCdn reads a file, generates AES key, gets upload URL, and uploads.
+func uploadMediaToCdn(ctx context.Context, api *APIClient, filePath, toUserID, cdnBaseURL string, mediaType int, label string) (*UploadedFileInfo, error) {
+	plaintext, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("%s: read file: %w", label, err)
+	}
+
+	rawSize := int64(len(plaintext))
+	hash := md5.Sum(plaintext)
+	rawFileMD5 := hex.EncodeToString(hash[:])
+	fileSize := aesEcbPaddedSize(len(plaintext))
+
+	fileKeyBytes := make([]byte, 16)
+	_, _ = rand.Read(fileKeyBytes)
+	fileKey := hex.EncodeToString(fileKeyBytes)
+
+	aesKeyBytes := make([]byte, 16)
+	_, _ = rand.Read(aesKeyBytes)
+	aesKeyHex := hex.EncodeToString(aesKeyBytes)
+
+	uploadResp, err := api.GetUploadURL(ctx, &GetUploadURLReq{
+		FileKey:     fileKey,
+		MediaType:   mediaType,
+		ToUserID:    toUserID,
+		RawSize:     rawSize,
+		RawFileMD5:  rawFileMD5,
+		FileSize:    fileSize,
+		NoNeedThumb: true,
+		AesKey:      aesKeyHex,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: getUploadUrl: %w", label, err)
+	}
+
+	uploadFullURL := strings.TrimSpace(uploadResp.UploadFullURL)
+	uploadParam := uploadResp.UploadParam
+	if uploadFullURL == "" && uploadParam == "" {
+		return nil, fmt.Errorf("%s: getUploadUrl returned no upload URL", label)
+	}
+
+	downloadParam, err := uploadBufferToCdn(ctx, plaintext, aesKeyBytes, uploadFullURL, uploadParam, fileKey, cdnBaseURL, label)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UploadedFileInfo{
+		FileKey:                     fileKey,
+		DownloadEncryptedQueryParam: downloadParam,
+		AesKeyHex:                   aesKeyHex,
+		FileSize:                    rawSize,
+		FileSizeCiphertext:          fileSize,
+	}, nil
+}
+
+// downloadAndDecrypt downloads and AES-128-ECB decrypts a CDN media file.
+func downloadAndDecrypt(ctx context.Context, encryptedQueryParam, aesKeyBase64, cdnBaseURL, label, fullURL string) ([]byte, error) {
+	key, err := parseAesKey(aesKeyBase64)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", label, err)
+	}
+
+	var downloadURL string
+	if fullURL != "" {
+		downloadURL = fullURL
+	} else {
+		downloadURL = buildCdnDownloadURL(encryptedQueryParam, cdnBaseURL)
+	}
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s: create request: %w", label, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: fetch: %w", label, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: CDN download %d", label, resp.StatusCode)
+	}
+
+	encrypted, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: read body: %w", label, err)
+	}
+
+	decrypted, err := decryptAesEcb(encrypted, key)
+	if err != nil {
+		return nil, fmt.Errorf("%s: decrypt: %w", label, err)
+	}
+	return decrypted, nil
+}
+
+// parseAesKey parses a base64-encoded AES key, handling two encodings.
+func parseAesKey(aesKeyBase64 string) ([]byte, error) {
+	decoded, err := tryDecodeBase64(aesKeyBase64)
+	if err != nil {
+		return nil, fmt.Errorf("decode aes_key base64: %w", err)
+	}
+	if len(decoded) == 16 {
+		return decoded, nil
+	}
+	if len(decoded) == 32 && isHexString(decoded) {
+		key, err := hex.DecodeString(string(decoded))
+		if err != nil {
+			return nil, fmt.Errorf("decode hex aes_key: %w", err)
+		}
+		return key, nil
+	}
+	return nil, fmt.Errorf("aes_key must decode to 16 raw bytes or 32-char hex, got %d bytes", len(decoded))
+}
+
+func isHexString(b []byte) bool {
+	for _, c := range b {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+func tryDecodeBase64(s string) ([]byte, error) {
+	if b, err := base64.StdEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	if b, err := base64.RawStdEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	return base64.URLEncoding.DecodeString(s)
+}
+
+// downloadRemoteToTemp downloads a remote URL to a local temp file.
+func downloadRemoteToTemp(ctx context.Context, remoteURL string) (string, error) {
+	client := &http.Client{Timeout: 60 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, remoteURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("remote media download failed: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	// Determine extension from URL or Content-Type
+	ext := guessExtFromContentType(resp.Header.Get("Content-Type"), remoteURL)
+
+	// Create temp file using standard Go pattern
+	tmpFile, err := os.CreateTemp("", "wechat-remote-*"+ext)
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	defer tmpFile.Close()
+
+	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("save file: %w", err)
+	}
+
+	return tmpFile.Name(), nil
+}
+
+func guessExtFromContentType(contentType, rawURL string) string {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	switch {
+	case strings.Contains(ct, "image/png"):
+		return ".png"
+	case strings.Contains(ct, "image/gif"):
+		return ".gif"
+	case strings.Contains(ct, "image/webp"):
+		return ".webp"
+	case strings.Contains(ct, "image/jpeg"), strings.Contains(ct, "image/jpg"):
+		return ".jpg"
+	case strings.Contains(ct, "video/mp4"):
+		return ".mp4"
+	case strings.Contains(ct, "audio/wav"):
+		return ".wav"
+	case strings.Contains(ct, "application/pdf"):
+		return ".pdf"
+	}
+	ext := filepath.Ext(rawURL)
+	if ext != "" && len(ext) <= 6 {
+		return ext
+	}
+	return ".bin"
+}

--- a/internal/channels/wechat/channel.go
+++ b/internal/channels/wechat/channel.go
@@ -1,0 +1,364 @@
+package wechat
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+const (
+	// DefaultBaseURL is the default iLink Bot API endpoint.
+	DefaultBaseURL = "https://ilinkai.weixin.qq.com"
+	// DefaultCDNBaseURL is the default CDN endpoint.
+	DefaultCDNBaseURL = "https://novac2c.cdn.weixin.qq.com/c2c"
+
+	maxConsecutiveFailures = 3
+	backoffDelayMs         = 30000
+	retryDelayMs           = 2000
+)
+
+// Channel implements channels.Channel for WeChat personal via iLink Bot API.
+type Channel struct {
+	*channels.BaseChannel
+	api        *APIClient
+	cfg        config.WechatConfig
+	cdnBaseURL string
+	tokens     *contextTokenStore
+	guard      *sessionGuard
+	botUserID  string // the bot's own WeChat ID (from ToUserID in inbound messages)
+
+	pollCancel context.CancelFunc
+	pollDone   chan struct{}
+	handlerWg  sync.WaitGroup
+}
+
+// New creates a new WeChat channel.
+func New(cfg config.WechatConfig, msgBus *bus.MessageBus, pairingSvc store.PairingStore) (*Channel, error) {
+	if cfg.Token == "" {
+		return nil, fmt.Errorf("wechat token is required")
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+
+	cdnBaseURL := cfg.CDNBaseURL
+	if cdnBaseURL == "" {
+		cdnBaseURL = DefaultCDNBaseURL
+	}
+
+	base := channels.NewBaseChannel(channels.TypeWeChat, msgBus, cfg.AllowFrom)
+	base.ValidatePolicy(cfg.DMPolicy, "")
+
+	api := NewAPIClient(baseURL, cfg.Token)
+
+	ch := &Channel{
+		BaseChannel: base,
+		api:         api,
+		cfg:         cfg,
+		cdnBaseURL:  cdnBaseURL,
+		tokens:      newContextTokenStore(),
+		guard:       newSessionGuard(),
+	}
+	ch.SetPairingService(pairingSvc)
+	return ch, nil
+}
+
+// Start begins the long-poll loop for inbound messages.
+func (ch *Channel) Start(ctx context.Context) error {
+	pollCtx, cancel := context.WithCancel(ctx)
+	ch.pollCancel = cancel
+	ch.pollDone = make(chan struct{})
+
+	go ch.monitorLoop(pollCtx)
+
+	slog.Info("wechat channel started", "baseUrl", ch.api.BaseURL)
+	ch.MarkHealthy(ch.connectedSummary())
+	return nil
+}
+
+// Stop gracefully shuts down the channel.
+func (ch *Channel) Stop(ctx context.Context) error {
+	if ch.pollCancel != nil {
+		ch.pollCancel()
+	}
+	if ch.pollDone != nil {
+		select {
+		case <-ch.pollDone:
+		case <-ctx.Done():
+		}
+	}
+	ch.handlerWg.Wait()
+	slog.Info("wechat channel stopped")
+	return nil
+}
+
+// Send delivers an outbound message to a WeChat user.
+func (ch *Channel) Send(ctx context.Context, msg bus.OutboundMessage) error {
+	to := msg.ChatID
+	if to == "" {
+		return fmt.Errorf("wechat send: chatID is required")
+	}
+
+	contextToken := ch.tokens.Get(ch.Name(), to)
+
+	// Handle media attachments
+	if len(msg.Media) > 0 {
+		for _, media := range msg.Media {
+			mediaURL := media.URL
+			if mediaURL == "" {
+				continue
+			}
+
+			var filePath string
+			var isDownloaded bool
+
+			if isLocalFilePath(mediaURL) {
+				filePath = resolveLocalPath(mediaURL)
+			} else if isRemoteURL(mediaURL) {
+				var err error
+				filePath, err = downloadRemoteToTemp(ctx, mediaURL)
+				if err != nil {
+					slog.Error("wechat send: download remote media failed", "url", mediaURL, "error", err)
+					continue
+				}
+				isDownloaded = true
+			} else {
+				slog.Warn("wechat send: unrecognized media URL scheme", "url", mediaURL)
+				continue
+			}
+
+			// Use a closure to ensure cleanup of downloaded files after each item
+			func(path string, downloaded bool, m bus.MediaAttachment) {
+				if downloaded {
+					defer os.Remove(path)
+				}
+
+				caption := m.Caption
+				if caption == "" {
+					caption = msg.Content
+					msg.Content = "" // Avoid sending text twice
+				}
+
+				_, err := sendMediaFile(ctx, ch.api, path, to, caption, contextToken, ch.cdnBaseURL)
+				if err != nil {
+					slog.Error("wechat send media failed", "to", to, "path", path, "error", err)
+				}
+			}(filePath, isDownloaded, media)
+		}
+
+		// If all media sent and text was consumed by caption, we're done
+		if msg.Content == "" {
+			return nil
+		}
+	}
+
+	// Send text message
+	if msg.Content != "" {
+		_, err := sendTextMessage(ctx, ch.api, to, msg.Content, contextToken)
+		if err != nil {
+			return fmt.Errorf("wechat sendText: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// monitorLoop is the long-poll getUpdates loop.
+func (ch *Channel) monitorLoop(ctx context.Context) {
+	defer close(ch.pollDone)
+
+	slog.Info("wechat monitor started", "baseUrl", ch.api.BaseURL)
+
+	var getUpdatesBuf string
+	nextTimeoutMs := defaultLongPollTimeoutMs
+	consecutiveFailures := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("wechat monitor stopped (context cancelled)")
+			return
+		default:
+		}
+
+		resp, err := ch.api.GetUpdates(ctx, getUpdatesBuf, nextTimeoutMs)
+		if err != nil {
+			if ctx.Err() != nil {
+				slog.Info("wechat monitor stopped (aborted)")
+				return
+			}
+			consecutiveFailures++
+			slog.Error("wechat getUpdates error",
+				"consecutive", consecutiveFailures,
+				"max", maxConsecutiveFailures,
+				"error", err,
+			)
+			if consecutiveFailures >= maxConsecutiveFailures {
+				slog.Error("wechat getUpdates: max failures reached, backing off 30s")
+				ch.MarkFailed("Network error", fmt.Sprintf("persistent getUpdates failure: %v", err), channels.ChannelFailureKindNetwork, true)
+				consecutiveFailures = 0
+				sleepCtx(ctx, backoffDelayMs)
+			} else {
+				sleepCtx(ctx, retryDelayMs)
+			}
+			continue
+		}
+
+		// Update long-poll timeout if server suggests one
+		if resp.LongPollingTimeoutMs > 0 {
+			nextTimeoutMs = resp.LongPollingTimeoutMs
+		}
+
+		// Check for API errors
+		isAPIError := (resp.Ret != 0) || (resp.ErrCode != 0)
+		if isAPIError {
+			isSessionExpired := resp.ErrCode == SessionExpiredErrCode || resp.Ret == SessionExpiredErrCode
+			if isSessionExpired {
+				ch.guard.Pause(ch.Name())
+				pauseMs := ch.guard.RemainingPauseMs(ch.Name())
+				slog.Error("wechat getUpdates: session expired, pausing",
+					"errcode", SessionExpiredErrCode,
+					"pauseMin", (pauseMs+59999)/60000,
+				)
+				ch.MarkFailed("Authentication failed", "401 unauthorized: session expired or token invalid", channels.ChannelFailureKindAuth, false)
+				consecutiveFailures = 0
+				sleepCtx(ctx, int(pauseMs))
+				continue
+			}
+
+			consecutiveFailures++
+			slog.Error("wechat getUpdates failed",
+				"ret", resp.Ret,
+				"errcode", resp.ErrCode,
+				"errmsg", resp.ErrMsg,
+				"consecutive", consecutiveFailures,
+			)
+			if consecutiveFailures >= maxConsecutiveFailures {
+				ch.MarkFailed("Network error", fmt.Sprintf("iLink API failure: code=%d msg=%s", resp.ErrCode, resp.ErrMsg), channels.ChannelFailureKindNetwork, true)
+				consecutiveFailures = 0
+				sleepCtx(ctx, backoffDelayMs)
+			} else {
+				sleepCtx(ctx, retryDelayMs)
+			}
+			continue
+		}
+
+		if consecutiveFailures > 0 {
+			ch.MarkHealthy(ch.connectedSummary())
+		}
+		consecutiveFailures = 0
+
+		// Update sync buf
+		if resp.GetUpdatesBuf != "" {
+			getUpdatesBuf = resp.GetUpdatesBuf
+		}
+
+		// Process inbound messages
+		for _, full := range resp.Msgs {
+			slog.Info("wechat inbound message",
+				"from", full.FromUserID,
+				"items", len(full.ItemList),
+			)
+
+			// Store context token for future replies
+			if full.ContextToken != "" && full.FromUserID != "" {
+				ch.tokens.Set(ch.Name(), full.FromUserID, full.ContextToken)
+			}
+
+			// Capture the bot's own WeChat ID from the first inbound message
+			if ch.botUserID == "" && full.ToUserID != "" {
+				ch.botUserID = full.ToUserID
+				ch.MarkHealthy(ch.connectedSummary())
+				slog.Info("wechat bot identity captured", "botUserID", ch.botUserID)
+			}
+
+			// Convert to bus message and publish
+			inbound := weixinMessageToInbound(&full, ch.Name())
+			inbound.AgentID = ch.AgentID()
+			inbound.TenantID = ch.TenantID()
+
+			// Download and attach media
+			mediaFiles := ch.downloadMedia(ctx, &full)
+			inbound.Media = mediaFiles
+			var tmpPaths []string
+			for _, m := range mediaFiles {
+				tmpPaths = append(tmpPaths, m.Path)
+			}
+			if len(tmpPaths) > 0 {
+				scheduleMediaCleanup(tmpPaths, 5*time.Minute)
+			}
+
+			// Check DM Policy (Pairing, Allowlist, or Open)
+			if inbound.PeerKind == "direct" {
+				if !ch.checkDMPolicy(ctx, inbound.SenderID, inbound.ChatID) {
+					continue
+				}
+			}
+
+			// Check allowlist (Secondary defense)
+			if !ch.IsAllowed(inbound.SenderID) {
+				slog.Debug("wechat: sender not in allowlist, skipping", "sender", inbound.SenderID)
+				continue
+			}
+
+			ch.Bus().PublishInbound(inbound)
+		}
+	}
+}
+
+// connectedSummary returns a health summary string.
+// Unlike Telegram (which has getMe for bot username), WeChat has no such API.
+// We show the channel name + bot WeChat ID once captured from an inbound message.
+func (ch *Channel) connectedSummary() string {
+	if ch.botUserID != "" {
+		return fmt.Sprintf("Connected as %s (%s)", ch.Name(), ch.botUserID)
+	}
+	name := ch.Name()
+	if name != "" {
+		return fmt.Sprintf("Connected as %s", name)
+	}
+	return "Connected"
+}
+
+func sleepCtx(ctx context.Context, ms int) {
+	timer := time.NewTimer(time.Duration(ms) * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}
+
+func isLocalFilePath(mediaURL string) bool {
+	return !strings.Contains(mediaURL, "://")
+}
+
+func isRemoteURL(mediaURL string) bool {
+	return strings.HasPrefix(mediaURL, "http://") || strings.HasPrefix(mediaURL, "https://")
+}
+
+func resolveLocalPath(mediaURL string) string {
+	if strings.HasPrefix(mediaURL, "file://") {
+		return strings.TrimPrefix(mediaURL, "file://")
+	}
+	if filepath.IsAbs(mediaURL) {
+		return mediaURL
+	}
+	abs, err := filepath.Abs(mediaURL)
+	if err != nil {
+		return mediaURL
+	}
+	return abs
+}

--- a/internal/channels/wechat/context_tokens.go
+++ b/internal/channels/wechat/context_tokens.go
@@ -1,0 +1,49 @@
+package wechat
+
+import (
+	"sync"
+)
+
+// contextTokenStore manages per-account per-user context tokens in memory.
+// The Weixin API requires echoing the context_token from inbound messages
+// in every outbound send to maintain conversation context.
+type contextTokenStore struct {
+	mu     sync.RWMutex
+	tokens map[string]string // key: "accountId:userId" -> context_token
+}
+
+func newContextTokenStore() *contextTokenStore {
+	return &contextTokenStore{
+		tokens: make(map[string]string),
+	}
+}
+
+func tokenKey(accountID, userID string) string {
+	return accountID + ":" + userID
+}
+
+// Set stores a context token for an account+user pair.
+func (s *contextTokenStore) Set(accountID, userID, token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tokens[tokenKey(accountID, userID)] = token
+}
+
+// Get retrieves the cached context token for an account+user pair.
+func (s *contextTokenStore) Get(accountID, userID string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tokens[tokenKey(accountID, userID)]
+}
+
+// Clear removes all tokens for a given account.
+func (s *contextTokenStore) Clear(accountID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prefix := accountID + ":"
+	for k := range s.tokens {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			delete(s.tokens, k)
+		}
+	}
+}

--- a/internal/channels/wechat/crypto.go
+++ b/internal/channels/wechat/crypto.go
@@ -1,0 +1,60 @@
+package wechat
+
+import (
+	"crypto/aes"
+	"fmt"
+)
+
+// aesEcbPaddedSize computes ciphertext size for AES-128-ECB with PKCS7 padding.
+func aesEcbPaddedSize(plaintextSize int) int64 {
+	return int64(((plaintextSize + 1) / aes.BlockSize + 1) * aes.BlockSize)
+}
+
+// encryptAesEcb encrypts plaintext with AES-128-ECB and PKCS7 padding.
+func encryptAesEcb(plaintext, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	bs := block.BlockSize()
+	padding := bs - len(plaintext)%bs
+	padded := make([]byte, len(plaintext)+padding)
+	copy(padded, plaintext)
+	for i := len(plaintext); i < len(padded); i++ {
+		padded[i] = byte(padding)
+	}
+	ciphertext := make([]byte, len(padded))
+	for i := 0; i < len(padded); i += bs {
+		block.Encrypt(ciphertext[i:i+bs], padded[i:i+bs])
+	}
+	return ciphertext, nil
+}
+
+// decryptAesEcb decrypts AES-128-ECB ciphertext with PKCS7 padding.
+func decryptAesEcb(ciphertext, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	bs := block.BlockSize()
+	if len(ciphertext)%bs != 0 {
+		return nil, fmt.Errorf("ciphertext length %d not multiple of block size %d", len(ciphertext), bs)
+	}
+	plaintext := make([]byte, len(ciphertext))
+	for i := 0; i < len(ciphertext); i += bs {
+		block.Decrypt(plaintext[i:i+bs], ciphertext[i:i+bs])
+	}
+	if len(plaintext) == 0 {
+		return plaintext, nil
+	}
+	padLen := int(plaintext[len(plaintext)-1])
+	if padLen > bs || padLen == 0 {
+		return nil, fmt.Errorf("invalid PKCS7 padding length %d", padLen)
+	}
+	for i := len(plaintext) - padLen; i < len(plaintext); i++ {
+		if plaintext[i] != byte(padLen) {
+			return nil, fmt.Errorf("invalid PKCS7 padding byte at position %d", i)
+		}
+	}
+	return plaintext[:len(plaintext)-padLen], nil
+}

--- a/internal/channels/wechat/factory.go
+++ b/internal/channels/wechat/factory.go
@@ -1,0 +1,60 @@
+package wechat
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+type wechatCreds struct {
+	Token string `json:"token"`
+}
+
+type wechatInstanceConfig struct {
+	AllowFrom  []string `json:"allow_from,omitempty"`
+	DMPolicy   string   `json:"dm_policy,omitempty"`
+	BaseURL    string   `json:"base_url,omitempty"`
+	CDNBaseURL string   `json:"cdn_base_url,omitempty"`
+}
+
+func Factory(name string, creds json.RawMessage, cfg json.RawMessage,
+	msgBus *bus.MessageBus, pairingSvc store.PairingStore) (channels.Channel, error) {
+
+	var c wechatCreds
+	if len(creds) > 0 {
+		if err := json.Unmarshal(creds, &c); err != nil {
+			return nil, fmt.Errorf("decode wechat credentials: %w", err)
+		}
+	}
+	if c.Token == "" {
+		return nil, fmt.Errorf("wechat token is required")
+	}
+
+	var ic wechatInstanceConfig
+	if len(cfg) > 0 {
+		if err := json.Unmarshal(cfg, &ic); err != nil {
+			return nil, fmt.Errorf("decode wechat config: %w", err)
+		}
+	}
+
+	wcCfg := config.WechatConfig{
+		Enabled:    true,
+		Token:      c.Token,
+		AllowFrom:  ic.AllowFrom,
+		DMPolicy:   ic.DMPolicy,
+		BaseURL:    ic.BaseURL,
+		CDNBaseURL: ic.CDNBaseURL,
+	}
+
+	ch, err := New(wcCfg, msgBus, pairingSvc)
+	if err != nil {
+		return nil, err
+	}
+
+	ch.SetName(name)
+	return ch, nil
+}

--- a/internal/channels/wechat/inbound.go
+++ b/internal/channels/wechat/inbound.go
@@ -1,0 +1,177 @@
+package wechat
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+)
+
+// hexKeyToBase64 converts a raw hex AES key (from image_item.aeskey) to base64,
+// matching the TypeScript reference: Buffer.from(hexKey, "hex").toString("base64").
+func hexKeyToBase64(hexKey string) (string, error) {
+	raw, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return "", fmt.Errorf("hex decode aeskey: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw), nil
+}
+
+// scheduleMediaCleanup removes temp media files after a delay.
+func scheduleMediaCleanup(paths []string, delay time.Duration) {
+	if len(paths) == 0 {
+		return
+	}
+	time.AfterFunc(delay, func() {
+		for _, path := range paths {
+			if path == "" {
+				continue
+			}
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				slog.Debug("failed to cleanup temp media", "path", path, "error", err)
+			}
+		}
+	})
+}
+
+// isMediaItem returns true if the item is image, video, file, or voice.
+func isMediaItem(item *MessageItem) bool {
+	return item.Type == MessageItemTypeImage ||
+		item.Type == MessageItemTypeVideo ||
+		item.Type == MessageItemTypeFile ||
+		item.Type == MessageItemTypeVoice
+}
+
+// bodyFromItemList extracts text body from a message's item list.
+func bodyFromItemList(items []MessageItem) string {
+	for _, item := range items {
+		if item.Type == MessageItemTypeText && item.TextItem != nil && item.TextItem.Text != "" {
+			text := item.TextItem.Text
+			ref := item.RefMsg
+			if ref == nil {
+				return text
+			}
+			// Quoted media: only include current text
+			if ref.MessageItem != nil && isMediaItem(ref.MessageItem) {
+				return text
+			}
+			// Build quoted context
+			var parts []string
+			if ref.Title != "" {
+				parts = append(parts, ref.Title)
+			}
+			if ref.MessageItem != nil {
+				refBody := bodyFromItemList([]MessageItem{*ref.MessageItem})
+				if refBody != "" {
+					parts = append(parts, refBody)
+				}
+			}
+			if len(parts) == 0 {
+				return text
+			}
+			return fmt.Sprintf("[引用: %s]\n%s", strings.Join(parts, " | "), text)
+		}
+		// Voice-to-text: use text field from voice item
+		if item.Type == MessageItemTypeVoice && item.VoiceItem != nil && item.VoiceItem.Text != "" {
+			return item.VoiceItem.Text
+		}
+	}
+	return ""
+}
+
+// weixinMessageToInbound converts a WeixinMessage to a bus.InboundMessage.
+func weixinMessageToInbound(msg *WeixinMessage, channelName string) bus.InboundMessage {
+	fromUserID := msg.FromUserID
+
+	body := bodyFromItemList(msg.ItemList)
+
+	inbound := bus.InboundMessage{
+		Channel:  channelName,
+		SenderID: fromUserID,
+		ChatID:   fromUserID,
+		Content:  body,
+		PeerKind: "direct",
+		Metadata: map[string]string{
+			"message_sid": "goclaw-wechat-" + uuid.New().String(),
+		},
+	}
+
+	if msg.ContextToken != "" {
+		inbound.Metadata["context_token"] = msg.ContextToken
+	}
+
+	return inbound
+}
+
+// downloadMedia handles CDN download and AES decryption for incoming media attachments.
+func (ch *Channel) downloadMedia(ctx context.Context, msg *WeixinMessage) []bus.MediaFile {
+	var mediaFiles []bus.MediaFile
+
+	for _, item := range msg.ItemList {
+		if item.Type == MessageItemTypeImage && item.ImageItem != nil {
+			img := item.ImageItem
+			var cdnMedia *CDNMedia
+			if img.Media != nil {
+				cdnMedia = img.Media
+			} else if img.ThumbMedia != nil {
+				cdnMedia = img.ThumbMedia
+			}
+			if cdnMedia == nil {
+				continue
+			}
+
+			// Resolve AES key: image_item.aeskey is raw hex, media.aes_key is already base64.
+			// Match TS: Buffer.from(img.aeskey, "hex").toString("base64")
+			var aesKeyBase64 string
+			if img.AesKey != "" {
+				b64, err := hexKeyToBase64(img.AesKey)
+				if err != nil {
+					slog.Error("wechat inbound image: invalid hex aeskey", "error", err)
+					continue
+				}
+				aesKeyBase64 = b64
+			} else if cdnMedia.AesKey != "" {
+				aesKeyBase64 = cdnMedia.AesKey // already base64
+			}
+
+			if aesKeyBase64 == "" {
+				slog.Debug("wechat inbound image: no AES key, skipping")
+				continue
+			}
+
+			decrypted, err := downloadAndDecrypt(ctx, cdnMedia.EncryptQueryParam, aesKeyBase64, ch.cdnBaseURL, "inbound_image", cdnMedia.FullURL)
+			if err != nil {
+				slog.Error("wechat inbound image download failed", "error", err)
+				continue
+			}
+			destDir := filepath.Join(os.TempDir(), "goclaw", "weixin", "media", "inbound")
+			if err := os.MkdirAll(destDir, 0o755); err != nil {
+				slog.Error("wechat inbound mkdir failed", "error", err)
+				continue
+			}
+
+			tmpFile := filepath.Join(destDir, fmt.Sprintf("inbound_wechat_%d.jpg", time.Now().UnixNano()))
+			if err := os.WriteFile(tmpFile, decrypted, 0o644); err != nil {
+				slog.Error("wechat inbound file write failed", "error", err)
+				continue
+			}
+
+			mediaFiles = append(mediaFiles, bus.MediaFile{
+				Path:     tmpFile,
+				MimeType: "image/jpeg",
+				Filename: "image.jpg",
+			})
+		}
+		// Future: implement MessageItemTypeVideo, MessageItemTypeVoice, MessageItemTypeFile
+	}
+	return mediaFiles
+}

--- a/internal/channels/wechat/policy.go
+++ b/internal/channels/wechat/policy.go
@@ -1,0 +1,65 @@
+package wechat
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+)
+
+const pairingDebounceTime = 60 * time.Second
+
+// checkDMPolicy evaluates the DM policy for a sender.
+func (c *Channel) checkDMPolicy(ctx context.Context, senderID, chatID string) bool {
+	dmPolicy := c.cfg.DMPolicy
+	if dmPolicy == "" {
+		dmPolicy = "pairing"
+	}
+	result := c.CheckDMPolicy(ctx, senderID, dmPolicy)
+	switch result {
+	case channels.PolicyAllow:
+		return true
+	case channels.PolicyNeedsPairing:
+		c.sendPairingReply(ctx, senderID, chatID)
+		return false
+	default:
+		slog.Debug("wechat DM rejected by policy", "sender_id", senderID, "policy", dmPolicy)
+		return false
+	}
+}
+
+// sendPairingReply sends a pairing code to the user via WeChat.
+func (c *Channel) sendPairingReply(ctx context.Context, senderID, chatID string) {
+	ps := c.PairingService()
+	if ps == nil {
+		slog.Warn("wechat pairing: no pairing service configured")
+		return
+	}
+
+	if !c.CanSendPairingNotif(senderID, pairingDebounceTime) {
+		slog.Info("wechat pairing: debounced", "sender_id", senderID)
+		return
+	}
+
+	code, err := ps.RequestPairing(ctx, senderID, c.Name(), chatID, "default", nil)
+	if err != nil {
+		slog.Warn("wechat pairing request failed", "sender_id", senderID, "channel", c.Name(), "error", err)
+		return
+	}
+
+	replyText := fmt.Sprintf(
+		"GoClaw: access not configured.\n\nYour WeChat ID: %s\n\nPairing code: %s\n\nAsk the account owner to approve with:\n  goclaw pairing approve %s",
+		senderID, code, code,
+	)
+
+	contextToken := c.tokens.Get(c.Name(), chatID)
+	
+	if _, sendErr := sendTextMessage(ctx, c.api, chatID, replyText, contextToken); sendErr != nil {
+		slog.Warn("failed to send wechat pairing reply", "error", sendErr)
+	} else {
+		c.MarkPairingNotifSent(senderID)
+		slog.Info("wechat pairing reply sent", "sender_id", senderID, "code", code)
+	}
+}

--- a/internal/channels/wechat/qr.go
+++ b/internal/channels/wechat/qr.go
@@ -1,0 +1,68 @@
+package wechat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+// GetBotQRCodeReq is the getBotQRCode request body.
+type GetBotQRCodeReq struct {
+	BotType  string    `json:"bot_type,omitempty"`
+	BaseInfo *BaseInfo `json:"base_info,omitempty"`
+}
+
+// GetBotQRCodeResp is the getBotQRCode response.
+type GetBotQRCodeResp struct {
+	QRCode           string `json:"qrcode,omitempty"`
+	QRCodeImgContent string `json:"qrcode_img_content,omitempty"`
+}
+
+// GetQRCodeStatusReq is the getQRCodeStatus request body.
+type GetQRCodeStatusReq struct {
+	QRCode   string    `json:"qrcode,omitempty"`
+	BaseInfo *BaseInfo `json:"base_info,omitempty"`
+}
+
+// GetQRCodeStatusResp is the getQRCodeStatus response.
+type GetQRCodeStatusResp struct {
+	Status      string `json:"status,omitempty"`
+	BotToken    string `json:"bot_token,omitempty"`
+	ILinkBotID  string `json:"ilink_bot_id,omitempty"`
+	BaseURL     string `json:"baseurl,omitempty"`
+	ILinkUserID string `json:"ilink_user_id,omitempty"`
+	RedirectHost string `json:"redirect_host,omitempty"`
+}
+
+// GetBotQRCode fetches the login QR code.
+func (c *APIClient) GetBotQRCode(ctx context.Context, botType string) (*GetBotQRCodeResp, error) {
+	q := url.Values{}
+	q.Set("bot_type", botType)
+
+	respBody, err := c.apiGet(ctx, "ilink/bot/get_bot_qrcode", q, defaultAPITimeoutMs)
+	if err != nil {
+		return nil, err
+	}
+	var resp GetBotQRCodeResp
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal getBotQRCode: %w", err)
+	}
+	return &resp, nil
+}
+
+// GetQRCodeStatus long-polls the QR code scan status.
+func (c *APIClient) GetQRCodeStatus(ctx context.Context, qrcode string, timeoutMs int) (*GetQRCodeStatusResp, error) {
+	q := url.Values{}
+	q.Set("qrcode", qrcode)
+
+	respBody, err := c.apiGet(ctx, "ilink/bot/get_qrcode_status", q, timeoutMs)
+	if err != nil {
+		return nil, err
+	}
+	var resp GetQRCodeStatusResp
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal getQRCodeStatus: %w", err)
+	}
+	return &resp, nil
+}

--- a/internal/channels/wechat/qr_methods.go
+++ b/internal/channels/wechat/qr_methods.go
@@ -1,0 +1,213 @@
+package wechat
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/skip2/go-qrcode"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/gateway"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+// cancelEntry wraps a CancelFunc so it can be stored in sync.Map.CompareAndDelete.
+type cancelEntry struct {
+	cancel context.CancelFunc
+}
+
+// QRMethods handles wechat.qr.start — delivers QR codes to the UI wizard
+// for WeChat personal login via the iLink Bot API.
+type QRMethods struct {
+	instanceStore  store.ChannelInstanceStore
+	msgBus         *bus.MessageBus
+	activeSessions sync.Map // instanceID (string) -> *cancelEntry
+}
+
+func NewQRMethods(s store.ChannelInstanceStore, msgBus *bus.MessageBus) *QRMethods {
+	return &QRMethods{instanceStore: s, msgBus: msgBus}
+}
+
+func (m *QRMethods) Register(router *gateway.MethodRouter) {
+	router.Register(protocol.MethodWeChatQRStart, m.handleQRStart)
+}
+
+func (m *QRMethods) handleQRStart(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	var params struct {
+		InstanceID string `json:"instance_id"`
+	}
+	if req.Params != nil {
+		_ = json.Unmarshal(req.Params, &params)
+	}
+
+	instID, err := uuid.Parse(params.InstanceID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid instance_id"))
+		return
+	}
+
+	inst, err := m.instanceStore.Get(ctx, instID)
+	if err != nil || inst.ChannelType != channels.TypeWeChat {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrNotFound, "wechat instance not found"))
+		return
+	}
+
+	qrCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	entry := &cancelEntry{cancel: cancel}
+
+	// Cancel any previous QR session for this instance.
+	if prev, loaded := m.activeSessions.Swap(params.InstanceID, entry); loaded {
+		if prevEntry, ok := prev.(*cancelEntry); ok {
+			prevEntry.cancel()
+		}
+	}
+
+	// ACK immediately — QR arrives via event.
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"status": "started"}))
+
+	go m.runQRFlow(qrCtx, entry, client, params.InstanceID, instID)
+}
+
+func (m *QRMethods) runQRFlow(ctx context.Context, entry *cancelEntry,
+	client *gateway.Client, instanceIDStr string, instanceID uuid.UUID) {
+
+	defer entry.cancel()
+	defer m.activeSessions.CompareAndDelete(instanceIDStr, entry)
+
+	// Create temporary API client — QR endpoints don't require a bot token.
+	api := NewAPIClient(DefaultBaseURL, "")
+
+	// 1. Fetch QR code from iLink.
+	qrResp, err := api.GetBotQRCode(ctx, "3")
+	if err != nil {
+		slog.Warn("WeChat QR: fetch QR failed", "instance", instanceIDStr, "error", err)
+		client.SendEvent(*protocol.NewEvent(protocol.EventWeChatQRDone, map[string]any{
+			"instance_id": instanceIDStr,
+			"success":     false,
+			"error":       err.Error(),
+		}))
+		return
+	}
+
+	// 2. Convert text URL to a QR code PNG, then base64 to avoid CSP issues.
+	var imgContent string
+	if pngBytes, err := qrcode.Encode(qrResp.QRCodeImgContent, qrcode.Medium, 256); err == nil {
+		imgContent = base64.StdEncoding.EncodeToString(pngBytes)
+	} else {
+		// Fallback strictly for error bounds; frontend will fail on this.
+		imgContent = qrResp.QRCodeImgContent
+	}
+
+	client.SendEvent(protocol.EventFrame{
+		Type:  protocol.FrameTypeEvent,
+		Event: protocol.EventWeChatQRCode,
+		Payload: map[string]any{
+			"instance_id": instanceIDStr,
+			"img_content": imgContent, // now base64 encoded PNG
+			"qrcode":      qrResp.QRCode,
+		},
+	})
+
+	// 3. Long-poll QR code status until scanned or timeout.
+	for {
+		select {
+		case <-ctx.Done():
+			client.SendEvent(*protocol.NewEvent(protocol.EventWeChatQRDone, map[string]any{
+				"instance_id": instanceIDStr,
+				"success":     false,
+				"error":       "QR session timed out — restart to try again",
+			}))
+			return
+		default:
+		}
+
+		status, err := api.GetQRCodeStatus(ctx, qrResp.QRCode, 40000)
+		if err != nil {
+			if ctx.Err() != nil {
+				// Context cancelled or timed out during poll — handled at top of loop.
+				continue
+			}
+			slog.Warn("WeChat QR: poll status failed", "instance", instanceIDStr, "error", err)
+			client.SendEvent(*protocol.NewEvent(protocol.EventWeChatQRDone, map[string]any{
+				"instance_id": instanceIDStr,
+				"success":     false,
+				"error":       err.Error(),
+			}))
+			return
+		}
+
+		if status.Status == "confirmed" && status.BotToken != "" {
+			// QR scanned — save credentials to the channel instance.
+			credsJSON, err := json.Marshal(map[string]any{
+				"token": status.BotToken,
+			})
+			if err != nil {
+				slog.Error("WeChat QR: marshal credentials failed", "error", err)
+				client.SendEvent(*protocol.NewEvent(protocol.EventWeChatQRDone, map[string]any{
+					"instance_id": instanceIDStr,
+					"success":     false,
+					"error":       "internal error: credential serialization failed",
+				}))
+				return
+			}
+
+			// Build config updates with baseURL/redirectHost if returned.
+			updates := map[string]any{
+				"credentials": string(credsJSON),
+			}
+			if status.BaseURL != "" || status.RedirectHost != "" {
+				// Fetch latest instance to avoid overwriting existing config like dm_policy.
+				if latestInst, err := m.instanceStore.Get(ctx, instanceID); err == nil {
+					var existingConfig map[string]any
+					if len(latestInst.Config) > 0 {
+						_ = json.Unmarshal(latestInst.Config, &existingConfig)
+					}
+					if existingConfig == nil {
+						existingConfig = make(map[string]any)
+					}
+					if status.RedirectHost != "" {
+						existingConfig["base_url"] = "https://" + status.RedirectHost
+					} else {
+						existingConfig["base_url"] = status.BaseURL
+					}
+					configJSON, _ := json.Marshal(existingConfig)
+					updates["config"] = string(configJSON)
+				}
+			}
+
+			if err := m.instanceStore.Update(ctx, instanceID, updates); err != nil {
+				slog.Error("WeChat QR: save credentials failed", "instance", instanceIDStr, "error", err)
+				client.SendEvent(*protocol.NewEvent(protocol.EventWeChatQRDone, map[string]any{
+					"instance_id": instanceIDStr,
+					"success":     false,
+					"error":       "failed to save credentials",
+				}))
+				return
+			}
+
+			// Trigger instanceLoader reload via cache invalidation.
+			if m.msgBus != nil {
+				m.msgBus.Broadcast(bus.Event{
+					Name:    protocol.EventCacheInvalidate,
+					Payload: bus.CacheInvalidatePayload{Kind: bus.CacheKindChannelInstances},
+				})
+			}
+
+			client.SendEvent(*protocol.NewEvent(protocol.EventWeChatQRDone, map[string]any{
+				"instance_id": instanceIDStr,
+				"success":     true,
+			}))
+			slog.Info("WeChat QR login completed, credentials saved", "instance", instanceIDStr)
+			return
+		}
+
+		// Status not confirmed yet — continue polling.
+	}
+}

--- a/internal/channels/wechat/send.go
+++ b/internal/channels/wechat/send.go
@@ -1,0 +1,215 @@
+package wechat
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// generateClientID creates a unique client ID for outbound messages.
+func generateClientID() string {
+	return "goclaw-wechat-" + uuid.New().String()
+}
+
+// sendTextMessage sends a plain text message downstream.
+func sendTextMessage(ctx context.Context, api *APIClient, to, text, contextToken string) (string, error) {
+	clientID := generateClientID()
+
+	var itemList []MessageItem
+	if text != "" {
+		itemList = []MessageItem{
+			{Type: MessageItemTypeText, TextItem: &TextItem{Text: text}},
+		}
+	}
+
+	req := &SendMessageReq{
+		Msg: &WeixinMessage{
+			FromUserID:   "",
+			ToUserID:     to,
+			ClientID:     clientID,
+			MessageType:  MessageTypeBot,
+			MessageState: MessageStateFinish,
+			ItemList:     itemList,
+			ContextToken: contextToken,
+		},
+	}
+
+	if err := api.SendMessage(ctx, req); err != nil {
+		slog.Error("wechat sendTextMessage failed", "to", to, "clientId", clientID, "error", err)
+		return "", err
+	}
+	return clientID, nil
+}
+
+// sendImageMessage sends an image using a previously uploaded file.
+func sendImageMessage(ctx context.Context, api *APIClient, to, text, contextToken string, uploaded *UploadedFileInfo) (string, error) {
+	aesKeyBase64 := base64.StdEncoding.EncodeToString([]byte(uploaded.AesKeyHex))
+
+	imageItem := MessageItem{
+		Type: MessageItemTypeImage,
+		ImageItem: &ImageItem{
+			Media: &CDNMedia{
+				EncryptQueryParam: uploaded.DownloadEncryptedQueryParam,
+				AesKey:            aesKeyBase64,
+				EncryptType:       1,
+			},
+			MidSize: uploaded.FileSizeCiphertext,
+		},
+	}
+
+	return sendMediaItems(ctx, api, to, text, contextToken, imageItem, "sendImageMessage")
+}
+
+// sendVideoMessage sends a video using a previously uploaded file.
+func sendVideoMessage(ctx context.Context, api *APIClient, to, text, contextToken string, uploaded *UploadedFileInfo) (string, error) {
+	aesKeyBase64 := base64.StdEncoding.EncodeToString([]byte(uploaded.AesKeyHex))
+
+	videoItem := MessageItem{
+		Type: MessageItemTypeVideo,
+		VideoItem: &VideoItem{
+			Media: &CDNMedia{
+				EncryptQueryParam: uploaded.DownloadEncryptedQueryParam,
+				AesKey:            aesKeyBase64,
+				EncryptType:       1,
+			},
+			VideoSize: uploaded.FileSizeCiphertext,
+		},
+	}
+
+	return sendMediaItems(ctx, api, to, text, contextToken, videoItem, "sendVideoMessage")
+}
+
+// sendFileMessage sends a file attachment using a previously uploaded file.
+func sendFileMessage(ctx context.Context, api *APIClient, to, text, contextToken, fileName string, uploaded *UploadedFileInfo) (string, error) {
+	aesKeyBase64 := base64.StdEncoding.EncodeToString([]byte(uploaded.AesKeyHex))
+
+	fileItem := MessageItem{
+		Type: MessageItemTypeFile,
+		FileItem: &FileItem{
+			Media: &CDNMedia{
+				EncryptQueryParam: uploaded.DownloadEncryptedQueryParam,
+				AesKey:            aesKeyBase64,
+				EncryptType:       1,
+			},
+			FileName: fileName,
+			Len:      fmt.Sprintf("%d", uploaded.FileSize),
+		},
+	}
+
+	return sendMediaItems(ctx, api, to, text, contextToken, fileItem, "sendFileMessage")
+}
+
+// sendMediaItems sends a media item optionally preceded by a text caption.
+func sendMediaItems(ctx context.Context, api *APIClient, to, text, contextToken string, mediaItem MessageItem, label string) (string, error) {
+	var items []MessageItem
+	if text != "" {
+		items = append(items, MessageItem{
+			Type:     MessageItemTypeText,
+			TextItem: &TextItem{Text: text},
+		})
+	}
+	items = append(items, mediaItem)
+
+	var lastClientID string
+	for _, item := range items {
+		lastClientID = generateClientID()
+		req := &SendMessageReq{
+			Msg: &WeixinMessage{
+				FromUserID:   "",
+				ToUserID:     to,
+				ClientID:     lastClientID,
+				MessageType:  MessageTypeBot,
+				MessageState: MessageStateFinish,
+				ItemList:     []MessageItem{item},
+				ContextToken: contextToken,
+			},
+		}
+		if err := api.SendMessage(ctx, req); err != nil {
+			slog.Error("wechat "+label+" failed", "to", to, "clientId", lastClientID, "error", err)
+			return "", err
+		}
+	}
+
+	slog.Info("wechat "+label+" success", "to", to, "clientId", lastClientID)
+	return lastClientID, nil
+}
+
+// sendMediaFile uploads a local file and sends it, routing by MIME type.
+func sendMediaFile(ctx context.Context, api *APIClient, filePath, to, text, contextToken, cdnBaseURL string) (string, error) {
+	mime := guessMimeFromFilename(filePath)
+
+	if strings.HasPrefix(mime, "video/") {
+		slog.Info("wechat sendMediaFile: uploading video", "path", filePath, "to", to)
+		uploaded, err := uploadMediaToCdn(ctx, api, filePath, to, cdnBaseURL, UploadMediaTypeVideo, "uploadVideo")
+		if err != nil {
+			return "", err
+		}
+		return sendVideoMessage(ctx, api, to, text, contextToken, uploaded)
+	}
+
+	if strings.HasPrefix(mime, "image/") {
+		slog.Info("wechat sendMediaFile: uploading image", "path", filePath, "to", to)
+		uploaded, err := uploadMediaToCdn(ctx, api, filePath, to, cdnBaseURL, UploadMediaTypeImage, "uploadImage")
+		if err != nil {
+			return "", err
+		}
+		return sendImageMessage(ctx, api, to, text, contextToken, uploaded)
+	}
+
+	// File attachment
+	fileName := filepath.Base(filePath)
+	slog.Info("wechat sendMediaFile: uploading file", "path", filePath, "name", fileName, "to", to)
+	uploaded, err := uploadMediaToCdn(ctx, api, filePath, to, cdnBaseURL, UploadMediaTypeFile, "uploadFile")
+	if err != nil {
+		return "", err
+	}
+	return sendFileMessage(ctx, api, to, text, contextToken, fileName, uploaded)
+}
+
+// guessMimeFromFilename returns a MIME type based on file extension.
+func guessMimeFromFilename(filePath string) string {
+	ext := strings.ToLower(filepath.Ext(filePath))
+	switch ext {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".bmp":
+		return "image/bmp"
+	case ".mp4":
+		return "video/mp4"
+	case ".mov":
+		return "video/quicktime"
+	case ".avi":
+		return "video/x-msvideo"
+	case ".mkv":
+		return "video/x-matroska"
+	case ".wav":
+		return "audio/wav"
+	case ".mp3":
+		return "audio/mpeg"
+	case ".ogg":
+		return "audio/ogg"
+	case ".pdf":
+		return "application/pdf"
+	case ".doc", ".docx":
+		return "application/msword"
+	case ".xls", ".xlsx":
+		return "application/vnd.ms-excel"
+	case ".ppt", ".pptx":
+		return "application/vnd.ms-powerpoint"
+	case ".zip":
+		return "application/zip"
+	default:
+		return "application/octet-stream"
+	}
+}

--- a/internal/channels/wechat/session_guard.go
+++ b/internal/channels/wechat/session_guard.go
@@ -1,0 +1,78 @@
+package wechat
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	// SessionExpiredErrCode is the server error code for expired sessions.
+	SessionExpiredErrCode = -14
+	// sessionPauseDuration is the cooldown period after session expiry.
+	sessionPauseDuration = 1 * time.Hour
+)
+
+// sessionGuard tracks session pause state per account.
+type sessionGuard struct {
+	mu         sync.RWMutex
+	pauseUntil map[string]time.Time
+}
+
+func newSessionGuard() *sessionGuard {
+	return &sessionGuard{
+		pauseUntil: make(map[string]time.Time),
+	}
+}
+
+// Pause marks the session as paused for one hour.
+func (g *sessionGuard) Pause(accountID string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.pauseUntil[accountID] = time.Now().Add(sessionPauseDuration)
+}
+
+// IsPaused returns true if the session is still paused.
+func (g *sessionGuard) IsPaused(accountID string) bool {
+	g.mu.RLock()
+	until, ok := g.pauseUntil[accountID]
+	g.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	if time.Now().After(until) {
+		g.mu.Lock()
+		delete(g.pauseUntil, accountID)
+		g.mu.Unlock()
+		return false
+	}
+	return true
+}
+
+// RemainingPauseMs returns milliseconds remaining until pause expires.
+func (g *sessionGuard) RemainingPauseMs(accountID string) int64 {
+	g.mu.RLock()
+	until, ok := g.pauseUntil[accountID]
+	g.mu.RUnlock()
+	if !ok {
+		return 0
+	}
+	remaining := time.Until(until)
+	if remaining <= 0 {
+		g.mu.Lock()
+		delete(g.pauseUntil, accountID)
+		g.mu.Unlock()
+		return 0
+	}
+	return remaining.Milliseconds()
+}
+
+// AssertActive throws if the session is paused.
+func (g *sessionGuard) AssertActive(accountID string) error {
+	if g.IsPaused(accountID) {
+		remainingMin := (g.RemainingPauseMs(accountID) + 59999) / 60000
+		return fmt.Errorf("session paused for accountId=%s, %d min remaining (errcode %d)",
+			accountID, remainingMin, SessionExpiredErrCode)
+	}
+	return nil
+}

--- a/internal/channels/wechat/types.go
+++ b/internal/channels/wechat/types.go
@@ -1,0 +1,205 @@
+// Package wechat implements the WeChat personal channel via the iLink Bot API.
+// Uses getUpdates long-poll for inbound messages and sendMessage for outbound.
+// Media is encrypted with AES-128-ECB and transferred via the Weixin CDN.
+package wechat
+
+// MessageType indicates the sender type.
+const (
+	MessageTypeNone = 0
+	MessageTypeUser = 1
+	MessageTypeBot  = 2
+)
+
+// MessageItemType indicates the content type within a message.
+const (
+	MessageItemTypeNone  = 0
+	MessageItemTypeText  = 1
+	MessageItemTypeImage = 2
+	MessageItemTypeVoice = 3
+	MessageItemTypeFile  = 4
+	MessageItemTypeVideo = 5
+)
+
+// MessageState indicates the generation state of a bot message.
+const (
+	MessageStateNew        = 0
+	MessageStateGenerating = 1
+	MessageStateFinish     = 2
+)
+
+// UploadMediaType for getUploadUrl requests.
+const (
+	UploadMediaTypeImage = 1
+	UploadMediaTypeVideo = 2
+	UploadMediaTypeFile  = 3
+	UploadMediaTypeVoice = 4
+)
+
+// TypingStatus for sendTyping requests.
+const (
+	TypingStatusTyping = 1
+	TypingStatusCancel = 2
+)
+
+// BaseInfo is common request metadata attached to every API request.
+type BaseInfo struct {
+	ChannelVersion string `json:"channel_version,omitempty"`
+}
+
+// CDNMedia is a CDN media reference; AesKey is base64-encoded in JSON.
+type CDNMedia struct {
+	EncryptQueryParam string `json:"encrypt_query_param,omitempty"`
+	AesKey            string `json:"aes_key,omitempty"`
+	EncryptType       int    `json:"encrypt_type,omitempty"`
+	FullURL           string `json:"full_url,omitempty"`
+}
+
+// TextItem holds text content.
+type TextItem struct {
+	Text string `json:"text,omitempty"`
+}
+
+// ImageItem holds image content.
+type ImageItem struct {
+	Media      *CDNMedia `json:"media,omitempty"`
+	ThumbMedia *CDNMedia `json:"thumb_media,omitempty"`
+	AesKey     string    `json:"aeskey,omitempty"` // raw hex AES key (preferred for inbound)
+	URL        string    `json:"url,omitempty"`
+	MidSize    int64     `json:"mid_size,omitempty"`
+	ThumbSize  int64     `json:"thumb_size,omitempty"`
+	HDSize     int64     `json:"hd_size,omitempty"`
+}
+
+// VoiceItem holds voice message content.
+type VoiceItem struct {
+	Media         *CDNMedia `json:"media,omitempty"`
+	EncodeType    int       `json:"encode_type,omitempty"`
+	BitsPerSample int      `json:"bits_per_sample,omitempty"`
+	SampleRate    int       `json:"sample_rate,omitempty"`
+	Playtime      int       `json:"playtime,omitempty"`
+	Text          string    `json:"text,omitempty"`
+}
+
+// FileItem holds file attachment content.
+type FileItem struct {
+	Media    *CDNMedia `json:"media,omitempty"`
+	FileName string    `json:"file_name,omitempty"`
+	MD5      string    `json:"md5,omitempty"`
+	Len      string    `json:"len,omitempty"`
+}
+
+// VideoItem holds video content.
+type VideoItem struct {
+	Media      *CDNMedia `json:"media,omitempty"`
+	VideoSize  int64     `json:"video_size,omitempty"`
+	PlayLength int       `json:"play_length,omitempty"`
+	VideoMD5   string    `json:"video_md5,omitempty"`
+	ThumbMedia *CDNMedia `json:"thumb_media,omitempty"`
+	ThumbSize  int64     `json:"thumb_size,omitempty"`
+}
+
+// RefMessage holds a quoted/referenced message.
+type RefMessage struct {
+	MessageItem *MessageItem `json:"message_item,omitempty"`
+	Title       string       `json:"title,omitempty"`
+}
+
+// MessageItem is a single content item within a message.
+type MessageItem struct {
+	Type         int         `json:"type,omitempty"`
+	CreateTimeMs int64       `json:"create_time_ms,omitempty"`
+	UpdateTimeMs int64       `json:"update_time_ms,omitempty"`
+	IsCompleted  bool        `json:"is_completed,omitempty"`
+	MsgID        string      `json:"msg_id,omitempty"`
+	RefMsg       *RefMessage `json:"ref_msg,omitempty"`
+	TextItem     *TextItem   `json:"text_item,omitempty"`
+	ImageItem    *ImageItem  `json:"image_item,omitempty"`
+	VoiceItem    *VoiceItem  `json:"voice_item,omitempty"`
+	FileItem     *FileItem   `json:"file_item,omitempty"`
+	VideoItem    *VideoItem  `json:"video_item,omitempty"`
+}
+
+// WeixinMessage is the unified message type from getUpdates.
+type WeixinMessage struct {
+	Seq          int64         `json:"seq,omitempty"`
+	MessageID    int64         `json:"message_id,omitempty"`
+	FromUserID   string        `json:"from_user_id,omitempty"`
+	ToUserID     string        `json:"to_user_id,omitempty"`
+	ClientID     string        `json:"client_id,omitempty"`
+	CreateTimeMs int64         `json:"create_time_ms,omitempty"`
+	UpdateTimeMs int64         `json:"update_time_ms,omitempty"`
+	DeleteTimeMs int64         `json:"delete_time_ms,omitempty"`
+	SessionID    string        `json:"session_id,omitempty"`
+	GroupID      string        `json:"group_id,omitempty"`
+	MessageType  int           `json:"message_type,omitempty"`
+	MessageState int           `json:"message_state,omitempty"`
+	ItemList     []MessageItem `json:"item_list,omitempty"`
+	ContextToken string        `json:"context_token,omitempty"`
+}
+
+// GetUpdatesReq is the getUpdates request body.
+type GetUpdatesReq struct {
+	GetUpdatesBuf string    `json:"get_updates_buf"`
+	BaseInfo      *BaseInfo `json:"base_info,omitempty"`
+}
+
+// GetUpdatesResp is the getUpdates response.
+type GetUpdatesResp struct {
+	Ret                  int             `json:"ret,omitempty"`
+	ErrCode              int             `json:"errcode,omitempty"`
+	ErrMsg               string          `json:"errmsg,omitempty"`
+	Msgs                 []WeixinMessage `json:"msgs,omitempty"`
+	GetUpdatesBuf        string          `json:"get_updates_buf,omitempty"`
+	LongPollingTimeoutMs int             `json:"longpolling_timeout_ms,omitempty"`
+}
+
+// SendMessageReq wraps a single WeixinMessage for sending.
+type SendMessageReq struct {
+	Msg      *WeixinMessage `json:"msg,omitempty"`
+	BaseInfo *BaseInfo      `json:"base_info,omitempty"`
+}
+
+// GetUploadURLReq is the getUploadUrl request.
+type GetUploadURLReq struct {
+	FileKey         string    `json:"filekey,omitempty"`
+	MediaType       int       `json:"media_type,omitempty"`
+	ToUserID        string    `json:"to_user_id,omitempty"`
+	RawSize         int64     `json:"rawsize,omitempty"`
+	RawFileMD5      string    `json:"rawfilemd5,omitempty"`
+	FileSize        int64     `json:"filesize,omitempty"`
+	ThumbRawSize    int64     `json:"thumb_rawsize,omitempty"`
+	ThumbRawFileMD5 string    `json:"thumb_rawfilemd5,omitempty"`
+	ThumbFileSize   int64     `json:"thumb_filesize,omitempty"`
+	NoNeedThumb     bool      `json:"no_need_thumb,omitempty"`
+	AesKey          string    `json:"aeskey,omitempty"`
+	BaseInfo        *BaseInfo `json:"base_info,omitempty"`
+}
+
+// GetUploadURLResp is the getUploadUrl response.
+type GetUploadURLResp struct {
+	UploadParam      string `json:"upload_param,omitempty"`
+	ThumbUploadParam string `json:"thumb_upload_param,omitempty"`
+	UploadFullURL    string `json:"upload_full_url,omitempty"`
+}
+
+// GetConfigReq is the getConfig request body.
+type GetConfigReq struct {
+	ILinkUserID  string    `json:"ilink_user_id,omitempty"`
+	ContextToken string    `json:"context_token,omitempty"`
+	BaseInfo     *BaseInfo `json:"base_info,omitempty"`
+}
+
+// GetConfigResp is the getConfig response (includes typing_ticket).
+type GetConfigResp struct {
+	Ret          int    `json:"ret,omitempty"`
+	ErrMsg       string `json:"errmsg,omitempty"`
+	TypingTicket string `json:"typing_ticket,omitempty"`
+}
+
+// SendTypingReq is the sendTyping request body.
+type SendTypingReq struct {
+	ILinkUserID  string    `json:"ilink_user_id,omitempty"`
+	TypingTicket string    `json:"typing_ticket,omitempty"`
+	Status       int       `json:"status,omitempty"`
+	BaseInfo     *BaseInfo `json:"base_info,omitempty"`
+}

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -20,6 +20,7 @@ type ChannelsConfig struct {
 	Zalo              ZaloConfig               `json:"zalo"`
 	ZaloPersonal      ZaloPersonalConfig       `json:"zalo_personal"`
 	Feishu            FeishuConfig             `json:"feishu"`
+	WeChat            WechatConfig             `json:"wechat"`
 	PendingCompaction *PendingCompactionConfig `json:"pending_compaction,omitempty"` // global pending message compaction settings
 }
 
@@ -192,6 +193,15 @@ type FeishuConfig struct {
 	STTTenantID       string              `json:"stt_tenant_id,omitempty"`
 	STTTimeoutSeconds int                 `json:"stt_timeout_seconds,omitempty"`
 	VoiceAgentID      string              `json:"voice_agent_id,omitempty"`
+}
+
+type WechatConfig struct {
+	Enabled    bool                `json:"enabled"`
+	Token      string              `json:"token"`
+	AllowFrom  FlexibleStringSlice `json:"allow_from"`
+	DMPolicy   string              `json:"dm_policy,omitempty"`
+	BaseURL    string              `json:"base_url,omitempty"`
+	CDNBaseURL string              `json:"cdn_base_url,omitempty"`
 }
 
 // ProvidersConfig maps provider name to its config.

--- a/internal/http/channel_instances.go
+++ b/internal/http/channel_instances.go
@@ -540,7 +540,7 @@ func (h *ChannelInstancesHandler) handleResolveContacts(w http.ResponseWriter, r
 // isValidChannelType checks if the channel type is supported.
 func isValidChannelType(ct string) bool {
 	switch ct {
-	case "telegram", "discord", "slack", "whatsapp", "zalo_oa", "zalo_personal", "feishu", "facebook", "pancake":
+	case "telegram", "discord", "slack", "whatsapp", "zalo_oa", "zalo_personal", "feishu", "facebook", "pancake", "wechat":
 		return true
 	}
 	return false

--- a/internal/permissions/policy.go
+++ b/internal/permissions/policy.go
@@ -319,6 +319,7 @@ func isWriteMethod(method string) bool {
 		// Channel pairing starts (QR scan flows).
 		protocol.MethodZaloPersonalQRStart,
 		protocol.MethodWhatsAppQRStart,
+		protocol.MethodWeChatQRStart,
 	}
 	return slices.Contains(writeExact, method)
 }

--- a/pkg/protocol/events.go
+++ b/pkg/protocol/events.go
@@ -105,6 +105,10 @@ const (
 	EventWhatsAppQRCode = "whatsapp.qr.code"
 	EventWhatsAppQRDone = "whatsapp.qr.done"
 
+	// WeChat QR login events (client-scoped, not broadcast).
+	EventWeChatQRCode = "wechat.qr.code"
+	EventWeChatQRDone = "wechat.qr.done"
+
 	// Tenant access revocation — forces affected user's UI to logout.
 	EventTenantAccessRevoked = "tenant.access.revoked"
 

--- a/pkg/protocol/methods.go
+++ b/pkg/protocol/methods.go
@@ -193,6 +193,9 @@ const (
 
 	// WhatsApp
 	MethodWhatsAppQRStart = "whatsapp.qr.start"
+
+	// WeChat
+	MethodWeChatQRStart = "wechat.qr.start"
 )
 
 // Agent hooks (Phase 3)

--- a/ui/desktop/frontend/src/i18n/locales/en/channels.json
+++ b/ui/desktop/frontend/src/i18n/locales/en/channels.json
@@ -16,7 +16,8 @@
   },
   "channelTypes": {
     "telegram": "Telegram",
-    "discord": "Discord"
+    "discord": "Discord",
+    "wechat": "WeChat"
   },
   "form": {
     "createTitle": "Add Channel",

--- a/ui/desktop/frontend/src/i18n/locales/vi/channels.json
+++ b/ui/desktop/frontend/src/i18n/locales/vi/channels.json
@@ -16,7 +16,8 @@
   },
   "channelTypes": {
     "telegram": "Telegram",
-    "discord": "Discord"
+    "discord": "Discord",
+    "wechat": "WeChat"
   },
   "form": {
     "createTitle": "Thêm kênh",

--- a/ui/desktop/frontend/src/i18n/locales/zh/channels.json
+++ b/ui/desktop/frontend/src/i18n/locales/zh/channels.json
@@ -16,7 +16,8 @@
   },
   "channelTypes": {
     "telegram": "Telegram",
-    "discord": "Discord"
+    "discord": "Discord",
+    "wechat": "微信"
   },
   "form": {
     "createTitle": "添加频道",

--- a/ui/web/src/constants/channels.ts
+++ b/ui/web/src/constants/channels.ts
@@ -6,6 +6,7 @@ export const CHANNEL_TYPES = [
   { value: "slack", label: "Slack" },
   { value: "telegram", label: "Telegram" },
   { value: "whatsapp", label: "WhatsApp" },
+  { value: "wechat", label: "WeChat" },
   { value: "zalo_oa", label: "Zalo OA" },
   { value: "zalo_personal", label: "Zalo Personal" },
 ] as const;

--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -433,6 +433,10 @@
     "whatsapp": {
       "createLabel": "Create & Scan QR",
       "formBanner": "After creating, scan the QR code with WhatsApp to authenticate."
+    },
+    "wechat": {
+      "createLabel": "Create & Scan QR",
+      "formBanner": "After creating, scan the QR code with WeChat to authenticate."
     }
   },
   "fallback": {
@@ -497,5 +501,17 @@
     "relinkDevice": "Re-link Device",
     "connectedSuccess": "✅ WhatsApp connected successfully!",
     "tabQrCode": "QR Code"
+  },
+  "wechat": {
+    "loginSuccessLoading": "✅ WeChat connected! Loading channel...",
+    "generatingQr": "Generating QR code...",
+    "scanHint": "Scan with WeChat to log in",
+    "reauthTitle": "Reconnect WeChat: {{name}}",
+    "waitingForQr": "Waiting for QR code...",
+    "connectedSuccess": "✅ WeChat connected successfully!",
+    "initializing": "Initializing...",
+    "skip": "Skip",
+    "retry": "Retry",
+    "close": "Close"
   }
 }

--- a/ui/web/src/i18n/locales/vi/channels.json
+++ b/ui/web/src/i18n/locales/vi/channels.json
@@ -348,6 +348,10 @@
     "whatsapp": {
       "createLabel": "Tạo & Quét QR",
       "formBanner": "Sau khi tạo, quét mã QR bằng WhatsApp để xác thực."
+    },
+    "wechat": {
+      "createLabel": "Tạo & Quét QR",
+      "formBanner": "Sau khi tạo, quét mã QR bằng WeChat để xác thực."
     }
   },
   "fallback": {
@@ -412,5 +416,17 @@
     "relinkDevice": "Liên kết lại",
     "connectedSuccess": "✅ Kết nối WhatsApp thành công!",
     "tabQrCode": "Mã QR"
+  },
+  "wechat": {
+    "loginSuccessLoading": "✅ Đăng nhập WeChat thành công! Đang tải channel...",
+    "generatingQr": "Đang tạo mã QR...",
+    "scanHint": "Quét bằng WeChat để đăng nhập",
+    "reauthTitle": "Kết nối lại WeChat: {{name}}",
+    "waitingForQr": "Đang chờ mã QR...",
+    "connectedSuccess": "✅ Kết nối WeChat thành công!",
+    "initializing": "Đang khởi tạo...",
+    "skip": "Bỏ qua",
+    "retry": "Thử lại",
+    "close": "Đóng"
   }
 }

--- a/ui/web/src/i18n/locales/zh/channels.json
+++ b/ui/web/src/i18n/locales/zh/channels.json
@@ -348,6 +348,10 @@
     "whatsapp": {
       "createLabel": "创建并扫码",
       "formBanner": "创建后，请用 WhatsApp 扫描二维码完成认证。"
+    },
+    "wechat": {
+      "createLabel": "创建并扫码",
+      "formBanner": "创建后，请用微信扫描二维码完成认证。"
     }
   },
   "fallback": {
@@ -412,5 +416,17 @@
     "relinkDevice": "重新连接",
     "connectedSuccess": "✅ WhatsApp 连接成功！",
     "tabQrCode": "二维码"
+  },
+  "wechat": {
+    "loginSuccessLoading": "✅ 微信登录成功！正在加载 channel...",
+    "generatingQr": "正在生成二维码...",
+    "scanHint": "请使用微信扫描上方二维码登录",
+    "reauthTitle": "重新连接微信：{{name}}",
+    "waitingForQr": "正在等待二维码...",
+    "connectedSuccess": "✅ 微信连接成功！",
+    "initializing": "初始化中...",
+    "skip": "跳过",
+    "retry": "重试",
+    "close": "关闭"
   }
 }

--- a/ui/web/src/pages/channels/channel-schemas.ts
+++ b/ui/web/src/pages/channels/channel-schemas.ts
@@ -81,6 +81,7 @@ export const credentialsSchema: Record<string, FieldDef[]> = {
     { key: "page_access_token", label: "Page Access Token", type: "password", required: true, help: "Page-level token from Pancake dashboard → Page Settings" },
     { key: "webhook_secret", label: "Webhook Secret (Optional)", type: "password", help: "HMAC-SHA256 secret for webhook signature verification. Leave empty to skip verification." },
   ],
+  wechat: [],
 };
 
 // --- Pancake platform options ---
@@ -220,6 +221,10 @@ export const configSchema: Record<string, FieldDef[]> = {
     { key: "allow_from", label: "Allowed Users", type: "tags", help: "Sender IDs to whitelist. Empty = accept all." },
     { key: "block_reply", label: "Block Reply", type: "select", options: blockReplyOptions, defaultValue: "inherit" },
   ],
+  wechat: [
+    { key: "dm_policy", label: "DM Policy", type: "select", options: dmPolicyOptions, defaultValue: "pairing" },
+    { key: "allow_from", label: "Allowed Users", type: "tags", help: "User IDs or @usernames" },
+  ],
 };
 
 // --- Group override schema (Telegram per-group/topic overrides) ---
@@ -293,5 +298,10 @@ export const wizardConfig: Partial<Record<string, WizardConfig>> = {
     steps: ["auth"],
     createLabel: "wizard.whatsapp.createLabel",
     formBanner: "wizard.whatsapp.formBanner",
+  },
+  wechat: {
+    steps: ["auth"],
+    createLabel: "wizard.wechat.createLabel",
+    formBanner: "wizard.wechat.formBanner",
   },
 };

--- a/ui/web/src/pages/channels/channel-wizard-registry.tsx
+++ b/ui/web/src/pages/channels/channel-wizard-registry.tsx
@@ -50,12 +50,15 @@ import { ZaloAuthStep, ZaloConfigStep, ZaloEditConfig } from "./zalo/zalo-wizard
 import { ZaloPersonalQRDialog } from "./zalo/zalo-personal-qr-dialog";
 import { WhatsAppAuthStep } from "./whatsapp/whatsapp-wizard-steps";
 import { WhatsAppReauthDialog } from "./whatsapp/whatsapp-reauth-dialog";
+import { WeChatAuthStep } from "./wechat/wechat-wizard-steps";
+import { WeChatReauthDialog } from "./wechat/wechat-reauth-dialog";
 
 // --- Component registries ---
 
 export const wizardAuthSteps: Record<string, ComponentType<WizardAuthStepProps>> = {
   zalo_personal: ZaloAuthStep,
   whatsapp: WhatsAppAuthStep,
+  wechat: WeChatAuthStep,
 };
 
 export const wizardConfigSteps: Record<string, ComponentType<WizardConfigStepProps>> = {
@@ -70,6 +73,7 @@ export const wizardEditConfigs: Record<string, ComponentType<WizardEditConfigPro
 export const reauthDialogs: Record<string, ComponentType<ReauthDialogProps>> = {
   zalo_personal: ZaloPersonalQRDialog,
   whatsapp: WhatsAppReauthDialog,
+  wechat: WeChatReauthDialog,
 };
 
 /** Set of channel types that support re-authentication from the table */

--- a/ui/web/src/pages/channels/channels-status-utils.ts
+++ b/ui/web/src/pages/channels/channels-status-utils.ts
@@ -15,6 +15,9 @@ export const channelTypeLabels: Record<string, string> = {
   zalo_oa: "Zalo OA",
   zalo_personal: "Zalo Personal",
   whatsapp: "WhatsApp",
+  wechat: "WeChat",
+  facebook: "Facebook",
+  pancake: "Pancake",
 };
 
 export type BadgeVariant =

--- a/ui/web/src/pages/channels/wechat/use-wechat-qr-login.ts
+++ b/ui/web/src/pages/channels/wechat/use-wechat-qr-login.ts
@@ -1,0 +1,65 @@
+import { useState, useCallback } from "react";
+import { useWsCall } from "@/hooks/use-ws-call";
+import { useWsEvent } from "@/hooks/use-ws-event";
+
+export type QrStatus = "idle" | "waiting" | "done" | "error";
+
+export function useWeChatQrLogin(instanceId: string | null) {
+  const [imgContent, setImgContent] = useState<string | null>(null);
+  const [status, setStatus] = useState<QrStatus>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const { call: startQR, loading } = useWsCall("wechat.qr.start");
+
+  const start = useCallback(async () => {
+    if (!instanceId) return;
+    setStatus("waiting");
+    setImgContent(null);
+    setErrorMsg("");
+    try {
+      await startQR({ instance_id: instanceId });
+    } catch (err) {
+      setStatus("error");
+      setErrorMsg(err instanceof Error ? err.message : "Failed to start QR session");
+    }
+  }, [startQR, instanceId]);
+
+  const reset = useCallback(() => {
+    setStatus("idle");
+    setImgContent(null);
+    setErrorMsg("");
+  }, []);
+
+  useWsEvent(
+    "wechat.qr.code",
+    useCallback(
+      (payload: unknown) => {
+        const p = payload as { instance_id: string; img_content: string };
+        if (p.instance_id !== instanceId) return;
+        setImgContent(p.img_content);
+        setStatus("waiting");
+      },
+      [instanceId],
+    ),
+  );
+
+  useWsEvent(
+    "wechat.qr.done",
+    useCallback(
+      (payload: unknown) => {
+        const p = payload as { instance_id: string; success: boolean; error?: string };
+        if (p.instance_id !== instanceId) return;
+        if (p.success) {
+          setStatus("done");
+        } else {
+          setStatus("error");
+          setErrorMsg(p.error ?? "QR authentication failed");
+        }
+      },
+      [instanceId],
+    ),
+  );
+
+  return {
+    imgContent, status, errorMsg, loading, start, reset, retry: start,
+  };
+}

--- a/ui/web/src/pages/channels/wechat/wechat-reauth-dialog.tsx
+++ b/ui/web/src/pages/channels/wechat/wechat-reauth-dialog.tsx
@@ -1,0 +1,97 @@
+// Re-authentication dialog for WeChat — triggered from the channels table.
+// QR code scan only.
+
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useWeChatQrLogin } from "./use-wechat-qr-login";
+import type { ReauthDialogProps } from "../channel-wizard-registry";
+
+export function WeChatReauthDialog({
+  open,
+  onOpenChange,
+  instanceId,
+  instanceName,
+  onSuccess,
+}: ReauthDialogProps) {
+  const { t } = useTranslation("channels");
+  const {
+    imgContent, status, errorMsg, loading, start, reset, retry,
+  } = useWeChatQrLogin(instanceId);
+
+  // Auto-start QR when dialog opens
+  useEffect(() => {
+    if (open && status === "idle") {
+      start();
+    }
+  }, [open, status, start]);
+
+  // Reset state when dialog closes
+  useEffect(() => {
+    if (!open) {
+      reset();
+    }
+  }, [open, reset]);
+
+  // Auto-close after successful scan
+  useEffect(() => {
+    if (status !== "done") return;
+    onSuccess();
+    const id = setTimeout(() => onOpenChange(false), 1500);
+    return () => clearTimeout(id);
+  }, [status, onSuccess, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!loading) onOpenChange(v); }}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{t("wechat.reauthTitle", { name: instanceName })}</DialogTitle>
+          <DialogDescription>
+            {t("wechat.scanHint")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col items-center gap-4 py-4 min-h-[200px]">
+          {status === "done" && (
+            <p className="text-sm text-green-600 font-medium">{t("wechat.connectedSuccess")}</p>
+          )}
+          {status === "error" && (
+            <p className="text-sm text-destructive">{errorMsg}</p>
+          )}
+          {status === "waiting" && !imgContent && (
+            <p className="text-sm text-muted-foreground">{t("wechat.waitingForQr")}</p>
+          )}
+          {status === "waiting" && imgContent && (
+            <>
+              <img
+                src={`data:image/png;base64,${imgContent}`}
+                alt="WeChat QR Code"
+                className="w-52 h-52 border rounded shadow-sm"
+              />
+              <p className="text-xs text-muted-foreground text-center">
+                {t("wechat.scanHint")}
+              </p>
+            </>
+          )}
+          {status === "idle" && (
+            <p className="text-sm text-muted-foreground">{t("wechat.initializing")}</p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>{t("wechat.close")}</Button>
+          {status === "error" && (
+            <Button onClick={() => retry()} disabled={loading}>{t("wechat.retry")}</Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/web/src/pages/channels/wechat/wechat-wizard-steps.tsx
+++ b/ui/web/src/pages/channels/wechat/wechat-wizard-steps.tsx
@@ -1,0 +1,74 @@
+// WeChat wizard step components for the channel create wizard.
+// QR auth is driven by the iLink Bot API, delivered via WS events.
+// Registered in channel-wizard-registry.tsx.
+
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog";
+import { useWeChatQrLogin } from "./use-wechat-qr-login";
+import type { WizardAuthStepProps } from "../channel-wizard-registry";
+
+/** QR code authentication step for WeChat — displayed in create wizard after instance creation. */
+export function WeChatAuthStep({ instanceId, onComplete, onSkip }: WizardAuthStepProps) {
+  const { t } = useTranslation("channels");
+  const { imgContent, status, errorMsg, loading, start, retry, reset } = useWeChatQrLogin(instanceId);
+
+  // Auto-start QR on mount
+  useEffect(() => {
+    start();
+    return () => reset();
+  }, [start, reset]);
+
+  // Signal completion to parent when QR confirms
+  useEffect(() => {
+    if (status === "done") onComplete();
+  }, [status, onComplete]);
+
+  return (
+    <>
+      <div className="flex flex-col items-center gap-4 py-4 min-h-0">
+        {status === "done" && (
+          <p className="text-sm text-green-600 font-medium">
+            {t("wechat.loginSuccessLoading", "Login successful — loading...")}
+          </p>
+        )}
+        {status === "error" && (
+          <p className="text-sm text-destructive">{errorMsg}</p>
+        )}
+        {status === "waiting" && !imgContent && (
+          <p className="text-sm text-muted-foreground">
+            {t("wechat.generatingQr", "Generating QR code...")}
+          </p>
+        )}
+        {status === "waiting" && imgContent && (
+          <>
+            <img
+              src={`data:image/png;base64,${imgContent}`}
+              alt="WeChat QR Code"
+              className="w-52 h-52 border rounded"
+            />
+            <p className="text-xs text-muted-foreground text-center">
+              {t("wechat.scanHint", "Scan with WeChat to log in")}
+            </p>
+          </>
+        )}
+        {status === "idle" && (
+          <p className="text-sm text-muted-foreground">
+            {t("wechat.initializing", "Initializing...")}
+          </p>
+        )}
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={onSkip} disabled={loading}>
+          {t("wechat.skip", "Skip")}
+        </Button>
+        {status === "error" && (
+          <Button onClick={() => retry()} disabled={loading}>
+            {t("wechat.retry", "Retry")}
+          </Button>
+        )}
+      </DialogFooter>
+    </>
+  );
+}


### PR DESCRIPTION
# Title
feat(channels) WeChat intergration porting from ts official lib

# Description
This PR introduces full support for the WeChat communication channel. By integrating the authentication protocol, it implements an automated QR code-based login flow, comprehensive backend session management, and a dedicated frontend UI for configuration and re-authentication.
This Change keeps the coding logic type similar to official library at maximum level for future update and fixing.
Official library: https://github.com/Tencent/openclaw-weixin 

# Key Changes

## 1. Backend Implementation (Go)
- **Core Channel Support**: Implemented the `Channel` interface in `internal/channels/wechat`, supporting initialization, startup, updates, and information retrieval.
- **QR Authentication Flow**:
  - Introduced `qr.go` to handle QR code generation and callback logic.
  - Real-time login status and QR code delivery via WebSocket events (`wechat.qr.code`, `wechat.qr.done`).
- **Session Protection**: Added `session_guard.go` to ensure WeChat session stability and implement automatic recovery mechanisms.
- **Gateway Integration**: Registered the `wechat.qr.start` command in `internal/gateway/wechat.go`, allowing clients to trigger the login flow on demand.

## 2. Protocol & Config Updates
- **Event Definitions**: Added QR-related event constants in `pkg/protocol/events.go`.
- **Method Definitions**: Added the `WeChatQRStart` method name in `pkg/protocol/methods.go`.
- **Configuration System**: Updated `internal/config/config_channels.go` to support WeChat-specific fields (e.g., `api_url`, `token`).

## 3. Frontend UI (React/TypeScript)
- **State Management**: Encapsulated login logic in the `useWeChatQrLogin` hook, handling WebSocket event subscription, Base64 image decoding, and complex login state transitions.
- **Creation Wizard**: Implemented the `WeChatAuthStep` component, seamlessly integrated into the existing channel creation wizard.
- **Re-authentication Dialog**: Implemented `WeChatReauthDialog` to allow users to trigger a QR scan directly from the channel list without needing to recreate the channel.
- **Registry & Schemas**: Updated `channel-wizard-registry.tsx` and `channel-schemas.ts` to officially register the WeChat components and validation schemas.

## 4. Internationalization (i18n)
- Updated `en`, `zh`, and `vi` translation files in `channels.json` with comprehensive UI strings for WeChat (e.g., "Scan to Login", "Initializing", "Login Successful").

# How to Test
1. Go to the **Channels** page and click **Add Channel**.
2. Select **WeChat**, enter an instance name, and submit.
3. In the following wizard step, verify that the QR code is received and displayed.
4. Scan the code with the WeChat mobile app to authorize.
5. Verify that the UI automatically transitions to "Login Successful" and the channel status becomes **Online**.

## Change Type
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking code change)

## Checklist
- [x] Code follows the project's existing coding style.
- [x] Basic functional tests passed in the local environment.
- [x] Configuration files have been updated.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
- feat/wechat-channel

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [x] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)