### PR TITLE
fix(tools): clean up Windows exec merge leftovers + expand credentialed env

### DIFF
--- a/internal/tools/credentialed_exec.go
+++ b/internal/tools/credentialed_exec.go
@@ -496,25 +496,41 @@ func (t *ExecTool) executeCredentialedSandbox(ctx context.Context, absPath strin
 
 // buildCredentialedEnv creates a minimal environment with injected credentials.
 // Inherits PATH and HOME from parent process, adds credential env vars.
+// On Windows, also passes through SYSTEMROOT / TEMP / APPDATA / etc. — these
+// are not secrets and many native CLIs (gh, az, aws, npm) require them to run.
 func buildCredentialedEnv(envMap map[string]string) []string {
-	var pathDefault string
-	var homeDefault string
+	var env []string
 	if runtime.GOOS == "windows" {
-		pathDefault = "C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem"
-		homeDefault = os.Getenv("USERPROFILE")
+		pathDefault := "C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem"
+		homeDefault := os.Getenv("USERPROFILE")
 		if homeDefault == "" {
 			homeDefault = "C:\\Users\\Default"
 		}
+		env = []string{
+			"PATH=" + getenvDefault("PATH", pathDefault),
+			"HOME=" + getenvDefault("HOME", homeDefault),
+			"LANG=" + getenvDefault("LANG", "en_US.UTF-8"),
+			"USERNAME=" + getenvDefault("USERNAME", "goclaw"),
+		}
+		// Pass through Windows runtime vars that native tools expect.
+		// Missing SYSTEMROOT breaks networking/registry in most Win32 programs.
+		for _, k := range []string{
+			"SYSTEMROOT", "SYSTEMDRIVE", "WINDIR", "COMSPEC", "PATHEXT",
+			"TEMP", "TMP", "USERPROFILE", "APPDATA", "LOCALAPPDATA",
+			"PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMDATA",
+			"HOMEDRIVE", "HOMEPATH", "COMPUTERNAME",
+		} {
+			if v := os.Getenv(k); v != "" {
+				env = append(env, k+"="+v)
+			}
+		}
 	} else {
-		pathDefault = "/usr/local/bin:/usr/bin:/bin"
-		homeDefault = "/tmp"
-	}
-
-	env := []string{
-		"PATH=" + getenvDefault("PATH", pathDefault),
-		"HOME=" + getenvDefault("HOME", homeDefault),
-		"LANG=" + getenvDefault("LANG", "en_US.UTF-8"),
-		"USER=" + getenvDefault("USER", "goclaw"),
+		env = []string{
+			"PATH=" + getenvDefault("PATH", "/usr/local/bin:/usr/bin:/bin"),
+			"HOME=" + getenvDefault("HOME", "/tmp"),
+			"LANG=" + getenvDefault("LANG", "en_US.UTF-8"),
+			"USER=" + getenvDefault("USER", "goclaw"),
+		}
 	}
 	for k, v := range envMap {
 		env = append(env, k+"="+v)

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -361,19 +361,15 @@ func (t *ExecTool) executeOnHost(ctx context.Context, command, cwd string) *Resu
 	ctx, cancel := context.WithTimeout(ctx, t.timeout)
 	defer cancel()
 
-	//<<<<<<< HEAD
+	// Use plain exec.Command (not CommandContext) so we control the kill sequence.
+	// CommandContext would SIGKILL only the direct child, leaving forked grandchildren alive.
+	// Route through the platform shell: cmd.exe on Windows, sh on POSIX.
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd", "/c", command)
+		cmd = exec.Command("cmd", "/C", command)
 	} else {
 		cmd = exec.Command("sh", "-c", command)
 	}
-
-	//=======
-	// Use plain exec.Command (not CommandContext) so we control the kill sequence.
-	// CommandContext would SIGKILL only the direct child, leaving forked grandchildren alive.
-	//	cmd := exec.Command("sh", "-c", command)
-	//>>>>>>> dev
 	cmd.Dir = cwd
 
 	// Scrub credential env vars so fall-through exec cannot exfiltrate


### PR DESCRIPTION
Follow-up to #961. Two cleanups after that PR merged into \`dev\`.

## Summary
- \`shell.go\`: PR #961 left literal git conflict markers (\`//<<<<<<< HEAD\`, \`//=======\`, \`//>>>>>>> dev\`) as comments and an orphaned commented-out line. Cleaned up and restored the load-bearing rationale for using plain \`exec.Command\` instead of \`exec.CommandContext\` (the dev-branch design uses ctx + process-group kill to reap forked grandchildren — future readers need to know why).
- \`credentialed_exec.go\`: the Windows minimal env only set \`PATH/HOME/LANG/USER\` which is too stripped for native Windows CLIs. Added passthrough of \`SYSTEMROOT\`, \`SYSTEMDRIVE\`, \`WINDIR\`, \`COMSPEC\`, \`PATHEXT\`, \`TEMP\`, \`TMP\`, \`USERPROFILE\`, \`APPDATA\`, \`LOCALAPPDATA\`, \`PROGRAMFILES\`, \`PROGRAMFILES(X86)\`, \`PROGRAMDATA\`, \`HOMEDRIVE\`, \`HOMEPATH\`, \`COMPUTERNAME\`. Without \`SYSTEMROOT\` most Win32 networking/registry calls fail. Also switched \`USER\` → \`USERNAME\` on Windows per platform convention.

## Type
- [x] Bug fix

## Target Branch
\`dev\`

## Checklist
- [x] \`go build ./...\` passes
- [x] \`go build -tags sqliteonly ./...\` passes
- [x] \`go vet ./...\` passes
- [x] \`go test ./internal/tools/\` passes
- [x] No hardcoded secrets
- [x] No SQL changes

## Test Plan
- Existing \`internal/tools\` tests still pass.
- Windows credentialed CLI (gh, az, aws) should no longer fail with \"SYSTEMROOT missing\" / temp-file errors.
- Non-Windows behavior unchanged (same env as before: PATH, HOME, LANG, USER).