### PR TITLE
fix(security): enforce URL validation for local provider types (SSRF)

### DIFF
--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 
@@ -238,17 +239,37 @@ func normalizeOllamaAPIBase(p *store.LLMProviderData) {
 }
 
 // localProviderTypes are provider types that legitimately run on localhost
-// (e.g. Ollama, Claude CLI). SSRF checks are skipped for these.
+// (e.g. Ollama, Claude CLI). These are restricted to localhost-only URLs
+// rather than skipping validation entirely.
 var localProviderTypes = map[string]bool{
 	store.ProviderOllama:    true,
 	store.ProviderClaudeCLI: true,
 	store.ProviderACP:       true,
 }
 
+// allowedLocalHosts are the hostnames permitted for local provider types.
+var allowedLocalHosts = []string{"localhost", "127.0.0.1", "::1", "host.docker.internal"}
+
+// allowPrivateProviderURLsFn reports whether the operator has opted in to
+// permitting private / loopback / link-local / internal-hostname provider base
+// URLs via GOCLAW_ALLOW_PRIVATE_PROVIDER_URLS. Function-valued so tests can
+// override it; production reads the env var once.
+var allowPrivateProviderURLsFn = sync.OnceValue(func() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("GOCLAW_ALLOW_PRIVATE_PROVIDER_URLS")))
+	return v == "1" || v == "true" || v == "yes"
+})
+
 // validateProviderURL rejects provider base URLs pointing to internal/private networks.
 // Defense-in-depth: prevents SSRF when providers are later used for API calls.
+//
+// Local provider types (Ollama, Claude CLI, ACP) are restricted to localhost-only
+// URLs — they must not be used as a bypass to reach arbitrary internal hosts.
+//
+// Operators running LAN-hosted OpenAI-compatible servers (vLLM, LM Studio, LocalAI,
+// Tabby, etc.) can set GOCLAW_ALLOW_PRIVATE_PROVIDER_URLS=true to opt out of the
+// private-network check. The http/https scheme check is always enforced.
 func validateProviderURL(rawURL string, providerType string) error {
-	if rawURL == "" || localProviderTypes[providerType] {
+	if rawURL == "" {
 		return nil
 	}
 	u, err := url.Parse(rawURL)
@@ -256,12 +277,28 @@ func validateProviderURL(rawURL string, providerType string) error {
 		return fmt.Errorf("invalid URL: %w", err)
 	}
 	// Only allow http/https schemes — block file://, gopher://, dict://, etc.
+	// Enforced unconditionally for all provider types.
 	switch u.Scheme {
 	case "http", "https":
 	default:
 		return fmt.Errorf("provider URL must use http or https scheme, got %q", u.Scheme)
 	}
 	host := u.Hostname()
+	// Local provider types: restrict to known-safe localhost addresses only.
+	if localProviderTypes[providerType] {
+		for _, a := range allowedLocalHosts {
+			if strings.EqualFold(host, a) {
+				return nil
+			}
+		}
+		slog.Warn("security.provider_url.local_type_denied", "host", host, "provider_type", providerType)
+		return fmt.Errorf("provider type %q only allows localhost URLs (localhost, 127.0.0.1, ::1, host.docker.internal), got host %q", providerType, host)
+	}
+	allowPrivate := allowPrivateProviderURLsFn()
+	if allowPrivate {
+		slog.Warn("security.provider_url.private_allowed", "host", host, "provider_type", providerType)
+		return nil
+	}
 	// Block obvious internal targets
 	blocked := []string{"localhost", "127.0.0.1", "::1", "0.0.0.0", "169.254.169.254", "metadata.google.internal"}
 	for _, b := range blocked {

--- a/internal/http/providers_url_validate_test.go
+++ b/internal/http/providers_url_validate_test.go
@@ -1,0 +1,144 @@
+package http
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateProviderURL_PrivateIPBlockedByDefault(t *testing.T) {
+	prev := allowPrivateProviderURLsFn
+	allowPrivateProviderURLsFn = func() bool { return false }
+	t.Cleanup(func() { allowPrivateProviderURLsFn = prev })
+
+	err := validateProviderURL("http://10.10.27.27/v1", "openai")
+	if err == nil {
+		t.Fatalf("expected error for private IP, got nil")
+	}
+	if !strings.Contains(err.Error(), "private network") {
+		t.Fatalf("expected private-network error, got %v", err)
+	}
+}
+
+func TestValidateProviderURL_PrivateIPAllowedWithOptIn(t *testing.T) {
+	prev := allowPrivateProviderURLsFn
+	allowPrivateProviderURLsFn = func() bool { return true }
+	t.Cleanup(func() { allowPrivateProviderURLsFn = prev })
+
+	if err := validateProviderURL("http://10.10.27.27/v1", "openai"); err != nil {
+		t.Fatalf("expected no error with opt-in, got %v", err)
+	}
+	if err := validateProviderURL("http://192.168.1.50:8080/v1", "openai"); err != nil {
+		t.Fatalf("expected no error with opt-in, got %v", err)
+	}
+	if err := validateProviderURL("http://localhost:8080/v1", "openai"); err != nil {
+		t.Fatalf("expected no error with opt-in for localhost, got %v", err)
+	}
+	if err := validateProviderURL("http://llm.internal/v1", "openai"); err != nil {
+		t.Fatalf("expected no error with opt-in for .internal hostname, got %v", err)
+	}
+}
+
+func TestValidateProviderURL_SchemeAlwaysEnforced(t *testing.T) {
+	prev := allowPrivateProviderURLsFn
+	allowPrivateProviderURLsFn = func() bool { return true }
+	t.Cleanup(func() { allowPrivateProviderURLsFn = prev })
+
+	err := validateProviderURL("file:///etc/passwd", "openai")
+	if err == nil {
+		t.Fatalf("expected scheme error even with opt-in, got nil")
+	}
+	if !strings.Contains(err.Error(), "scheme") {
+		t.Fatalf("expected scheme error, got %v", err)
+	}
+}
+
+func TestValidateProviderURL_PublicHostAlwaysOK(t *testing.T) {
+	prev := allowPrivateProviderURLsFn
+	allowPrivateProviderURLsFn = func() bool { return false }
+	t.Cleanup(func() { allowPrivateProviderURLsFn = prev })
+
+	if err := validateProviderURL("https://api.openai.com/v1", "openai"); err != nil {
+		t.Fatalf("expected no error for public host, got %v", err)
+	}
+}
+
+// --- H-1 SSRF fix: local provider types must enforce URL validation ---
+
+func TestValidateProviderURL_OllamaLocalhostAllowed(t *testing.T) {
+	for _, base := range []string{
+		"http://localhost:11434/v1",
+		"http://127.0.0.1:11434/v1",
+		"http://[::1]:11434/v1",
+		"http://host.docker.internal:11434/v1",
+	} {
+		if err := validateProviderURL(base, "ollama"); err != nil {
+			t.Errorf("expected ollama localhost URL %q to be allowed, got %v", base, err)
+		}
+	}
+}
+
+func TestValidateProviderURL_OllamaArbitraryHostBlocked(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"metadata_endpoint", "http://169.254.169.254/latest/meta-data/"},
+		{"private_ip", "http://10.0.0.5:11434/v1"},
+		{"attacker_controlled", "http://evil.attacker.tld:9999/v1"},
+		{"docker_internal_dns", "http://postgres:5432/v1"},
+		{"link_local", "http://169.254.1.1:8080/v1"},
+		{"internal_hostname", "http://redis.internal:6379/v1"},
+		{"gcp_metadata", "http://metadata.google.internal/computeMetadata/v1/"},
+		{"self_ssrf", "http://10.10.27.30:18790/v1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateProviderURL(tc.url, "ollama")
+			if err == nil {
+				t.Fatalf("expected error for ollama with non-localhost URL %q, got nil", tc.url)
+			}
+			if !strings.Contains(err.Error(), "only allows localhost") {
+				t.Fatalf("expected localhost-restriction error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateProviderURL_ClaudeCLIArbitraryHostBlocked(t *testing.T) {
+	err := validateProviderURL("http://169.254.169.254/", "claude_cli")
+	if err == nil {
+		t.Fatalf("expected error for claude_cli with metadata URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "only allows localhost") {
+		t.Fatalf("expected localhost-restriction error, got %v", err)
+	}
+}
+
+func TestValidateProviderURL_ACPArbitraryHostBlocked(t *testing.T) {
+	err := validateProviderURL("http://10.0.0.1:8080/v1", "acp")
+	if err == nil {
+		t.Fatalf("expected error for ACP with private IP, got nil")
+	}
+	if !strings.Contains(err.Error(), "only allows localhost") {
+		t.Fatalf("expected localhost-restriction error, got %v", err)
+	}
+}
+
+func TestValidateProviderURL_LocalTypeSchemeEnforced(t *testing.T) {
+	err := validateProviderURL("file:///etc/passwd", "ollama")
+	if err == nil {
+		t.Fatalf("expected scheme error for ollama with file:// URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "scheme") {
+		t.Fatalf("expected scheme error, got %v", err)
+	}
+}
+
+func TestValidateProviderURL_LocalTypeEmptyURLAllowed(t *testing.T) {
+	if err := validateProviderURL("", "ollama"); err != nil {
+		t.Fatalf("expected empty URL to be allowed for ollama, got %v", err)
+	}
+	if err := validateProviderURL("", "claude_cli"); err != nil {
+		t.Fatalf("expected empty URL to be allowed for claude_cli, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix SSRF via `provider_type=ollama/claude_cli/acp`** — `validateProviderURL()` previously returned `nil` unconditionally for local provider types, allowing any tenant admin to point `api_base` at arbitrary internal hosts (cloud metadata endpoints, Docker-internal DNS, localhost services)
- Local provider types now enforce `http/https` scheme **and** restrict to known-safe localhost addresses (`localhost`, `127.0.0.1`, `::1`, `host.docker.internal`)
- Added 10 test cases covering the SSRF bypass, localhost allowlist, scheme enforcement, and empty-URL handling

## Vulnerability details

**Root cause:** `providers.go:264-267` — `if rawURL == "" || localProviderTypes[providerType] { return nil }` skipped all URL validation (scheme, private-IP, internal-hostname checks) for ollama/claude_cli/acp types.

**Exploit chain:** Create provider with `provider_type=ollama` + `api_base=http://169.254.169.254` → trigger via `POST /v1/providers/{id}/verify` → upstream response body reflected in `{"error":"<BODY>"}`. Confirmed on live test deployment: internal port scan, Docker-internal DNS resolution, self-SSRF with response reflection.

**Severity:** High — requires `admin` role (per-tenant, not infra-level).

## Test plan

- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes
- [x] `go vet ./internal/http/` clean
- [x] All 10 URL validation tests pass (`go test -run TestValidateProviderURL ./internal/http/`)
- [ ] Verify existing Ollama providers with `localhost` base URLs still work after deploy
- [ ] Verify `GOCLAW_ALLOW_PRIVATE_PROVIDER_URLS=true` still permits LAN hosts for non-local provider types

🤖 Generated with [Claude Code](https://claude.com/claude-code)