### PR TITLE
fix(security): fail-closed on pairing DB errors across all channels

### DIFF
--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -321,9 +321,9 @@ func (c *BaseChannel) CheckDMPolicy(ctx context.Context, senderID, dmPolicy stri
 		if c.pairingService != nil {
 			paired, err := c.pairingService.IsPaired(ctx, senderID, c.name)
 			if err != nil {
-				slog.Warn("security.pairing_check_failed, assuming paired (fail-open)",
+				slog.Warn("security.pairing_check_failed, denying access (fail-closed)",
 					"sender_id", senderID, "channel", c.name, "error", err)
-				return PolicyAllow
+				return PolicyDeny
 			}
 			if paired {
 				return PolicyAllow
@@ -360,9 +360,9 @@ func (c *BaseChannel) CheckGroupPolicy(ctx context.Context, senderID, chatID, gr
 		if c.pairingService != nil {
 			paired, err := c.pairingService.IsPaired(ctx, groupSenderID, c.name)
 			if err != nil {
-				slog.Warn("security.pairing_check_failed, assuming paired (fail-open)",
+				slog.Warn("security.pairing_check_failed, denying access (fail-closed)",
 					"group_sender", groupSenderID, "channel", c.name, "error", err)
-				return PolicyAllow
+				return PolicyDeny
 			}
 			if paired {
 				c.MarkGroupApproved(chatID)

--- a/internal/channels/policy_test.go
+++ b/internal/channels/policy_test.go
@@ -174,12 +174,12 @@ func TestCheckDMPolicy_PolicyPairing(t *testing.T) {
 			wantResult:       PolicyAllow,
 		},
 		{
-			name:             "Pairing service error allows message (fail-open)",
+			name:             "Pairing service error denies message (fail-closed)",
 			senderID:         "user999",
 			allowList:        []string{},
 			paired:           false,
 			failPairingCheck: true,
-			wantResult:       PolicyAllow,
+			wantResult:       PolicyDeny,
 		},
 	}
 
@@ -319,14 +319,14 @@ func TestCheckGroupPolicy_PolicyPairing(t *testing.T) {
 			wantResult:    PolicyNeedsPairing,
 		},
 		{
-			name:             "Pairing service error allows (fail-open)",
+			name:             "Pairing service error denies (fail-closed)",
 			senderID:         "user999",
 			chatID:           "chat_2",
 			allowList:        []string{},
 			groupApproved:    false,
 			paired:           false,
 			failPairingCheck: true,
-			wantResult:       PolicyAllow,
+			wantResult:       PolicyDeny,
 		},
 	}
 
@@ -553,13 +553,13 @@ func TestCheckDMPolicy_AllPolicies_TableDriven(t *testing.T) {
 			wantResult: PolicyNeedsPairing,
 		},
 		{
-			name:             "pairing policy fail-open on service error",
+			name:             "pairing policy fail-closed on service error",
 			policy:           "pairing",
 			senderID:         "user3",
 			allowList:        []string{},
 			paired:           false,
 			failPairingCheck: true,
-			wantResult:       PolicyAllow,
+			wantResult:       PolicyDeny,
 		},
 	}
 

--- a/internal/channels/telegram/handlers.go
+++ b/internal/channels/telegram/handlers.go
@@ -159,9 +159,8 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 				p1, err1 := ps.IsPaired(ctx, userID, c.Name())
 				p2, err2 := ps.IsPaired(ctx, senderID, c.Name())
 				if err1 != nil || err2 != nil {
-					slog.Warn("security.pairing_check_failed, assuming paired (fail-open)",
+					slog.Warn("security.pairing_check_failed, denying access (fail-closed)",
 						"user_id", userID, "channel", c.Name(), "err1", err1, "err2", err2)
-					paired = true
 				} else {
 					paired = p1 || p2
 				}
@@ -265,9 +264,8 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 					groupSenderID := fmt.Sprintf("group:%d", chatID)
 					paired, pairErr := c.PairingService().IsPaired(ctx, groupSenderID, c.Name())
 					if pairErr != nil {
-						slog.Warn("security.pairing_check_failed, assuming paired (fail-open)",
+						slog.Warn("security.pairing_check_failed, denying access (fail-closed)",
 							"group_sender", groupSenderID, "channel", c.Name(), "error", pairErr)
-						paired = true
 					}
 					if paired {
 						c.MarkGroupApproved(chatIDStr)
@@ -320,9 +318,8 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 					groupSenderID := fmt.Sprintf("group:%d", chatID)
 					paired, pairErr := c.PairingService().IsPaired(ctx, groupSenderID, c.Name())
 					if pairErr != nil {
-						slog.Warn("security.pairing_check_failed, assuming paired (fail-open)",
+						slog.Warn("security.pairing_check_failed, denying access (fail-closed)",
 							"group_sender", groupSenderID, "channel", c.Name(), "error", pairErr)
-						paired = true
 					}
 					if paired {
 						c.MarkGroupApproved(chatIDStr)
@@ -367,9 +364,8 @@ func (c *Channel) handleMessage(ctx context.Context, update telego.Update) {
 			groupSenderID := fmt.Sprintf("group:%d", chatID)
 			paired, err := c.PairingService().IsPaired(ctx, groupSenderID, c.Name())
 			if err != nil {
-				slog.Warn("security.pairing_check_failed, assuming paired (fail-open)",
+				slog.Warn("security.pairing_check_failed, denying access (fail-closed)",
 					"group_sender", groupSenderID, "channel", c.Name(), "error", err)
-				paired = true
 			}
 			if paired {
 				c.MarkGroupApproved(chatIDStr)


### PR DESCRIPTION
## Summary

- `CheckDMPolicy` and `CheckGroupPolicy` in `internal/channels/channel.go` returned `PolicyAllow` when `IsPaired()` returned a DB error, silently granting access to unpaired senders
- Telegram DM and group pairing checks in `internal/channels/telegram/handlers.go` set `paired = true` on DB error, with the same effect
- 3 test cases in `policy_test.go` asserted the incorrect fail-open behavior

## Root Cause

The browser pairing path in `internal/gateway/router.go` already handles this correctly with an explicit comment:
```go
// Fail-closed: deny access on DB error instead of granting operator role.
```

The channel pairing paths were inconsistent with this — using fail-open instead.

This also violates the project's stated security principle (CLAUDE.md):
> **Fail-Closed** — Allowlists block by default

## Fix

- `channel.go`: `return PolicyAllow` → `return PolicyDeny` on `IsPaired` error (2 locations)
- `telegram/handlers.go`: `paired = true` → `paired = false` (left as default) on `IsPaired` error (4 locations)
- `policy_test.go`: updated 3 test cases to assert `PolicyDeny` on pairing service error

## Test plan

- [ ] Existing unit tests in `internal/channels/` pass with updated assertions
- [ ] Verify that normal paired users are unaffected (DB errors during pairing check are rare/transient)
- [ ] Verify that unpaired senders receive pairing reply instead of access during DB outage

🤖 Generated with [Claude Code](https://claude.com/claude-code)