### PR TITLE
feat(skills): add openrouter-cli and shot-scraper skills

### DIFF
--- a/skills/openrouter-cli/SKILL.md
+++ b/skills/openrouter-cli/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: openrouter-cli
+description: Use this skill when the user wants to interact with OpenRouter API — send chat completions, list/search models, check credits/usage, manage API keys, create embeddings, rerank documents, or generate videos. Activate when user mentions OpenRouter, model browsing, or needs multi-provider LLM access.
+---
+
+# OpenRouter CLI Skill
+
+## Overview
+
+OpenRouter CLI (`openrouter`) provides unified access to 300+ LLM models from multiple providers (OpenAI, Anthropic, Google, Meta, Mistral, etc.) via a single API.
+
+## Prerequisites
+
+```bash
+# Install
+npm install -g @mrgoonie/openrouter-cli
+
+# Authenticate
+openrouter auth set-key sk-or-v1-...
+# or via env: export OPENROUTER_API_KEY=sk-or-v1-...
+```
+
+## Core Commands
+
+### Chat Completions
+
+```bash
+# Basic chat
+openrouter chat send "What is the capital of France?" --model openai/gpt-4o
+
+# With system prompt
+openrouter chat send "Translate to Vietnamese" --model anthropic/claude-sonnet-4 --system "You are a translator"
+
+# JSON output (agent-friendly)
+openrouter chat send "Summarize this" --model openai/gpt-4o --json --no-stream
+
+# Streaming NDJSON
+openrouter chat send "Write a haiku" --model openai/gpt-4o --output ndjson
+
+# With temperature and max tokens
+openrouter chat send "Be creative" --model openai/gpt-4o --temperature 0.9 --max-tokens 500
+
+# Pipe input from file
+cat essay.txt | openrouter chat send "Proofread this" --model anthropic/claude-sonnet-4
+```
+
+### Model Discovery
+
+```bash
+# List all models
+openrouter models list
+
+# Search models
+openrouter models list --search "claude"
+openrouter models list --search "gpt-4"
+
+# Filter by provider
+openrouter models list --provider anthropic
+
+# JSON output for parsing
+openrouter models list --json
+```
+
+### Credits & Usage
+
+```bash
+# Check balance
+openrouter credits show
+
+# Usage analytics
+openrouter analytics show
+openrouter analytics show --json
+```
+
+### API Key Management
+
+```bash
+# Auth status
+openrouter auth status
+openrouter auth whoami
+
+# Manage sub-keys (requires management key)
+openrouter keys list
+openrouter keys create --name "my-agent" --limit 10
+```
+
+### Embeddings
+
+```bash
+# Create embeddings
+openrouter embeddings create "Hello world" --model openai/text-embedding-3-small
+openrouter embeddings create --file input.txt --model openai/text-embedding-3-small --json
+```
+
+### Reranking
+
+```bash
+# Rerank documents by relevance
+openrouter rerank create --query "machine learning" --documents '["doc1 content", "doc2 content"]'
+```
+
+### Video Generation
+
+```bash
+# Create video
+openrouter video create "A sunset over mountains" --model provider/model
+
+# Check status and download
+openrouter video status <job-id>
+openrouter video wait <job-id>
+openrouter video download <job-id> --output video.mp4
+```
+
+## JSON Output Format
+
+All commands support `--json` for machine-readable output:
+
+```json
+{
+  "schema_version": "1",
+  "success": true,
+  "data": { "..." },
+  "error": null,
+  "meta": { "request_id": "gen-...", "elapsed_ms": 312 }
+}
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 64 | API key not set |
+| 65 | Unauthorized (401) |
+| 68 | Insufficient credits (402) |
+| 69 | Rate limited (429) |
+| 70 | Server error (5xx) |
+
+## Configuration
+
+```bash
+# Set default model
+openrouter config set defaults.model openai/gpt-4o
+
+# Show config
+openrouter config doctor --json
+
+# Config file location
+openrouter config path
+```
+
+## Popular Models
+
+| Model | ID |
+|-------|----|
+| GPT-4o | `openai/gpt-4o` |
+| GPT-4o Mini | `openai/gpt-4o-mini` |
+| Claude Sonnet 4 | `anthropic/claude-sonnet-4` |
+| Claude Haiku 3.5 | `anthropic/claude-3.5-haiku` |
+| Gemini 2.5 Pro | `google/gemini-2.5-pro` |
+| Llama 3.3 70B | `meta-llama/llama-3.3-70b` |
+| Mistral Large | `mistralai/mistral-large` |
+| DeepSeek V3 | `deepseek/deepseek-chat` |
+
+## Tips
+
+- Always use `--json --no-stream` when calling from scripts/agents for reliable parsing
+- Use `--model` flag to specify model; set default with `openrouter config set defaults.model`
+- Pipe large inputs via stdin rather than CLI args for large texts
+- Check credits before heavy usage: `openrouter credits show`

--- a/skills/shot-scraper/SKILL.md
+++ b/skills/shot-scraper/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: shot-scraper
+description: Use this skill when the user wants to take screenshots of websites or web pages. Supports full-page capture, element selection via CSS selectors, custom viewport sizes, JavaScript execution before capture, PDF export, and multi-URL batch screenshots. Activate when user mentions screenshot, capture, webpage image, or web page snapshot.
+dependencies:
+  - pip:shot-scraper
+  - pip:playwright
+---
+
+# Shot-Scraper Skill
+
+## Overview
+
+`shot-scraper` is a CLI tool for taking automated screenshots of websites using Playwright (Chromium).
+
+## Installation
+
+```bash
+pip install shot-scraper
+shot-scraper install  # downloads Chromium browser
+```
+
+## Workflow: Screenshot → Public Download Link
+
+After taking a screenshot, always create a shareable download link:
+
+```bash
+# 1. Take screenshot — save to workspace directory
+shot-scraper https://example.com -o /app/workspace/screenshots/example-$(date +%s).png --full-page
+
+# 2. Create signed public URL via GoClaw API
+curl -s -X POST http://localhost:18790/v1/files/sign \
+  -H "Authorization: Bearer $GOCLAW_GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/app/workspace/screenshots/example-1234567890.png"}'
+# Returns: {"url": "/v1/files/app/workspace/screenshots/example-1234567890.png?ft=signed_token"}
+
+# 3. Build full public URL
+# https://<GOCLAW_SITE_URL>/v1/files/app/workspace/screenshots/example-1234567890.png?ft=signed_token
+```
+
+**IMPORTANT:** Always follow this 3-step flow:
+1. `shot-scraper` → save file to workspace
+2. Sign the file path via `/v1/files/sign` API
+3. Return the full public URL to the user so they can click to download
+
+## Basic Usage
+
+```bash
+# Screenshot a URL (default: viewport-sized PNG)
+shot-scraper https://example.com -o output.png
+
+# Full-page screenshot
+shot-scraper https://example.com -o full.png --full-page
+
+# Custom viewport size
+shot-scraper https://example.com -o mobile.png --width 375 --height 812
+
+# JPEG with quality
+shot-scraper https://example.com -o photo.jpg --quality 80
+```
+
+## Element Selection
+
+```bash
+# Capture specific element by CSS selector
+shot-scraper https://example.com -s "h1" -o header.png
+shot-scraper https://example.com -s ".main-content" -o content.png
+
+# Add padding around element
+shot-scraper https://example.com -s "h1" --padding 20 -o padded.png
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JS before screenshot (dismiss modals, scroll, click)
+shot-scraper https://example.com -o clean.png \
+  --javascript "document.querySelector('.cookie-banner')?.remove()"
+
+# Wait for content to load
+shot-scraper https://example.com -o loaded.png \
+  --javascript "await new Promise(r => setTimeout(r, 3000))"
+```
+
+## Wait Options
+
+```bash
+# Wait for specific element to appear
+shot-scraper https://example.com -o ready.png --wait-for "article.loaded"
+
+# Wait milliseconds before capture
+shot-scraper https://example.com -o delayed.png --wait 3000
+```
+
+## PDF Export
+
+```bash
+shot-scraper pdf https://example.com -o page.pdf
+shot-scraper pdf https://example.com -o page.pdf --landscape
+```
+
+## Multi-URL Batch
+
+Create a YAML file `shots.yml`:
+
+```yaml
+- url: https://example.com
+  output: example.png
+  full_page: true
+- url: https://github.com
+  output: github.png
+  width: 1200
+  height: 800
+```
+
+Then run:
+
+```bash
+shot-scraper multi shots.yml
+```
+
+## HTML to Screenshot
+
+```bash
+# Screenshot from HTML string
+echo "<h1>Hello</h1>" | shot-scraper html -o hello.png
+
+# From HTML file
+shot-scraper html -i page.html -o output.png
+```
+
+## Common Options
+
+| Flag | Description |
+|------|-------------|
+| `-o FILE` | Output file path |
+| `--full-page` | Capture entire scrollable page |
+| `-s SELECTOR` | CSS selector for specific element |
+| `--width N` | Viewport width (default: 1280) |
+| `--height N` | Viewport height (default: 720) |
+| `--quality N` | JPEG quality 0-100 |
+| `--wait N` | Wait N ms before capture |
+| `--wait-for SEL` | Wait for CSS selector to appear |
+| `--javascript JS` | Run JS before screenshot |
+| `--padding N` | Padding around selected element |
+| `--retina` | High-DPI (2x) screenshot |
+
+## Tips
+
+- Default output is PNG; use `.jpg` extension for JPEG
+- For SPAs, use `--wait` or `--javascript` to ensure content loads
+- Use `--full-page` for long pages, otherwise only viewport is captured
+- Always save to workspace dir so the file is accessible via GoClaw file API
+- Always create a signed URL and return a clickable public link to the user

--- a/skills/shot-scraper/SKILL.md
+++ b/skills/shot-scraper/SKILL.md
@@ -19,29 +19,80 @@ pip install shot-scraper
 shot-scraper install  # downloads Chromium browser
 ```
 
-## Workflow: Screenshot → Public Download Link
+## Sharing Mode
 
-After taking a screenshot, always create a shareable download link:
+After taking a screenshot, share it via one of two modes. Check environment variables to determine which mode to use:
+
+### Mode 1: GoClaw Signed URL (default)
+
+Use when `GOCLAW_GATEWAY_TOKEN` and `GOCLAW_SITE_URL` are set. No extra config needed.
 
 ```bash
-# 1. Take screenshot — save to workspace directory
-shot-scraper https://example.com -o /app/workspace/screenshots/example-$(date +%s).png --full-page
+# 1. Take screenshot — save to workspace
+FILENAME="screenshot-$(date +%s).png"
+shot-scraper https://example.com -o "$GOCLAW_WORKSPACE_DIR/screenshots/$FILENAME" --full-page
 
-# 2. Create signed public URL via GoClaw API
-curl -s -X POST http://localhost:18790/v1/files/sign \
+# 2. Sign the file path to get a public token
+SIGN_RESPONSE=$(curl -s -X POST http://localhost:${GOCLAW_PORT:-18790}/v1/files/sign \
   -H "Authorization: Bearer $GOCLAW_GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"path": "/app/workspace/screenshots/example-1234567890.png"}'
-# Returns: {"url": "/v1/files/app/workspace/screenshots/example-1234567890.png?ft=signed_token"}
+  -d "{\"path\": \"$GOCLAW_WORKSPACE_DIR/screenshots/$FILENAME\"}")
 
-# 3. Build full public URL
-# https://<GOCLAW_SITE_URL>/v1/files/app/workspace/screenshots/example-1234567890.png?ft=signed_token
+# 3. Extract URL path and build full public link
+URL_PATH=$(echo "$SIGN_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])")
+PUBLIC_URL="${GOCLAW_SITE_URL}${URL_PATH}"
+
+echo "Download: $PUBLIC_URL"
 ```
 
-**IMPORTANT:** Always follow this 3-step flow:
-1. `shot-scraper` → save file to workspace
-2. Sign the file path via `/v1/files/sign` API
-3. Return the full public URL to the user so they can click to download
+### Mode 2: S3 Upload
+
+Use when S3 environment variables are configured. Supports AWS S3, MinIO, Cloudflare R2, DigitalOcean Spaces, or any S3-compatible service.
+
+**Required env vars:**
+- `SCREENSHOT_S3_BUCKET` — bucket name
+- `SCREENSHOT_S3_REGION` — region (default: us-east-1)
+- `AWS_ACCESS_KEY_ID` — access key
+- `AWS_SECRET_ACCESS_KEY` — secret key
+- `SCREENSHOT_S3_ENDPOINT` — custom endpoint for S3-compatible services (optional)
+- `SCREENSHOT_S3_PREFIX` — key prefix (default: screenshots/)
+- `SCREENSHOT_S3_PUBLIC_URL` — base URL for public access (e.g. https://cdn.example.com)
+
+```bash
+# 1. Take screenshot
+FILENAME="screenshot-$(date +%s).png"
+shot-scraper https://example.com -o "/tmp/$FILENAME" --full-page
+
+# 2. Upload to S3
+S3_KEY="${SCREENSHOT_S3_PREFIX:-screenshots/}$FILENAME"
+
+# For AWS S3:
+aws s3 cp "/tmp/$FILENAME" "s3://${SCREENSHOT_S3_BUCKET}/${S3_KEY}" --acl public-read
+
+# For S3-compatible (MinIO, R2, DO Spaces):
+aws s3 cp "/tmp/$FILENAME" "s3://${SCREENSHOT_S3_BUCKET}/${S3_KEY}" \
+  --endpoint-url "$SCREENSHOT_S3_ENDPOINT" --acl public-read
+
+# 3. Build public URL
+if [ -n "$SCREENSHOT_S3_PUBLIC_URL" ]; then
+  PUBLIC_URL="${SCREENSHOT_S3_PUBLIC_URL}/${S3_KEY}"
+else
+  PUBLIC_URL="https://${SCREENSHOT_S3_BUCKET}.s3.${SCREENSHOT_S3_REGION:-us-east-1}.amazonaws.com/${S3_KEY}"
+fi
+
+echo "Download: $PUBLIC_URL"
+
+# 4. Clean up local file
+rm -f "/tmp/$FILENAME"
+```
+
+### Mode Selection Logic
+
+Use this decision flow:
+1. If `SCREENSHOT_S3_BUCKET` is set → use **S3 mode**
+2. Otherwise → use **GoClaw signed URL mode** (default)
+
+Always return the public URL to the user as a clickable link.
 
 ## Basic Usage
 
@@ -150,5 +201,5 @@ shot-scraper html -i page.html -o output.png
 - Default output is PNG; use `.jpg` extension for JPEG
 - For SPAs, use `--wait` or `--javascript` to ensure content loads
 - Use `--full-page` for long pages, otherwise only viewport is captured
-- Always save to workspace dir so the file is accessible via GoClaw file API
-- Always create a signed URL and return a clickable public link to the user
+- Always return a clickable public download link to the user
+- S3 mode is best for permanent links; GoClaw signed URLs expire after a set TTL


### PR DESCRIPTION
## Summary
- **openrouter-cli**: Skill for unified access to 300+ LLM models via OpenRouter API (chat, models, credits, embeddings, rerank, video)
- **shot-scraper**: Website screenshot skill with Playwright — supports full-page capture, CSS selector, JS execution, and public download link workflow via GoClaw file signing API

## Test plan
- [x] Verify skills are auto-discovered on gateway startup (`skills watcher` log)
- [x] Test `openrouter-cli` skill activation when asking about OpenRouter models
- [x] Test `shot-scraper` skill activation when requesting website screenshots
- [x] Verify signed file URL returns downloadable screenshot