### PR TITLE
fix(tts): make ElevenLabs voice picker selectable with portaled dropdown

### DIFF
--- a/ui/web/src/components/voice-picker.tsx
+++ b/ui/web/src/components/voice-picker.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { RefreshCwIcon, ChevronDownIcon } from "lucide-react";
 import { createPortal } from "react-dom";
@@ -185,11 +185,38 @@ function DynamicVoicePicker({
     refresh();
   };
 
-  const handleBlur = (e: React.FocusEvent) => {
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-      setOpen(false);
+  useEffect(() => {
+    if (!open) {
+      return;
     }
-  };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (!target) {
+        return;
+      }
+
+      if (triggerRef.current?.contains(target) || dropdownRef.current?.contains(target)) {
+        return;
+      }
+
+      setOpen(false);
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [open]);
 
   const dropdownContent = open && (
     <div
@@ -253,7 +280,7 @@ function DynamicVoicePicker({
   );
 
   return (
-    <div ref={triggerRef} className="relative" onBlur={handleBlur}>
+    <div ref={triggerRef} className="relative">
       <button
         type="button"
         disabled={disabled}


### PR DESCRIPTION
### PR Description

## Summary
Fixes the ElevenLabs voice picker on `/tts` being effectively non-interactive when the dropdown is rendered via portal. The PR replaces fragile blur-based close behavior with robust outside-click and `Escape` handling so users can reliably select a voice.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
`dev`

## Checklist
- [ ] `go build ./...` passes
- [ ] `go build -tags sqliteonly ./...` passes (if Go changes)
- [ ] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
- Reproduced issue on `/tts` with ElevenLabs provider where voice dropdown appeared inactive/non-clickable.
- Confirmed `/v1/voices` returns populated voices list (backend data is healthy).
- Updated `ui/web/src/components/voice-picker.tsx`:
  - Removed wrapper `onBlur` close behavior.
  - Added document-level `pointerdown` listener to close only on true outside click.
  - Added `Escape` key handling to close dropdown.
  - Preserved inside click behavior for trigger/dropdown elements.
- Verified lint for changed file:
  - `cd ui/web && npm run lint -- src/components/voice-picker.tsx`
  - Result: no errors; one unrelated warning about unused eslint-disable directive.
- Manual validation:
  - Open `/tts`, select ElevenLabs provider, open voices dropdown.
  - Click a voice option and verify selection is applied (dropdown is now interactive).
  - Click outside and press `Escape` to verify close behavior still works.

#### Notes
- UI-only change; no Go/backend, DB migration, or locale string additions involved.
