### PR TITLE
feat(channels): suppress_placeholder toggle for Discord and Slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ All notable changes to GoClaw are documented here. For full documentation, see [
 
 ### Improvements
 
+- **`suppress_placeholder` toggle for Discord and Slack.** New optional boolean
+  on each channel's config. When set, skips the "Thinking..." placeholder
+  message and its later edit-with-response. For Discord, the typing indicator
+  now covers the full agent turn (TTL raised to 30 min as a safety net) and
+  the final response posts as a new message. For Slack, streaming is
+  force-disabled (streaming edits the placeholder); the `thinking_face`
+  reaction from `reaction_level: minimal|full` acts as the in-progress signal.
+  Tradeoff: LLM retry notifications and tool-status updates (which ride on
+  placeholder edits) are silently dropped — that's the point of the toggle.
 - **Context pruning cleanup.** Removed redundant Pass 0 (per-result 30% guard),
   deduplicated double prune call per iteration, added SanitizeHistory to
   PruneStage for broken tool_use/tool_result pair cleanup.

--- a/docs/05-channels-messaging.md
+++ b/docs/05-channels-messaging.md
@@ -487,7 +487,7 @@ The Discord channel uses the `discordgo` library to connect via the Discord Gate
 
 - **Gateway intents**: Requests `GuildMessages`, `DirectMessages`, and `MessageContent` intents
 - **Message limit**: 2,000-character limit with automatic splitting at newlines
-- **Placeholder editing**: Sends "Thinking..." → edits with actual response. Set `suppress_placeholder: true` to skip the placeholder; the typing indicator then runs for the full agent turn (TTL raised to 10 min) and the final response is posted as a new message.
+- **Placeholder editing**: Sends "Thinking..." → edits with actual response. Set `suppress_placeholder: true` to skip the placeholder; the typing indicator then runs for the full agent turn (TTL raised to 30 min as a safety net) and the final response is posted as a new message. Tradeoffs: LLM retry notifications and non-streaming tool-status updates are delivered by editing the placeholder, so both are silently dropped when suppressed — the typing indicator is the only in-progress signal.
 - **Mention gating**: `requireMention` default true; bot mention stripped from content
 - **Bot identity**: Fetches `@me` on startup to detect and ignore own messages
 - **Typing indicator**: 9-second keepalive while agent processes
@@ -505,7 +505,7 @@ The Slack channel uses the `slack-go/slack` library to connect via Socket Mode (
 - **Three token types**: `xoxb-` (Bot Token, required), `xapp-` (App-Level Token, required), `xoxp-` (User Token, optional for custom identity)
 - **Token prefix validation**: Tokens validated at startup (`xoxb-`, `xapp-`, `xoxp-` prefixes)
 - **Message limit**: 4,000-character limit with automatic splitting at newline boundaries
-- **Placeholder editing**: Sends "Thinking..." → edits with actual response (same as Discord). Set `suppress_placeholder: true` to skip the placeholder entirely; the final response is posted as a new message and the thinking-face reaction (when `reaction_level` is on) acts as the in-progress indicator. Force-disables streaming since Slack streaming edits the placeholder.
+- **Placeholder editing**: Sends "Thinking..." → edits with actual response (same as Discord). Set `suppress_placeholder: true` to skip the placeholder entirely; the final response is posted as a new message and the thinking-face reaction (when `reaction_level` is set to `minimal` or `full` — off by default) acts as the in-progress indicator. Force-disables streaming since Slack streaming edits the placeholder, and silently drops LLM retry notifications and tool-status updates for the same reason.
 - **Mention gating**: `requireMention` default true; `<@botUserID>` stripped from content
 - **Thread participation cache**: After bot replies in a thread, subsequent messages in that thread auto-trigger response without @mention (24h TTL)
 - **Message dedup**: `channel+ts` key prevents duplicate processing on Socket Mode reconnect

--- a/docs/05-channels-messaging.md
+++ b/docs/05-channels-messaging.md
@@ -487,7 +487,7 @@ The Discord channel uses the `discordgo` library to connect via the Discord Gate
 
 - **Gateway intents**: Requests `GuildMessages`, `DirectMessages`, and `MessageContent` intents
 - **Message limit**: 2,000-character limit with automatic splitting at newlines
-- **Placeholder editing**: Sends "Thinking..." → edits with actual response
+- **Placeholder editing**: Sends "Thinking..." → edits with actual response. Set `suppress_placeholder: true` to skip the placeholder; the typing indicator then runs for the full agent turn (TTL raised to 10 min) and the final response is posted as a new message.
 - **Mention gating**: `requireMention` default true; bot mention stripped from content
 - **Bot identity**: Fetches `@me` on startup to detect and ignore own messages
 - **Typing indicator**: 9-second keepalive while agent processes
@@ -505,7 +505,7 @@ The Slack channel uses the `slack-go/slack` library to connect via Socket Mode (
 - **Three token types**: `xoxb-` (Bot Token, required), `xapp-` (App-Level Token, required), `xoxp-` (User Token, optional for custom identity)
 - **Token prefix validation**: Tokens validated at startup (`xoxb-`, `xapp-`, `xoxp-` prefixes)
 - **Message limit**: 4,000-character limit with automatic splitting at newline boundaries
-- **Placeholder editing**: Sends "Thinking..." → edits with actual response (same as Discord)
+- **Placeholder editing**: Sends "Thinking..." → edits with actual response (same as Discord). Set `suppress_placeholder: true` to skip the placeholder entirely; the final response is posted as a new message and the thinking-face reaction (when `reaction_level` is on) acts as the in-progress indicator. Force-disables streaming since Slack streaming edits the placeholder.
 - **Mention gating**: `requireMention` default true; `<@botUserID>` stripped from content
 - **Thread participation cache**: After bot replies in a thread, subsequent messages in that thread auto-trigger response without @mention (24h TTL)
 - **Message dedup**: `channel+ts` key prevents duplicate processing on Socket Mode reconnect

--- a/internal/channels/discord/discord.go
+++ b/internal/channels/discord/discord.go
@@ -19,7 +19,17 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
-const pairingDebounceTime = 60 * time.Second
+const (
+	pairingDebounceTime = 60 * time.Second
+	// defaultTypingTTL caps the typing indicator when the "Thinking..." placeholder is shown —
+	// the placeholder carries the in-progress signal, so typing only needs to cover the first
+	// flush. When suppress_placeholder is set the indicator is the sole signal for the whole
+	// turn, so we raise the cap via suppressedPlaceholderTypingTTL. 30 min is a pragmatic
+	// ceiling: it covers long multi-step tool chains while still stopping a stuck indicator
+	// if a run fails silently without any Send() call on the channel.
+	defaultTypingTTL               = 60 * time.Second
+	suppressedPlaceholderTypingTTL = 30 * time.Minute
+)
 
 // Channel connects to Discord via the Bot API using gateway events.
 type Channel struct {

--- a/internal/channels/discord/factory.go
+++ b/internal/channels/discord/factory.go
@@ -18,18 +18,19 @@ type discordCreds struct {
 
 // discordInstanceConfig maps the non-secret config JSONB from the channel_instances table.
 type discordInstanceConfig struct {
-	DMPolicy          string   `json:"dm_policy,omitempty"`
-	GroupPolicy       string   `json:"group_policy,omitempty"`
-	AllowFrom         []string `json:"allow_from,omitempty"`
-	RequireMention    *bool    `json:"require_mention,omitempty"`
-	HistoryLimit      int      `json:"history_limit,omitempty"`
-	BlockReply        *bool    `json:"block_reply,omitempty"`
-	MediaMaxBytes     int64    `json:"media_max_bytes,omitempty"`
-	STTProxyURL       string   `json:"stt_proxy_url,omitempty"`
-	STTAPIKey         string   `json:"stt_api_key,omitempty"`
-	STTTenantID       string   `json:"stt_tenant_id,omitempty"`
-	STTTimeoutSeconds int      `json:"stt_timeout_seconds,omitempty"`
-	VoiceAgentID      string   `json:"voice_agent_id,omitempty"`
+	DMPolicy            string   `json:"dm_policy,omitempty"`
+	GroupPolicy         string   `json:"group_policy,omitempty"`
+	AllowFrom           []string `json:"allow_from,omitempty"`
+	RequireMention      *bool    `json:"require_mention,omitempty"`
+	HistoryLimit        int      `json:"history_limit,omitempty"`
+	BlockReply          *bool    `json:"block_reply,omitempty"`
+	MediaMaxBytes       int64    `json:"media_max_bytes,omitempty"`
+	SuppressPlaceholder *bool    `json:"suppress_placeholder,omitempty"`
+	STTProxyURL         string   `json:"stt_proxy_url,omitempty"`
+	STTAPIKey           string   `json:"stt_api_key,omitempty"`
+	STTTenantID         string   `json:"stt_tenant_id,omitempty"`
+	STTTimeoutSeconds   int      `json:"stt_timeout_seconds,omitempty"`
+	VoiceAgentID        string   `json:"voice_agent_id,omitempty"`
 }
 
 // Factory creates a Discord channel from DB instance data (no extra stores).
@@ -74,20 +75,21 @@ func buildChannel(name string, creds json.RawMessage, cfg json.RawMessage,
 	}
 
 	dcCfg := config.DiscordConfig{
-		Enabled:           true,
-		Token:             c.Token,
-		AllowFrom:         ic.AllowFrom,
-		DMPolicy:          ic.DMPolicy,
-		GroupPolicy:       ic.GroupPolicy,
-		RequireMention:    ic.RequireMention,
-		HistoryLimit:      ic.HistoryLimit,
-		BlockReply:        ic.BlockReply,
-		MediaMaxBytes:     ic.MediaMaxBytes,
-		STTProxyURL:       ic.STTProxyURL,
-		STTAPIKey:         ic.STTAPIKey,
-		STTTenantID:       ic.STTTenantID,
-		STTTimeoutSeconds: ic.STTTimeoutSeconds,
-		VoiceAgentID:      ic.VoiceAgentID,
+		Enabled:             true,
+		Token:               c.Token,
+		AllowFrom:           ic.AllowFrom,
+		DMPolicy:            ic.DMPolicy,
+		GroupPolicy:         ic.GroupPolicy,
+		RequireMention:      ic.RequireMention,
+		HistoryLimit:        ic.HistoryLimit,
+		BlockReply:          ic.BlockReply,
+		MediaMaxBytes:       ic.MediaMaxBytes,
+		SuppressPlaceholder: ic.SuppressPlaceholder,
+		STTProxyURL:         ic.STTProxyURL,
+		STTAPIKey:           ic.STTAPIKey,
+		STTTenantID:         ic.STTTenantID,
+		STTTimeoutSeconds:   ic.STTTimeoutSeconds,
+		VoiceAgentID:        ic.VoiceAgentID,
 	}
 
 	// DB instances default to "pairing" for groups (secure by default).

--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -230,12 +230,12 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 
 	// Send typing indicator with keepalive + TTL safety net.
 	// Discord typing expires after 10s, so keepalive every 9s.
-	// TTL auto-stops after 60s (or 10min when the placeholder is suppressed)
-	// to prevent stuck indicators.
+	// TTL auto-stops to prevent stuck indicators when a run ends without a Send()
+	// (e.g. silent run.failed / run.cancelled).
 	suppressPlaceholder := c.config.SuppressPlaceholder != nil && *c.config.SuppressPlaceholder
-	typingTTL := 60 * time.Second
+	typingTTL := defaultTypingTTL
 	if suppressPlaceholder {
-		typingTTL = 10 * time.Minute
+		typingTTL = suppressedPlaceholderTypingTTL
 	}
 	typingCtrl := typing.New(typing.Options{
 		MaxDuration:       typingTTL,

--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -230,9 +230,15 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 
 	// Send typing indicator with keepalive + TTL safety net.
 	// Discord typing expires after 10s, so keepalive every 9s.
-	// TTL auto-stops after 60s to prevent stuck indicators.
+	// TTL auto-stops after 60s (or 10min when the placeholder is suppressed)
+	// to prevent stuck indicators.
+	suppressPlaceholder := c.config.SuppressPlaceholder != nil && *c.config.SuppressPlaceholder
+	typingTTL := 60 * time.Second
+	if suppressPlaceholder {
+		typingTTL = 10 * time.Minute
+	}
 	typingCtrl := typing.New(typing.Options{
-		MaxDuration:       60 * time.Second,
+		MaxDuration:       typingTTL,
 		KeepaliveInterval: 9 * time.Second,
 		StartFn: func() error {
 			return c.session.ChannelTyping(channelID)
@@ -245,12 +251,16 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 	c.typingCtrls.Store(channelID, typingCtrl)
 	typingCtrl.Start()
 
-	// Send placeholder "Thinking..." message.
+	// Send placeholder "Thinking..." message unless suppressed via config.
+	// When suppressed, the typing indicator alone signals progress until the
+	// final response is sent (as a new message, not an edit).
 	// Key by inbound message ID (not channel ID) to avoid race conditions
 	// when multiple messages arrive in the same channel concurrently.
-	placeholder, err := c.session.ChannelMessageSend(channelID, "Thinking...")
-	if err == nil {
-		c.placeholders.Store(m.ID, placeholder.ID)
+	if !suppressPlaceholder {
+		placeholder, err := c.session.ChannelMessageSend(channelID, "Thinking...")
+		if err == nil {
+			c.placeholders.Store(m.ID, placeholder.ID)
+		}
 	}
 
 	// Strip bot @mention from content — it's just the trigger, not meaningful.

--- a/internal/channels/slack/channel.go
+++ b/internal/channels/slack/channel.go
@@ -127,6 +127,16 @@ func New(cfg config.SlackConfig, msgBus *bus.MessageBus, pairingSvc store.Pairin
 	ch.SetPairingService(pairingSvc)
 	ch.SetGroupHistory(channels.MakeHistory(channels.TypeSlack, pendingStore, base.TenantID()))
 	ch.SetHistoryLimit(historyLimit)
+
+	if cfg.SuppressPlaceholder != nil && *cfg.SuppressPlaceholder {
+		dmStream := cfg.DMStream != nil && *cfg.DMStream
+		groupStream := cfg.GroupStream != nil && *cfg.GroupStream
+		if dmStream || groupStream {
+			slog.Warn("slack: suppress_placeholder is enabled; streaming edits require a placeholder and will be skipped",
+				"dm_stream", dmStream, "group_stream", groupStream)
+		}
+	}
+
 	return ch, nil
 }
 

--- a/internal/channels/slack/channel.go
+++ b/internal/channels/slack/channel.go
@@ -128,7 +128,7 @@ func New(cfg config.SlackConfig, msgBus *bus.MessageBus, pairingSvc store.Pairin
 	ch.SetGroupHistory(channels.MakeHistory(channels.TypeSlack, pendingStore, base.TenantID()))
 	ch.SetHistoryLimit(historyLimit)
 
-	if cfg.SuppressPlaceholder != nil && *cfg.SuppressPlaceholder {
+	if ch.placeholderSuppressed() {
 		dmStream := cfg.DMStream != nil && *cfg.DMStream
 		groupStream := cfg.GroupStream != nil && *cfg.GroupStream
 		if dmStream || groupStream {
@@ -138,6 +138,12 @@ func New(cfg config.SlackConfig, msgBus *bus.MessageBus, pairingSvc store.Pairin
 	}
 
 	return ch, nil
+}
+
+// placeholderSuppressed reports whether the channel is configured to skip the
+// "Thinking..." placeholder message and rely on reactions / no indicator only.
+func (c *Channel) placeholderSuppressed() bool {
+	return c.config.SuppressPlaceholder != nil && *c.config.SuppressPlaceholder
 }
 
 // Start opens the Socket Mode connection and begins receiving events.

--- a/internal/channels/slack/factory.go
+++ b/internal/channels/slack/factory.go
@@ -19,18 +19,19 @@ type slackCreds struct {
 
 // slackInstanceConfig maps the non-secret config JSONB from the channel_instances table.
 type slackInstanceConfig struct {
-	DMPolicy       string   `json:"dm_policy,omitempty"`
-	GroupPolicy    string   `json:"group_policy,omitempty"`
-	AllowFrom      []string `json:"allow_from,omitempty"`
-	RequireMention *bool    `json:"require_mention,omitempty"`
-	HistoryLimit   int      `json:"history_limit,omitempty"`
-	DMStream       *bool    `json:"dm_stream,omitempty"`
-	GroupStream    *bool    `json:"group_stream,omitempty"`
-	NativeStream   *bool    `json:"native_stream,omitempty"`
-	ReactionLevel  string   `json:"reaction_level,omitempty"`
-	BlockReply     *bool    `json:"block_reply,omitempty"`
-	DebounceDelay  int      `json:"debounce_delay,omitempty"`
-	ThreadTTL      *int     `json:"thread_ttl,omitempty"`
+	DMPolicy            string   `json:"dm_policy,omitempty"`
+	GroupPolicy         string   `json:"group_policy,omitempty"`
+	AllowFrom           []string `json:"allow_from,omitempty"`
+	RequireMention      *bool    `json:"require_mention,omitempty"`
+	HistoryLimit        int      `json:"history_limit,omitempty"`
+	DMStream            *bool    `json:"dm_stream,omitempty"`
+	GroupStream         *bool    `json:"group_stream,omitempty"`
+	NativeStream        *bool    `json:"native_stream,omitempty"`
+	SuppressPlaceholder *bool    `json:"suppress_placeholder,omitempty"`
+	ReactionLevel       string   `json:"reaction_level,omitempty"`
+	BlockReply          *bool    `json:"block_reply,omitempty"`
+	DebounceDelay       int      `json:"debounce_delay,omitempty"`
+	ThreadTTL           *int     `json:"thread_ttl,omitempty"`
 }
 
 // Factory creates a Slack channel from DB instance data.
@@ -58,22 +59,23 @@ func Factory(name string, creds json.RawMessage, cfg json.RawMessage,
 	}
 
 	slackCfg := config.SlackConfig{
-		Enabled:        true,
-		BotToken:       c.BotToken,
-		AppToken:       c.AppToken,
-		UserToken:      c.UserToken,
-		AllowFrom:      ic.AllowFrom,
-		DMPolicy:       ic.DMPolicy,
-		GroupPolicy:    ic.GroupPolicy,
-		RequireMention: ic.RequireMention,
-		HistoryLimit:   ic.HistoryLimit,
-		DMStream:       ic.DMStream,
-		GroupStream:    ic.GroupStream,
-		NativeStream:   ic.NativeStream,
-		ReactionLevel:  ic.ReactionLevel,
-		BlockReply:     ic.BlockReply,
-		DebounceDelay:  ic.DebounceDelay,
-		ThreadTTL:      ic.ThreadTTL,
+		Enabled:             true,
+		BotToken:            c.BotToken,
+		AppToken:            c.AppToken,
+		UserToken:           c.UserToken,
+		AllowFrom:           ic.AllowFrom,
+		DMPolicy:            ic.DMPolicy,
+		GroupPolicy:         ic.GroupPolicy,
+		RequireMention:      ic.RequireMention,
+		HistoryLimit:        ic.HistoryLimit,
+		DMStream:            ic.DMStream,
+		GroupStream:         ic.GroupStream,
+		NativeStream:        ic.NativeStream,
+		SuppressPlaceholder: ic.SuppressPlaceholder,
+		ReactionLevel:       ic.ReactionLevel,
+		BlockReply:          ic.BlockReply,
+		DebounceDelay:       ic.DebounceDelay,
+		ThreadTTL:           ic.ThreadTTL,
 	}
 
 	// Secure default: DB instances default to "pairing" for groups.
@@ -115,22 +117,23 @@ func FactoryWithPendingStore(pendingStore store.PendingMessageStore) channels.Ch
 		}
 
 		slackCfg := config.SlackConfig{
-			Enabled:        true,
-			BotToken:       c.BotToken,
-			AppToken:       c.AppToken,
-			UserToken:      c.UserToken,
-			AllowFrom:      ic.AllowFrom,
-			DMPolicy:       ic.DMPolicy,
-			GroupPolicy:    ic.GroupPolicy,
-			RequireMention: ic.RequireMention,
-			HistoryLimit:   ic.HistoryLimit,
-			DMStream:       ic.DMStream,
-			GroupStream:    ic.GroupStream,
-			NativeStream:   ic.NativeStream,
-			ReactionLevel:  ic.ReactionLevel,
-			BlockReply:     ic.BlockReply,
-			DebounceDelay:  ic.DebounceDelay,
-			ThreadTTL:      ic.ThreadTTL,
+			Enabled:             true,
+			BotToken:            c.BotToken,
+			AppToken:            c.AppToken,
+			UserToken:           c.UserToken,
+			AllowFrom:           ic.AllowFrom,
+			DMPolicy:            ic.DMPolicy,
+			GroupPolicy:         ic.GroupPolicy,
+			RequireMention:      ic.RequireMention,
+			HistoryLimit:        ic.HistoryLimit,
+			DMStream:            ic.DMStream,
+			GroupStream:         ic.GroupStream,
+			NativeStream:        ic.NativeStream,
+			SuppressPlaceholder: ic.SuppressPlaceholder,
+			ReactionLevel:       ic.ReactionLevel,
+			BlockReply:          ic.BlockReply,
+			DebounceDelay:       ic.DebounceDelay,
+			ThreadTTL:           ic.ThreadTTL,
 		}
 
 		if slackCfg.GroupPolicy == "" {

--- a/internal/channels/slack/handlers.go
+++ b/internal/channels/slack/handlers.go
@@ -223,7 +223,7 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 		replyThreadTS = ev.TimeStamp // start thread from the triggering message
 	}
 
-	if c.config.SuppressPlaceholder == nil || !*c.config.SuppressPlaceholder {
+	if !c.placeholderSuppressed() {
 		placeholderOpts := []slackapi.MsgOption{
 			slackapi.MsgOptionText("Thinking...", false),
 		}

--- a/internal/channels/slack/handlers.go
+++ b/internal/channels/slack/handlers.go
@@ -214,22 +214,27 @@ func (c *Channel) handleMessage(ev *slackevents.MessageEvent) {
 		"sender_id", senderID, "channel_id", channelID,
 		"is_dm", isDM, "preview", channels.Truncate(content, 50))
 
-	// Send "Thinking..." placeholder
+	// Send "Thinking..." placeholder unless suppressed via config.
+	// When suppressed, no placeholder is created; the final response is posted
+	// as a new message. The thinking_face reaction (when reaction_level is
+	// enabled) remains the only in-progress indicator.
 	replyThreadTS := threadTS
 	if !isDM && replyThreadTS == "" {
 		replyThreadTS = ev.TimeStamp // start thread from the triggering message
 	}
 
-	placeholderOpts := []slackapi.MsgOption{
-		slackapi.MsgOptionText("Thinking...", false),
-	}
-	if replyThreadTS != "" {
-		placeholderOpts = append(placeholderOpts, slackapi.MsgOptionTS(replyThreadTS))
-	}
+	if c.config.SuppressPlaceholder == nil || !*c.config.SuppressPlaceholder {
+		placeholderOpts := []slackapi.MsgOption{
+			slackapi.MsgOptionText("Thinking...", false),
+		}
+		if replyThreadTS != "" {
+			placeholderOpts = append(placeholderOpts, slackapi.MsgOptionTS(replyThreadTS))
+		}
 
-	_, placeholderTS, err := c.api.PostMessage(channelID, placeholderOpts...)
-	if err == nil {
-		c.placeholders.Store(localKey, placeholderTS)
+		_, placeholderTS, err := c.api.PostMessage(channelID, placeholderOpts...)
+		if err == nil {
+			c.placeholders.Store(localKey, placeholderTS)
+		}
 	}
 
 	// Build final content with group history context

--- a/internal/channels/slack/handlers_mention.go
+++ b/internal/channels/slack/handlers_mention.go
@@ -68,7 +68,7 @@ func (c *Channel) handleAppMention(ev *slackevents.AppMentionEvent) {
 	}
 
 	// Send "Thinking..." placeholder unless suppressed via config.
-	if c.config.SuppressPlaceholder == nil || !*c.config.SuppressPlaceholder {
+	if !c.placeholderSuppressed() {
 		placeholderOpts := []slackapi.MsgOption{
 			slackapi.MsgOptionText("Thinking...", false),
 		}

--- a/internal/channels/slack/handlers_mention.go
+++ b/internal/channels/slack/handlers_mention.go
@@ -67,16 +67,19 @@ func (c *Channel) handleAppMention(ev *slackevents.AppMentionEvent) {
 		replyThreadTS = ev.TimeStamp
 	}
 
-	placeholderOpts := []slackapi.MsgOption{
-		slackapi.MsgOptionText("Thinking...", false),
-	}
-	if replyThreadTS != "" {
-		placeholderOpts = append(placeholderOpts, slackapi.MsgOptionTS(replyThreadTS))
-	}
+	// Send "Thinking..." placeholder unless suppressed via config.
+	if c.config.SuppressPlaceholder == nil || !*c.config.SuppressPlaceholder {
+		placeholderOpts := []slackapi.MsgOption{
+			slackapi.MsgOptionText("Thinking...", false),
+		}
+		if replyThreadTS != "" {
+			placeholderOpts = append(placeholderOpts, slackapi.MsgOptionTS(replyThreadTS))
+		}
 
-	_, placeholderTS, err := c.api.PostMessage(channelID, placeholderOpts...)
-	if err == nil {
-		c.placeholders.Store(localKey, placeholderTS)
+		_, placeholderTS, err := c.api.PostMessage(channelID, placeholderOpts...)
+		if err == nil {
+			c.placeholders.Store(localKey, placeholderTS)
+		}
 	}
 
 	annotated := fmt.Sprintf("[From: %s]\n%s", displayName, content)

--- a/internal/channels/slack/stream.go
+++ b/internal/channels/slack/stream.go
@@ -69,7 +69,12 @@ func (s *slackStream) MsgTS() string {
 }
 
 // StreamEnabled reports whether streaming is active for DMs or groups.
+// When suppress_placeholder is set, streaming is force-disabled because
+// Slack streaming edits the placeholder message and there is none to edit.
 func (c *Channel) StreamEnabled(isGroup bool) bool {
+	if c.config.SuppressPlaceholder != nil && *c.config.SuppressPlaceholder {
+		return false
+	}
 	if isGroup {
 		return c.config.GroupStream != nil && *c.config.GroupStream
 	}

--- a/internal/channels/slack/stream.go
+++ b/internal/channels/slack/stream.go
@@ -72,7 +72,7 @@ func (s *slackStream) MsgTS() string {
 // When suppress_placeholder is set, streaming is force-disabled because
 // Slack streaming edits the placeholder message and there is none to edit.
 func (c *Channel) StreamEnabled(isGroup bool) bool {
-	if c.config.SuppressPlaceholder != nil && *c.config.SuppressPlaceholder {
+	if c.placeholderSuppressed() {
 		return false
 	}
 	if isGroup {

--- a/internal/channels/slack/stream_test.go
+++ b/internal/channels/slack/stream_test.go
@@ -62,6 +62,38 @@ func TestExtractChannelID(t *testing.T) {
 	}
 }
 
+func TestStreamEnabledSuppressPlaceholder(t *testing.T) {
+	ptrBool := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name                string
+		dmStream            *bool
+		groupStream         *bool
+		suppressPlaceholder *bool
+		isGroup             bool
+		want                bool
+	}{
+		{"dm stream on", ptrBool(true), nil, nil, false, true},
+		{"group stream on", nil, ptrBool(true), nil, true, true},
+		{"dm stream on, suppress on → off", ptrBool(true), nil, ptrBool(true), false, false},
+		{"group stream on, suppress on → off", nil, ptrBool(true), ptrBool(true), true, false},
+		{"suppress off → dm stream still on", ptrBool(true), nil, ptrBool(false), false, true},
+		{"both off", nil, nil, nil, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Channel{}
+			c.config.DMStream = tt.dmStream
+			c.config.GroupStream = tt.groupStream
+			c.config.SuppressPlaceholder = tt.suppressPlaceholder
+			if got := c.StreamEnabled(tt.isGroup); got != tt.want {
+				t.Errorf("StreamEnabled(isGroup=%v) = %v, want %v", tt.isGroup, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtractThreadTS(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -104,6 +104,7 @@ type DiscordConfig struct {
 	HistoryLimit      int                 `json:"history_limit,omitempty"`   // max pending group messages for context (default 50, 0=disabled)
 	BlockReply        *bool               `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
 	MediaMaxBytes     int64               `json:"media_max_bytes,omitempty"` // max media download size (default 25MB)
+	SuppressPlaceholder *bool               `json:"suppress_placeholder,omitempty"` // skip "Thinking..." placeholder + edit; rely on typing indicator for the full run (default false)
 	STTProxyURL       string              `json:"stt_proxy_url,omitempty"`
 	STTAPIKey         string              `json:"stt_api_key,omitempty"`
 	STTTenantID       string              `json:"stt_tenant_id,omitempty"`
@@ -124,6 +125,7 @@ type SlackConfig struct {
 	DMStream       *bool               `json:"dm_stream,omitempty"`       // enable streaming for DMs (default false)
 	GroupStream    *bool               `json:"group_stream,omitempty"`    // enable streaming for groups (default false)
 	NativeStream   *bool               `json:"native_stream,omitempty"`   // use Slack ChatStreamer API if available (default false)
+	SuppressPlaceholder *bool          `json:"suppress_placeholder,omitempty"` // skip "Thinking..." placeholder + edit; rely on thinking reaction for the full run (default false). Incompatible with streaming.
 	ReactionLevel  string              `json:"reaction_level,omitempty"`  // "off" (default), "minimal", "full"
 	BlockReply     *bool               `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
 	DebounceDelay  int                 `json:"debounce_delay,omitempty"`  // ms delay before dispatching rapid messages (default 300, 0=disabled)


### PR DESCRIPTION
## Summary

- Adds a `suppress_placeholder` boolean to `DiscordConfig` and `SlackConfig` (also wired through each channel's DB-instance factory).
- When enabled on Discord, the "Thinking..." placeholder + later edit is skipped; the typing indicator runs for the full agent turn (TTL raised 60s → 30 min as a safety net) and the final response is posted as a new message.
- When enabled on Slack, the placeholder is skipped; streaming is force-disabled (Slack streaming edits the placeholder) and the `thinking_face` reaction (when `reaction_level` is `minimal`/`full`) acts as the in-progress indicator.
- Extracted `placeholderSuppressed()` helper on the Slack channel to replace 5 repeated pointer-deref checks.

## Why

On channels with a proper presence API, the intermediate "Thinking..." text message + message-edit cycle can feel clunky, especially in shared groups or when users prefer a quieter indicator. WhatsApp and Telegram already skip this pattern; this PR brings the same option to Discord and Slack behind an opt-in flag.

## Compatibility

- Default is unchanged (placeholder + edit); existing deployments see no behavior change.
- Retry notifications and non-streaming tool-status updates are delivered by editing the placeholder, so both are silently dropped when suppressed. That's the point of the toggle (minimize in-progress chatter) and is documented in `docs/05-channels-messaging.md`.

## Pre-Landing Review

Ran the full review pipeline (4 specialists + red team on a 266-line diff). Findings:

- **Testing specialist** (4 informational) — flagged missing handler-level tests for the suppress paths. Skipped this round because the existing `TestStreamEnabledSuppressPlaceholder` covers the main risk vector; adding handler tests requires a session/postMessage spy harness that doesn't yet exist in the repo, which is larger than this PR's scope.
- **Maintainability specialist** (4 informational) — magic number, DRY violation (inverted-nil guard repeated 5 times), factory-duplication, struct tag alignment. **Auto-fixed:** named the Discord typing TTL constants and the helper. **Skipped:** factory.go DRY refactor (pre-existing) and struct alignment (gofmt wants to reflow the unrelated TelegramConfig struct — not touching upstream code).
- **Security specialist** — NO FINDINGS.
- **Performance specialist** — NO FINDINGS.
- **Red Team** (4 critical, 4 informational) — flagged the silent-drop of retry/tool-status notifications (intentional per feature design, now called out in docs), the 10-min TTL ceiling for long agent runs (**fixed** — bumped to 30 min with a named constant), concurrent-typing race (pre-existing, skipped), and a doc undersell (**fixed**).

**PR Quality Score: 8.5/10**

## Test Plan

- [x] `go build ./...` + `go build -tags sqliteonly ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/channels/... ./internal/config/...` — all pass
- [x] New `TestStreamEnabledSuppressPlaceholder` covers the Slack stream-disable interaction
- [ ] Manual Discord DM + group turn with `suppress_placeholder: true` — confirm typing runs for full turn, no "Thinking..." message, final response arrives as a new message
- [ ] Manual Slack DM + thread turn with `suppress_placeholder: true` + `reaction_level: minimal` — confirm no placeholder, thinking-face reaction fires, final response as a new message

> Note: one unrelated pre-existing flaky test in `internal/tools/shell_abort_test.go` was noticed during `/ship` (process-group cleanup detecting orphan `sleep 60` PIDs in the environment). No code in this PR touches `internal/tools/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)