### PR TITLE
feat(tools): add create_discord_thread tool

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -450,6 +450,15 @@ func runGateway() {
 			gl.SetGroupMemberLister(channelMgr.ListGroupMembers)
 		}
 	}
+	// Wire Discord thread creator + tenant checker on create_discord_thread tool
+	if t, ok := toolsReg.Get("create_discord_thread"); ok {
+		if dta, ok := t.(tools.DiscordThreadCreatorAware); ok {
+			dta.SetDiscordThreadCreator(channelMgr.CreateDiscordThread)
+		}
+		if tc, ok := t.(tools.ChannelTenantCheckerAware); ok {
+			tc.SetChannelTenantChecker(channelMgr.ChannelTenantID)
+		}
+	}
 
 	// Load channel instances from DB.
 	var instanceLoader *channels.InstanceLoader

--- a/cmd/gateway_tools_wiring.go
+++ b/cmd/gateway_tools_wiring.go
@@ -51,6 +51,8 @@ func wireExtraTools(
 	toolsReg.Register(tools.NewMessageTool(workspace, agentCfg.RestrictToWorkspace))
 	// Group members tool (list members in group chats)
 	toolsReg.Register(tools.NewListGroupMembersTool())
+	// Discord thread creation tool
+	toolsReg.Register(tools.NewCreateDiscordThreadTool())
 	slog.Info("session + message tools registered")
 
 	// Register legacy tool aliases (backward-compat names from policy.go).

--- a/docs/03-tools-system.md
+++ b/docs/03-tools-system.md
@@ -136,6 +136,7 @@ Memory layers: L1 (`memory_search`) returns ranked abstracts; L2 (`memory_expand
 | `message` | Send a message to a channel |
 | `create_forum_topic` | Create a Telegram forum topic |
 | `list_group_members` | List members in a group chat (Feishu/Lark) |
+| `create_discord_thread` | Create a Discord thread (text channel) or post (forum channel) |
 
 ### Delegation
 

--- a/internal/agent/systemprompt.go
+++ b/internal/agent/systemprompt.go
@@ -210,6 +210,7 @@ var coreToolSummaries = map[string]string{
 	"team_tasks":             "Team task board — track progress, manage dependencies (spawn auto-creates delegation tasks)",
 	"list_group_members":     "List all members of the current group chat (Feishu/Lark only)",
 	"create_forum_topic":     "Create a forum topic in a Telegram supergroup",
+	"create_discord_thread":  "Create a new thread in a Discord text channel or post in a Discord forum channel (Discord only, not available in DMs)",
 	"delegate":               "Delegate a task to a linked agent (requires agent_links). See ## Delegation Targets for available agents",
 	"memory_expand":          "Retrieve full session details from episodic memory results — use after memory_search returns episodic hits",
 	"vault_search":           "Search documents in the knowledge vault (hybrid keyword + semantic). Pass the returned doc_id to vault_read for full content",

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -638,6 +638,32 @@ type GroupMemberProvider interface {
 	ListGroupMembers(ctx context.Context, chatID string) ([]GroupMember, error)
 }
 
+// DiscordThreadParams is the input for creating a Discord thread. Defined in the
+// channels package (not channels/discord) so channels.Manager can reference it
+// without the channels→channels/discord→channels import cycle.
+type DiscordThreadParams struct {
+	ChannelID          string   // parent channel (text or forum)
+	MessageID          string   // optional; if set, create a message-rooted thread
+	Name               string   // required, 1-100 chars
+	AutoArchiveMinutes int      // 60|1440|4320|10080; 0 → default 1440
+	Private            bool     // default false (public thread)
+	InitialMessage     string   // required for forum channels; ignored for text-channel threads
+	AppliedTags        []string // forum-only
+}
+
+// DiscordThreadResult is returned after successfully creating a Discord thread.
+type DiscordThreadResult struct {
+	ThreadID        string `json:"thread_id"`
+	Name            string `json:"name"`
+	ParentChannelID string `json:"parent_channel_id"`
+	IsForum         bool   `json:"is_forum"`
+}
+
+// DiscordThreadCreator is optionally implemented by channels that can create Discord threads.
+type DiscordThreadCreator interface {
+	CreateThread(ctx context.Context, params DiscordThreadParams) (DiscordThreadResult, error)
+}
+
 // PendingCompactable is optionally implemented by channels that have a PendingHistory
 // supporting LLM-based compaction. InstanceLoader uses this to wire compaction config
 // after channel creation.

--- a/internal/channels/discord/thread.go
+++ b/internal/channels/discord/thread.go
@@ -1,0 +1,133 @@
+package discord
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+)
+
+// threadAPI abstracts the discordgo calls used by CreateThread so tests can stub them.
+// The live implementation (sessionThreadAPI) wraps c.session directly.
+type threadAPI interface {
+	stateChannel(channelID string) (*discordgo.Channel, error)
+	restChannel(ctx context.Context, channelID string) (*discordgo.Channel, error)
+	messageThreadStartComplex(ctx context.Context, channelID, messageID string, data *discordgo.ThreadStart) (*discordgo.Channel, error)
+	threadStartComplex(ctx context.Context, channelID string, data *discordgo.ThreadStart) (*discordgo.Channel, error)
+	forumThreadStartComplex(ctx context.Context, channelID string, threadData *discordgo.ThreadStart, messageData *discordgo.MessageSend) (*discordgo.Channel, error)
+}
+
+type sessionThreadAPI struct{ s *discordgo.Session }
+
+func (a sessionThreadAPI) stateChannel(channelID string) (*discordgo.Channel, error) {
+	if a.s.State == nil {
+		return nil, discordgo.ErrStateNotFound
+	}
+	return a.s.State.Channel(channelID)
+}
+
+func (a sessionThreadAPI) restChannel(ctx context.Context, channelID string) (*discordgo.Channel, error) {
+	return a.s.Channel(channelID, discordgo.WithContext(ctx))
+}
+
+func (a sessionThreadAPI) messageThreadStartComplex(ctx context.Context, channelID, messageID string, data *discordgo.ThreadStart) (*discordgo.Channel, error) {
+	return a.s.MessageThreadStartComplex(channelID, messageID, data, discordgo.WithContext(ctx))
+}
+
+func (a sessionThreadAPI) threadStartComplex(ctx context.Context, channelID string, data *discordgo.ThreadStart) (*discordgo.Channel, error) {
+	return a.s.ThreadStartComplex(channelID, data, discordgo.WithContext(ctx))
+}
+
+func (a sessionThreadAPI) forumThreadStartComplex(ctx context.Context, channelID string, threadData *discordgo.ThreadStart, messageData *discordgo.MessageSend) (*discordgo.Channel, error) {
+	return a.s.ForumThreadStartComplex(channelID, threadData, messageData, discordgo.WithContext(ctx))
+}
+
+// CreateThread creates a Discord thread. Implements channels.DiscordThreadCreator.
+//
+// Dispatch:
+//   - Parent is DM / GroupDM → rejected (Discord does not support threads in DMs).
+//   - Parent is forum channel → ForumThreadStartComplex (requires params.InitialMessage).
+//   - params.MessageID != "" → MessageThreadStartComplex (thread rooted at that message).
+//   - Otherwise → ThreadStartComplex (standalone thread). params.InitialMessage is ignored.
+func (c *Channel) CreateThread(ctx context.Context, params channels.DiscordThreadParams) (channels.DiscordThreadResult, error) {
+	return createThread(ctx, sessionThreadAPI{s: c.session}, params)
+}
+
+func createThread(ctx context.Context, api threadAPI, params channels.DiscordThreadParams) (channels.DiscordThreadResult, error) {
+	if params.ChannelID == "" {
+		return channels.DiscordThreadResult{}, errors.New("channel_id is required")
+	}
+	if params.Name == "" {
+		return channels.DiscordThreadResult{}, errors.New("name is required")
+	}
+	if l := len([]rune(params.Name)); l < 1 || l > 100 {
+		return channels.DiscordThreadResult{}, fmt.Errorf("name must be 1-100 characters (got %d)", l)
+	}
+
+	parent, err := lookupChannel(ctx, api, params.ChannelID)
+	if err != nil {
+		return channels.DiscordThreadResult{}, fmt.Errorf("lookup parent channel: %w", err)
+	}
+
+	switch parent.Type {
+	case discordgo.ChannelTypeDM, discordgo.ChannelTypeGroupDM:
+		return channels.DiscordThreadResult{}, errors.New("threads are not supported in DMs")
+	}
+
+	archive := params.AutoArchiveMinutes
+	if archive == 0 {
+		archive = 1440
+	}
+	threadType := discordgo.ChannelTypeGuildPublicThread
+	if params.Private {
+		threadType = discordgo.ChannelTypeGuildPrivateThread
+	}
+
+	ts := &discordgo.ThreadStart{
+		Name:                params.Name,
+		AutoArchiveDuration: archive,
+		Type:                threadType,
+		Invitable:           false,
+	}
+
+	var created *discordgo.Channel
+
+	switch {
+	case parent.Type == discordgo.ChannelTypeGuildForum:
+		if params.InitialMessage == "" {
+			return channels.DiscordThreadResult{}, errors.New("initial_message is required for forum channels")
+		}
+		ts.AppliedTags = params.AppliedTags
+		msg := &discordgo.MessageSend{Content: params.InitialMessage}
+		created, err = api.forumThreadStartComplex(ctx, params.ChannelID, ts, msg)
+	case params.MessageID != "":
+		created, err = api.messageThreadStartComplex(ctx, params.ChannelID, params.MessageID, ts)
+	default:
+		created, err = api.threadStartComplex(ctx, params.ChannelID, ts)
+	}
+
+	if err != nil {
+		return channels.DiscordThreadResult{}, fmt.Errorf("discord API: %w", err)
+	}
+	if created == nil {
+		return channels.DiscordThreadResult{}, errors.New("discord API returned nil channel")
+	}
+
+	return channels.DiscordThreadResult{
+		ThreadID:        created.ID,
+		Name:            created.Name,
+		ParentChannelID: params.ChannelID,
+		IsForum:         parent.Type == discordgo.ChannelTypeGuildForum,
+	}, nil
+}
+
+// lookupChannel prefers the in-memory state cache and falls back to REST on miss.
+func lookupChannel(ctx context.Context, api threadAPI, channelID string) (*discordgo.Channel, error) {
+	if ch, err := api.stateChannel(channelID); err == nil && ch != nil {
+		return ch, nil
+	}
+	return api.restChannel(ctx, channelID)
+}

--- a/internal/channels/discord/thread_test.go
+++ b/internal/channels/discord/thread_test.go
@@ -1,0 +1,260 @@
+package discord
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+)
+
+type stubAPI struct {
+	state *discordgo.Channel
+	rest  *discordgo.Channel
+
+	// per-dispatch flags
+	messageCalled bool
+	threadCalled  bool
+	forumCalled   bool
+
+	// captured params
+	gotMessageID string
+	gotTS        *discordgo.ThreadStart
+	gotMessage   *discordgo.MessageSend
+
+	// return values
+	created *discordgo.Channel
+	err     error
+}
+
+func (s *stubAPI) stateChannel(id string) (*discordgo.Channel, error) {
+	if s.state == nil {
+		return nil, discordgo.ErrStateNotFound
+	}
+	return s.state, nil
+}
+
+func (s *stubAPI) restChannel(ctx context.Context, id string) (*discordgo.Channel, error) {
+	if s.rest == nil {
+		return nil, errors.New("not found")
+	}
+	return s.rest, nil
+}
+
+func (s *stubAPI) messageThreadStartComplex(ctx context.Context, channelID, messageID string, data *discordgo.ThreadStart) (*discordgo.Channel, error) {
+	s.messageCalled = true
+	s.gotMessageID = messageID
+	s.gotTS = data
+	return s.created, s.err
+}
+
+func (s *stubAPI) threadStartComplex(ctx context.Context, channelID string, data *discordgo.ThreadStart) (*discordgo.Channel, error) {
+	s.threadCalled = true
+	s.gotTS = data
+	return s.created, s.err
+}
+
+func (s *stubAPI) forumThreadStartComplex(ctx context.Context, channelID string, threadData *discordgo.ThreadStart, messageData *discordgo.MessageSend) (*discordgo.Channel, error) {
+	s.forumCalled = true
+	s.gotTS = threadData
+	s.gotMessage = messageData
+	return s.created, s.err
+}
+
+func guildText(id string) *discordgo.Channel {
+	return &discordgo.Channel{ID: id, Type: discordgo.ChannelTypeGuildText}
+}
+
+func forumChannel(id string) *discordgo.Channel {
+	return &discordgo.Channel{ID: id, Type: discordgo.ChannelTypeGuildForum}
+}
+
+func TestCreateThread_MissingChannelID(t *testing.T) {
+	api := &stubAPI{state: guildText("c")}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{Name: "x"})
+	if err == nil || !strings.Contains(err.Error(), "channel_id") {
+		t.Fatalf("expected channel_id error, got %v", err)
+	}
+}
+
+func TestCreateThread_NameValidation(t *testing.T) {
+	api := &stubAPI{state: guildText("c"), created: &discordgo.Channel{ID: "t"}}
+	cases := []struct {
+		label string
+		name  string
+	}{
+		{"missing", ""},
+		{"too-long", strings.Repeat("a", 101)},
+	}
+	for _, tc := range cases {
+		_, err := createThread(context.Background(), api, channels.DiscordThreadParams{ChannelID: "c", Name: tc.name})
+		if err == nil {
+			t.Fatalf("%s: expected error, got nil", tc.label)
+		}
+	}
+}
+
+func TestCreateThread_DMRejected(t *testing.T) {
+	api := &stubAPI{state: &discordgo.Channel{ID: "c", Type: discordgo.ChannelTypeDM}}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{ChannelID: "c", Name: "x"})
+	if err == nil || !strings.Contains(err.Error(), "DMs") {
+		t.Fatalf("expected DM rejection, got %v", err)
+	}
+	if api.messageCalled || api.threadCalled || api.forumCalled {
+		t.Fatal("no API call should be made for DM parent")
+	}
+}
+
+func TestCreateThread_GroupDMRejected(t *testing.T) {
+	api := &stubAPI{state: &discordgo.Channel{ID: "c", Type: discordgo.ChannelTypeGroupDM}}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{ChannelID: "c", Name: "x"})
+	if err == nil || !strings.Contains(err.Error(), "DMs") {
+		t.Fatalf("expected DM rejection, got %v", err)
+	}
+}
+
+func TestCreateThread_ForumRequiresInitialMessage(t *testing.T) {
+	api := &stubAPI{state: forumChannel("c")}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{ChannelID: "c", Name: "x"})
+	if err == nil || !strings.Contains(err.Error(), "initial_message") {
+		t.Fatalf("expected initial_message error, got %v", err)
+	}
+	if api.forumCalled {
+		t.Fatal("forum dispatch should not have been called")
+	}
+}
+
+func TestCreateThread_ForumHappyPath(t *testing.T) {
+	api := &stubAPI{
+		state:   forumChannel("c"),
+		created: &discordgo.Channel{ID: "t1", Name: "post"},
+	}
+	res, err := createThread(context.Background(), api, channels.DiscordThreadParams{
+		ChannelID:      "c",
+		Name:           "post",
+		InitialMessage: "hello",
+		AppliedTags:    []string{"tag-a"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !api.forumCalled {
+		t.Fatal("expected ForumThreadStartComplex dispatch")
+	}
+	if api.gotMessage == nil || api.gotMessage.Content != "hello" {
+		t.Errorf("initial message not propagated: %+v", api.gotMessage)
+	}
+	if api.gotTS == nil || len(api.gotTS.AppliedTags) != 1 || api.gotTS.AppliedTags[0] != "tag-a" {
+		t.Errorf("applied tags not propagated: %+v", api.gotTS)
+	}
+	if !res.IsForum {
+		t.Errorf("expected IsForum=true")
+	}
+}
+
+func TestCreateThread_MessageRooted(t *testing.T) {
+	api := &stubAPI{
+		state:   guildText("c"),
+		created: &discordgo.Channel{ID: "t2", Name: "thread"},
+	}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{
+		ChannelID: "c",
+		MessageID: "m1",
+		Name:      "thread",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !api.messageCalled {
+		t.Fatal("expected MessageThreadStartComplex dispatch")
+	}
+	if api.gotMessageID != "m1" {
+		t.Errorf("message_id: got %q want %q", api.gotMessageID, "m1")
+	}
+}
+
+func TestCreateThread_StandaloneText(t *testing.T) {
+	api := &stubAPI{
+		state:   guildText("c"),
+		created: &discordgo.Channel{ID: "t3", Name: "standalone"},
+	}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{
+		ChannelID:      "c",
+		Name:           "standalone",
+		InitialMessage: "ignored for text",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !api.threadCalled {
+		t.Fatal("expected ThreadStartComplex dispatch")
+	}
+	if api.messageCalled || api.forumCalled {
+		t.Fatal("only ThreadStartComplex should be called for standalone text thread")
+	}
+}
+
+func TestCreateThread_PrivateTranslatesType(t *testing.T) {
+	api := &stubAPI{state: guildText("c"), created: &discordgo.Channel{ID: "t"}}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{
+		ChannelID: "c",
+		Name:      "x",
+		Private:   true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.gotTS.Type != discordgo.ChannelTypeGuildPrivateThread {
+		t.Errorf("expected private thread type (%d), got %d",
+			discordgo.ChannelTypeGuildPrivateThread, api.gotTS.Type)
+	}
+}
+
+func TestCreateThread_PublicDefault(t *testing.T) {
+	api := &stubAPI{state: guildText("c"), created: &discordgo.Channel{ID: "t"}}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{
+		ChannelID: "c",
+		Name:      "x",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.gotTS.Type != discordgo.ChannelTypeGuildPublicThread {
+		t.Errorf("expected public thread type, got %d", api.gotTS.Type)
+	}
+}
+
+func TestCreateThread_StateMissFallsBackToREST(t *testing.T) {
+	api := &stubAPI{
+		state:   nil, // state miss
+		rest:    guildText("c"),
+		created: &discordgo.Channel{ID: "t"},
+	}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{
+		ChannelID: "c",
+		Name:      "x",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !api.threadCalled {
+		t.Fatal("expected ThreadStartComplex dispatch after REST fallback")
+	}
+}
+
+func TestCreateThread_AutoArchiveDefault(t *testing.T) {
+	api := &stubAPI{state: guildText("c"), created: &discordgo.Channel{ID: "t"}}
+	_, err := createThread(context.Background(), api, channels.DiscordThreadParams{
+		ChannelID: "c",
+		Name:      "x",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.gotTS.AutoArchiveDuration != 1440 {
+		t.Errorf("expected default 1440 minutes, got %d", api.gotTS.AutoArchiveDuration)
+	}
+}

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -309,6 +309,21 @@ func (m *Manager) ListGroupMembers(ctx context.Context, channelName, chatID stri
 	return gmp.ListGroupMembers(ctx, chatID)
 }
 
+// CreateDiscordThread delegates to the named channel's DiscordThreadCreator if available.
+func (m *Manager) CreateDiscordThread(ctx context.Context, channelName string, params DiscordThreadParams) (DiscordThreadResult, error) {
+	m.mu.RLock()
+	ch, ok := m.channels[channelName]
+	m.mu.RUnlock()
+	if !ok {
+		return DiscordThreadResult{}, fmt.Errorf("channel %q not found", channelName)
+	}
+	dtc, ok := ch.(DiscordThreadCreator)
+	if !ok {
+		return DiscordThreadResult{}, fmt.Errorf("channel %q does not support thread creation", channelName)
+	}
+	return dtc.CreateThread(ctx, params)
+}
+
 // UnregisterChannel removes a channel from the manager.
 func (m *Manager) UnregisterChannel(name string) {
 	m.mu.Lock()

--- a/internal/channels/manager_thread_test.go
+++ b/internal/channels/manager_thread_test.go
@@ -1,0 +1,92 @@
+package channels
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+)
+
+// stubChannel is a minimal Channel implementation that optionally implements
+// DiscordThreadCreator. The want flag toggles whether the assertion succeeds.
+type stubChannel struct {
+	name   string
+	typ    string
+	create func(ctx context.Context, params DiscordThreadParams) (DiscordThreadResult, error)
+}
+
+func (s *stubChannel) Name() string                                 { return s.name }
+func (s *stubChannel) Type() string                                 { return s.typ }
+func (s *stubChannel) Start(context.Context) error                  { return nil }
+func (s *stubChannel) Stop(context.Context) error                   { return nil }
+func (s *stubChannel) Send(context.Context, bus.OutboundMessage) error { return nil }
+func (s *stubChannel) IsRunning() bool                              { return true }
+func (s *stubChannel) IsAllowed(string) bool                        { return true }
+
+// threadedStub additionally implements DiscordThreadCreator.
+type threadedStub struct {
+	stubChannel
+}
+
+func (t *threadedStub) CreateThread(ctx context.Context, p DiscordThreadParams) (DiscordThreadResult, error) {
+	return t.create(ctx, p)
+}
+
+func TestManagerCreateDiscordThread_ChannelNotFound(t *testing.T) {
+	m := NewManager(nil)
+	_, err := m.CreateDiscordThread(context.Background(), "missing", DiscordThreadParams{Name: "x"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found error, got %v", err)
+	}
+}
+
+func TestManagerCreateDiscordThread_ChannelDoesNotImplementInterface(t *testing.T) {
+	m := NewManager(nil)
+	m.RegisterChannel("feishu", &stubChannel{name: "feishu", typ: "feishu"})
+
+	_, err := m.CreateDiscordThread(context.Background(), "feishu", DiscordThreadParams{Name: "x"})
+	if err == nil || !strings.Contains(err.Error(), "does not support thread creation") {
+		t.Fatalf("expected does-not-support error, got %v", err)
+	}
+}
+
+func TestManagerCreateDiscordThread_HappyPath(t *testing.T) {
+	m := NewManager(nil)
+	var gotParams DiscordThreadParams
+	ch := &threadedStub{
+		stubChannel: stubChannel{name: "disc", typ: "discord"},
+	}
+	ch.create = func(ctx context.Context, p DiscordThreadParams) (DiscordThreadResult, error) {
+		gotParams = p
+		return DiscordThreadResult{ThreadID: "42", Name: p.Name, ParentChannelID: p.ChannelID}, nil
+	}
+	m.RegisterChannel("disc", ch)
+
+	params := DiscordThreadParams{ChannelID: "c1", Name: "discuss"}
+	res, err := m.CreateDiscordThread(context.Background(), "disc", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ThreadID != "42" || res.Name != "discuss" {
+		t.Errorf("unexpected result: %+v", res)
+	}
+	if gotParams.ChannelID != "c1" {
+		t.Errorf("params not propagated: %+v", gotParams)
+	}
+}
+
+func TestManagerCreateDiscordThread_ChannelErrorPropagates(t *testing.T) {
+	m := NewManager(nil)
+	ch := &threadedStub{stubChannel: stubChannel{name: "disc", typ: "discord"}}
+	ch.create = func(ctx context.Context, p DiscordThreadParams) (DiscordThreadResult, error) {
+		return DiscordThreadResult{}, errors.New("boom")
+	}
+	m.RegisterChannel("disc", ch)
+
+	_, err := m.CreateDiscordThread(context.Background(), "disc", DiscordThreadParams{Name: "x"})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected underlying error, got %v", err)
+	}
+}

--- a/internal/mcp/bridge_server.go
+++ b/internal/mcp/bridge_server.go
@@ -16,7 +16,8 @@ import (
 )
 
 // BridgeToolNames is the subset of GoClaw tools exposed via the MCP bridge.
-// Excluded: spawn (agent loop), create_forum_topic (channels).
+// Excluded: spawn (agent loop), create_forum_topic + create_discord_thread (channel-specific,
+// require a live channel instance and outbound bus wiring).
 var BridgeToolNames = map[string]bool{
 	// Filesystem
 	"read_file":  true,

--- a/internal/tools/discord_thread.go
+++ b/internal/tools/discord_thread.go
@@ -5,12 +5,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/google/uuid"
 
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
+
+// discordThreadAutoArchiveAllowed lists the exact auto-archive durations the
+// Discord API accepts, in minutes. Any other value is rejected by Discord
+// with a 400; validating at the tool layer surfaces a clearer error to the
+// LLM before the HTTP round-trip. See
+// https://discord.com/developers/docs/resources/channel#channel-object-channel-flags
+var discordThreadAutoArchiveAllowed = []int{60, 1440, 4320, 10080}
 
 // DiscordThreadCreatorFn creates a Discord thread on the named channel.
 // Implemented by channels.Manager.CreateDiscordThread.
@@ -101,7 +109,9 @@ func (t *CreateDiscordThreadTool) Execute(ctx context.Context, args map[string]a
 		return ErrorResult("create_discord_thread: no Discord thread creator available")
 	}
 
-	channel, _ := args["channel"].(string)
+	// argString rather than plain .(string) so a Discord snowflake ID emitted
+	// by the LLM as a JSON number doesn't silently fall back to context.
+	channel := argString(args, "channel")
 	if channel == "" {
 		channel = ToolChannelFromCtx(ctx)
 	}
@@ -109,7 +119,7 @@ func (t *CreateDiscordThreadTool) Execute(ctx context.Context, args map[string]a
 		return ErrorResult("channel is required (no current channel in context)")
 	}
 
-	channelID, _ := args["channel_id"].(string)
+	channelID := argString(args, "channel_id")
 	if channelID == "" {
 		channelID = ToolChatIDFromCtx(ctx)
 	}
@@ -117,7 +127,7 @@ func (t *CreateDiscordThreadTool) Execute(ctx context.Context, args map[string]a
 		return ErrorResult("channel_id is required (no current channel_id in context)")
 	}
 
-	name, _ := args["name"].(string)
+	name := strings.TrimSpace(argString(args, "name"))
 	if l := len([]rune(name)); l < 1 || l > 100 {
 		return ErrorResult(fmt.Sprintf("name must be 1-100 characters (got %d)", l))
 	}
@@ -154,7 +164,18 @@ func (t *CreateDiscordThreadTool) Execute(ctx context.Context, args map[string]a
 		InitialMessage: argString(args, "initial_message"),
 	}
 	if v, ok := args["auto_archive_minutes"].(float64); ok {
-		params.AutoArchiveMinutes = int(v)
+		mins := int(v)
+		valid := false
+		for _, allowed := range discordThreadAutoArchiveAllowed {
+			if mins == allowed {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return ErrorResult(fmt.Sprintf("auto_archive_minutes must be one of %v (got %d)", discordThreadAutoArchiveAllowed, mins))
+		}
+		params.AutoArchiveMinutes = mins
 	}
 	if raw, ok := args["applied_tags"].([]any); ok {
 		tags := make([]string, 0, len(raw))

--- a/internal/tools/discord_thread.go
+++ b/internal/tools/discord_thread.go
@@ -1,0 +1,177 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// DiscordThreadCreatorFn creates a Discord thread on the named channel.
+// Implemented by channels.Manager.CreateDiscordThread.
+type DiscordThreadCreatorFn func(ctx context.Context, channel string, params channels.DiscordThreadParams) (channels.DiscordThreadResult, error)
+
+// DiscordThreadCreatorAware tools can receive a DiscordThreadCreatorFn.
+type DiscordThreadCreatorAware interface {
+	SetDiscordThreadCreator(DiscordThreadCreatorFn)
+}
+
+// CreateDiscordThreadTool lets agents create a Discord thread (text or forum)
+// on a Discord channel instance they have access to.
+type CreateDiscordThreadTool struct {
+	creator       DiscordThreadCreatorFn
+	tenantChecker ChannelTenantChecker
+}
+
+// NewCreateDiscordThreadTool constructs the tool. Both the creator fn and the
+// tenant checker are wired at gateway startup via the *Aware interfaces.
+func NewCreateDiscordThreadTool() *CreateDiscordThreadTool {
+	return &CreateDiscordThreadTool{}
+}
+
+// SetDiscordThreadCreator injects the channel-manager-backed creator fn.
+func (t *CreateDiscordThreadTool) SetDiscordThreadCreator(fn DiscordThreadCreatorFn) {
+	t.creator = fn
+}
+
+// SetChannelTenantChecker injects the tenant guard function.
+func (t *CreateDiscordThreadTool) SetChannelTenantChecker(c ChannelTenantChecker) {
+	t.tenantChecker = c
+}
+
+func (t *CreateDiscordThreadTool) Name() string { return "create_discord_thread" }
+
+func (t *CreateDiscordThreadTool) RequiredChannelTypes() []string { return []string{"discord"} }
+
+func (t *CreateDiscordThreadTool) Description() string {
+	return "Create a new Discord thread in a text channel or post in a forum channel. " +
+		"Returns the new thread's ID. To post messages into the thread afterwards, call the " +
+		"`message` tool with chat_id set to the returned thread_id. Not available in DMs."
+}
+
+func (t *CreateDiscordThreadTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"channel": map[string]any{
+				"type":        "string",
+				"description": "Discord channel instance name (default: current channel from context).",
+			},
+			"channel_id": map[string]any{
+				"type":        "string",
+				"description": "Parent Discord channel ID (text or forum). Default: current channel ID from context.",
+			},
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Thread name (1-100 characters).",
+			},
+			"message_id": map[string]any{
+				"type":        "string",
+				"description": "Optional. If set, the thread is rooted at this existing message.",
+			},
+			"auto_archive_minutes": map[string]any{
+				"type":        "integer",
+				"description": "Auto-archive duration in minutes. One of 60, 1440, 4320, 10080. Default 1440.",
+			},
+			"private": map[string]any{
+				"type":        "boolean",
+				"description": "If true, create a private thread (requires bot CREATE_PRIVATE_THREADS permission). Default false.",
+			},
+			"initial_message": map[string]any{
+				"type":        "string",
+				"description": "Required for forum channels (Discord API mandate). Ignored for text-channel threads — use the message tool with chat_id=thread_id to post afterwards.",
+			},
+			"applied_tags": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "string"},
+				"description": "Forum-only. Tag IDs to apply to the new forum post.",
+			},
+		},
+		"required": []string{"name"},
+	}
+}
+
+func (t *CreateDiscordThreadTool) Execute(ctx context.Context, args map[string]any) *Result {
+	if t.creator == nil {
+		return ErrorResult("create_discord_thread: no Discord thread creator available")
+	}
+
+	channel, _ := args["channel"].(string)
+	if channel == "" {
+		channel = ToolChannelFromCtx(ctx)
+	}
+	if channel == "" {
+		return ErrorResult("channel is required (no current channel in context)")
+	}
+
+	channelID, _ := args["channel_id"].(string)
+	if channelID == "" {
+		channelID = ToolChatIDFromCtx(ctx)
+	}
+	if channelID == "" {
+		return ErrorResult("channel_id is required (no current channel_id in context)")
+	}
+
+	name, _ := args["name"].(string)
+	if l := len([]rune(name)); l < 1 || l > 100 {
+		return ErrorResult(fmt.Sprintf("name must be 1-100 characters (got %d)", l))
+	}
+
+	// Tenant gate: mirrors the check in MessageTool.validateChannelTenant.
+	if t.tenantChecker != nil {
+		chTenant, exists := t.tenantChecker(channel)
+		if !exists {
+			return ErrorResult(fmt.Sprintf("channel %q not found", channel))
+		}
+		if chTenant != uuid.Nil {
+			ctxTenant := store.TenantIDFromContext(ctx)
+			if ctxTenant != uuid.Nil && chTenant != ctxTenant {
+				slog.Warn("security.cross_tenant_thread_blocked",
+					"channel", channel, "channel_id", channelID,
+					"ctx_tenant", ctxTenant, "ch_tenant", chTenant)
+				return ErrorResult("channel not accessible from this tenant")
+			}
+		}
+	}
+
+	// DM rejection at the tool layer (peer kind from inbound context).
+	// Belt-and-braces: CreateThread also rejects DM/GroupDM parent channels.
+	if ToolPeerKindFromCtx(ctx) == "direct" {
+		return ErrorResult("threads are not supported in Discord DMs")
+	}
+
+	private, _ := args["private"].(bool)
+	params := channels.DiscordThreadParams{
+		ChannelID:      channelID,
+		Name:           name,
+		MessageID:      argString(args, "message_id"),
+		Private:        private,
+		InitialMessage: argString(args, "initial_message"),
+	}
+	if v, ok := args["auto_archive_minutes"].(float64); ok {
+		params.AutoArchiveMinutes = int(v)
+	}
+	if raw, ok := args["applied_tags"].([]any); ok {
+		tags := make([]string, 0, len(raw))
+		for _, v := range raw {
+			if s, ok := v.(string); ok && s != "" {
+				tags = append(tags, s)
+			}
+		}
+		params.AppliedTags = tags
+	}
+
+	result, err := t.creator(ctx, channel, params)
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("creating discord thread: %v", err))
+	}
+
+	data, _ := json.Marshal(result)
+	return NewResult(string(data))
+}
+

--- a/internal/tools/discord_thread_test.go
+++ b/internal/tools/discord_thread_test.go
@@ -50,9 +50,10 @@ func TestCreateDiscordThread_NameValidation(t *testing.T) {
 	tool.SetDiscordThreadCreator(f.fn)
 
 	cases := map[string]any{
-		"missing": nil,
-		"empty":   "",
-		"too-long": strings.Repeat("a", 101),
+		"missing":        nil,
+		"empty":          "",
+		"whitespace-only": "   ",
+		"too-long":       strings.Repeat("a", 101),
 	}
 	for label, name := range cases {
 		args := map[string]any{}
@@ -67,6 +68,48 @@ func TestCreateDiscordThread_NameValidation(t *testing.T) {
 			t.Fatalf("%s: creator should not be called for invalid name", label)
 		}
 	}
+}
+
+// TestCreateDiscordThread_AutoArchiveEnum covers the Discord-enum validation
+// on auto_archive_minutes — the spec allows exactly {60, 1440, 4320, 10080}
+// and any other value is rejected with a 400 at Discord. Validating locally
+// gives the LLM a clearer, cheaper error.
+func TestCreateDiscordThread_AutoArchiveEnum(t *testing.T) {
+	f := &fakeCreator{result: channels.DiscordThreadResult{ThreadID: "t1", Name: "ok"}}
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator(f.fn)
+
+	t.Run("invalid value rejected before API", func(t *testing.T) {
+		f.called = false
+		res := tool.Execute(baseCtx(), map[string]any{
+			"name":                 "ok",
+			"auto_archive_minutes": float64(120),
+		})
+		if res == nil || !res.IsError || !strings.Contains(res.ForLLM, "auto_archive_minutes") {
+			t.Fatalf("expected auto_archive_minutes rejection, got %+v", res)
+		}
+		if f.called {
+			t.Fatal("creator should not be called on invalid enum")
+		}
+	})
+
+	t.Run("each allowed value passes through", func(t *testing.T) {
+		for _, v := range []int{60, 1440, 4320, 10080} {
+			f.called = false
+			f.gotParam = channels.DiscordThreadParams{}
+			res := tool.Execute(baseCtx(), map[string]any{
+				"name":                 "ok",
+				"auto_archive_minutes": float64(v),
+			})
+			if res == nil || res.IsError {
+				t.Errorf("auto_archive=%d: expected success, got %+v", v, res)
+				continue
+			}
+			if f.gotParam.AutoArchiveMinutes != v {
+				t.Errorf("auto_archive=%d: param value = %d", v, f.gotParam.AutoArchiveMinutes)
+			}
+		}
+	})
 }
 
 func TestCreateDiscordThread_ContextFallback(t *testing.T) {

--- a/internal/tools/discord_thread_test.go
+++ b/internal/tools/discord_thread_test.go
@@ -1,0 +1,257 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+type fakeCreator struct {
+	called   bool
+	gotCh    string
+	gotParam channels.DiscordThreadParams
+	result   channels.DiscordThreadResult
+	err      error
+}
+
+func (f *fakeCreator) fn(ctx context.Context, ch string, params channels.DiscordThreadParams) (channels.DiscordThreadResult, error) {
+	f.called = true
+	f.gotCh = ch
+	f.gotParam = params
+	return f.result, f.err
+}
+
+func baseCtx() context.Context {
+	ctx := context.Background()
+	ctx = WithToolChannel(ctx, "disc")
+	ctx = WithToolChatID(ctx, "1111")
+	ctx = WithToolPeerKind(ctx, "group")
+	return ctx
+}
+
+func TestCreateDiscordThread_NoCreator(t *testing.T) {
+	tool := NewCreateDiscordThreadTool()
+	res := tool.Execute(baseCtx(), map[string]any{"name": "x"})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result when creator is unset, got %+v", res)
+	}
+}
+
+func TestCreateDiscordThread_NameValidation(t *testing.T) {
+	f := &fakeCreator{}
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator(f.fn)
+
+	cases := map[string]any{
+		"missing": nil,
+		"empty":   "",
+		"too-long": strings.Repeat("a", 101),
+	}
+	for label, name := range cases {
+		args := map[string]any{}
+		if name != nil {
+			args["name"] = name
+		}
+		res := tool.Execute(baseCtx(), args)
+		if res == nil || !res.IsError {
+			t.Fatalf("%s: expected error result, got %+v", label, res)
+		}
+		if f.called {
+			t.Fatalf("%s: creator should not be called for invalid name", label)
+		}
+	}
+}
+
+func TestCreateDiscordThread_ContextFallback(t *testing.T) {
+	f := &fakeCreator{result: channels.DiscordThreadResult{ThreadID: "t1", Name: "hello", ParentChannelID: "1111"}}
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator(f.fn)
+
+	res := tool.Execute(baseCtx(), map[string]any{"name": "hello"})
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %+v", res)
+	}
+	if !f.called {
+		t.Fatal("creator not called")
+	}
+	if f.gotCh != "disc" {
+		t.Errorf("channel: got %q want %q", f.gotCh, "disc")
+	}
+	if f.gotParam.ChannelID != "1111" {
+		t.Errorf("channel_id fallback: got %q want %q", f.gotParam.ChannelID, "1111")
+	}
+}
+
+func TestCreateDiscordThread_DMRejected(t *testing.T) {
+	f := &fakeCreator{}
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator(f.fn)
+
+	ctx := baseCtx()
+	ctx = WithToolPeerKind(ctx, "direct")
+
+	res := tool.Execute(ctx, map[string]any{"name": "hello"})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result for DM, got %+v", res)
+	}
+	if !strings.Contains(res.ForLLM, "DM") {
+		t.Errorf("expected DM-specific error, got %q", res.ForLLM)
+	}
+	if f.called {
+		t.Fatal("creator should not be called in DM")
+	}
+}
+
+// TestCreateDiscordThread_TenantMismatch is the critical regression test for the
+// cross-tenant thread creation gate.
+func TestCreateDiscordThread_TenantMismatch(t *testing.T) {
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+
+	f := &fakeCreator{}
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator(f.fn)
+	tool.SetChannelTenantChecker(func(ch string) (uuid.UUID, bool) {
+		if ch == "disc-b" {
+			return tenantB, true
+		}
+		return uuid.Nil, false
+	})
+
+	ctx := baseCtx()
+	ctx = WithToolChannel(ctx, "disc-b")
+	ctx = store.WithTenantID(ctx, tenantA)
+
+	res := tool.Execute(ctx, map[string]any{"name": "hello"})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected tenant-mismatch error, got %+v", res)
+	}
+	if f.called {
+		t.Fatal("creator must NOT be called on tenant mismatch")
+	}
+	if !strings.Contains(res.ForLLM, "tenant") {
+		t.Errorf("expected tenant-specific error, got %q", res.ForLLM)
+	}
+}
+
+func TestCreateDiscordThread_TenantMatch(t *testing.T) {
+	tenantA := uuid.New()
+
+	f := &fakeCreator{result: channels.DiscordThreadResult{ThreadID: "t1", Name: "ok", ParentChannelID: "1111"}}
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator(f.fn)
+	tool.SetChannelTenantChecker(func(ch string) (uuid.UUID, bool) {
+		return tenantA, true
+	})
+
+	ctx := baseCtx()
+	ctx = store.WithTenantID(ctx, tenantA)
+
+	res := tool.Execute(ctx, map[string]any{"name": "ok"})
+	if res == nil || res.IsError {
+		t.Fatalf("expected success on tenant match, got %+v", res)
+	}
+	if !f.called {
+		t.Fatal("creator should have been called")
+	}
+}
+
+func TestCreateDiscordThread_LegacyChannelBypassesTenantCheck(t *testing.T) {
+	tenantA := uuid.New()
+
+	f := &fakeCreator{result: channels.DiscordThreadResult{ThreadID: "t1", Name: "ok", ParentChannelID: "1111"}}
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator(f.fn)
+	tool.SetChannelTenantChecker(func(ch string) (uuid.UUID, bool) {
+		return uuid.Nil, true // legacy/config-based channel — no tenant
+	})
+
+	ctx := baseCtx()
+	ctx = store.WithTenantID(ctx, tenantA)
+
+	res := tool.Execute(ctx, map[string]any{"name": "ok"})
+	if res == nil || res.IsError {
+		t.Fatalf("expected success for legacy channel, got %+v", res)
+	}
+	if !f.called {
+		t.Fatal("creator should have been called for legacy channel")
+	}
+}
+
+func TestCreateDiscordThread_ChannelNotFound(t *testing.T) {
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator((&fakeCreator{}).fn)
+	tool.SetChannelTenantChecker(func(ch string) (uuid.UUID, bool) {
+		return uuid.Nil, false
+	})
+
+	ctx := baseCtx()
+	res := tool.Execute(ctx, map[string]any{"name": "ok"})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error for unknown channel, got %+v", res)
+	}
+	if !strings.Contains(res.ForLLM, "not found") {
+		t.Errorf("expected not-found error, got %q", res.ForLLM)
+	}
+}
+
+func TestCreateDiscordThread_HappyPathJSON(t *testing.T) {
+	f := &fakeCreator{result: channels.DiscordThreadResult{
+		ThreadID:        "99",
+		Name:            "discuss",
+		ParentChannelID: "1111",
+		IsForum:         true,
+	}}
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator(f.fn)
+
+	args := map[string]any{
+		"name":                 "discuss",
+		"auto_archive_minutes": float64(4320),
+		"private":              true,
+		"initial_message":      "kickoff",
+		"applied_tags":         []any{"tag-a", "tag-b"},
+		"message_id":           "m1",
+	}
+	res := tool.Execute(baseCtx(), args)
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %+v", res)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.ForLLM), &out); err != nil {
+		t.Fatalf("json unmarshal: %v; payload=%s", err, res.ForLLM)
+	}
+	if out["thread_id"] != "99" || out["name"] != "discuss" || out["is_forum"] != true || out["parent_channel_id"] != "1111" {
+		t.Errorf("unexpected result fields: %+v", out)
+	}
+
+	// Parameters propagated.
+	if f.gotParam.AutoArchiveMinutes != 4320 || !f.gotParam.Private || f.gotParam.InitialMessage != "kickoff" || f.gotParam.MessageID != "m1" {
+		t.Errorf("params not propagated: %+v", f.gotParam)
+	}
+	if len(f.gotParam.AppliedTags) != 2 || f.gotParam.AppliedTags[0] != "tag-a" || f.gotParam.AppliedTags[1] != "tag-b" {
+		t.Errorf("applied_tags not propagated: %+v", f.gotParam.AppliedTags)
+	}
+}
+
+func TestCreateDiscordThread_CreatorError(t *testing.T) {
+	f := &fakeCreator{err: errors.New("discord 403")}
+	tool := NewCreateDiscordThreadTool()
+	tool.SetDiscordThreadCreator(f.fn)
+
+	res := tool.Execute(baseCtx(), map[string]any{"name": "ok"})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result, got %+v", res)
+	}
+	if !strings.Contains(res.ForLLM, "discord 403") {
+		t.Errorf("expected underlying error surfaced, got %q", res.ForLLM)
+	}
+}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -20,7 +20,7 @@ var builtinToolGroups = map[string][]string{
 	"sessions":   {"sessions_list", "sessions_history", "sessions_send", "spawn", "session_status"},
 	"ui":         {"browser"},
 	"automation": {"cron"},
-	"messaging":  {"message", "create_forum_topic", "list_group_members"},
+	"messaging":  {"message", "create_forum_topic", "list_group_members", "create_discord_thread"},
 	"team":       {"team_tasks"},
 	// Composite group: all goclaw native tools (excludes MCP/custom plugins).
 	"goclaw": {
@@ -31,7 +31,7 @@ var builtinToolGroups = map[string][]string{
 		"sessions_list", "sessions_history", "sessions_send", "spawn", "session_status",
 		"delegate",
 		"cron", "datetime", "heartbeat",
-		"message", "create_forum_topic", "list_group_members",
+		"message", "create_forum_topic", "list_group_members", "create_discord_thread",
 		"read_image", "read_document", "read_audio", "read_video",
 		"create_image", "create_video", "create_audio",
 		"skill_search", "skill_manage", "publish_skill", "use_skill",


### PR DESCRIPTION
## Summary

Adds a new agent tool `create_discord_thread` that creates Discord threads (text channel threads, message-rooted threads, or forum posts) via a clean channels.Manager dispatch layer. Mirrors the tenant-gating pattern used by the message tool. Ships with the full tool + channel impl + wiring + tests.

## Review (added commit `182efd2d`)

Pre-landing review surfaced three small robustness issues on the input path, now fixed:

1. **Snowflake numeric IDs.** `channel` and `channel_id` now use `argString` (same numeric-coercion helper used by `message_id`) so a Discord ID emitted by the LLM as a JSON number doesn't silently fall back to the invoking context.
2. **Whitespace-only name.** `name` is trimmed before the 1-100-character length check. Previously `"   "` (rune length 3) passed the local check and was rejected only by Discord with a generic 400.
3. **auto_archive_minutes enum validation.** Validated against Discord's allowed set `{60, 1440, 4320, 10080}` at the tool layer so the LLM gets an actionable error instead of a Discord 400.

Tests added: whitespace-only name case; auto-archive enum (invalid value rejected pre-API, and each of the four allowed values pass-through).

## Test plan

- [x] `go build ./...` + `go build -tags sqliteonly ./...` + `go vet ./...`
- [x] `go test ./internal/channels/discord/... ./internal/tools/` — discord-thread tests green (unrelated pre-existing shell-abort flake in `internal/tools/shell_abort_test.go` not touched by this PR)
- [ ] Manual: invoke the tool in a text channel, forum channel, and DM (should be rejected) — confirm the dispatch produces the right thread kind in each case

🤖 Generated with [Claude Code](https://claude.com/claude-code)