### PR TITLE
feat(tools): add read-only GitHub REST tool for agents 

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -134,7 +134,7 @@ func runGateway() {
 		tools.DetectServerIPs(context.Background())
 	}
 
-	toolsReg, execApprovalMgr, mcpMgr, sandboxMgr, browserMgr, webFetchTool, ttsTool, audioMgr, permPE, toolPE, dataDir, agentCfg := setupToolRegistry(cfg, workspace, providerRegistry)
+	toolsReg, execApprovalMgr, mcpMgr, sandboxMgr, browserMgr, webFetchTool, githubTool, ttsTool, audioMgr, permPE, toolPE, dataDir, agentCfg := setupToolRegistry(cfg, workspace, providerRegistry)
 	if browserMgr != nil {
 		defer browserMgr.Close()
 	}
@@ -569,6 +569,7 @@ func runGateway() {
 		heartbeatTicker:   heartbeatTicker,
 		quotaChecker:      quotaChecker,
 		webFetchTool:      webFetchTool,
+		githubTool:        githubTool,
 		ttsTool:           ttsTool,
 		sandboxMgr:        sandboxMgr,
 		postTurn:          postTurn,

--- a/cmd/gateway_lifecycle.go
+++ b/cmd/gateway_lifecycle.go
@@ -27,6 +27,7 @@ type lifecycleDeps struct {
 	heartbeatTicker   *heartbeat.Ticker
 	quotaChecker      *channels.QuotaChecker
 	webFetchTool      *tools.WebFetchTool
+	githubTool        *tools.GitHubTool
 	ttsTool           *tools.TtsTool
 	sandboxMgr        sandbox.Manager
 	postTurn          tools.PostTurnProcessor
@@ -82,6 +83,27 @@ func (d *gatewayDeps) runLifecycle(
 			return
 		}
 		deps.webFetchTool.UpdatePolicy(updatedCfg.Tools.WebFetch.Policy, updatedCfg.Tools.WebFetch.AllowedDomains, updatedCfg.Tools.WebFetch.BlockedDomains)
+	})
+
+	// Reload GitHub auth on config changes via pub/sub.
+	d.msgBus.Subscribe("github-config-reload", func(evt bus.Event) {
+		if evt.Name != bus.TopicConfigChanged {
+			return
+		}
+		if deps.githubTool == nil {
+			return
+		}
+		updatedCfg, ok := evt.Payload.(*config.Config)
+		if !ok {
+			return
+		}
+		if d.pgStores.ConfigSecrets != nil {
+			if secrets, err := d.pgStores.ConfigSecrets.GetAll(context.Background()); err == nil && len(secrets) > 0 {
+				updatedCfg.ApplyDBSecrets(secrets)
+			}
+		}
+		deps.githubTool.UpdateToken(updatedCfg.Tools.GitHub.Token)
+		slog.Info("github token reloaded", "configured", updatedCfg.Tools.GitHub.Token != "")
 	})
 
 	// Reload TTS providers on config changes via pub/sub.

--- a/cmd/gateway_setup.go
+++ b/cmd/gateway_setup.go
@@ -31,7 +31,7 @@ import (
 
 // setupToolRegistry creates the tool registry and registers all tools.
 // Returns the registry, exec approval manager, MCP manager, sandbox manager,
-// browser manager (caller must defer Close), web fetch tool, TTS tool,
+// browser manager (caller must defer Close), web fetch tool, GitHub tool, TTS tool,
 // permission policy engine, tool policy engine, data directory, and resolved agent defaults.
 func setupToolRegistry(
 	cfg *config.Config,
@@ -44,6 +44,7 @@ func setupToolRegistry(
 	sandboxMgr sandbox.Manager,
 	browserMgr *browser.Manager,
 	webFetchTool *tools.WebFetchTool,
+	githubTool *tools.GitHubTool,
 	ttsTool *tools.TtsTool,
 	audioMgr *audio.Manager,
 	permPE *permissions.PolicyEngine,
@@ -125,6 +126,14 @@ func setupToolRegistry(
 	})
 	toolsReg.Register(webFetchTool)
 	slog.Info("web_fetch tool enabled", "policy", cfg.Tools.WebFetch.Policy, "blocked", len(cfg.Tools.WebFetch.BlockedDomains))
+
+	githubTool = tools.NewGitHubTool(tools.GitHubToolConfig{Token: cfg.Tools.GitHub.Token})
+	toolsReg.RegisterWithMetadata(githubTool, tools.ToolMetadata{
+		Capabilities:      []tools.ToolCapability{tools.CapReadOnly},
+		Group:             "web",
+		RequiresWorkspace: false,
+	})
+	slog.Info("github_read tool enabled")
 
 	// Vision fallback tool (for non-vision providers like MiniMax)
 	toolsReg.Register(tools.NewReadImageTool(providerRegistry))

--- a/cmd/gateway_setup_exec_workspace_test.go
+++ b/cmd/gateway_setup_exec_workspace_test.go
@@ -22,7 +22,7 @@ func testExecToolFromGatewaySetup(t *testing.T, workspace, dataDir string) *tool
 	cfg.Tools.Browser.Enabled = false
 
 	providerRegistry := providers.NewRegistry(nil)
-	toolsReg, _, _, _, _, _, _, _, _, _, _, _ := setupToolRegistry(cfg, workspace, providerRegistry)
+	toolsReg, _, _, _, _, _, _, _, _, _, _, _, _ := setupToolRegistry(cfg, workspace, providerRegistry)
 
 	execToolAny, ok := toolsReg.Get("exec")
 	if !ok {

--- a/internal/agent/preview_prompt.go
+++ b/internal/agent/preview_prompt.go
@@ -333,6 +333,6 @@ func defaultTeamGuidance() string {
 var fallbackPreviewToolNames = []string{
 	"read_file", "write_file", "list_files", "edit", "exec",
 	"memory_search", "memory_get", "spawn",
-	"web_search", "web_fetch", "skill_search", "use_skill",
+	"web_search", "web_fetch", "github_read", "skill_search", "use_skill",
 	"datetime", "cron",
 }

--- a/internal/agent/systemprompt.go
+++ b/internal/agent/systemprompt.go
@@ -183,6 +183,7 @@ var coreToolSummaries = map[string]string{
 	"spawn":                  "Spawn a self-clone subagent to handle a task in the background",
 	"web_search":             "Search the web",
 	"web_fetch":              "Fetch and extract content from a URL",
+	"github_read":            "Read GitHub repositories, files, issues, pull requests, and releases",
 	"datetime":               "Get current date/time with timezone — use before creating cron jobs",
 	"cron":                   "Manage scheduled jobs and reminders (e.g. 'remind me at 9am', 'check every morning')",
 	"heartbeat":              "Periodic background monitoring with HEARTBEAT.md. Unlike cron, auto-suppresses 'all OK' via HEARTBEAT_OK",

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -372,6 +372,7 @@ type ToolsConfig struct {
 	ByProvider       map[string]*ToolPolicySpec  `json:"byProvider,omitempty"` // per-provider overrides
 	ExecApproval     ExecApprovalCfg             `json:"execApproval"`         // exec command approval settings
 	WebFetch         WebFetchPolicyConfig        `json:"web_fetch"`            // domain policy for URL fetching
+	GitHub           GitHubToolConfig            `json:"github"`               // GitHub REST API token for github_read
 	Browser          BrowserToolConfig           `json:"browser"`
 	RateLimitPerHour int                         `json:"rate_limit_per_hour,omitempty"` // max tool executions per hour per session (0 = disabled)
 	ScrubCredentials *bool                       `json:"scrub_credentials,omitempty"`   // auto-redact API keys/tokens in tool output (default true)

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -373,6 +373,7 @@ type ToolsConfig struct {
 	ExecApproval     ExecApprovalCfg             `json:"execApproval"`         // exec command approval settings
 	WebFetch         WebFetchPolicyConfig        `json:"web_fetch"`            // domain policy for URL fetching
 	GitHub           GitHubToolConfig            `json:"github"`               // GitHub REST API token for github_read
+	Web              WebToolsConfig              `json:"web"`
 	Browser          BrowserToolConfig           `json:"browser"`
 	RateLimitPerHour int                         `json:"rate_limit_per_hour,omitempty"` // max tool executions per hour per session (0 = disabled)
 	ScrubCredentials *bool                       `json:"scrub_credentials,omitempty"`   // auto-redact API keys/tokens in tool output (default true)
@@ -409,6 +410,47 @@ type WebFetchPolicyConfig struct {
 	Policy         string   `json:"policy,omitempty"`          // "allow_all" (default), "allowlist"
 	AllowedDomains []string `json:"allowed_domains,omitempty"` // e.g. ["github.com", "*.example.com"]
 	BlockedDomains []string `json:"blocked_domains,omitempty"` // always checked regardless of policy
+}
+
+// GitHubToolConfig configures the built-in GitHub read-only tool.
+type GitHubToolConfig struct {
+	Token string `json:"token,omitempty"`
+}
+
+// WebToolsConfig controls web search helper configuration.
+type WebToolsConfig struct {
+	ProviderOrder []string         `json:"provider_order,omitempty"`
+	Exa           ExaConfig        `json:"exa"`
+	Tavily        TavilyConfig     `json:"tavily"`
+	Brave         BraveConfig      `json:"brave"`
+	DuckDuckGo    DuckDuckGoConfig `json:"duckduckgo"`
+}
+
+// ExaConfig configures the Exa web search provider.
+type ExaConfig struct {
+	Enabled    bool   `json:"enabled"`
+	APIKey     string `json:"api_key"`
+	MaxResults int    `json:"max_results"`
+}
+
+// TavilyConfig configures the Tavily web search provider.
+type TavilyConfig struct {
+	Enabled    bool   `json:"enabled"`
+	APIKey     string `json:"api_key"`
+	MaxResults int    `json:"max_results"`
+}
+
+// BraveConfig configures the Brave web search provider.
+type BraveConfig struct {
+	Enabled    bool   `json:"enabled"`
+	APIKey     string `json:"api_key"`
+	MaxResults int    `json:"max_results"`
+}
+
+// DuckDuckGoConfig configures the DuckDuckGo web search provider.
+type DuckDuckGoConfig struct {
+	Enabled    bool `json:"enabled"`
+	MaxResults int  `json:"max_results"`
 }
 
 // BrowserToolConfig controls the browser automation tool.

--- a/internal/config/config_extras_test.go
+++ b/internal/config/config_extras_test.go
@@ -217,6 +217,38 @@ func TestReplaceFrom(t *testing.T) {
 	}
 }
 
+func TestConfig_GitHubTokenSecretHandling(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.GitHub.Token = "ghp_test_token"
+
+	masked := cfg.MaskedCopy()
+	if masked.Tools.GitHub.Token != "***" {
+		t.Fatalf("MaskedCopy should mask GitHub token, got %q", masked.Tools.GitHub.Token)
+	}
+
+	secrets := cfg.ExtractDBSecrets()
+	if secrets["tools.github.token"] != "ghp_test_token" {
+		t.Fatalf("ExtractDBSecrets should include GitHub token, got %q", secrets["tools.github.token"])
+	}
+
+	cfg.StripSecrets()
+	if cfg.Tools.GitHub.Token != "" {
+		t.Fatalf("StripSecrets should clear GitHub token, got %q", cfg.Tools.GitHub.Token)
+	}
+
+	cfg.Tools.GitHub.Token = "***"
+	cfg.StripMaskedSecrets()
+	if cfg.Tools.GitHub.Token != "" {
+		t.Fatalf("StripMaskedSecrets should clear masked GitHub token, got %q", cfg.Tools.GitHub.Token)
+	}
+
+	loaded := Default()
+	loaded.ApplyDBSecrets(map[string]string{"tools.github.token": "db-token"})
+	if loaded.Tools.GitHub.Token != "db-token" {
+		t.Fatalf("ApplyDBSecrets should restore GitHub token, got %q", loaded.Tools.GitHub.Token)
+	}
+}
+
 // --- CronConfig helpers ---
 
 func TestCronConfig_JobTimeoutDuration_Default(t *testing.T) {

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -122,6 +122,13 @@ func (c *Config) applyEnvOverrides() {
 	envStr("GOCLAW_SLACK_APP_TOKEN", &c.Channels.Slack.AppToken)
 	envStr("GOCLAW_SLACK_USER_TOKEN", &c.Channels.Slack.UserToken)
 
+	// GitHub token precedence matches the REST-first GitHub tool.
+	// Highest priority wins because envStr overwrites previous values.
+	envStr("GITHUB_TOKEN", &c.Tools.GitHub.Token)
+	envStr("GH_TOKEN", &c.Tools.GitHub.Token)
+	envStr("COPILOT_GITHUB_TOKEN", &c.Tools.GitHub.Token)
+	envStr("GOCLAW_GITHUB_TOKEN", &c.Tools.GitHub.Token)
+
 	// TTS secrets
 	envStr("GOCLAW_TTS_OPENAI_API_KEY", &c.Tts.OpenAI.APIKey)
 	envStr("GOCLAW_TTS_ELEVENLABS_API_KEY", &c.Tts.ElevenLabs.APIKey)

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -130,6 +130,21 @@ func TestLoad_EnvVarAPIKeys(t *testing.T) {
 	}
 }
 
+func TestLoad_EnvVarGitHubTokenPrecedence(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "legacy-token")
+	t.Setenv("GH_TOKEN", "gh-token")
+	t.Setenv("COPILOT_GITHUB_TOKEN", "copilot-token")
+	t.Setenv("GOCLAW_GITHUB_TOKEN", "goclaw-token")
+
+	cfg, err := Load("/nonexistent/path")
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if cfg.Tools.GitHub.Token != "goclaw-token" {
+		t.Fatalf("github token precedence failed: got %q, want goclaw-token", cfg.Tools.GitHub.Token)
+	}
+}
+
 // --- Allowed origins from JSON5 ---
 
 func TestLoad_AllowedOrigins_JSON5(t *testing.T) {

--- a/internal/config/config_secrets.go
+++ b/internal/config/config_secrets.go
@@ -58,6 +58,14 @@ func (c *Config) MaskedCopy() *Config {
 	maskNonEmpty(&cp.Tts.ElevenLabs.APIKey)
 	maskNonEmpty(&cp.Tts.MiniMax.APIKey)
 
+	// Mask GitHub token
+	maskNonEmpty(&cp.Tools.GitHub.Token)
+
+	// Mask web tool keys
+	maskNonEmpty(&cp.Tools.Web.Exa.APIKey)
+	maskNonEmpty(&cp.Tools.Web.Tavily.APIKey)
+	maskNonEmpty(&cp.Tools.Web.Brave.APIKey)
+
 	// Mask Tailscale auth key
 	maskNonEmpty(&cp.Tailscale.AuthKey)
 
@@ -104,6 +112,12 @@ func (c *Config) StripSecrets() {
 	c.Tts.OpenAI.APIKey = ""
 	c.Tts.ElevenLabs.APIKey = ""
 	c.Tts.MiniMax.APIKey = ""
+	c.Tools.GitHub.Token = ""
+
+	// Web tool keys
+	c.Tools.Web.Exa.APIKey = ""
+	c.Tools.Web.Tavily.APIKey = ""
+	c.Tools.Web.Brave.APIKey = ""
 
 	// Tailscale auth key
 	c.Tailscale.AuthKey = ""
@@ -156,6 +170,12 @@ func (c *Config) StripMaskedSecrets() {
 	stripIfMasked(&c.Tts.OpenAI.APIKey)
 	stripIfMasked(&c.Tts.ElevenLabs.APIKey)
 	stripIfMasked(&c.Tts.MiniMax.APIKey)
+	stripIfMasked(&c.Tools.GitHub.Token)
+
+	// Web tool keys
+	stripIfMasked(&c.Tools.Web.Exa.APIKey)
+	stripIfMasked(&c.Tools.Web.Tavily.APIKey)
+	stripIfMasked(&c.Tools.Web.Brave.APIKey)
 
 	// Tailscale auth key
 	stripIfMasked(&c.Tailscale.AuthKey)
@@ -176,6 +196,10 @@ func (c *Config) ApplyDBSecrets(secrets map[string]string) {
 	apply("tts.elevenlabs.api_key", &c.Tts.ElevenLabs.APIKey)
 	apply("tts.minimax.api_key", &c.Tts.MiniMax.APIKey)
 	apply("tts.minimax.group_id", &c.Tts.MiniMax.GroupID)
+	apply("tools.github.token", &c.Tools.GitHub.Token)
+	apply("tools.web.exa.api_key", &c.Tools.Web.Exa.APIKey)
+	apply("tools.web.tavily.api_key", &c.Tools.Web.Tavily.APIKey)
+	apply("tools.web.brave.api_key", &c.Tools.Web.Brave.APIKey)
 	apply("tailscale.auth_key", &c.Tailscale.AuthKey)
 }
 
@@ -195,6 +219,10 @@ func (c *Config) ExtractDBSecrets() map[string]string {
 	collect("tts.elevenlabs.api_key", c.Tts.ElevenLabs.APIKey)
 	collect("tts.minimax.api_key", c.Tts.MiniMax.APIKey)
 	collect("tts.minimax.group_id", c.Tts.MiniMax.GroupID)
+	collect("tools.github.token", c.Tools.GitHub.Token)
+	collect("tools.web.exa.api_key", c.Tools.Web.Exa.APIKey)
+	collect("tools.web.tavily.api_key", c.Tools.Web.Tavily.APIKey)
+	collect("tools.web.brave.api_key", c.Tools.Web.Brave.APIKey)
 	collect("tailscale.auth_key", c.Tailscale.AuthKey)
 
 	return secrets

--- a/internal/tools/capability.go
+++ b/internal/tools/capability.go
@@ -46,7 +46,7 @@ func inferMetadata(name string) ToolMetadata {
 		name == "memory_search" || name == "memory_get" || name == "memory_expand" ||
 		name == "skill_search" || name == "knowledge_graph_search" ||
 		name == "sessions_list" || name == "session_status" || name == "sessions_history" ||
-		name == "datetime" || name == "web_search" || name == "web_fetch":
+		name == "datetime" || name == "web_search" || name == "web_fetch" || name == "github_read":
 		meta.Capabilities = []ToolCapability{CapReadOnly}
 	case name == "spawn":
 		meta.Capabilities = []ToolCapability{CapAsync}

--- a/internal/tools/github_read.go
+++ b/internal/tools/github_read.go
@@ -1,0 +1,1264 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	githubAPIBaseURL      = "https://api.github.com"
+	githubUserAgent       = "GoClaw-GitHubTool/1.0"
+	githubRequestTimeout  = 30 * time.Second
+	githubDefaultMaxChars = 40000
+	githubDefaultLimit    = 20
+	githubMaxLimit        = 100
+)
+
+// GitHubToolConfig configures the GitHub read-only tool.
+type GitHubToolConfig struct {
+	Token string
+}
+
+// GitHubTool reads GitHub repositories, files, issues, pull requests, and releases.
+type GitHubTool struct {
+	mu      sync.RWMutex
+	token   string
+	apiBase string
+	client  *http.Client
+	maxChars int
+}
+
+// NewGitHubTool creates a GitHub tool backed by the GitHub REST API.
+func NewGitHubTool(cfg GitHubToolConfig) *GitHubTool {
+	return &GitHubTool{
+		token:    cfg.Token,
+		apiBase:  githubAPIBaseURL,
+		client:   &http.Client{Timeout: githubRequestTimeout},
+		maxChars: githubDefaultMaxChars,
+	}
+}
+
+// UpdateToken swaps the bearer token used for subsequent requests.
+func (t *GitHubTool) UpdateToken(token string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.token = token
+}
+
+func (t *GitHubTool) Name() string { return "github_read" }
+
+func (t *GitHubTool) Description() string {
+	return "Read GitHub repositories, files, issues, pull requests, and releases via the GitHub REST API."
+}
+
+func (t *GitHubTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"repo": map[string]any{
+				"type":        "string",
+				"description": "Repository in owner/repo form, or a GitHub URL such as https://github.com/owner/repo/blob/main/path.go. If omitted, the tool tries to infer the current workspace origin remote.",
+			},
+			"kind": map[string]any{
+				"type": "string",
+				"enum": []string{"repo", "file", "tree", "issue", "pull", "release", "releases"},
+				"description": "Resource type to read. Optional — inferred from the GitHub URL path or other arguments when omitted.",
+			},
+			"path": map[string]any{
+				"type":        "string",
+				"description": "Path within the repository for file/tree reads.",
+			},
+			"ref": map[string]any{
+				"type":        "string",
+				"description": "Branch, tag, or commit ref for file/tree reads.",
+			},
+			"number": map[string]any{
+				"type":        "number",
+				"description": "Issue or pull request number.",
+				"minimum":     1.0,
+			},
+			"tag": map[string]any{
+				"type":        "string",
+				"description": "Release tag for release reads.",
+			},
+			"limit": map[string]any{
+				"type":        "number",
+				"description": "Maximum number of entries to return for tree/release lists.",
+				"minimum":     1.0,
+				"maximum":     float64(githubMaxLimit),
+			},
+			"recursive": map[string]any{
+				"type":        "boolean",
+				"description": "When reading a tree, walk nested directories recursively.",
+			},
+			"maxChars": map[string]any{
+				"type":        "number",
+				"description": "Maximum number of characters to return after formatting.",
+				"minimum":     1.0,
+			},
+		},
+	}
+}
+
+func (t *GitHubTool) Execute(ctx context.Context, args map[string]any) *Result {
+	req, source, err := t.resolveRequest(ctx, args)
+	if err != nil {
+		return ErrorResult("github_read: " + err.Error())
+	}
+
+	content, err := t.readResource(ctx, req)
+	if err != nil {
+		return ErrorResult("github_read: " + err.Error())
+	}
+
+	content = truncateRunes(content, req.MaxChars)
+	return NewResult(wrapExternalContent(content, source, true))
+}
+
+type githubReadRequest struct {
+	Owner     string
+	Repo      string
+	Kind      string
+	Path      string
+	Ref       string
+	Tag       string
+	Number    int
+	Limit     int
+	Recursive bool
+	MaxChars  int
+}
+
+type githubTargetSpec struct {
+	Owner  string
+	Repo   string
+	Kind   string
+	Path   string
+	Ref    string
+	Tag    string
+	Number int
+}
+
+func (t *GitHubTool) resolveRequest(ctx context.Context, args map[string]any) (githubReadRequest, string, error) {
+	_, hasRecursiveArg := args["recursive"]
+	req := githubReadRequest{
+		Kind:      normalizeGitHubKind(stringArg(args, "kind")),
+		Path:      strings.TrimSpace(stringArg(args, "path")),
+		Ref:       strings.TrimSpace(stringArg(args, "ref")),
+		Tag:       strings.TrimSpace(stringArg(args, "tag")),
+		Number:    intArgAny(args, "number", 0),
+		Limit:     intArgAny(args, "limit", 0),
+		Recursive: boolArgAny(args, "recursive", false),
+		MaxChars:  intArgAny(args, "maxChars", 0),
+	}
+	if req.MaxChars <= 0 {
+		req.MaxChars = t.defaultMaxChars()
+	}
+	if req.Limit <= 0 {
+		req.Limit = githubDefaultLimit
+	}
+	if req.Limit > githubMaxLimit {
+		req.Limit = githubMaxLimit
+	}
+
+	repoSource := strings.TrimSpace(stringArg(args, "repo"))
+	if repoSource == "" {
+		inferredRepo, err := inferGitHubRepoSpec(ctx)
+		if err != nil {
+			return githubReadRequest{}, "", err
+		}
+		repoSource = inferredRepo
+	}
+
+	target, ok := parseGitHubTargetSpec(repoSource)
+	if !ok {
+		owner, repo, err := parseGitHubRepoSpec(repoSource)
+		if err != nil {
+			return githubReadRequest{}, "", err
+		}
+		target.Owner = owner
+		target.Repo = repo
+	}
+
+	if target.Kind != "" && req.Kind == "" {
+		req.Kind = target.Kind
+	}
+	if target.Path != "" && req.Path == "" {
+		req.Path = target.Path
+	}
+	if target.Ref != "" && req.Ref == "" {
+		req.Ref = target.Ref
+	}
+	if target.Tag != "" && req.Tag == "" {
+		req.Tag = target.Tag
+	}
+	if target.Number > 0 && req.Number <= 0 {
+		req.Number = target.Number
+	}
+	req.Owner = target.Owner
+	req.Repo = target.Repo
+
+	if req.Kind == "" {
+		switch {
+		case req.Tag != "":
+			req.Kind = "release"
+		case req.Number > 0:
+			req.Kind = "issue"
+		case req.Path != "":
+			req.Kind = "file"
+		default:
+			req.Kind = "repo"
+		}
+	}
+
+	if req.Kind == "tree" && !hasRecursiveArg {
+		req.Recursive = true
+	}
+
+	if req.Owner == "" || req.Repo == "" {
+		return githubReadRequest{}, "", fmt.Errorf("repo is required")
+	}
+
+	if req.Kind == "releases" && req.Limit <= 0 {
+		req.Limit = githubDefaultLimit
+	}
+
+	return req, req.sourceLabel(), nil
+}
+
+func (r githubReadRequest) sourceLabel() string {
+	base := fmt.Sprintf("GitHub %s/%s", r.Owner, r.Repo)
+	switch r.Kind {
+	case "file":
+		if r.Path != "" {
+			return base + ":" + r.Path
+		}
+		return base + " repository contents"
+	case "tree":
+		if r.Path != "" {
+			return base + ":" + r.Path + " tree"
+		}
+		return base + " tree"
+	case "issue":
+		if r.Number > 0 {
+			return fmt.Sprintf("%s issue #%d", base, r.Number)
+		}
+		return base + " issue"
+	case "pull":
+		if r.Number > 0 {
+			return fmt.Sprintf("%s pull request #%d", base, r.Number)
+		}
+		return base + " pull request"
+	case "release":
+		if r.Tag != "" {
+			return fmt.Sprintf("%s release %s", base, r.Tag)
+		}
+		return base + " latest release"
+	case "releases":
+		return base + " releases"
+	default:
+		return base + " repository"
+	}
+}
+
+func normalizeGitHubKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "", "auto":
+		return ""
+	case "repo", "repository":
+		return "repo"
+	case "file", "files", "contents", "content":
+		return "file"
+	case "tree", "dir", "directory":
+		return "tree"
+	case "issue", "issues":
+		return "issue"
+	case "pull", "pr", "pull_request", "pull-request", "pulls":
+		return "pull"
+	case "release", "tag":
+		return "release"
+	case "releases":
+		return "releases"
+	default:
+		return strings.ToLower(strings.TrimSpace(kind))
+	}
+}
+
+func parseGitHubTargetSpec(spec string) (githubTargetSpec, bool) {
+	s := strings.TrimSpace(spec)
+	if s == "" {
+		return githubTargetSpec{}, false
+	}
+	if idx := strings.IndexAny(s, "?#"); idx >= 0 {
+		s = s[:idx]
+	}
+	s = strings.TrimSuffix(s, ".git")
+
+	lower := strings.ToLower(s)
+	if idx := strings.Index(lower, "github.com/"); idx >= 0 {
+		s = s[idx+len("github.com/") :]
+	} else if idx := strings.Index(lower, "github.com:"); idx >= 0 {
+		s = s[idx+len("github.com:") :]
+	}
+	s = strings.TrimPrefix(s, "/")
+	parts := strings.Split(strings.Trim(s, "/"), "/")
+	if len(parts) < 2 {
+		return githubTargetSpec{}, false
+	}
+
+	target := githubTargetSpec{
+		Owner: urlUnescapeSegment(parts[0]),
+		Repo:  urlUnescapeSegment(parts[1]),
+	}
+	if len(parts) < 3 {
+		return target, true
+	}
+
+	switch parts[2] {
+	case "blob":
+		if len(parts) >= 5 {
+			target.Kind = "file"
+			target.Ref = urlUnescapeSegment(parts[3])
+			target.Path = joinUnescapedPath(parts[4:])
+		}
+	case "tree":
+		if len(parts) >= 4 {
+			target.Kind = "tree"
+			target.Ref = urlUnescapeSegment(parts[3])
+			if len(parts) > 4 {
+				target.Path = joinUnescapedPath(parts[4:])
+			}
+		}
+	case "issues":
+		if len(parts) >= 4 {
+			target.Kind = "issue"
+			target.Number = mustAtoi(urlUnescapeSegment(parts[3]))
+		}
+	case "pull", "pulls":
+		if len(parts) >= 4 {
+			target.Kind = "pull"
+			target.Number = mustAtoi(urlUnescapeSegment(parts[3]))
+		}
+	case "releases":
+		if len(parts) == 3 {
+			target.Kind = "releases"
+			return target, true
+		}
+		if len(parts) >= 5 && parts[3] == "tag" {
+			target.Kind = "release"
+			target.Tag = joinUnescapedPath(parts[4:])
+		}
+	}
+
+	return target, true
+}
+
+func parseGitHubRepoSpec(spec string) (owner, repo string, err error) {
+	target, ok := parseGitHubTargetSpec(spec)
+	if !ok {
+		return "", "", fmt.Errorf("invalid GitHub repository %q", spec)
+	}
+	return target.Owner, target.Repo, nil
+}
+
+func inferGitHubRepoSpec(ctx context.Context) (string, error) {
+	workspace := ToolWorkspaceFromCtx(ctx)
+	if workspace == "" {
+		return "", fmt.Errorf("repo is required when no workspace is available")
+	}
+
+	for _, args := range [][]string{
+		{"-C", workspace, "remote", "get-url", "origin"},
+		{"-C", workspace, "config", "--get", "remote.origin.url"},
+	} {
+		cmd := exec.Command("git", args...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			continue
+		}
+		remote := strings.TrimSpace(string(out))
+		if remote != "" {
+			return remote, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to infer GitHub repository from workspace %q", workspace)
+}
+
+func urlUnescapeSegment(value string) string {
+	if decoded, err := url.PathUnescape(value); err == nil {
+		return decoded
+	}
+	return value
+}
+
+func joinUnescapedPath(segments []string) string {
+	if len(segments) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		parts = append(parts, urlUnescapeSegment(segment))
+	}
+	return strings.Join(parts, "/")
+}
+
+func mustAtoi(value string) int {
+	if value == "" {
+		return 0
+	}
+	n, _ := strconv.Atoi(value)
+	return n
+}
+
+func stringArg(args map[string]any, key string) string {
+	switch v := args[key].(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return ""
+	}
+}
+
+func intArgAny(args map[string]any, key string, fallback int) int {
+	switch v := args[key].(type) {
+	case float64:
+		return int(v)
+	case float32:
+		return int(v)
+	case int:
+		return v
+	case int32:
+		return int(v)
+	case int64:
+		return int(v)
+	case json.Number:
+		if n, err := v.Int64(); err == nil {
+			return int(n)
+		}
+	case string:
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func boolArgAny(args map[string]any, key string, fallback bool) bool {
+	switch v := args[key].(type) {
+	case bool:
+		return v
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "true", "1", "yes", "on":
+			return true
+		case "false", "0", "no", "off":
+			return false
+		}
+	}
+	return fallback
+}
+
+func (t *GitHubTool) defaultMaxChars() int {
+	if t == nil || t.maxChars <= 0 {
+		return githubDefaultMaxChars
+	}
+	return t.maxChars
+}
+
+func (t *GitHubTool) clientOrDefault() *http.Client {
+	if t != nil && t.client != nil {
+		return t.client
+	}
+	return http.DefaultClient
+}
+
+func (t *GitHubTool) apiBaseURL() string {
+	if t == nil || strings.TrimSpace(t.apiBase) == "" {
+		return githubAPIBaseURL
+	}
+	return strings.TrimRight(t.apiBase, "/")
+}
+
+func (t *GitHubTool) tokenValue() string {
+	if t == nil {
+		return ""
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.token
+}
+
+func (t *GitHubTool) endpoint(path string, query url.Values) string {
+	base := t.apiBaseURL()
+	full := strings.TrimRight(base, "/") + "/" + strings.TrimLeft(path, "/")
+	if query != nil {
+		if encoded := query.Encode(); encoded != "" {
+			full += "?" + encoded
+		}
+	}
+	return full
+}
+
+func (t *GitHubTool) doRequest(ctx context.Context, method, path string, query url.Values) ([]byte, http.Header, error) {
+	req, err := http.NewRequestWithContext(ctx, method, t.endpoint(path, query), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", githubUserAgent)
+	if token := t.tokenValue(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := t.clientOrDefault().Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.Header, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, resp.Header, t.apiError(resp, body)
+	}
+	return body, resp.Header, nil
+}
+
+func (t *GitHubTool) apiError(resp *http.Response, body []byte) error {
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		msg = resp.Status
+	}
+	msg = truncateStr(msg, 500)
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("GitHub authentication failed: %s", msg)
+	case http.StatusForbidden:
+		if resp.Header.Get("X-RateLimit-Remaining") == "0" {
+			if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+				if ts, err := strconv.ParseInt(reset, 10, 64); err == nil {
+					return fmt.Errorf("GitHub API rate limit exceeded until %s: %s", time.Unix(ts, 0).UTC().Format(time.RFC3339), msg)
+				}
+			}
+			return fmt.Errorf("GitHub API rate limit exceeded: %s", msg)
+		}
+		return fmt.Errorf("GitHub API forbidden: %s", msg)
+	case http.StatusNotFound:
+		return fmt.Errorf("GitHub resource not found: %s", msg)
+	default:
+		path := ""
+		if resp.Request != nil && resp.Request.URL != nil {
+			path = resp.Request.URL.Path
+		}
+		if path != "" {
+			return fmt.Errorf("GitHub API %s %s returned %d: %s", resp.Request.Method, path, resp.StatusCode, msg)
+		}
+		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, msg)
+	}
+}
+
+type githubRepo struct {
+	FullName      string `json:"full_name"`
+	Description   string `json:"description"`
+	DefaultBranch string `json:"default_branch"`
+	HTMLURL       string `json:"html_url"`
+	Visibility    string `json:"visibility"`
+	Private       bool   `json:"private"`
+	Archived      bool   `json:"archived"`
+	Fork          bool   `json:"fork"`
+	Stars         int    `json:"stargazers_count"`
+	Forks         int    `json:"forks_count"`
+	OpenIssues    int    `json:"open_issues_count"`
+	Language      string `json:"language"`
+	Homepage      string `json:"homepage"`
+	UpdatedAt     string `json:"updated_at"`
+	License       *struct {
+		SPDXID string `json:"spdx_id"`
+		Name   string `json:"name"`
+	} `json:"license"`
+}
+
+type githubContentEntry struct {
+	Type        string `json:"type"`
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	SHA         string `json:"sha"`
+	Size        int    `json:"size"`
+	HTMLURL     string `json:"html_url"`
+	DownloadURL string `json:"download_url"`
+	Content     string `json:"content"`
+	Encoding    string `json:"encoding"`
+	Truncated   bool   `json:"truncated"`
+	URL         string `json:"url"`
+	Submodule   string `json:"submodule_git_url,omitempty"`
+	Target      string `json:"target,omitempty"`
+}
+
+type githubBlob struct {
+	Content  string `json:"content"`
+	Encoding string `json:"encoding"`
+	Size     int    `json:"size"`
+	SHA      string `json:"sha"`
+}
+
+type githubIssue struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	State       string `json:"state"`
+	Locked      bool   `json:"locked"`
+	HTMLURL     string `json:"html_url"`
+	Body        string `json:"body"`
+	Comments    int    `json:"comments"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+	ClosedAt    string `json:"closed_at"`
+	User        struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	Assignees []struct {
+		Login string `json:"login"`
+	} `json:"assignees"`
+	Milestone *struct {
+		Title string `json:"title"`
+	} `json:"milestone"`
+	PullRequest *struct{} `json:"pull_request,omitempty"`
+}
+
+type githubPullRequest struct {
+	Number        int    `json:"number"`
+	Title         string `json:"title"`
+	State         string `json:"state"`
+	Draft         bool   `json:"draft"`
+	Locked        bool   `json:"locked"`
+	Merged        bool   `json:"merged"`
+	HTMLURL       string `json:"html_url"`
+	Body          string `json:"body"`
+	Comments      int    `json:"comments"`
+	ReviewComments int   `json:"review_comments"`
+	Commits       int    `json:"commits"`
+	Additions     int    `json:"additions"`
+	Deletions     int    `json:"deletions"`
+	ChangedFiles  int    `json:"changed_files"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
+	ClosedAt      string `json:"closed_at"`
+	MergedAt      string `json:"merged_at"`
+	User          struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+	Head struct {
+		Ref string `json:"ref"`
+	} `json:"head"`
+}
+
+type githubRelease struct {
+	TagName     string `json:"tag_name"`
+	Name        string `json:"name"`
+	Draft       bool   `json:"draft"`
+	Prerelease  bool   `json:"prerelease"`
+	HTMLURL     string `json:"html_url"`
+	Body        string `json:"body"`
+	PublishedAt string `json:"published_at"`
+	CreatedAt   string `json:"created_at"`
+	Author      struct {
+		Login string `json:"login"`
+	} `json:"author"`
+}
+
+func (t *GitHubTool) readResource(ctx context.Context, req githubReadRequest) (string, error) {
+	switch req.Kind {
+	case "repo":
+		repo, err := t.getRepo(ctx, req.Owner, req.Repo)
+		if err != nil {
+			return "", err
+		}
+		return formatGitHubRepo(req, repo), nil
+	case "file":
+		return t.readFileOrDirectory(ctx, req, false)
+	case "tree":
+		return t.readFileOrDirectory(ctx, req, true)
+	case "issue":
+		issue, err := t.getIssue(ctx, req.Owner, req.Repo, req.Number)
+		if err != nil {
+			return "", err
+		}
+		return formatGitHubIssue(req, issue), nil
+	case "pull":
+		pull, err := t.getPull(ctx, req.Owner, req.Repo, req.Number)
+		if err != nil {
+			return "", err
+		}
+		return formatGitHubPull(req, pull), nil
+	case "release":
+		release, err := t.getRelease(ctx, req.Owner, req.Repo, req.Tag)
+		if err != nil {
+			return "", err
+		}
+		return formatGitHubRelease(req, release), nil
+	case "releases":
+		releases, err := t.listReleases(ctx, req.Owner, req.Repo, req.Limit)
+		if err != nil {
+			return "", err
+		}
+		return formatGitHubReleases(req, releases), nil
+	default:
+		return "", fmt.Errorf("unsupported kind %q", req.Kind)
+	}
+}
+
+func (t *GitHubTool) readFileOrDirectory(ctx context.Context, req githubReadRequest, recursive bool) (string, error) {
+	result, err := t.getContents(ctx, req.Owner, req.Repo, req.Path, req.Ref)
+	if err != nil {
+		return "", err
+	}
+	if result.kind == "file" {
+		return formatGitHubFile(req, result.file), nil
+	}
+	if recursive {
+		entries, err := t.collectTree(ctx, req.Owner, req.Repo, req.Path, req.Ref, req.Limit)
+		if err != nil {
+			return "", err
+		}
+		return formatGitHubTree(req, entries, true), nil
+	}
+	return formatGitHubDirectory(req, result.entries), nil
+}
+
+func (t *GitHubTool) getRepo(ctx context.Context, owner, repo string) (*githubRepo, error) {
+	var out githubRepo
+	if err := t.getJSON(ctx, fmt.Sprintf("/repos/%s/%s", escapePathSegment(owner), escapePathSegment(repo)), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (t *GitHubTool) getIssue(ctx context.Context, owner, repo string, number int) (*githubIssue, error) {
+	if number <= 0 {
+		return nil, fmt.Errorf("issue number is required")
+	}
+	var out githubIssue
+	if err := t.getJSON(ctx, fmt.Sprintf("/repos/%s/%s/issues/%d", escapePathSegment(owner), escapePathSegment(repo), number), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (t *GitHubTool) getPull(ctx context.Context, owner, repo string, number int) (*githubPullRequest, error) {
+	if number <= 0 {
+		return nil, fmt.Errorf("pull request number is required")
+	}
+	var out githubPullRequest
+	if err := t.getJSON(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d", escapePathSegment(owner), escapePathSegment(repo), number), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (t *GitHubTool) getRelease(ctx context.Context, owner, repo, tag string) (*githubRelease, error) {
+	var out githubRelease
+	endpoint := fmt.Sprintf("/repos/%s/%s/releases/latest", escapePathSegment(owner), escapePathSegment(repo))
+	if tag != "" {
+		endpoint = fmt.Sprintf("/repos/%s/%s/releases/tags/%s", escapePathSegment(owner), escapePathSegment(repo), escapePathSegment(tag))
+	}
+	if err := t.getJSON(ctx, endpoint, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (t *GitHubTool) listReleases(ctx context.Context, owner, repo string, limit int) ([]githubRelease, error) {
+	if limit <= 0 {
+		limit = githubDefaultLimit
+	}
+	if limit > githubMaxLimit {
+		limit = githubMaxLimit
+	}
+	query := url.Values{}
+	query.Set("per_page", strconv.Itoa(limit))
+	var out []githubRelease
+	if err := t.getJSON(ctx, fmt.Sprintf("/repos/%s/%s/releases", escapePathSegment(owner), escapePathSegment(repo)), query, &out); err != nil {
+		return nil, err
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+type githubContentsResult struct {
+	kind    string
+	file    *githubContentEntry
+	entries []githubContentEntry
+}
+
+func (t *GitHubTool) getContents(ctx context.Context, owner, repo, repoPath, ref string) (githubContentsResult, error) {
+	endpoint := fmt.Sprintf("/repos/%s/%s/contents", escapePathSegment(owner), escapePathSegment(repo))
+	if repoPath != "" {
+		endpoint += "/" + escapePath(repoPath)
+	}
+	query := url.Values{}
+	if ref != "" {
+		query.Set("ref", ref)
+	}
+	body, _, err := t.doRequest(ctx, http.MethodGet, endpoint, query)
+	if err != nil {
+		return githubContentsResult{}, err
+	}
+	if len(body) == 0 {
+		return githubContentsResult{}, fmt.Errorf("GitHub contents response was empty")
+	}
+	if body[0] == '[' {
+		var entries []githubContentEntry
+		if err := json.Unmarshal(body, &entries); err != nil {
+			return githubContentsResult{}, err
+		}
+		sortGitHubEntries(entries)
+		return githubContentsResult{kind: "dir", entries: entries}, nil
+	}
+
+	var entry githubContentEntry
+	if err := json.Unmarshal(body, &entry); err != nil {
+		return githubContentsResult{}, err
+	}
+	if entry.Type == "dir" {
+		return githubContentsResult{kind: "dir", entries: []githubContentEntry{entry}}, nil
+	}
+
+	text, binary, err := decodeGitHubContent(entry.Content, entry.Encoding)
+	if err != nil {
+		return githubContentsResult{}, err
+	}
+	if (text == "" || entry.Truncated) && entry.SHA != "" {
+		if blobText, blobBinary, blobErr := t.getBlobText(ctx, owner, repo, entry.SHA); blobErr == nil {
+			text = blobText
+			binary = blobBinary
+		} else if text == "" {
+			return githubContentsResult{}, blobErr
+		}
+	}
+	entry.Content = text
+	if binary {
+		entry.Content = ""
+	}
+	return githubContentsResult{kind: "file", file: &entry}, nil
+}
+
+func (t *GitHubTool) getBlobText(ctx context.Context, owner, repo, sha string) (string, bool, error) {
+	var blob githubBlob
+	if err := t.getJSON(ctx, fmt.Sprintf("/repos/%s/%s/git/blobs/%s", escapePathSegment(owner), escapePathSegment(repo), escapePathSegment(sha)), nil, &blob); err != nil {
+		return "", false, err
+	}
+	text, binary, err := decodeGitHubContent(blob.Content, blob.Encoding)
+	if err != nil {
+		return "", false, err
+	}
+	return text, binary, nil
+}
+
+func (t *GitHubTool) collectTree(ctx context.Context, owner, repo, repoPath, ref string, limit int) ([]githubContentEntry, error) {
+	result, err := t.getContents(ctx, owner, repo, repoPath, ref)
+	if err != nil {
+		return nil, err
+	}
+	if result.kind == "file" {
+		return []githubContentEntry{*result.file}, nil
+	}
+
+	var entries []githubContentEntry
+	stack := append([]githubContentEntry(nil), result.entries...)
+	for len(stack) > 0 {
+		entry := stack[0]
+		stack = stack[1:]
+		entries = append(entries, entry)
+		if limit > 0 && len(entries) >= limit {
+			break
+		}
+		if entry.Type != "dir" {
+			continue
+		}
+		nested, err := t.getContents(ctx, owner, repo, entry.Path, ref)
+		if err != nil {
+			return nil, err
+		}
+		if nested.kind != "dir" {
+			continue
+		}
+		stack = append(nested.entries, stack...)
+		sortGitHubEntries(stack)
+	}
+	if limit > 0 && len(entries) > limit {
+		entries = entries[:limit]
+	}
+	return entries, nil
+}
+
+func (t *GitHubTool) getJSON(ctx context.Context, path string, query url.Values, out any) error {
+	body, _, err := t.doRequest(ctx, http.MethodGet, path, query)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, out)
+}
+
+func decodeGitHubContent(content, encoding string) (string, bool, error) {
+	text := strings.TrimSpace(content)
+	if text == "" {
+		return "", false, nil
+	}
+	if encoding != "" && !strings.EqualFold(encoding, "base64") {
+		return text, false, nil
+	}
+	cleaned := strings.NewReplacer("\n", "", "\r", "", " ", "").Replace(text)
+	decoded, err := base64.StdEncoding.DecodeString(cleaned)
+	if err != nil {
+		return text, false, nil
+	}
+	if !utf8.Valid(decoded) {
+		return "", true, nil
+	}
+	return string(decoded), false, nil
+}
+
+func escapePathSegment(value string) string {
+	return url.PathEscape(value)
+}
+
+func escapePath(repoPath string) string {
+	parts := strings.Split(strings.Trim(repoPath, "/"), "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func sortGitHubEntries(entries []githubContentEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Path == entries[j].Path {
+			return entries[i].Type < entries[j].Type
+		}
+		return entries[i].Path < entries[j].Path
+	})
+}
+
+func formatGitHubRepo(req githubReadRequest, repo *githubRepo) string {
+	var sb strings.Builder
+	writeKV(&sb, "Repository", coalesce(repo.FullName, req.Owner+"/"+req.Repo))
+	writeKV(&sb, "Kind", "repo")
+	writeKV(&sb, "Default branch", coalesce(repo.DefaultBranch, "(unknown)"))
+	writeKV(&sb, "Visibility", visibilityLabel(repo))
+	writeKV(&sb, "Archived", boolLabel(repo.Archived, "yes", "no"))
+	writeKV(&sb, "Fork", boolLabel(repo.Fork, "yes", "no"))
+	writeKV(&sb, "Stars", strconv.Itoa(repo.Stars))
+	writeKV(&sb, "Forks", strconv.Itoa(repo.Forks))
+	writeKV(&sb, "Open issues", strconv.Itoa(repo.OpenIssues))
+	writeKV(&sb, "Language", coalesce(repo.Language, "(unknown)"))
+	writeKV(&sb, "Updated at", coalesce(repo.UpdatedAt, "(unknown)"))
+	if repo.Homepage != "" {
+		writeKV(&sb, "Homepage", repo.Homepage)
+	}
+	if repo.License != nil {
+		license := repo.License.Name
+		if repo.License.SPDXID != "" {
+			license += " (" + repo.License.SPDXID + ")"
+		}
+		writeKV(&sb, "License", license)
+	}
+	writeKV(&sb, "URL", repo.HTMLURL)
+	if repo.Description != "" {
+		writeKV(&sb, "Description", repo.Description)
+	}
+	return sb.String()
+}
+
+func formatGitHubFile(req githubReadRequest, entry *githubContentEntry) string {
+	var sb strings.Builder
+	writeKV(&sb, "Repository", req.Owner+"/"+req.Repo)
+	writeKV(&sb, "Kind", "file")
+	writeKV(&sb, "Path", coalesce(entry.Path, req.Path))
+	if req.Ref != "" {
+		writeKV(&sb, "Ref", req.Ref)
+	}
+	writeKV(&sb, "Type", coalesce(entry.Type, "file"))
+	if entry.Size > 0 {
+		writeKV(&sb, "Size", fmt.Sprintf("%d bytes", entry.Size))
+	}
+	if entry.SHA != "" {
+		writeKV(&sb, "SHA", entry.SHA)
+	}
+	if entry.HTMLURL != "" {
+		writeKV(&sb, "URL", entry.HTMLURL)
+	}
+	if entry.DownloadURL != "" {
+		writeKV(&sb, "Download URL", entry.DownloadURL)
+	}
+	if entry.Content != "" {
+		sb.WriteString("Content:\n")
+		sb.WriteString(entry.Content)
+		sb.WriteString("\n")
+	} else {
+		writeKV(&sb, "Content", "(binary or empty file)")
+	}
+	return sb.String()
+}
+
+func formatGitHubDirectory(req githubReadRequest, entries []githubContentEntry) string {
+	var sb strings.Builder
+	writeKV(&sb, "Repository", req.Owner+"/"+req.Repo)
+	writeKV(&sb, "Kind", "directory")
+	writeKV(&sb, "Path", dirLabel(req.Path))
+	if req.Ref != "" {
+		writeKV(&sb, "Ref", req.Ref)
+	}
+	writeKV(&sb, "Entries", strconv.Itoa(len(entries)))
+	for _, entry := range entries {
+		sb.WriteString("- ")
+		sb.WriteString(entry.Path)
+		sb.WriteString(" [")
+		sb.WriteString(entry.Type)
+		sb.WriteString("]")
+		if entry.Size > 0 {
+			sb.WriteString(" ")
+			sb.WriteString(fmt.Sprintf("%d bytes", entry.Size))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func formatGitHubTree(req githubReadRequest, entries []githubContentEntry, recursive bool) string {
+	var sb strings.Builder
+	writeKV(&sb, "Repository", req.Owner+"/"+req.Repo)
+	writeKV(&sb, "Kind", "tree")
+	writeKV(&sb, "Path", dirLabel(req.Path))
+	if req.Ref != "" {
+		writeKV(&sb, "Ref", req.Ref)
+	}
+	writeKV(&sb, "Recursive", boolLabel(recursive, "yes", "no"))
+	writeKV(&sb, "Entries", strconv.Itoa(len(entries)))
+	for _, entry := range entries {
+		indent := strings.Count(entry.Path, "/")
+		if indent < 0 {
+			indent = 0
+		}
+		sb.WriteString(strings.Repeat("  ", indent))
+		sb.WriteString("- ")
+		sb.WriteString(entry.Path)
+		sb.WriteString(" [")
+		sb.WriteString(entry.Type)
+		sb.WriteString("]")
+		if entry.Size > 0 {
+			sb.WriteString(" ")
+			sb.WriteString(fmt.Sprintf("%d bytes", entry.Size))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func formatGitHubIssue(req githubReadRequest, issue *githubIssue) string {
+	var sb strings.Builder
+	writeKV(&sb, "Repository", req.Owner+"/"+req.Repo)
+	writeKV(&sb, "Kind", "issue")
+	writeKV(&sb, "Number", strconv.Itoa(issue.Number))
+	writeKV(&sb, "Title", issue.Title)
+	writeKV(&sb, "State", issue.State)
+	writeKV(&sb, "Locked", boolLabel(issue.Locked, "yes", "no"))
+	writeKV(&sb, "Author", issue.User.Login)
+	writeKV(&sb, "Comments", strconv.Itoa(issue.Comments))
+	writeKV(&sb, "Created at", issue.CreatedAt)
+	writeKV(&sb, "Updated at", issue.UpdatedAt)
+	if issue.ClosedAt != "" {
+		writeKV(&sb, "Closed at", issue.ClosedAt)
+	}
+	if issue.Milestone != nil && issue.Milestone.Title != "" {
+		writeKV(&sb, "Milestone", issue.Milestone.Title)
+	}
+	if len(issue.Labels) > 0 {
+		labels := make([]string, 0, len(issue.Labels))
+		for _, label := range issue.Labels {
+			labels = append(labels, label.Name)
+		}
+		writeKV(&sb, "Labels", strings.Join(labels, ", "))
+	}
+	if len(issue.Assignees) > 0 {
+		assignees := make([]string, 0, len(issue.Assignees))
+		for _, assignee := range issue.Assignees {
+			assignees = append(assignees, assignee.Login)
+		}
+		writeKV(&sb, "Assignees", strings.Join(assignees, ", "))
+	}
+	writeKV(&sb, "URL", issue.HTMLURL)
+	if issue.Body != "" {
+		sb.WriteString("Body:\n")
+		sb.WriteString(issue.Body)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func formatGitHubPull(req githubReadRequest, pull *githubPullRequest) string {
+	var sb strings.Builder
+	writeKV(&sb, "Repository", req.Owner+"/"+req.Repo)
+	writeKV(&sb, "Kind", "pull")
+	writeKV(&sb, "Number", strconv.Itoa(pull.Number))
+	writeKV(&sb, "Title", pull.Title)
+	writeKV(&sb, "State", pull.State)
+	writeKV(&sb, "Draft", boolLabel(pull.Draft, "yes", "no"))
+	writeKV(&sb, "Locked", boolLabel(pull.Locked, "yes", "no"))
+	writeKV(&sb, "Merged", boolLabel(pull.Merged, "yes", "no"))
+	writeKV(&sb, "Author", pull.User.Login)
+	writeKV(&sb, "Base", pull.Base.Ref)
+	writeKV(&sb, "Head", pull.Head.Ref)
+	writeKV(&sb, "Commits", strconv.Itoa(pull.Commits))
+	writeKV(&sb, "Changed files", strconv.Itoa(pull.ChangedFiles))
+	writeKV(&sb, "Additions", strconv.Itoa(pull.Additions))
+	writeKV(&sb, "Deletions", strconv.Itoa(pull.Deletions))
+	writeKV(&sb, "Comments", strconv.Itoa(pull.Comments))
+	writeKV(&sb, "Review comments", strconv.Itoa(pull.ReviewComments))
+	writeKV(&sb, "Created at", pull.CreatedAt)
+	writeKV(&sb, "Updated at", pull.UpdatedAt)
+	if pull.ClosedAt != "" {
+		writeKV(&sb, "Closed at", pull.ClosedAt)
+	}
+	if pull.MergedAt != "" {
+		writeKV(&sb, "Merged at", pull.MergedAt)
+	}
+	writeKV(&sb, "URL", pull.HTMLURL)
+	if pull.Body != "" {
+		sb.WriteString("Body:\n")
+		sb.WriteString(pull.Body)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func formatGitHubRelease(req githubReadRequest, release *githubRelease) string {
+	var sb strings.Builder
+	writeKV(&sb, "Repository", req.Owner+"/"+req.Repo)
+	writeKV(&sb, "Kind", "release")
+	writeKV(&sb, "Tag", release.TagName)
+	writeKV(&sb, "Name", release.Name)
+	writeKV(&sb, "Draft", boolLabel(release.Draft, "yes", "no"))
+	writeKV(&sb, "Prerelease", boolLabel(release.Prerelease, "yes", "no"))
+	writeKV(&sb, "Author", release.Author.Login)
+	writeKV(&sb, "Published at", release.PublishedAt)
+	writeKV(&sb, "Created at", release.CreatedAt)
+	writeKV(&sb, "URL", release.HTMLURL)
+	if release.Body != "" {
+		sb.WriteString("Body:\n")
+		sb.WriteString(release.Body)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func formatGitHubReleases(req githubReadRequest, releases []githubRelease) string {
+	var sb strings.Builder
+	writeKV(&sb, "Repository", req.Owner+"/"+req.Repo)
+	writeKV(&sb, "Kind", "releases")
+	writeKV(&sb, "Limit", strconv.Itoa(req.Limit))
+	writeKV(&sb, "Entries", strconv.Itoa(len(releases)))
+	for _, release := range releases {
+		sb.WriteString("- ")
+		sb.WriteString(coalesce(release.TagName, "(untagged)"))
+		if release.Name != "" {
+			sb.WriteString(" — ")
+			sb.WriteString(release.Name)
+		}
+		sb.WriteString(" [")
+		if release.Draft {
+			sb.WriteString("draft")
+		} else if release.Prerelease {
+			sb.WriteString("prerelease")
+		} else {
+			sb.WriteString("release")
+		}
+		sb.WriteString("]")
+		if release.PublishedAt != "" {
+			sb.WriteString(" ")
+			sb.WriteString(release.PublishedAt)
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func writeKV(sb *strings.Builder, key, value string) {
+	if value == "" {
+		return
+	}
+	sb.WriteString(key)
+	sb.WriteString(": ")
+	sb.WriteString(value)
+	sb.WriteString("\n")
+}
+
+func coalesce(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func visibilityLabel(repo *githubRepo) string {
+	if repo.Private {
+		return "private"
+	}
+	if repo.Visibility != "" {
+		return repo.Visibility
+	}
+	return "public"
+}
+
+func dirLabel(path string) string {
+	if path == "" {
+		return "."
+	}
+	return path
+}
+
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 40 {
+		return string(runes[:max])
+	}
+	note := fmt.Sprintf("\n\n[Output truncated to %d characters]", max)
+	noteRunes := []rune(note)
+	if max <= len(noteRunes) {
+		return string(runes[:max])
+	}
+	cut := max - len(noteRunes)
+	return string(runes[:cut]) + note
+}

--- a/internal/tools/github_read_test.go
+++ b/internal/tools/github_read_test.go
@@ -1,0 +1,162 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseGitHubTargetSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     string
+		wantKind string
+		wantPath string
+		wantRef  string
+		wantTag  string
+		wantNum  int
+	}{
+		{
+			name:     "blob url",
+			spec:     "https://github.com/owner/repo/blob/main/path/to/file.go",
+			wantKind: "file",
+			wantPath: "path/to/file.go",
+			wantRef:  "main",
+		},
+		{
+			name:     "tree url with encoded branch",
+			spec:     "https://github.com/owner/repo/tree/feature%2Fbranch/src",
+			wantKind: "tree",
+			wantPath: "src",
+			wantRef:  "feature/branch",
+		},
+		{
+			name:     "issue url",
+			spec:     "https://github.com/owner/repo/issues/123",
+			wantKind: "issue",
+			wantNum:  123,
+		},
+		{
+			name:     "release url",
+			spec:     "https://github.com/owner/repo/releases/tag/v1.2.3",
+			wantKind: "release",
+			wantTag:  "v1.2.3",
+		},
+		{
+			name:     "plain remote",
+			spec:     "git@github.com:owner/repo.git",
+			wantKind: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, ok := parseGitHubTargetSpec(tt.spec)
+			if !ok {
+				t.Fatalf("parseGitHubTargetSpec(%q) returned false", tt.spec)
+			}
+			if target.Owner != "owner" || target.Repo != "repo" {
+				t.Fatalf("owner/repo = %q/%q, want owner/repo", target.Owner, target.Repo)
+			}
+			if target.Kind != tt.wantKind {
+				t.Fatalf("kind = %q, want %q", target.Kind, tt.wantKind)
+			}
+			if target.Path != tt.wantPath {
+				t.Fatalf("path = %q, want %q", target.Path, tt.wantPath)
+			}
+			if target.Ref != tt.wantRef {
+				t.Fatalf("ref = %q, want %q", target.Ref, tt.wantRef)
+			}
+			if target.Tag != tt.wantTag {
+				t.Fatalf("tag = %q, want %q", target.Tag, tt.wantTag)
+			}
+			if target.Number != tt.wantNum {
+				t.Fatalf("number = %d, want %d", target.Number, tt.wantNum)
+			}
+		})
+	}
+}
+
+func TestGitHubToolExecuteRepoAndFile(t *testing.T) {
+	tool := NewGitHubTool(GitHubToolConfig{Token: "test-token"})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want Bearer test-token", got)
+		}
+		switch {
+		case r.URL.Path == "/repos/owner/repo":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"full_name":       "owner/repo",
+				"description":     "repo description",
+				"default_branch":   "main",
+				"html_url":        "https://github.com/owner/repo",
+				"visibility":      "public",
+				"private":         false,
+				"archived":        false,
+				"fork":            false,
+				"stargazers_count": 12,
+				"forks_count":     3,
+				"open_issues_count": 4,
+				"language":        "Go",
+				"updated_at":      "2026-04-18T12:34:56Z",
+			})
+		case r.URL.Path == "/repos/owner/repo/contents/README.md":
+			if got := r.URL.Query().Get("ref"); got != "main" {
+				t.Fatalf("ref = %q, want main", got)
+			}
+			body := base64.StdEncoding.EncodeToString([]byte("hello from GitHub"))
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"type":         "file",
+				"name":         "README.md",
+				"path":         "README.md",
+				"sha":          "abc123",
+				"size":         17,
+				"html_url":     "https://github.com/owner/repo/blob/main/README.md",
+				"download_url": "https://raw.githubusercontent.com/owner/repo/main/README.md",
+				"content":      body,
+				"encoding":     "base64",
+				"truncated":    false,
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	tool.apiBase = server.URL
+
+	repoResult := tool.Execute(context.Background(), map[string]any{
+		"repo": "owner/repo",
+		"kind": "repo",
+	})
+	if repoResult.IsError {
+		t.Fatalf("repo result error: %s", repoResult.ForLLM)
+	}
+	if !strings.Contains(repoResult.ForLLM, "Repository: owner/repo") {
+		t.Fatalf("repo output missing repository line: %s", repoResult.ForLLM)
+	}
+	if !strings.Contains(repoResult.ForLLM, "Default branch: main") {
+		t.Fatalf("repo output missing default branch: %s", repoResult.ForLLM)
+	}
+
+	fileResult := tool.Execute(context.Background(), map[string]any{
+		"repo": "https://github.com/owner/repo/blob/main/README.md",
+	})
+	if fileResult.IsError {
+		t.Fatalf("file result error: %s", fileResult.ForLLM)
+	}
+	if !strings.Contains(fileResult.ForLLM, "<<<EXTERNAL_UNTRUSTED_CONTENT>>>") {
+		t.Fatalf("file output missing external wrapper: %s", fileResult.ForLLM)
+	}
+	if !strings.Contains(fileResult.ForLLM, "Content:\nhello from GitHub") {
+		t.Fatalf("file output missing file content: %s", fileResult.ForLLM)
+	}
+	if !strings.Contains(fileResult.ForLLM, "Path: README.md") {
+		t.Fatalf("file output missing path: %s", fileResult.ForLLM)
+	}
+}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -14,7 +14,7 @@ import (
 // Do NOT modify at runtime — each Registry gets a deep copy in NewRegistry().
 var builtinToolGroups = map[string][]string{
 	"memory":     {"memory_search", "memory_get"},
-	"web":        {"web_search", "web_fetch"},
+	"web":        {"web_search", "web_fetch", "github_read"},
 	"fs":         {"read_file", "write_file", "list_files", "edit"},
 	"runtime":    {"exec"},
 	"sessions":   {"sessions_list", "sessions_history", "sessions_send", "spawn", "session_status"},
@@ -26,6 +26,7 @@ var builtinToolGroups = map[string][]string{
 	"goclaw": {
 		"read_file", "write_file", "list_files", "edit", "exec",
 		"web_search", "web_fetch", "browser",
+		"github_read",
 		"memory_search", "memory_get", "memory_expand",
 		"knowledge_graph_search", "vault_search", "vault_read",
 		"sessions_list", "sessions_history", "sessions_send", "spawn", "session_status",

--- a/internal/tools/policy_race_test.go
+++ b/internal/tools/policy_race_test.go
@@ -156,8 +156,8 @@ func TestToolGroups_BuiltinGroups_Seeded(t *testing.T) {
 	if !ok {
 		t.Fatal("expected 'web' builtin group to exist")
 	}
-	if !containsTool(web, "web_search") || !containsTool(web, "web_fetch") {
-		t.Errorf("web group should contain web_search and web_fetch, got: %v", web)
+	if !containsTool(web, "web_search") || !containsTool(web, "web_fetch") || !containsTool(web, "github_read") {
+		t.Errorf("web group should contain web_search, web_fetch, and github_read, got: %v", web)
 	}
 }
 

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -64,6 +64,14 @@ func TestRegistry_Count(t *testing.T) {
 	}
 }
 
+func TestRegistry_GetMetadata_GitHubReadOnly(t *testing.T) {
+	reg := NewRegistry()
+	meta := reg.GetMetadata("github_read")
+	if !meta.IsReadOnly() {
+		t.Fatalf("github_read should infer read-only metadata, got %+v", meta)
+	}
+}
+
 func TestRegistry_ExecuteUnknownTool(t *testing.T) {
 	reg := NewRegistry()
 	result := reg.Execute(context.Background(), "missing", nil)


### PR DESCRIPTION
## Summary
Adds a read-only `github_read` tool so agents can inspect GitHub repositories, files, issues, pull requests, and releases through the GitHub REST API. It also wires config/env/secret plumbing, hot-reload token updates, and prompt/policy exposure so the tool is available without restarting the gateway.

## Type
<!-- Check one -->
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->
`dev`

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
Focused tests passed for the touched surfaces:

- `go test ./internal/config -run 'TestLoad_EnvVarGitHubTokenPrecedence|TestConfig_GitHubTokenSecretHandling' -count=1`
- `go test ./internal/tools -run 'TestParseGitHubTargetSpec|TestGitHubToolExecuteRepoAndFile|TestRegistry_GetMetadata_GitHubReadOnly|TestToolGroups_BuiltinGroups_Seeded' -count=1`
- `go test ./cmd -run 'TestSetupToolRegistryExecWorkspacePaths' -count=1`
- `go test ./internal/agent -run 'TestBuildSystemPrompt|TestBuildPreviewPrompt' -count=1`
