### PR TITLE
feat(discord): expose channel_id in inbound prefix

### DIFF
--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -260,7 +260,7 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 	// Build final content with group context.
 	finalContent := content
 	if peerKind == "group" {
-		annotated := fmt.Sprintf("[From: %s (<@%s>)]\n%s", senderName, senderID, content)
+		annotated := annotateGroupInboundMessage(senderName, senderID, channelID, content)
 		if c.HistoryLimit() > 0 {
 			finalContent = c.GroupHistory().BuildContext(channelID, annotated, c.HistoryLimit())
 		} else {
@@ -324,6 +324,10 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 	if peerKind == "group" {
 		c.GroupHistory().Clear(channelID)
 	}
+}
+
+func annotateGroupInboundMessage(senderName, senderID, channelID, content string) string {
+	return fmt.Sprintf("[From: %s (<@%s>) | channel_id: %s]\n%s", senderName, senderID, channelID, content)
 }
 
 // checkGroupPolicy evaluates the group policy for a sender, with pairing support.

--- a/internal/channels/discord/handler_test.go
+++ b/internal/channels/discord/handler_test.go
@@ -49,6 +49,14 @@ func TestResolveDisplayName(t *testing.T) {
 	}
 }
 
+func TestAnnotateGroupInboundMessageIncludesChannelID(t *testing.T) {
+	got := annotateGroupInboundMessage("Username", "user-1", "channel-1", "message content")
+	want := "[From: Username (<@user-1>) | channel_id: channel-1]\nmessage content"
+	if got != want {
+		t.Fatalf("annotateGroupInboundMessage() = %q, want %q", got, want)
+	}
+}
+
 // --- tryHandleCommand: routing only (no session calls) ---
 
 func TestTryHandleCommandRoutingNonCommand(t *testing.T) {


### PR DESCRIPTION
## Summary
Discord group inbound messages now include `channel_id` in the LLM-facing prefix, so agents can pass the correct Discord channel into tools like `discord_read_history` when a user asks about "this channel". DMs are unchanged.

## Type
<!-- Check one -->
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
dev

## Checklist
- [ ] `go build ./...` passes
- [ ] `go build -tags sqliteonly ./...` passes (if Go changes)
- [ ] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [ ] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
- `go test ./internal/channels/discord`