### PR TITLE
fix(slack,background): deliver media through placeholder path + auto-resolve background model

### DIFF
--- a/internal/channels/slack/send.go
+++ b/internal/channels/slack/send.go
@@ -41,13 +41,24 @@ func (c *Channel) Send(_ context.Context, msg bus.OutboundMessage) error {
 
 	content := msg.Content
 
-	// NO_REPLY: delete placeholder, return
+	uploadMedia := func() {
+		for _, media := range msg.Media {
+			if err := c.uploadFile(channelID, threadTS, media); err != nil {
+				slog.Warn("slack: file upload failed",
+					"file", media.URL, "error", err)
+				c.sendChunked(channelID, fmt.Sprintf("[File upload failed: %s]", media.URL), threadTS)
+			}
+		}
+	}
+
+	// NO_REPLY: delete placeholder, still deliver any media attachments
 	if content == "" {
 		if pTS, ok := c.placeholders.Load(placeholderKey); ok {
 			c.placeholders.Delete(placeholderKey)
 			ts := pTS.(string)
 			_, _, _ = c.api.DeleteMessage(channelID, ts)
 		}
+		uploadMedia()
 		return nil
 	}
 
@@ -66,6 +77,7 @@ func (c *Channel) Send(_ context.Context, msg bus.OutboundMessage) error {
 		}
 
 		if _, _, _, editErr := c.api.UpdateMessage(channelID, ts, opts...); editErr == nil {
+			uploadMedia()
 			if remaining != "" {
 				return c.sendChunked(channelID, remaining, threadTS)
 			}
@@ -76,14 +88,7 @@ func (c *Channel) Send(_ context.Context, msg bus.OutboundMessage) error {
 		}
 	}
 
-	// Handle media attachments
-	for _, media := range msg.Media {
-		if err := c.uploadFile(channelID, threadTS, media); err != nil {
-			slog.Warn("slack: file upload failed",
-				"file", media.URL, "error", err)
-			c.sendChunked(channelID, fmt.Sprintf("[File upload failed: %s]", media.URL), threadTS)
-		}
-	}
+	uploadMedia()
 
 	return c.sendChunked(channelID, content, threadTS)
 }

--- a/internal/providerresolve/background_provider.go
+++ b/internal/providerresolve/background_provider.go
@@ -3,6 +3,7 @@ package providerresolve
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
@@ -52,6 +53,15 @@ func ResolveBackgroundProvider(
 		if model == "" {
 			model = p.DefaultModel()
 		}
+		if model == "" {
+			model = firstAvailableModel(ctx, p, source, tenantID)
+		}
+		if model == "" {
+			slog.Warn("background: provider resolved but model is empty — skipping",
+				"source", source, "name", name, "tenant", tenantID,
+				"hint", "set background.model / agent.default_model in system_configs, or default_model on the provider")
+			return nil, "", false
+		}
 		slog.Debug("background: resolved provider",
 			"source", source, "name", name, "model", model, "tenant", tenantID)
 		return p, model, true
@@ -76,9 +86,45 @@ func ResolveBackgroundProvider(
 		slog.Warn("background: fallback provider failed", "tenant", tenantID, "name", names[0], "error", err)
 		return nil, ""
 	}
+	model := p.DefaultModel()
+	if model == "" {
+		model = firstAvailableModel(ctx, p, "fallback", tenantID)
+	}
+	if model == "" {
+		slog.Warn("background: fallback provider has empty default_model and no upstream models — skipping",
+			"tenant", tenantID, "provider", names[0],
+			"hint", "set background.model / agent.default_model in system_configs, or default_model on the provider")
+		return nil, ""
+	}
 	slog.Warn("background: using fallback provider (no explicit config)",
-		"tenant", tenantID, "provider", names[0], "available", names,
+		"tenant", tenantID, "provider", names[0], "model", model, "available", names,
 		"background.provider", configs["background.provider"],
 		"agent.default_provider", configs["agent.default_provider"])
-	return p, p.DefaultModel()
+	return p, model
+}
+
+// firstAvailableModel asks the provider to enumerate upstream models and
+// returns the first ID, if the provider implements ModelLister. Logs and
+// returns "" on any failure. Used as a last-resort fallback for background
+// workers when no default_model is configured.
+func firstAvailableModel(ctx context.Context, p providers.Provider, source string, tenantID uuid.UUID) string {
+	lister, ok := p.(providers.ModelLister)
+	if !ok {
+		return ""
+	}
+	lctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	models, err := lister.ListModels(lctx)
+	if err != nil {
+		slog.Warn("background: ListModels failed",
+			"source", source, "provider", p.Name(), "tenant", tenantID, "error", err)
+		return ""
+	}
+	if len(models) == 0 {
+		return ""
+	}
+	slog.Info("background: auto-picked first available model",
+		"source", source, "provider", p.Name(), "tenant", tenantID,
+		"model", models[0], "total_available", len(models))
+	return models[0]
 }

--- a/internal/providers/openai_config.go
+++ b/internal/providers/openai_config.go
@@ -1,8 +1,14 @@
 package providers
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 )
 
 // OpenAIProvider implements Provider for OpenAI-compatible APIs
@@ -21,6 +27,10 @@ type OpenAIProvider struct {
 	retryConfig  RetryConfig
 	middlewares  RequestMiddleware // composed middleware chain (nil = no-op)
 	registry     ModelRegistry    // model resolution registry (nil = skip)
+
+	modelsMu    sync.Mutex
+	modelsCache []string
+	modelsCacheAt time.Time
 }
 
 func NewOpenAIProvider(name, apiKey, apiBase, defaultModel string) *OpenAIProvider {
@@ -140,4 +150,69 @@ func (p *OpenAIProvider) resolveModel(model string) string {
 		_ = p.registry.Resolve("openai", model)
 	}
 	return model
+}
+
+// ListModels fetches available model IDs from the upstream OpenAI-compatible
+// /models endpoint. Results are cached for 5 minutes to avoid repeated calls
+// from background workers. Returns an empty slice (not an error) if the
+// upstream doesn't support /models or the API key is missing.
+func (p *OpenAIProvider) ListModels(ctx context.Context) ([]string, error) {
+	p.modelsMu.Lock()
+	if len(p.modelsCache) > 0 && time.Since(p.modelsCacheAt) < 5*time.Minute {
+		out := append([]string(nil), p.modelsCache...)
+		p.modelsMu.Unlock()
+		return out, nil
+	}
+	p.modelsMu.Unlock()
+
+	if p.apiKey == "" {
+		return nil, nil
+	}
+
+	rctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(rctx, "GET", p.apiBase+"/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	prefix := p.authPrefix
+	if prefix == "" {
+		prefix = "Bearer "
+	}
+	req.Header.Set("Authorization", prefix+p.apiKey)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("provider /models returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode /models: %w", err)
+	}
+
+	ids := make([]string, 0, len(result.Data))
+	for _, m := range result.Data {
+		if m.ID != "" {
+			ids = append(ids, m.ID)
+		}
+	}
+
+	p.modelsMu.Lock()
+	p.modelsCache = ids
+	p.modelsCacheAt = time.Now()
+	p.modelsMu.Unlock()
+
+	return ids, nil
 }

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -71,6 +71,13 @@ type ThinkingCapable interface {
 	SupportsThinking() bool
 }
 
+// ModelLister is optionally implemented by providers that can enumerate
+// available models from the upstream API. Used as a fallback when
+// DefaultModel() is empty (e.g. background workers resolving a model).
+type ModelLister interface {
+	ListModels(ctx context.Context) ([]string, error)
+}
+
 // ChatRequest contains the input for a Chat/ChatStream call.
 type ChatRequest struct {
 	Messages []Message        `json:"messages"`


### PR DESCRIPTION
## Summary
- Slack channel dropped outbound media when a placeholder (typing/thinking message) existed — `Send()` edited the placeholder with text and returned before reaching the media upload loop, so files never appeared in the channel while the tool reported `{"status":"sent"}`. Media uploads now run on every return path (empty-content, placeholder edit success, fallback).
- Episodic summarization (and other background workers) were calling upstream LLMs with an empty `model` when neither `background.model`, `agent.default_model`, nor the provider's `default_model` were set, producing litellm `400 you must provide a model parameter`. Background resolver now falls back to `ModelLister.ListModels()` and skips entries that still resolve to an empty model.
- Added `ModelLister` interface and implementation for the OpenAI-compatible provider (cached 5 min) so the fallback works against litellm/vLLM/LocalAI/etc.

## Test plan
- [ ] Send a file to a user that triggers the Slack placeholder flow — file shows up in the channel, not just `[File upload failed]`.
- [ ] Finish a session with an openai-compat provider that has no `default_model` — episodic summary is created successfully, no `Model Group=` 400s in logs.
- [ ] Existing providers with explicit `default_model` still use it (no regression).
- [ ] `go build ./...`, `go build -tags sqliteonly ./...`, `go vet ./...` clean.

## Notes for reviewers
`read_image` is intentionally **not** extended here — a generic openai-compat chain would pick a random (possibly text-only) model from `/models`. Vision should be configured explicitly via `builtin_tools.settings.read_image`; the existing "No vision provider configured" error gives the right guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)