### PR TITLE
fix(memory): truncate embeddings locally

### DIFF
--- a/cmd/gateway_agents_test.go
+++ b/cmd/gateway_agents_test.go
@@ -86,7 +86,7 @@ func TestSubagentExecTool_NilStoreIsSafe(t *testing.T) {
 	}
 }
 
-func captureEmbeddingRequest(t *testing.T, es *store.EmbeddingSettings) map[string]any {
+func captureEmbeddingRequest(t *testing.T, es *store.EmbeddingSettings, responseDim int) (map[string]any, [][]float32) {
 	t.Helper()
 
 	var requestBody map[string]any
@@ -95,7 +95,7 @@ func captureEmbeddingRequest(t *testing.T, es *store.EmbeddingSettings) map[stri
 			t.Fatalf("Decode() error = %v", err)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1,0.2]}]}`))
+		_, _ = w.Write([]byte(`{"data":[{"embedding":` + makeEmbeddingJSON(responseDim) + `}]}`))
 	}))
 	defer server.Close()
 
@@ -111,26 +111,42 @@ func captureEmbeddingRequest(t *testing.T, es *store.EmbeddingSettings) map[stri
 	if ep == nil {
 		t.Fatal("buildEmbeddingProvider() = nil, want provider")
 	}
-	if _, err := ep.Embed(context.Background(), []string{"hello"}); err != nil {
+	embeddings, err := ep.Embed(context.Background(), []string{"hello"})
+	if err != nil {
 		t.Fatalf("Embed() error = %v", err)
 	}
-	return requestBody
+	return requestBody, embeddings
 }
 
-func TestBuildEmbeddingProviderDefaultsTo1536Dimensions(t *testing.T) {
-	requestBody := captureEmbeddingRequest(t, nil)
-	if got := requestBody["dimensions"]; got != float64(1536) {
-		t.Fatalf("dimensions = %v, want 1536", got)
+func makeEmbeddingJSON(dim int) string {
+	values := make([]float64, dim)
+	for i := range values {
+		values[i] = float64(i)
+	}
+	encoded, _ := json.Marshal(values)
+	return string(encoded)
+}
+
+func TestBuildEmbeddingProviderOmitsDimensionsByDefault(t *testing.T) {
+	requestBody, embeddings := captureEmbeddingRequest(t, nil, 3072)
+	if _, ok := requestBody["dimensions"]; ok {
+		t.Fatalf("request body unexpectedly included dimensions: %v", requestBody)
+	}
+	if got := len(embeddings[0]); got != store.RequiredMemoryEmbeddingDimensions {
+		t.Fatalf("embedding length = %d, want %d", got, store.RequiredMemoryEmbeddingDimensions)
 	}
 }
 
-func TestBuildEmbeddingProviderIgnoresIncompatibleStoredDimensions(t *testing.T) {
-	requestBody := captureEmbeddingRequest(t, &store.EmbeddingSettings{
+func TestBuildEmbeddingProviderOmitsDimensionsWithIncompatibleStoredValue(t *testing.T) {
+	requestBody, embeddings := captureEmbeddingRequest(t, &store.EmbeddingSettings{
 		Enabled:    true,
 		Model:      "voyage-4-nano",
 		Dimensions: 2048,
-	})
-	if got := requestBody["dimensions"]; got != float64(1536) {
-		t.Fatalf("dimensions = %v, want fallback 1536", got)
+	}, 3072)
+	if _, ok := requestBody["dimensions"]; ok {
+		t.Fatalf("request body unexpectedly included dimensions: %v", requestBody)
+	}
+	if got := len(embeddings[0]); got != store.RequiredMemoryEmbeddingDimensions {
+		t.Fatalf("embedding length = %d, want %d", got, store.RequiredMemoryEmbeddingDimensions)
 	}
 }

--- a/internal/http/provider_verify_embedding.go
+++ b/internal/http/provider_verify_embedding.go
@@ -66,8 +66,8 @@ func (h *ProvidersHandler) handleVerifyEmbedding(w http.ResponseWriter, r *http.
 
 	ep := memory.NewOpenAIEmbeddingProvider(p.Name, p.APIKey, apiBase, model)
 
-	// Apply dimension truncation: request body → provider settings → none.
-	// Clamp to reasonable range to avoid sending absurd values upstream.
+	// Apply local dimension truncation: request body → provider settings → none.
+	// Clamp to reasonable range to avoid nonsensical truncation targets.
 	truncDims := req.Dimensions
 	if truncDims <= 0 && es != nil && es.Dimensions > 0 {
 		truncDims = es.Dimensions

--- a/internal/memory/embeddings.go
+++ b/internal/memory/embeddings.go
@@ -143,7 +143,7 @@ type OpenAIEmbeddingProvider struct {
 	model      string
 	apiKey     string
 	apiURL     string
-	dimensions int // optional: truncate output to this many dimensions (0 = use model default)
+	dimensions int // optional local truncation target (0 = use model output as-is)
 }
 
 // NewOpenAIEmbeddingProvider creates a provider for OpenAI-compatible embedding APIs.
@@ -163,7 +163,7 @@ func NewOpenAIEmbeddingProvider(name, apiKey, apiURL, model string) *OpenAIEmbed
 	}
 }
 
-// WithDimensions sets the output dimensions for models that support dimension truncation.
+// WithDimensions sets the local output target used to truncate larger embeddings after fetch.
 func (p *OpenAIEmbeddingProvider) WithDimensions(d int) *OpenAIEmbeddingProvider {
 	p.dimensions = d
 	return p
@@ -176,9 +176,6 @@ func (p *OpenAIEmbeddingProvider) Embed(ctx context.Context, texts []string) ([]
 	reqBody := map[string]any{
 		"input": texts,
 		"model": p.model,
-	}
-	if p.dimensions > 0 {
-		reqBody["dimensions"] = p.dimensions
 	}
 
 	bodyJSON, err := json.Marshal(reqBody)
@@ -215,9 +212,27 @@ func (p *OpenAIEmbeddingProvider) Embed(ctx context.Context, texts []string) ([]
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 
+	// Convert response vectors to float32 and apply local truncation.
 	embeddings := make([][]float32, len(result.Data))
 	for i, d := range result.Data {
-		embeddings[i] = d.Embedding
+		vec := make([]float32, len(d.Embedding))
+		for j, v := range d.Embedding {
+			vec[j] = v
+		}
+		if p.dimensions > 0 {
+			if len(vec) < p.dimensions {
+				return nil, fmt.Errorf(
+					"embedding dimension mismatch: provider %s model %s returned %d dimensions, need at least %d for local truncation",
+					p.name, p.model, len(vec), p.dimensions,
+				)
+			}
+			if len(vec) > p.dimensions {
+				truncated := make([]float32, p.dimensions)
+				copy(truncated, vec[:p.dimensions])
+				vec = truncated
+			}
+		}
+		embeddings[i] = vec
 	}
 
 	return embeddings, nil

--- a/internal/memory/embeddings_test.go
+++ b/internal/memory/embeddings_test.go
@@ -1,0 +1,100 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func makeEmbedding(dim int) []float32 {
+	vec := make([]float32, dim)
+	for i := range vec {
+		vec[i] = float32(i)
+	}
+	return vec
+}
+
+func TestOpenAIEmbedding_LocalTruncationWithoutDimensionsRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if _, ok := reqBody["dimensions"]; ok {
+			t.Fatalf("request must not include dimensions field: %v", reqBody)
+		}
+
+		inputs, ok := reqBody["input"].([]any)
+		if !ok || len(inputs) != 1 {
+			t.Fatalf("unexpected input payload: %v", reqBody["input"])
+		}
+
+		resp := struct {
+			Data []struct {
+				Embedding []float32 `json:"embedding"`
+			} `json:"data"`
+		}{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: makeEmbedding(3072)}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewOpenAIEmbeddingProvider("vllm", "test-key", server.URL, "gemma-2b-embeddings")
+	provider.WithDimensions(1536)
+
+	embeddings, err := provider.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if len(embeddings) != 1 {
+		t.Fatalf("expected 1 embedding, got %d", len(embeddings))
+	}
+	if len(embeddings[0]) != 1536 {
+		t.Fatalf("expected truncated embedding length 1536, got %d", len(embeddings[0]))
+	}
+	if embeddings[0][1535] != 1535 {
+		t.Fatalf("unexpected truncation result: last value = %v", embeddings[0][1535])
+	}
+}
+
+func TestOpenAIEmbedding_LocalTruncationErrorsWhenVectorTooShort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := struct {
+			Data []struct {
+				Embedding []float32 `json:"embedding"`
+			} `json:"data"`
+		}{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: makeEmbedding(1024)}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewOpenAIEmbeddingProvider("vllm", "test-key", server.URL, "gemma-2b-embeddings")
+	provider.WithDimensions(1536)
+
+	_, err := provider.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatal("expected error for too-short embedding, got nil")
+	}
+	if !strings.Contains(err.Error(), "returned 1024") {
+		t.Fatalf("expected dimension count in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "1536") {
+		t.Fatalf("expected target dimension in error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes embedding verification and generation so GoClaw no longer sends a `dimensions` field upstream to OpenAI-compatible embedding backends. That avoids failures on vLLM and other non-Matryoshka models, while still preserving the 1536-dim contract by truncating vectors locally after the model returns the full embedding.

## Type
<!-- Check one -->
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->
dev

## Checklist
- [x] `go build ./...` passes
- [ ] `go build -tags sqliteonly ./...` passes (if Go changes)
- [ ] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
`go test ./internal/memory`
`go test ./cmd -run TestBuildEmbeddingProvider`
`go test ./internal/http -run TestDoesNotExist`