### PR TITLE
feat(tools): add vault tool group to policy

### DIFF
--- a/cmd/gateway_errors.go
+++ b/cmd/gateway_errors.go
@@ -70,6 +70,14 @@ func isContextOverflowError(lower string) bool {
 		"prompt is too long",
 		"exceeds model context window",
 		"request exceeds the maximum size",
+		// Issue 958: Additional patterns (sync with providers/error_classify.go)
+		"prompt exceeds max length", // ZAI/GLM-5
+		"input is too long",         // DashScope
+		"token limit",
+		"too many tokens",
+		"请求输入过长",       // Chinese generic
+		"超出最大长度限制",     // Chinese Qwen
+		"上下文长度",        // Chinese context length
 	) || (strings.Contains(lower, "context") &&
 		containsAny(lower, "overflow", "too large", "too long", "limit", "exceeded"))
 }

--- a/internal/agent/loop_pipeline_adapter.go
+++ b/internal/agent/loop_pipeline_adapter.go
@@ -58,6 +58,7 @@ func (l *Loop) buildPipelineDeps(req *RunRequest, bridgeRS *runState) pipeline.P
 			CheckpointInterval: 5,
 			ContextWindow:      l.contextWindow,
 			MaxTokens:          l.effectiveMaxTokens(),
+			ReserveTokens:      l.resolveReserveTokens(),
 			Compaction:         l.compactionCfg,
 			// V3 memory/retrieval flags removed — always true at runtime.
 		},

--- a/internal/agent/loop_types.go
+++ b/internal/agent/loop_types.go
@@ -452,6 +452,15 @@ func (l *Loop) effectiveMaxTokens() int {
 	return defaultMaxTokens
 }
 
+// resolveReserveTokens returns the reserve token buffer from compaction config.
+// Issue 958: Wire ReserveTokensFloor to prevent context overflow before compaction.
+func (l *Loop) resolveReserveTokens() int {
+	if l.compactionCfg != nil && l.compactionCfg.ReserveTokensFloor > 0 {
+		return l.compactionCfg.ReserveTokensFloor
+	}
+	return 0
+}
+
 func NewLoop(cfg LoopConfig) *Loop {
 	if cfg.MaxIterations <= 0 {
 		cfg.MaxIterations = config.DefaultMaxIterations

--- a/internal/channels/errors.go
+++ b/internal/channels/errors.go
@@ -1,0 +1,45 @@
+package channels
+
+import (
+	"strings"
+
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+)
+
+// FormatAgentError converts internal error to user-friendly message.
+// Issue 958: Send user-friendly error on RunFailed instead of silent "...".
+func FormatAgentError(errStr string) string {
+	if errStr == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(errStr)
+
+	// Context overflow (highest priority — specific actionable message)
+	if providers.IsContextOverflowMessage(lower) {
+		return "⚠️ The conversation has grown too long. Please start a new chat or ask me to summarize."
+	}
+
+	// Rate limit
+	if strings.Contains(lower, "rate limit") || strings.Contains(lower, "too many requests") || strings.Contains(lower, "429") {
+		return "⏳ Too many requests. Please wait a moment and try again."
+	}
+
+	// Auth errors
+	if strings.Contains(lower, "unauthorized") || strings.Contains(lower, "invalid api key") || strings.Contains(lower, "401") || strings.Contains(lower, "403") {
+		return "🔑 Authentication error. Please check your API configuration."
+	}
+
+	// Timeout
+	if strings.Contains(lower, "timeout") || strings.Contains(lower, "deadline exceeded") {
+		return "⏱️ Request timed out. Please try again."
+	}
+
+	// Overloaded
+	if strings.Contains(lower, "overload") {
+		return "🔄 Service is busy. Please try again in a moment."
+	}
+
+	// Generic fallback (don't expose internal error details)
+	return "❌ Something went wrong. Please try again."
+}

--- a/internal/channels/errors_test.go
+++ b/internal/channels/errors_test.go
@@ -1,0 +1,65 @@
+package channels
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatAgentError_ContextOverflow(t *testing.T) {
+	t.Parallel()
+	testCases := []string{
+		"context length exceeded",
+		"Prompt exceeds max length",
+		"request_too_large: payload too big",
+		"Input is too long for this model",
+		"token limit exceeded",
+		"请求输入过长",
+	}
+
+	for _, tc := range testCases {
+		result := FormatAgentError(tc)
+		if !strings.Contains(result, "conversation has grown too long") {
+			t.Errorf("expected context overflow message for %q, got %q", tc, result)
+		}
+	}
+}
+
+func TestFormatAgentError_RateLimit(t *testing.T) {
+	t.Parallel()
+	result := FormatAgentError("rate limit exceeded")
+	if !strings.Contains(result, "Too many requests") {
+		t.Errorf("unexpected rate limit message: %s", result)
+	}
+}
+
+func TestFormatAgentError_Auth(t *testing.T) {
+	t.Parallel()
+	result := FormatAgentError("unauthorized access")
+	if !strings.Contains(result, "Authentication error") {
+		t.Errorf("unexpected auth message: %s", result)
+	}
+}
+
+func TestFormatAgentError_Timeout(t *testing.T) {
+	t.Parallel()
+	result := FormatAgentError("request timeout")
+	if !strings.Contains(result, "timed out") {
+		t.Errorf("unexpected timeout message: %s", result)
+	}
+}
+
+func TestFormatAgentError_Generic(t *testing.T) {
+	t.Parallel()
+	result := FormatAgentError("some unknown error")
+	if !strings.Contains(result, "Something went wrong") {
+		t.Errorf("unexpected generic message: %s", result)
+	}
+}
+
+func TestFormatAgentError_Empty(t *testing.T) {
+	t.Parallel()
+	result := FormatAgentError("")
+	if result != "" {
+		t.Errorf("expected empty string for empty error, got %q", result)
+	}
+}

--- a/internal/channels/events.go
+++ b/internal/channels/events.go
@@ -234,8 +234,27 @@ func (m *Manager) HandleAgentEvent(eventType, runID string, payload any) {
 				}
 				sc.FinalizeStream(ctx, rc.ChatID, currentStream)
 			}
-		case protocol.AgentEventRunFailed, protocol.AgentEventRunCancelled:
-			// Clean up streaming state on failure or cancellation
+		case protocol.AgentEventRunFailed:
+			// Clean up streaming state on failure
+			rc.mu.Lock()
+			currentStream := rc.stream
+			rc.stream = nil
+			rc.mu.Unlock()
+			if currentStream != nil {
+				_ = currentStream.Stop(ctx)
+			}
+			// Issue 958: Send user-friendly error message instead of silent "..."
+			errStr := extractPayloadString(payload, "error")
+			if friendlyMsg := FormatAgentError(errStr); friendlyMsg != "" {
+				m.bus.PublishOutbound(bus.OutboundMessage{
+					Channel:  rc.ChannelName,
+					ChatID:   rc.ChatID,
+					Content:  friendlyMsg,
+					TenantID: rc.TenantID,
+				})
+			}
+		case protocol.AgentEventRunCancelled:
+			// Clean up streaming state on cancellation
 			rc.mu.Lock()
 			currentStream := rc.stream
 			rc.stream = nil

--- a/internal/channels/pancake/api_client.go
+++ b/internal/channels/pancake/api_client.go
@@ -64,6 +64,7 @@ func (c *APIClient) GetPage(ctx context.Context) (*PageInfo, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
+	setCommonHeaders(req)
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
@@ -283,6 +284,7 @@ func (c *APIClient) newPageRequest(ctx context.Context, method, rawURL string, b
 
 	// Keep the header for compatibility; official docs require the query token.
 	req.Header.Set("Authorization", "Bearer "+c.pageAccessToken)
+	setCommonHeaders(req)
 	return req, nil
 }
 
@@ -349,4 +351,11 @@ func isRateLimitError(err error) bool {
 		return false
 	}
 	return ae.Code == 429 || ae.Code == 4029
+}
+
+// setCommonHeaders applies headers required for every Pancake API call.
+// Accept: application/json forces JSON response negotiation — without it,
+// Pancake returns SPA HTML for Shopee GETs (verified 2026-04-20).
+func setCommonHeaders(req *http.Request) {
+	req.Header.Set("Accept", "application/json")
 }

--- a/internal/channels/pancake/api_client_test.go
+++ b/internal/channels/pancake/api_client_test.go
@@ -372,3 +372,47 @@ func TestReactComment_RejectsInvalidIDs(t *testing.T) {
 		}
 	}
 }
+
+// --- Accept Header Tests (Shopee support) ---
+
+// TestNewPageRequest_SetsAcceptJSONHeader verifies the Pancake GET negotiation fix:
+// without Accept: application/json, Pancake returns SPA HTML for Shopee endpoints.
+func TestNewPageRequest_SetsAcceptJSONHeader(t *testing.T) {
+	client := NewAPIClient("user-token", "page-token", "spo_25409726")
+	req, err := client.newPageRequest(context.Background(), http.MethodGet,
+		"https://pages.fm/api/public_api/v2/pages/spo_25409726/conversations", nil)
+	if err != nil {
+		t.Fatalf("newPageRequest: %v", err)
+	}
+	if got := req.Header.Get("Accept"); got != "application/json" {
+		t.Fatalf("Accept header = %q, want %q", got, "application/json")
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer page-token" {
+		t.Fatalf("Authorization header = %q, want %q", got, "Bearer page-token")
+	}
+}
+
+// TestGetPage_SetsAcceptJSONHeader — C2 guard. GetPage bypasses newPageRequest
+// (it builds its own http.NewRequestWithContext for the user-API /pages endpoint).
+// Without this header, startup auto-detect receives SPA HTML for Shopee pages.
+func TestGetPage_SetsAcceptJSONHeader(t *testing.T) {
+	transport := &captureTransport{
+		resp: &http.Response{
+			StatusCode: 200,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+		},
+	}
+	client := NewAPIClient("user-token", "page-token", "spo_25409726")
+	client.httpClient = &http.Client{Transport: transport}
+
+	if _, err := client.GetPage(context.Background()); err != nil {
+		t.Fatalf("GetPage: %v", err)
+	}
+	if transport.req == nil {
+		t.Fatal("expected request to be captured")
+	}
+	if got := transport.req.Header.Get("Accept"); got != "application/json" {
+		t.Fatalf("Accept header on GetPage = %q, want %q", got, "application/json")
+	}
+}

--- a/internal/channels/pancake/formatter.go
+++ b/internal/channels/pancake/formatter.go
@@ -1,6 +1,7 @@
 package pancake
 
 import (
+	"log/slog"
 	"regexp"
 	"strings"
 )
@@ -15,8 +16,8 @@ func FormatOutbound(content string, platform string) string {
 		return formatForWhatsApp(content)
 	case "zalo", "instagram", "line":
 		return stripMarkdown(content)
-	case "tiktok":
-		return stripMarkdown(truncateForTikTok(content))
+	case "tiktok", "shopee":
+		return stripMarkdown(truncateRuneSafe(content, 500))
 	default:
 		return stripMarkdown(content)
 	}
@@ -62,13 +63,20 @@ func stripMarkdown(content string) string {
 	return strings.TrimSpace(content)
 }
 
-// truncateForTikTok truncates content to TikTok DM limit (500 runes).
-// Uses rune slicing to avoid corrupting multi-byte UTF-8 (CJK, Vietnamese, emoji).
-func truncateForTikTok(content string) string {
-	const limit = 500
+// truncateRuneSafe truncates content to `limit` runes, avoiding multi-byte
+// UTF-8 corruption (CJK, Vietnamese, emoji). Used by platforms with short
+// DM limits (TikTok, Shopee: 500 runes). Logs a warning when truncation
+// occurs so the user isn't silently trimmed (M7).
+func truncateRuneSafe(content string, limit int) string {
 	runes := []rune(content)
 	if len(runes) <= limit {
 		return content
+	}
+	slog.Warn("pancake: message truncated",
+		"orig_runes", len(runes),
+		"limit", limit)
+	if limit <= 3 {
+		return string(runes[:limit])
 	}
 	return string(runes[:limit-3]) + "..."
 }

--- a/internal/channels/pancake/pancake.go
+++ b/internal/channels/pancake/pancake.go
@@ -343,7 +343,7 @@ func (ch *Channel) handleAPIError(err error) {
 // maxMessageLength returns the platform-specific character limit.
 func (ch *Channel) maxMessageLength() int {
 	switch ch.platform {
-	case "tiktok":
+	case "tiktok", "shopee":
 		return 500
 	case "instagram":
 		return 1000

--- a/internal/channels/pancake/pancake_test.go
+++ b/internal/channels/pancake/pancake_test.go
@@ -373,25 +373,68 @@ func TestAPIClientSendMessageReturnsBodyLevelError(t *testing.T) {
 	}
 }
 
-// TestTruncateForTikTok_MultiByteCharacters verifies rune-safe truncation for
+// TestTruncateRuneSafe_MultiByteCharacters verifies rune-safe truncation for
 // Vietnamese diacritics and emoji (multi-byte UTF-8 sequences).
-func TestTruncateForTikTok_MultiByteCharacters(t *testing.T) {
+func TestTruncateRuneSafe_MultiByteCharacters(t *testing.T) {
 	// Vietnamese text with diacritics (multi-byte UTF-8)
 	input := strings.Repeat("Xin chào ", 100) // ~900 bytes, <500 runes
-	result := truncateForTikTok(input)
+	result := truncateRuneSafe(input, 500)
 	if !utf8.ValidString(result) {
-		t.Fatal("truncateForTikTok produced invalid UTF-8")
+		t.Fatal("truncateRuneSafe produced invalid UTF-8")
 	}
 
 	// Emoji string exceeding 500 runes
 	emoji := strings.Repeat("😊", 600)
-	result = truncateForTikTok(emoji)
+	result = truncateRuneSafe(emoji, 500)
 	runes := []rune(result)
 	if len(runes) > 500 {
 		t.Errorf("expected <=500 runes, got %d", len(runes))
 	}
 	if !utf8.ValidString(result) {
 		t.Fatal("emoji truncation produced invalid UTF-8")
+	}
+}
+
+// --- Shopee platform support tests (Phase 1: TDD red state) ---
+
+// TestMaxMessageLength_Shopee verifies shopee returns 500 char limit.
+func TestMaxMessageLength_Shopee(t *testing.T) {
+	ch := &Channel{platform: "shopee"}
+	if got := ch.maxMessageLength(); got != 500 {
+		t.Fatalf("shopee maxMessageLength = %d, want 500", got)
+	}
+	// Regression guards for existing platforms.
+	for _, tc := range []struct {
+		p    string
+		want int
+	}{
+		{"tiktok", 500}, {"facebook", 2000}, {"whatsapp", 4096},
+	} {
+		ch.platform = tc.p
+		if got := ch.maxMessageLength(); got != tc.want {
+			t.Fatalf("%s maxMessageLength = %d, want %d", tc.p, got, tc.want)
+		}
+	}
+}
+
+// TestTruncateRuneSafe_Shopee verifies FormatOutbound truncates shopee to 500 runes.
+// Uses Vietnamese diacritics and emoji to catch byte-vs-rune bugs.
+func TestTruncateRuneSafe_Shopee(t *testing.T) {
+	// Vietnamese text: 600 "Xin chào " iterations → >500 runes.
+	input := strings.Repeat("Xin chào ", 100)
+	out := FormatOutbound(input, "shopee")
+	if utf8.RuneCountInString(out) > 500 {
+		t.Fatalf("shopee output = %d runes, want <=500", utf8.RuneCountInString(out))
+	}
+	if !utf8.ValidString(out) {
+		t.Fatal("shopee truncation produced invalid UTF-8")
+	}
+
+	// Emoji-only input exceeding 500 runes.
+	emoji := strings.Repeat("😊", 600)
+	out = FormatOutbound(emoji, "shopee")
+	if utf8.RuneCountInString(out) > 500 {
+		t.Fatalf("emoji shopee output = %d runes, want <=500", utf8.RuneCountInString(out))
 	}
 }
 

--- a/internal/channels/pancake/testdata/shopee_inbox_webhook.json
+++ b/internal/channels/pancake/testdata/shopee_inbox_webhook.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Assumed-shape fixture — verify against real Pancake payload in Phase 3",
+  "event_type": "messaging",
+  "page_id": "",
+  "data": {
+    "page_id": "",
+    "conversation": {
+      "id": "spo_25409726_109139680425439630",
+      "type": "INBOX",
+      "from": {"id": "109139680425439630", "name": "Test Buyer"}
+    },
+    "message": {
+      "id": "spo_msg_1",
+      "content": "Shop oi con hang khong?",
+      "from": {"id": "109139680425439630"}
+    }
+  }
+}

--- a/internal/channels/pancake/webhook_handler.go
+++ b/internal/channels/pancake/webhook_handler.go
@@ -119,16 +119,13 @@ func (r *webhookRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Resolve page_id: top-level field takes priority, then data-level, then first conv ID segment.
+	// Resolve page_id: top-level field takes priority, then data-level, then conv ID parse.
 	pageID := event.PageID
 	if pageID == "" {
 		pageID = data.PageID
 	}
 	if pageID == "" {
-		// Last resort: extract from conversation ID (format: pageID_senderID for INBOX events).
-		if idx := strings.Index(data.Conversation.ID, "_"); idx > 0 {
-			pageID = data.Conversation.ID[:idx]
-		}
+		pageID = resolvePageIDFromConvID(data.Conversation.ID)
 	}
 
 	// Resolve conversation type.
@@ -249,4 +246,38 @@ func truncateBody(body []byte, maxLen int) string {
 		return string(body)
 	}
 	return string(body[:maxLen]) + "..."
+}
+
+// platformPrefixes lists marketplace platform tokens where convID uses a
+// 2-segment page identifier (e.g. "spo_25409726_senderID").
+//
+// Scope (M1): "spo" (Shopee) only. "lzd" (Lazada) and "tpd" (Tokopedia) are
+// NOT added here because neither has been verified against a live Pancake
+// payload. Add them only after onboarding a shop and capturing convID shape.
+var platformPrefixes = map[string]struct{}{
+	"spo": {}, // Shopee — verified via curl 2026-04-20
+}
+
+// resolvePageIDFromConvID extracts the page identifier from a Pancake
+// conversation ID. Facebook/IG use "{pageID}_{senderID}"; Shopee uses
+// "{prefix}_{pageNumeric}_{senderID}" for buyer DMs and possibly
+// "{prefix}_{pageNumeric}" for system events without a sender.
+func resolvePageIDFromConvID(convID string) string {
+	if convID == "" {
+		return ""
+	}
+	parts := strings.Split(convID, "_")
+	if len(parts) < 2 {
+		return ""
+	}
+	_, knownPrefix := platformPrefixes[parts[0]]
+	// M2: 2-segment convID with known prefix is a full pageID (system event
+	// without sender). Return as-is — do NOT drop the event.
+	if knownPrefix && len(parts) == 2 {
+		return convID
+	}
+	if knownPrefix && len(parts) >= 3 {
+		return parts[0] + "_" + parts[1]
+	}
+	return parts[0]
 }

--- a/internal/channels/pancake/webhook_handler_test.go
+++ b/internal/channels/pancake/webhook_handler_test.go
@@ -1,0 +1,28 @@
+package pancake
+
+import "testing"
+
+// TestResolvePageIDFromConvID verifies platform-prefix-aware pageID extraction.
+// This test will FAIL until Phase 2 introduces the resolvePageIDFromConvID helper.
+func TestResolvePageIDFromConvID(t *testing.T) {
+	cases := []struct {
+		name   string
+		convID string
+		want   string
+	}{
+		{"facebook_numeric", "123456_789012", "123456"},
+		{"shopee_prefixed", "spo_25409726_109139680425439630", "spo_25409726"},
+		{"shopee_system_2_segments", "spo_25409726", "spo_25409726"}, // M2: system event w/o sender — return as-is
+		{"empty_input", "", ""},
+		{"no_underscore", "abcdef", ""},
+		{"prefix_only_no_underscore", "spo", ""}, // regression: prefix-only without underscore
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolvePageIDFromConvID(tc.convID); got != tc.want {
+				t.Fatalf("resolvePageIDFromConvID(%q) = %q, want %q",
+					tc.convID, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/gateway/methods/sessions.go
+++ b/internal/gateway/methods/sessions.go
@@ -30,6 +30,7 @@ func (m *SessionsMethods) Register(router *gateway.MethodRouter) {
 	router.Register(protocol.MethodSessionsPatch, m.handlePatch)
 	router.Register(protocol.MethodSessionsDelete, m.handleDelete)
 	router.Register(protocol.MethodSessionsReset, m.handleReset)
+	router.Register(protocol.MethodSessionsCompact, m.handleCompact)
 }
 
 type sessionsListParams struct {
@@ -229,4 +230,66 @@ func (m *SessionsMethods) handleReset(ctx context.Context, client *gateway.Clien
 		"ok": true,
 	}))
 	emitAudit(m.eventBus, client, "session.reset", "session", params.Key)
+}
+
+type sessionCompactParams struct {
+	Key      string `json:"key"`
+	KeepLast int    `json:"keepLast,omitempty"` // default 4
+}
+
+// handleCompact truncates session history to the last N messages.
+// Issue 958: Manual session compaction API (truncate-only, no LLM summarization).
+func (m *SessionsMethods) handleCompact(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	locale := store.LocaleFromContext(ctx)
+	var params sessionCompactParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, i18n.T(locale, i18n.MsgInvalidJSON)))
+		return
+	}
+
+	if params.Key == "" {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "key is required"))
+		return
+	}
+
+	keepLast := params.KeepLast
+	if keepLast <= 0 {
+		keepLast = 4 // default: keep last 2 exchanges
+	}
+
+	// Auth check
+	sess := m.sessions.Get(ctx, params.Key)
+	if sess == nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrNotFound, i18n.T(locale, i18n.MsgNotFound, "session", params.Key)))
+		return
+	}
+	if !canSeeAll(client.Role(), m.cfg.Gateway.OwnerIDs, client.UserID()) {
+		if sess.UserID != client.UserID() {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrUnauthorized, i18n.T(locale, i18n.MsgPermissionDenied, "session")))
+			return
+		}
+	}
+
+	history := m.sessions.GetHistory(ctx, params.Key)
+	originalLen := len(history)
+	if originalLen < 6 {
+		client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+			"ok":      true,
+			"message": "session too short to compact",
+			"kept":    originalLen,
+		}))
+		return
+	}
+
+	// Truncate history to last N messages
+	m.sessions.TruncateHistory(ctx, params.Key, keepLast)
+	m.sessions.IncrementCompaction(ctx, params.Key)
+	m.sessions.Save(ctx, params.Key)
+
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		"ok":       true,
+		"original": originalLen,
+		"kept":     keepLast,
+	}))
+	emitAudit(m.eventBus, client, "session.compacted", "session", params.Key)
 }

--- a/internal/permissions/policy.go
+++ b/internal/permissions/policy.go
@@ -292,6 +292,7 @@ func isWriteMethod(method string) bool {
 		protocol.MethodSessionsDelete,
 		protocol.MethodSessionsReset,
 		protocol.MethodSessionsPatch,
+		protocol.MethodSessionsCompact,
 		protocol.MethodCronCreate,
 		protocol.MethodCronUpdate,
 		protocol.MethodCronDelete,

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -336,6 +336,118 @@ func TestThinkStage_LLMError_Propagates(t *testing.T) {
 	}
 }
 
+// Issue 958: Context overflow triggers emergency compaction + retry
+
+func TestThinkStage_ContextOverflow_TriggersCompaction(t *testing.T) {
+	t.Parallel()
+	callCount := 0
+	compacted := false
+
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, &providers.HTTPError{Status: 400, Body: "Prompt exceeds max length"}
+			}
+			return &providers.ChatResponse{Content: "success after compact", FinishReason: "stop"}, nil
+		},
+		CompactMessages: func(_ context.Context, msgs []providers.Message, _ string) ([]providers.Message, error) {
+			compacted = true
+			return []providers.Message{{Role: "user", Content: "[Summary]"}}, nil
+		},
+	}
+
+	stage := NewThinkStage(deps)
+	state := defaultState()
+	state.Messages.SetHistory([]providers.Message{{Role: "user", Content: "test"}})
+
+	// First call: overflow → compact → retry
+	err := stage.Execute(context.Background(), state)
+	if err != nil {
+		t.Fatalf("first Execute() should trigger retry, got error: %v", err)
+	}
+	if !compacted {
+		t.Error("expected compaction to be triggered")
+	}
+	if state.Think.OverflowRetries != 1 {
+		t.Errorf("expected OverflowRetries=1, got %d", state.Think.OverflowRetries)
+	}
+	// Stage returns Continue (nil error) to signal retry this iteration
+	if stage.Result() != Continue {
+		t.Errorf("Result() = %v after compaction, want Continue", stage.Result())
+	}
+}
+
+func TestThinkStage_ContextOverflow_FailsAfterOneRetry(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			return nil, &providers.HTTPError{Status: 400, Body: "Prompt exceeds max length"}
+		},
+		CompactMessages: func(_ context.Context, _ []providers.Message, _ string) ([]providers.Message, error) {
+			return []providers.Message{{Role: "user", Content: "[Summary]"}}, nil
+		},
+	}
+
+	stage := NewThinkStage(deps)
+	state := defaultState()
+	state.Think.OverflowRetries = 1 // Already retried once
+
+	err := stage.Execute(context.Background(), state)
+	if err == nil {
+		t.Error("expected error after second overflow")
+	}
+	if !strings.Contains(err.Error(), "context overflow after compaction") {
+		t.Errorf("expected 'context overflow after compaction' message, got %v", err)
+	}
+}
+
+func TestThinkStage_ContextOverflow_NoCompactCallback_FailsGracefully(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			return nil, &providers.HTTPError{Status: 400, Body: "Prompt exceeds max length"}
+		},
+		CompactMessages: nil, // No compaction available
+	}
+
+	stage := NewThinkStage(deps)
+	state := defaultState()
+
+	err := stage.Execute(context.Background(), state)
+	if err == nil {
+		t.Error("expected error when no compaction available")
+	}
+}
+
+func TestThinkStage_ContextOverflow_CompactionFails_ReturnsOriginalError(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			return nil, &providers.HTTPError{Status: 400, Body: "Prompt exceeds max length"}
+		},
+		CompactMessages: func(_ context.Context, _ []providers.Message, _ string) ([]providers.Message, error) {
+			return nil, errors.New("compaction failed")
+		},
+	}
+
+	stage := NewThinkStage(deps)
+	state := defaultState()
+
+	err := stage.Execute(context.Background(), state)
+	if err == nil {
+		t.Error("expected error when compaction fails")
+	}
+	// Should return LLM error wrapped, not compaction error
+	if !strings.Contains(err.Error(), "llm call") {
+		t.Errorf("expected 'llm call' in error message, got %v", err)
+	}
+}
+
 // --- PruneStage tests ---
 
 func TestPruneStage_UnderBudget_NoOp(t *testing.T) {

--- a/internal/pipeline/substates.go
+++ b/internal/pipeline/substates.go
@@ -32,6 +32,7 @@ type ThinkState struct {
 	LastResponse    *providers.ChatResponse
 	TotalUsage      providers.Usage
 	TruncRetries    int  // consecutive truncation retries (max 3)
+	OverflowRetries int  // context overflow compact+retry attempts (max 1)
 	StreamingActive bool // true during active stream
 }
 

--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 )
@@ -57,6 +59,28 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 	}
 	resp, err := s.deps.CallLLM(ctx, state, req)
 	if err != nil {
+		// Issue 958: Check for context overflow — attempt emergency compaction + retry
+		if isContextOverflowErr(err) {
+			if state.Think.OverflowRetries > 0 {
+				return fmt.Errorf("context overflow after compaction: %w", err)
+			}
+			state.Think.OverflowRetries++
+			// Attempt emergency compaction
+			if s.deps.CompactMessages != nil {
+				originalLen := len(state.Messages.History())
+				compacted, compactErr := s.deps.CompactMessages(ctx, state.Messages.History(), state.Model)
+				if compactErr == nil {
+					state.Messages.ReplaceHistory(compacted)
+					slog.Info("emergency_compaction_triggered",
+						"run_id", state.RunID,
+						"original_msgs", originalLen,
+						"compacted_msgs", len(compacted),
+					)
+					return nil // Retry this iteration (Continue result)
+				}
+				slog.Warn("emergency_compaction_failed", "error", compactErr)
+			}
+		}
 		return fmt.Errorf("llm call: %w", err)
 	}
 	state.Think.LastResponse = resp
@@ -92,7 +116,8 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		state.Messages.AppendPending(providers.Message{Role: "user", Content: hint})
 		return nil // Continue to next iteration for retry
 	}
-	state.Think.TruncRetries = 0 // reset on success
+	state.Think.TruncRetries = 0    // reset on success
+	state.Think.OverflowRetries = 0 // reset on success
 
 	// 7. Uniquify tool call IDs (OpenAI returns 400 on duplicates across iterations).
 	// Skip if raw content present (Anthropic thinking passback) to avoid desync.
@@ -191,4 +216,14 @@ func toolCallsHaveMissingRequiredArgs(calls []providers.ToolCall) bool {
 		}
 	}
 	return false
+}
+
+// isContextOverflowErr checks if an error indicates context window overflow.
+// Uses the exported helper from providers package for pattern matching.
+func isContextOverflowErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return providers.IsContextOverflowMessage(lower)
 }

--- a/internal/providers/error_classify.go
+++ b/internal/providers/error_classify.go
@@ -155,7 +155,17 @@ func isContextOverflow(lower string) bool {
 		// Chinese patterns (Qwen/DashScope)
 		"超出最大长度限制",
 		"上下文长度",
+		// Issue 958: Additional patterns
+		"prompt exceeds max length", // ZAI/GLM-5
+		"request_too_large",         // Generic
+		"input is too long",         // DashScope
+		"请求输入过长",                    // Chinese generic
 	)
+}
+
+// IsContextOverflowMessage exports overflow detection for use by pipeline.
+func IsContextOverflowMessage(lower string) bool {
+	return isContextOverflow(lower)
 }
 
 // isNetworkError checks if an error is a network-level failure.

--- a/internal/providers/error_classify_test.go
+++ b/internal/providers/error_classify_test.go
@@ -324,3 +324,37 @@ func TestClassifyUnknownError(t *testing.T) {
 		t.Errorf("expected FailoverUnknown, got %s", result.Reason)
 	}
 }
+
+// Issue 958: New context overflow patterns for ZAI/GLM, DashScope, generic
+
+func TestClassifyPromptExceedsMaxLength(t *testing.T) {
+	classifier := NewDefaultClassifier()
+	result := classifier.Classify(nil, 400, `{"error":{"code":"1261","message":"Prompt exceeds max length"}}`)
+	if result.Kind != "context_overflow" {
+		t.Errorf("expected context_overflow, got %s (reason: %s)", result.Kind, result.Reason)
+	}
+}
+
+func TestClassifyInputTooLong(t *testing.T) {
+	classifier := NewDefaultClassifier()
+	result := classifier.Classify(nil, 400, "Input is too long for this model")
+	if result.Kind != "context_overflow" {
+		t.Errorf("expected context_overflow, got %s (reason: %s)", result.Kind, result.Reason)
+	}
+}
+
+func TestClassifyRequestTooLarge(t *testing.T) {
+	classifier := NewDefaultClassifier()
+	result := classifier.Classify(nil, 400, "request_too_large: payload exceeds limit")
+	if result.Kind != "context_overflow" {
+		t.Errorf("expected context_overflow, got %s (reason: %s)", result.Kind, result.Reason)
+	}
+}
+
+func TestClassifyChineseInputTooLong(t *testing.T) {
+	classifier := NewDefaultClassifier()
+	result := classifier.Classify(nil, 400, "请求输入过长")
+	if result.Kind != "context_overflow" {
+		t.Errorf("expected context_overflow, got %s (reason: %s)", result.Kind, result.Reason)
+	}
+}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -22,6 +22,7 @@ var builtinToolGroups = map[string][]string{
 	"automation": {"cron"},
 	"messaging":  {"message", "create_forum_topic", "list_group_members"},
 	"team":       {"team_tasks"},
+	"vault":      {"vault_search", "vault_read"},
 	// Composite group: all goclaw native tools (excludes MCP/custom plugins).
 	"goclaw": {
 		"read_file", "write_file", "list_files", "edit", "exec",
@@ -46,8 +47,8 @@ var builtinToolGroups = map[string][]string{
 // Tool profiles define preset allow sets.
 var toolProfiles = map[string][]string{
 	"minimal":   {"session_status"},
-	"coding":    {"group:fs", "group:runtime", "group:sessions", "group:memory", "group:web", "read_image", "create_image", "skill_search"},
-	"messaging": {"group:messaging", "group:web", "sessions_list", "sessions_history", "sessions_send", "session_status", "read_image", "skill_search"},
+	"coding":    {"group:fs", "group:runtime", "group:sessions", "group:memory", "group:web", "group:vault", "read_image", "create_image", "skill_search"},
+	"messaging": {"group:messaging", "group:web", "group:vault", "sessions_list", "sessions_history", "sessions_send", "session_status", "read_image", "skill_search"},
 	"full":      {}, // empty = no restrictions
 }
 

--- a/pkg/protocol/methods.go
+++ b/pkg/protocol/methods.go
@@ -39,6 +39,7 @@ const (
 	MethodSessionsPatch   = "sessions.patch"
 	MethodSessionsDelete  = "sessions.delete"
 	MethodSessionsReset   = "sessions.reset"
+	MethodSessionsCompact = "sessions.compact"
 
 	// System
 	MethodConnect = "connect"

--- a/tests/integration/tts_gemini_live_test.go
+++ b/tests/integration/tts_gemini_live_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/nextlevelbuilder/goclaw/internal/audio"
@@ -87,15 +88,5 @@ func isServerError(err error) bool {
 		return false
 	}
 	msg := err.Error()
-	return contains(msg, "500") || contains(msg, "503") || contains(msg, "server error")
-}
-
-// contains checks if a string contains a substring (case-insensitive).
-func contains(s, substr string) bool {
-	for i := 0; i < len(s)-len(substr)+1; i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(msg, "500") || strings.Contains(msg, "503") || strings.Contains(msg, "server error")
 }


### PR DESCRIPTION
## Summary
- Add `vault` tool group containing `vault_search` and `vault_read`
- Include `group:vault` in `messaging` and `coding` profiles
- Enables profile-restricted agents (e.g. Telegram bots) to access vault documents

## Problem
Agents using `messaging` profile couldn't access `vault_search`/`vault_read` tools, causing them to hallucinate file paths instead of searching vault first.

## Solution
Create dedicated `vault` group and add to relevant profiles. This also enables per-agent Tool Policy configuration via `group:vault`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/tools/... -run Policy` passes