### PR TITLE
feat(tools): add send_discord_embed tool for rich embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ All notable changes to GoClaw are documented here. For full documentation, see [
 
 ### Improvements
 
+- **`send_discord_embed` tool.** Agents can post Discord rich embeds (full
+  embed schema: title, description, url, color, timestamp, author, footer,
+  image, thumbnail, fields) via a dedicated tool that mirrors the
+  `create_discord_thread` pattern. Supports 1-10 embeds per call, optional
+  plain-text content, optional reply-to. Validates all Discord embed limits
+  (256/4096/2048/6000/25 rules) before hitting the API so the LLM gets
+  actionable errors. Tool schema includes usage recipes (success card,
+  error card, stats grid, article card, alert) so the LLM knows when and
+  how to reach for it. Added to the `messaging` tool group.
 - **Context pruning cleanup.** Removed redundant Pass 0 (per-result 30% guard),
   deduplicated double prune call per iteration, added SanitizeHistory to
   PruneStage for broken tool_use/tool_result pair cleanup.

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -450,6 +450,15 @@ func runGateway() {
 			gl.SetGroupMemberLister(channelMgr.ListGroupMembers)
 		}
 	}
+	// Wire Discord embed sender + tenant checker on send_discord_embed tool
+	if t, ok := toolsReg.Get("send_discord_embed"); ok {
+		if es, ok := t.(tools.DiscordEmbedSenderAware); ok {
+			es.SetDiscordEmbedSender(channelMgr.SendDiscordEmbed)
+		}
+		if tc, ok := t.(tools.ChannelTenantCheckerAware); ok {
+			tc.SetChannelTenantChecker(channelMgr.ChannelTenantID)
+		}
+	}
 
 	// Load channel instances from DB.
 	var instanceLoader *channels.InstanceLoader

--- a/cmd/gateway_tools_wiring.go
+++ b/cmd/gateway_tools_wiring.go
@@ -51,6 +51,8 @@ func wireExtraTools(
 	toolsReg.Register(tools.NewMessageTool(workspace, agentCfg.RestrictToWorkspace))
 	// Group members tool (list members in group chats)
 	toolsReg.Register(tools.NewListGroupMembersTool())
+	// Discord rich embed tool
+	toolsReg.Register(tools.NewSendDiscordEmbedTool())
 	slog.Info("session + message tools registered")
 
 	// Register legacy tool aliases (backward-compat names from policy.go).

--- a/docs/05-channels-messaging.md
+++ b/docs/05-channels-messaging.md
@@ -492,6 +492,7 @@ The Discord channel uses the `discordgo` library to connect via the Discord Gate
 - **Bot identity**: Fetches `@me` on startup to detect and ignore own messages
 - **Typing indicator**: 9-second keepalive while agent processes
 - **Group history**: Pending message buffer for context when mentioned
+- **Rich embeds**: Agents can post Discord rich embeds via the `send_discord_embed` tool. Supports all embed fields (title, description, url, color, timestamp, author, footer, image, thumbnail, fields), up to 10 embeds per message, and optional plain-text content + reply-to. Validation mirrors Discord's embed limits so the LLM gets a clear error instead of a generic API rejection.
 
 ---
 

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -638,6 +638,73 @@ type GroupMemberProvider interface {
 	ListGroupMembers(ctx context.Context, chatID string) ([]GroupMember, error)
 }
 
+// DiscordEmbed is a rich embed payload matching the Discord embed object shape.
+// Types live in the channels package (not channels/discord) so channels.Manager
+// can reference them without the channels→channels/discord→channels import cycle.
+//
+// All fields are optional at the type level; per-field validation (length
+// limits, required sub-fields) happens at the channel implementation layer so
+// errors come back with the Discord API's own messages where possible.
+type DiscordEmbed struct {
+	Title       string              `json:"title,omitempty"`       // 256 char limit
+	Description string              `json:"description,omitempty"` // 4096 char limit
+	URL         string              `json:"url,omitempty"`         // makes the title a link
+	Color       int                 `json:"color,omitempty"`       // decimal RGB (e.g. 0x5865F2 = Discord blurple)
+	Timestamp   string              `json:"timestamp,omitempty"`   // ISO 8601 (RFC 3339)
+	Footer      *DiscordEmbedFooter `json:"footer,omitempty"`
+	Image       *DiscordEmbedMedia  `json:"image,omitempty"`
+	Thumbnail   *DiscordEmbedMedia  `json:"thumbnail,omitempty"`
+	Author      *DiscordEmbedAuthor `json:"author,omitempty"`
+	Fields      []DiscordEmbedField `json:"fields,omitempty"` // max 25
+}
+
+// DiscordEmbedFooter is the footer block shown at the bottom of an embed.
+type DiscordEmbedFooter struct {
+	Text    string `json:"text"`               // required if Footer is set (2048 char limit)
+	IconURL string `json:"icon_url,omitempty"` // http(s) or attachment:// URL
+}
+
+// DiscordEmbedMedia represents an embed image or thumbnail.
+type DiscordEmbedMedia struct {
+	URL string `json:"url"` // http(s) URL
+}
+
+// DiscordEmbedAuthor is the author block shown at the top of an embed.
+type DiscordEmbedAuthor struct {
+	Name    string `json:"name"`               // required if Author is set (256 char limit)
+	URL     string `json:"url,omitempty"`      // makes the name a link
+	IconURL string `json:"icon_url,omitempty"` // avatar shown next to the name
+}
+
+// DiscordEmbedField is a single key/value row inside an embed.
+// Up to 25 fields per embed. Set Inline=true to pack up to three fields on one row.
+type DiscordEmbedField struct {
+	Name   string `json:"name"`             // required (256 char limit)
+	Value  string `json:"value"`            // required (1024 char limit)
+	Inline bool   `json:"inline,omitempty"` // render inline with adjacent inline fields
+}
+
+// DiscordSendEmbedParams is the input for sending a Discord message with one
+// or more rich embeds. Discord allows up to 10 embeds per message and a
+// combined character budget of 6000 across all embed text in a single message.
+type DiscordSendEmbedParams struct {
+	ChannelID string         // target channel (or thread) ID
+	Content   string         // optional plain text shown above the embeds (2000 char limit)
+	Embeds    []DiscordEmbed // 1-10 embeds
+	ReplyTo   string         // optional message ID to reply to
+}
+
+// DiscordSendEmbedResult is returned after a successful embed send.
+type DiscordSendEmbedResult struct {
+	MessageID string `json:"message_id"`
+	ChannelID string `json:"channel_id"`
+}
+
+// DiscordEmbedSender is optionally implemented by channels that can send Discord rich embeds.
+type DiscordEmbedSender interface {
+	SendEmbed(ctx context.Context, params DiscordSendEmbedParams) (DiscordSendEmbedResult, error)
+}
+
 // PendingCompactable is optionally implemented by channels that have a PendingHistory
 // supporting LLM-based compaction. InstanceLoader uses this to wire compaction config
 // after channel creation.

--- a/internal/channels/discord/embed.go
+++ b/internal/channels/discord/embed.go
@@ -1,0 +1,201 @@
+package discord
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+)
+
+// Discord embed limits. These mirror the Discord API limits documented at
+// https://discord.com/developers/docs/resources/channel#embed-object-embed-limits.
+// We enforce them in the channel layer so the agent gets a clear error instead
+// of a less-friendly Discord API rejection.
+const (
+	embedTitleMax       = 256
+	embedDescriptionMax = 4096
+	embedFooterTextMax  = 2048
+	embedAuthorNameMax  = 256
+	embedFieldNameMax   = 256
+	embedFieldValueMax  = 1024
+	embedMaxFields      = 25
+	embedTotalCharMax   = 6000 // combined across all embeds in a single message
+	embedMaxPerMessage  = 10
+	messageContentMax   = 2000
+)
+
+// embedAPI abstracts the discordgo calls used by SendEmbed so tests can stub
+// the Discord API surface without needing a live session. The live
+// implementation (sessionEmbedAPI) wraps c.session directly.
+type embedAPI interface {
+	channelMessageSendComplex(ctx context.Context, channelID string, data *discordgo.MessageSend) (*discordgo.Message, error)
+}
+
+type sessionEmbedAPI struct{ s *discordgo.Session }
+
+func (a sessionEmbedAPI) channelMessageSendComplex(ctx context.Context, channelID string, data *discordgo.MessageSend) (*discordgo.Message, error) {
+	return a.s.ChannelMessageSendComplex(channelID, data, discordgo.WithContext(ctx))
+}
+
+// SendEmbed sends one or more Discord rich embeds (optionally with accompanying
+// plain-text content) to the target channel. Implements channels.DiscordEmbedSender.
+func (c *Channel) SendEmbed(ctx context.Context, params channels.DiscordSendEmbedParams) (channels.DiscordSendEmbedResult, error) {
+	return sendEmbed(ctx, sessionEmbedAPI{s: c.session}, params)
+}
+
+func sendEmbed(ctx context.Context, api embedAPI, params channels.DiscordSendEmbedParams) (channels.DiscordSendEmbedResult, error) {
+	if params.ChannelID == "" {
+		return channels.DiscordSendEmbedResult{}, errors.New("channel_id is required")
+	}
+	if len(params.Embeds) == 0 {
+		return channels.DiscordSendEmbedResult{}, errors.New("at least one embed is required")
+	}
+	if len(params.Embeds) > embedMaxPerMessage {
+		return channels.DiscordSendEmbedResult{}, fmt.Errorf("too many embeds: %d (max %d per message)", len(params.Embeds), embedMaxPerMessage)
+	}
+	if l := len([]rune(params.Content)); l > messageContentMax {
+		return channels.DiscordSendEmbedResult{}, fmt.Errorf("content exceeds %d characters (got %d)", messageContentMax, l)
+	}
+
+	embeds := make([]*discordgo.MessageEmbed, 0, len(params.Embeds))
+	total := len([]rune(params.Content))
+	for i := range params.Embeds {
+		e, chars, err := convertEmbed(params.Embeds[i])
+		if err != nil {
+			return channels.DiscordSendEmbedResult{}, fmt.Errorf("embed[%d]: %w", i, err)
+		}
+		total += chars
+		if total > embedTotalCharMax {
+			return channels.DiscordSendEmbedResult{}, fmt.Errorf("combined embed text exceeds %d characters (at embed[%d])", embedTotalCharMax, i)
+		}
+		embeds = append(embeds, e)
+	}
+
+	send := &discordgo.MessageSend{
+		Content: params.Content,
+		Embeds:  embeds,
+	}
+	if params.ReplyTo != "" {
+		send.Reference = &discordgo.MessageReference{
+			MessageID: params.ReplyTo,
+			ChannelID: params.ChannelID,
+		}
+	}
+
+	msg, err := api.channelMessageSendComplex(ctx, params.ChannelID, send)
+	if err != nil {
+		return channels.DiscordSendEmbedResult{}, fmt.Errorf("discord API: %w", err)
+	}
+	if msg == nil {
+		return channels.DiscordSendEmbedResult{}, errors.New("discord API returned nil message")
+	}
+
+	return channels.DiscordSendEmbedResult{
+		MessageID: msg.ID,
+		ChannelID: msg.ChannelID,
+	}, nil
+}
+
+// convertEmbed validates a channels.DiscordEmbed and converts it to the
+// discordgo shape. Returns the converted embed plus the rune count of all
+// text fields, used by the caller to enforce the 6000-char per-message cap.
+func convertEmbed(in channels.DiscordEmbed) (*discordgo.MessageEmbed, int, error) {
+	if l := len([]rune(in.Title)); l > embedTitleMax {
+		return nil, 0, fmt.Errorf("title exceeds %d characters (got %d)", embedTitleMax, l)
+	}
+	if l := len([]rune(in.Description)); l > embedDescriptionMax {
+		return nil, 0, fmt.Errorf("description exceeds %d characters (got %d)", embedDescriptionMax, l)
+	}
+	if len(in.Fields) > embedMaxFields {
+		return nil, 0, fmt.Errorf("too many fields: %d (max %d)", len(in.Fields), embedMaxFields)
+	}
+
+	chars := len([]rune(in.Title)) + len([]rune(in.Description))
+
+	out := &discordgo.MessageEmbed{
+		Title:       in.Title,
+		Description: in.Description,
+		URL:         in.URL,
+		Color:       in.Color,
+	}
+
+	if in.Timestamp != "" {
+		if _, err := time.Parse(time.RFC3339, in.Timestamp); err != nil {
+			return nil, 0, fmt.Errorf("timestamp must be ISO 8601 / RFC 3339: %w", err)
+		}
+		out.Timestamp = in.Timestamp
+	}
+
+	if in.Footer != nil {
+		if in.Footer.Text == "" {
+			return nil, 0, errors.New("footer.text is required when footer is set")
+		}
+		if l := len([]rune(in.Footer.Text)); l > embedFooterTextMax {
+			return nil, 0, fmt.Errorf("footer.text exceeds %d characters (got %d)", embedFooterTextMax, l)
+		}
+		chars += len([]rune(in.Footer.Text))
+		out.Footer = &discordgo.MessageEmbedFooter{
+			Text:    in.Footer.Text,
+			IconURL: in.Footer.IconURL,
+		}
+	}
+
+	if in.Image != nil {
+		if in.Image.URL == "" {
+			return nil, 0, errors.New("image.url is required when image is set")
+		}
+		out.Image = &discordgo.MessageEmbedImage{URL: in.Image.URL}
+	}
+
+	if in.Thumbnail != nil {
+		if in.Thumbnail.URL == "" {
+			return nil, 0, errors.New("thumbnail.url is required when thumbnail is set")
+		}
+		out.Thumbnail = &discordgo.MessageEmbedThumbnail{URL: in.Thumbnail.URL}
+	}
+
+	if in.Author != nil {
+		if in.Author.Name == "" {
+			return nil, 0, errors.New("author.name is required when author is set")
+		}
+		if l := len([]rune(in.Author.Name)); l > embedAuthorNameMax {
+			return nil, 0, fmt.Errorf("author.name exceeds %d characters (got %d)", embedAuthorNameMax, l)
+		}
+		chars += len([]rune(in.Author.Name))
+		out.Author = &discordgo.MessageEmbedAuthor{
+			Name:    in.Author.Name,
+			URL:     in.Author.URL,
+			IconURL: in.Author.IconURL,
+		}
+	}
+
+	if len(in.Fields) > 0 {
+		out.Fields = make([]*discordgo.MessageEmbedField, 0, len(in.Fields))
+		for i, f := range in.Fields {
+			if f.Name == "" {
+				return nil, 0, fmt.Errorf("fields[%d].name is required", i)
+			}
+			if f.Value == "" {
+				return nil, 0, fmt.Errorf("fields[%d].value is required", i)
+			}
+			if l := len([]rune(f.Name)); l > embedFieldNameMax {
+				return nil, 0, fmt.Errorf("fields[%d].name exceeds %d characters (got %d)", i, embedFieldNameMax, l)
+			}
+			if l := len([]rune(f.Value)); l > embedFieldValueMax {
+				return nil, 0, fmt.Errorf("fields[%d].value exceeds %d characters (got %d)", i, embedFieldValueMax, l)
+			}
+			chars += len([]rune(f.Name)) + len([]rune(f.Value))
+			out.Fields = append(out.Fields, &discordgo.MessageEmbedField{
+				Name:   f.Name,
+				Value:  f.Value,
+				Inline: f.Inline,
+			})
+		}
+	}
+
+	return out, chars, nil
+}

--- a/internal/channels/discord/embed.go
+++ b/internal/channels/discord/embed.go
@@ -62,7 +62,11 @@ func sendEmbed(ctx context.Context, api embedAPI, params channels.DiscordSendEmb
 	}
 
 	embeds := make([]*discordgo.MessageEmbed, 0, len(params.Embeds))
-	total := len([]rune(params.Content))
+	// Discord's 6000-char cap applies to embed text only. message.content has
+	// its own 2000 cap (enforced above) and does NOT count toward this total.
+	// Earlier this function counted params.Content here, rejecting legitimate
+	// Content+Embeds sends with a spurious "combined embed text exceeds 6000".
+	total := 0
 	for i := range params.Embeds {
 		e, chars, err := convertEmbed(params.Embeds[i])
 		if err != nil {

--- a/internal/channels/discord/embed_test.go
+++ b/internal/channels/discord/embed_test.go
@@ -120,6 +120,32 @@ func TestSendEmbed_TotalCharCap(t *testing.T) {
 	}
 }
 
+// TestSendEmbed_ContentDoesNotCountTowardEmbedCap proves the fix for the bug
+// where params.Content was added to the embed 6000-char total. Discord caps
+// content separately (2000 — see TestSendEmbed_ContentTooLong); including it
+// in the embed cap rejected legitimate Content+Embeds<=6000 sends.
+func TestSendEmbed_ContentDoesNotCountTowardEmbedCap(t *testing.T) {
+	f := &fakeEmbedAPI{}
+	// Content near its 2000 cap + two embeds totaling 5500 chars = 7400
+	// combined. Embed-only is 5500, under Discord's 6000 cap. Before the fix
+	// the sum was compared against 6000 and rejected; after the fix only the
+	// 5500 embed total is checked and the send proceeds.
+	_, err := sendEmbed(context.Background(), f, channels.DiscordSendEmbedParams{
+		ChannelID: "c1",
+		Content:   strings.Repeat("x", 1900),
+		Embeds: []channels.DiscordEmbed{
+			{Description: strings.Repeat("y", 3000)},
+			{Description: strings.Repeat("z", 2500)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !f.called {
+		t.Fatal("API not called — send should have succeeded")
+	}
+}
+
 func TestSendEmbed_ContentTooLong(t *testing.T) {
 	_, err := sendEmbed(context.Background(), &fakeEmbedAPI{}, channels.DiscordSendEmbedParams{
 		ChannelID: "c1",

--- a/internal/channels/discord/embed_test.go
+++ b/internal/channels/discord/embed_test.go
@@ -1,0 +1,217 @@
+package discord
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+)
+
+type fakeEmbedAPI struct {
+	called  bool
+	gotCID  string
+	gotData *discordgo.MessageSend
+	result  *discordgo.Message
+	err     error
+}
+
+func (f *fakeEmbedAPI) channelMessageSendComplex(_ context.Context, channelID string, data *discordgo.MessageSend) (*discordgo.Message, error) {
+	f.called = true
+	f.gotCID = channelID
+	f.gotData = data
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.result == nil {
+		return &discordgo.Message{ID: "m1", ChannelID: channelID}, nil
+	}
+	return f.result, nil
+}
+
+func basicEmbed() channels.DiscordEmbed {
+	return channels.DiscordEmbed{Title: "Hello", Description: "world"}
+}
+
+func TestSendEmbed_RequiresChannelID(t *testing.T) {
+	f := &fakeEmbedAPI{}
+	_, err := sendEmbed(context.Background(), f, channels.DiscordSendEmbedParams{
+		Embeds: []channels.DiscordEmbed{basicEmbed()},
+	})
+	if err == nil || !strings.Contains(err.Error(), "channel_id") {
+		t.Fatalf("expected channel_id error, got %v", err)
+	}
+	if f.called {
+		t.Fatal("API should not be called when channel_id missing")
+	}
+}
+
+func TestSendEmbed_RequiresAtLeastOneEmbed(t *testing.T) {
+	f := &fakeEmbedAPI{}
+	_, err := sendEmbed(context.Background(), f, channels.DiscordSendEmbedParams{ChannelID: "c1"})
+	if err == nil || !strings.Contains(err.Error(), "at least one embed") {
+		t.Fatalf("expected 'at least one embed' error, got %v", err)
+	}
+}
+
+func TestSendEmbed_TooManyEmbeds(t *testing.T) {
+	embeds := make([]channels.DiscordEmbed, embedMaxPerMessage+1)
+	for i := range embeds {
+		embeds[i] = basicEmbed()
+	}
+	_, err := sendEmbed(context.Background(), &fakeEmbedAPI{}, channels.DiscordSendEmbedParams{
+		ChannelID: "c1",
+		Embeds:    embeds,
+	})
+	if err == nil || !strings.Contains(err.Error(), "too many embeds") {
+		t.Fatalf("expected too-many-embeds error, got %v", err)
+	}
+}
+
+func TestSendEmbed_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		embed channels.DiscordEmbed
+		want  string
+	}{
+		{"title too long", channels.DiscordEmbed{Title: strings.Repeat("a", embedTitleMax+1)}, "title exceeds"},
+		{"description too long", channels.DiscordEmbed{Description: strings.Repeat("a", embedDescriptionMax+1)}, "description exceeds"},
+		{"footer without text", channels.DiscordEmbed{Title: "t", Footer: &channels.DiscordEmbedFooter{IconURL: "https://x"}}, "footer.text is required"},
+		{"image without url", channels.DiscordEmbed{Title: "t", Image: &channels.DiscordEmbedMedia{}}, "image.url is required"},
+		{"thumbnail without url", channels.DiscordEmbed{Title: "t", Thumbnail: &channels.DiscordEmbedMedia{}}, "thumbnail.url is required"},
+		{"author without name", channels.DiscordEmbed{Title: "t", Author: &channels.DiscordEmbedAuthor{URL: "https://x"}}, "author.name is required"},
+		{"bad timestamp", channels.DiscordEmbed{Title: "t", Timestamp: "not-a-time"}, "timestamp must be ISO 8601"},
+		{"too many fields", channels.DiscordEmbed{Title: "t", Fields: makeFields(embedMaxFields + 1)}, "too many fields"},
+		{"field missing name", channels.DiscordEmbed{Title: "t", Fields: []channels.DiscordEmbedField{{Value: "v"}}}, "fields[0].name is required"},
+		{"field missing value", channels.DiscordEmbed{Title: "t", Fields: []channels.DiscordEmbedField{{Name: "n"}}}, "fields[0].value is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeEmbedAPI{}
+			_, err := sendEmbed(context.Background(), f, channels.DiscordSendEmbedParams{
+				ChannelID: "c1",
+				Embeds:    []channels.DiscordEmbed{tc.embed},
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error containing %q, got %v", tc.want, err)
+			}
+			if f.called {
+				t.Fatal("API should not be called when validation fails")
+			}
+		})
+	}
+}
+
+func TestSendEmbed_TotalCharCap(t *testing.T) {
+	// Two embeds, each ~3500 chars of description — together they exceed 6000.
+	big := strings.Repeat("x", 3500)
+	_, err := sendEmbed(context.Background(), &fakeEmbedAPI{}, channels.DiscordSendEmbedParams{
+		ChannelID: "c1",
+		Embeds: []channels.DiscordEmbed{
+			{Description: big},
+			{Description: big},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "combined embed text exceeds") {
+		t.Fatalf("expected combined-cap error, got %v", err)
+	}
+}
+
+func TestSendEmbed_ContentTooLong(t *testing.T) {
+	_, err := sendEmbed(context.Background(), &fakeEmbedAPI{}, channels.DiscordSendEmbedParams{
+		ChannelID: "c1",
+		Content:   strings.Repeat("x", messageContentMax+1),
+		Embeds:    []channels.DiscordEmbed{basicEmbed()},
+	})
+	if err == nil || !strings.Contains(err.Error(), "content exceeds") {
+		t.Fatalf("expected content-too-long error, got %v", err)
+	}
+}
+
+func TestSendEmbed_FullConversion(t *testing.T) {
+	f := &fakeEmbedAPI{}
+	res, err := sendEmbed(context.Background(), f, channels.DiscordSendEmbedParams{
+		ChannelID: "c1",
+		Content:   "above text",
+		ReplyTo:   "m0",
+		Embeds: []channels.DiscordEmbed{
+			{
+				Title:       "Status",
+				Description: "All systems go.",
+				URL:         "https://example.com",
+				Color:       0x2ECC71,
+				Timestamp:   "2026-04-21T15:04:05Z",
+				Author:      &channels.DiscordEmbedAuthor{Name: "ci", URL: "https://example.com/ci", IconURL: "https://example.com/ci.png"},
+				Footer:      &channels.DiscordEmbedFooter{Text: "build #42", IconURL: "https://example.com/logo.png"},
+				Image:       &channels.DiscordEmbedMedia{URL: "https://example.com/banner.png"},
+				Thumbnail:   &channels.DiscordEmbedMedia{URL: "https://example.com/thumb.png"},
+				Fields: []channels.DiscordEmbedField{
+					{Name: "env", Value: "prod", Inline: true},
+					{Name: "duration", Value: "12s", Inline: true},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.MessageID != "m1" || res.ChannelID != "c1" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if !f.called {
+		t.Fatal("API was not called")
+	}
+	if f.gotCID != "c1" {
+		t.Errorf("channel id = %q, want c1", f.gotCID)
+	}
+	if f.gotData.Content != "above text" {
+		t.Errorf("content = %q", f.gotData.Content)
+	}
+	if f.gotData.Reference == nil || f.gotData.Reference.MessageID != "m0" {
+		t.Errorf("reply reference not set correctly: %+v", f.gotData.Reference)
+	}
+	if len(f.gotData.Embeds) != 1 {
+		t.Fatalf("embeds count = %d", len(f.gotData.Embeds))
+	}
+	got := f.gotData.Embeds[0]
+	if got.Title != "Status" || got.Description != "All systems go." || got.Color != 0x2ECC71 {
+		t.Errorf("basic fields not copied: %+v", got)
+	}
+	if got.Author == nil || got.Author.Name != "ci" {
+		t.Error("author not copied")
+	}
+	if got.Footer == nil || got.Footer.Text != "build #42" {
+		t.Error("footer not copied")
+	}
+	if got.Image == nil || got.Image.URL != "https://example.com/banner.png" {
+		t.Error("image not copied")
+	}
+	if got.Thumbnail == nil || got.Thumbnail.URL != "https://example.com/thumb.png" {
+		t.Error("thumbnail not copied")
+	}
+	if len(got.Fields) != 2 || got.Fields[0].Name != "env" || !got.Fields[0].Inline {
+		t.Errorf("fields not copied: %+v", got.Fields)
+	}
+}
+
+func TestSendEmbed_APIError(t *testing.T) {
+	f := &fakeEmbedAPI{err: errors.New("HTTP 403: Missing Permissions")}
+	_, err := sendEmbed(context.Background(), f, channels.DiscordSendEmbedParams{
+		ChannelID: "c1",
+		Embeds:    []channels.DiscordEmbed{basicEmbed()},
+	})
+	if err == nil || !strings.Contains(err.Error(), "Missing Permissions") {
+		t.Fatalf("expected wrapped API error, got %v", err)
+	}
+}
+
+func makeFields(n int) []channels.DiscordEmbedField {
+	out := make([]channels.DiscordEmbedField, n)
+	for i := range out {
+		out[i] = channels.DiscordEmbedField{Name: "n", Value: "v"}
+	}
+	return out
+}

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -309,6 +309,21 @@ func (m *Manager) ListGroupMembers(ctx context.Context, channelName, chatID stri
 	return gmp.ListGroupMembers(ctx, chatID)
 }
 
+// SendDiscordEmbed delegates to the named channel's DiscordEmbedSender if available.
+func (m *Manager) SendDiscordEmbed(ctx context.Context, channelName string, params DiscordSendEmbedParams) (DiscordSendEmbedResult, error) {
+	m.mu.RLock()
+	ch, ok := m.channels[channelName]
+	m.mu.RUnlock()
+	if !ok {
+		return DiscordSendEmbedResult{}, fmt.Errorf("channel %q not found", channelName)
+	}
+	des, ok := ch.(DiscordEmbedSender)
+	if !ok {
+		return DiscordSendEmbedResult{}, fmt.Errorf("channel %q does not support Discord embeds", channelName)
+	}
+	return des.SendEmbed(ctx, params)
+}
+
 // UnregisterChannel removes a channel from the manager.
 func (m *Manager) UnregisterChannel(name string) {
 	m.mu.Lock()

--- a/internal/tools/discord_embed.go
+++ b/internal/tools/discord_embed.go
@@ -1,0 +1,309 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// DiscordEmbedSenderFn sends Discord rich embeds on the named channel.
+// Implemented by channels.Manager.SendDiscordEmbed.
+type DiscordEmbedSenderFn func(ctx context.Context, channel string, params channels.DiscordSendEmbedParams) (channels.DiscordSendEmbedResult, error)
+
+// DiscordEmbedSenderAware tools can receive a DiscordEmbedSenderFn.
+type DiscordEmbedSenderAware interface {
+	SetDiscordEmbedSender(DiscordEmbedSenderFn)
+}
+
+// SendDiscordEmbedTool lets agents post Discord rich embeds on a Discord
+// channel instance they have access to.
+type SendDiscordEmbedTool struct {
+	sender        DiscordEmbedSenderFn
+	tenantChecker ChannelTenantChecker
+}
+
+// NewSendDiscordEmbedTool constructs the tool. Both the sender fn and the
+// tenant checker are wired at gateway startup via the *Aware interfaces.
+func NewSendDiscordEmbedTool() *SendDiscordEmbedTool {
+	return &SendDiscordEmbedTool{}
+}
+
+// SetDiscordEmbedSender injects the channel-manager-backed sender fn.
+func (t *SendDiscordEmbedTool) SetDiscordEmbedSender(fn DiscordEmbedSenderFn) {
+	t.sender = fn
+}
+
+// SetChannelTenantChecker injects the tenant guard function.
+func (t *SendDiscordEmbedTool) SetChannelTenantChecker(c ChannelTenantChecker) {
+	t.tenantChecker = c
+}
+
+func (t *SendDiscordEmbedTool) Name() string { return "send_discord_embed" }
+
+func (t *SendDiscordEmbedTool) RequiredChannelTypes() []string { return []string{"discord"} }
+
+func (t *SendDiscordEmbedTool) Description() string {
+	return "Post a Discord rich embed (or up to 10 embeds) on a Discord channel or thread. " +
+		"Use embeds when you have STRUCTURED content that benefits from visual formatting: " +
+		"status cards, search results, leaderboards, release notes, error reports, key-value " +
+		"summaries, or anything with sections/fields. For a plain text reply, just return the " +
+		"reply text normally — do NOT wrap ordinary answers in an embed. " +
+		"\n\n" +
+		"Quick recipes:" +
+		"\n  * Success card: title + green color (0x2ECC71) + checkmark prefix in description." +
+		"\n  * Error card: title + red color (0xE74C3C) + description with cause." +
+		"\n  * Stats card: title + 3-6 fields with inline=true for a grid layout." +
+		"\n  * Article card: title + url (makes title a link) + description + thumbnail." +
+		"\n  * Alert: author (name + icon) + description + timestamp + footer for source." +
+		"\n\n" +
+		"Defaults: targets the current Discord channel from context — set `channel_id` only " +
+		"to post elsewhere (e.g. a thread returned by create_discord_thread). " +
+		"Limits: 10 embeds per call, 25 fields per embed, 6000 total chars across all embed " +
+		"text, 2000 chars for `content`."
+}
+
+// embedFieldSchema is the JSON schema for a single embed field.
+var embedFieldSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"name": map[string]any{
+			"type":        "string",
+			"description": "Field label (max 256 chars, e.g. \"Status\", \"Owner\").",
+		},
+		"value": map[string]any{
+			"type":        "string",
+			"description": "Field value (max 1024 chars, supports markdown).",
+		},
+		"inline": map[string]any{
+			"type":        "boolean",
+			"description": "If true, Discord packs this field alongside adjacent inline fields (up to three per row). Use for compact stat grids.",
+		},
+	},
+	"required": []string{"name", "value"},
+}
+
+// embedSchema is the JSON schema for a single embed object.
+var embedSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"title": map[string]any{
+			"type":        "string",
+			"description": "Embed title shown in bold at the top (max 256 chars). Combine with `url` to make it a clickable link.",
+		},
+		"description": map[string]any{
+			"type":        "string",
+			"description": "Main body text (max 4096 chars, supports markdown including links and code blocks).",
+		},
+		"url": map[string]any{
+			"type":        "string",
+			"description": "Optional URL. Turns the title into a link.",
+		},
+		"color": map[string]any{
+			"type":        "integer",
+			"description": "Accent color as decimal RGB (e.g. 3447003 = blue, 5763719 = green, 15158332 = red, 15844367 = yellow). Hex-to-decimal: 0x5865F2 = 5793266 (Discord blurple).",
+		},
+		"timestamp": map[string]any{
+			"type":        "string",
+			"description": "ISO 8601 / RFC 3339 timestamp shown in the footer area (e.g. \"2026-04-21T15:04:05Z\").",
+		},
+		"footer": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"text":     map[string]any{"type": "string", "description": "Footer text (max 2048 chars)."},
+				"icon_url": map[string]any{"type": "string", "description": "Small icon shown left of the footer text."},
+			},
+			"required":    []string{"text"},
+			"description": "Footer block at the bottom of the embed.",
+		},
+		"image": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"url": map[string]any{"type": "string", "description": "Public http(s) URL of the image."},
+			},
+			"required":    []string{"url"},
+			"description": "Large image shown below the description.",
+		},
+		"thumbnail": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"url": map[string]any{"type": "string", "description": "Public http(s) URL of the thumbnail."},
+			},
+			"required":    []string{"url"},
+			"description": "Small image shown in the top-right corner of the embed.",
+		},
+		"author": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name":     map[string]any{"type": "string", "description": "Author name shown at the top (max 256 chars)."},
+				"url":      map[string]any{"type": "string", "description": "Makes the author name a link."},
+				"icon_url": map[string]any{"type": "string", "description": "Avatar shown to the left of the author name."},
+			},
+			"required":    []string{"name"},
+			"description": "Author block at the top of the embed (above the title).",
+		},
+		"fields": map[string]any{
+			"type":        "array",
+			"items":       embedFieldSchema,
+			"description": "Up to 25 key/value rows. Set inline=true to pack adjacent fields on one line.",
+		},
+	},
+}
+
+func (t *SendDiscordEmbedTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"channel": map[string]any{
+				"type":        "string",
+				"description": "Discord channel instance name (default: current channel from context).",
+			},
+			"channel_id": map[string]any{
+				"type":        "string",
+				"description": "Target Discord channel or thread ID. Default: current channel ID from context. Use a thread_id returned by create_discord_thread to post into that thread.",
+			},
+			"content": map[string]any{
+				"type":        "string",
+				"description": "Optional plain text shown above the embeds. 2000 char limit. Omit for embed-only messages.",
+			},
+			"reply_to": map[string]any{
+				"type":        "string",
+				"description": "Optional message ID to reply to. Creates a Discord inline reply pointing at that message.",
+			},
+			"embeds": map[string]any{
+				"type":        "array",
+				"items":       embedSchema,
+				"description": "1 to 10 embeds to send in a single message. Combined text across all embeds is capped at 6000 chars by Discord.",
+			},
+		},
+		"required": []string{"embeds"},
+	}
+}
+
+func (t *SendDiscordEmbedTool) Execute(ctx context.Context, args map[string]any) *Result {
+	if t.sender == nil {
+		return ErrorResult("send_discord_embed: no Discord embed sender available")
+	}
+
+	channel, _ := args["channel"].(string)
+	if channel == "" {
+		channel = ToolChannelFromCtx(ctx)
+	}
+	if channel == "" {
+		return ErrorResult("channel is required (no current channel in context)")
+	}
+
+	channelID, _ := args["channel_id"].(string)
+	if channelID == "" {
+		channelID = ToolChatIDFromCtx(ctx)
+	}
+	if channelID == "" {
+		return ErrorResult("channel_id is required (no current channel_id in context)")
+	}
+
+	rawEmbeds, ok := args["embeds"].([]any)
+	if !ok || len(rawEmbeds) == 0 {
+		return ErrorResult("embeds is required (at least one embed)")
+	}
+	embeds := make([]channels.DiscordEmbed, 0, len(rawEmbeds))
+	for i, raw := range rawEmbeds {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return ErrorResult(fmt.Sprintf("embeds[%d] must be an object", i))
+		}
+		e, err := decodeEmbed(m)
+		if err != nil {
+			return ErrorResult(fmt.Sprintf("embeds[%d]: %v", i, err))
+		}
+		embeds = append(embeds, e)
+	}
+
+	// Tenant gate: mirrors the pattern from MessageTool / CreateDiscordThreadTool.
+	if t.tenantChecker != nil {
+		chTenant, exists := t.tenantChecker(channel)
+		if !exists {
+			return ErrorResult(fmt.Sprintf("channel %q not found", channel))
+		}
+		if chTenant != uuid.Nil {
+			ctxTenant := store.TenantIDFromContext(ctx)
+			if ctxTenant != uuid.Nil && chTenant != ctxTenant {
+				slog.Warn("security.cross_tenant_embed_blocked",
+					"channel", channel, "channel_id", channelID,
+					"ctx_tenant", ctxTenant, "ch_tenant", chTenant)
+				return ErrorResult("channel not accessible from this tenant")
+			}
+		}
+	}
+
+	params := channels.DiscordSendEmbedParams{
+		ChannelID: channelID,
+		Content:   argString(args, "content"),
+		ReplyTo:   argString(args, "reply_to"),
+		Embeds:    embeds,
+	}
+
+	result, err := t.sender(ctx, channel, params)
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("sending discord embed: %v", err))
+	}
+
+	data, _ := json.Marshal(result)
+	return NewResult(string(data))
+}
+
+// decodeEmbed converts an untyped tool-args embed map into the structured
+// channels.DiscordEmbed. Field-level shape errors are returned here so the
+// LLM gets an immediate, explicit error rather than a Discord API rejection.
+func decodeEmbed(m map[string]any) (channels.DiscordEmbed, error) {
+	out := channels.DiscordEmbed{
+		Title:       argString(m, "title"),
+		Description: argString(m, "description"),
+		URL:         argString(m, "url"),
+		Timestamp:   argString(m, "timestamp"),
+	}
+	if v, ok := m["color"].(float64); ok {
+		out.Color = int(v)
+	}
+
+	if v, ok := m["footer"].(map[string]any); ok {
+		out.Footer = &channels.DiscordEmbedFooter{
+			Text:    argString(v, "text"),
+			IconURL: argString(v, "icon_url"),
+		}
+	}
+	if v, ok := m["image"].(map[string]any); ok {
+		out.Image = &channels.DiscordEmbedMedia{URL: argString(v, "url")}
+	}
+	if v, ok := m["thumbnail"].(map[string]any); ok {
+		out.Thumbnail = &channels.DiscordEmbedMedia{URL: argString(v, "url")}
+	}
+	if v, ok := m["author"].(map[string]any); ok {
+		out.Author = &channels.DiscordEmbedAuthor{
+			Name:    argString(v, "name"),
+			URL:     argString(v, "url"),
+			IconURL: argString(v, "icon_url"),
+		}
+	}
+	if raw, ok := m["fields"].([]any); ok {
+		out.Fields = make([]channels.DiscordEmbedField, 0, len(raw))
+		for i, r := range raw {
+			fm, ok := r.(map[string]any)
+			if !ok {
+				return channels.DiscordEmbed{}, fmt.Errorf("fields[%d] must be an object", i)
+			}
+			inline, _ := fm["inline"].(bool)
+			out.Fields = append(out.Fields, channels.DiscordEmbedField{
+				Name:   argString(fm, "name"),
+				Value:  argString(fm, "value"),
+				Inline: inline,
+			})
+		}
+	}
+
+	return out, nil
+}

--- a/internal/tools/discord_embed_test.go
+++ b/internal/tools/discord_embed_test.go
@@ -177,6 +177,49 @@ func TestSendDiscordEmbed_TenantBlock(t *testing.T) {
 	}
 }
 
+// TestSendDiscordEmbed_ChannelNotFound covers the tenant-checker path where
+// the named channel instance does not exist in the manager. Mirrors the same
+// test in create_discord_thread so the coverage shape is consistent.
+func TestSendDiscordEmbed_ChannelNotFound(t *testing.T) {
+	f := &fakeEmbedSender{}
+	tool := NewSendDiscordEmbedTool()
+	tool.SetDiscordEmbedSender(f.fn)
+	tool.SetChannelTenantChecker(func(_ string) (uuid.UUID, bool) { return uuid.Nil, false })
+
+	res := tool.Execute(embedCtx(), map[string]any{
+		"embeds": []any{map[string]any{"title": "x"}},
+	})
+	if res == nil || !res.IsError || !strings.Contains(res.ForLLM, "not found") {
+		t.Fatalf("expected channel-not-found error, got %+v", res)
+	}
+	if f.called {
+		t.Fatal("sender should not be invoked when channel is unknown")
+	}
+}
+
+// TestSendDiscordEmbed_LegacyChannelBypassesTenantCheck covers the code path
+// where the channel instance is tenant-less (uuid.Nil — legacy/config-based
+// channels). The tenant check should fall through and the send should
+// proceed regardless of any tenant on the context.
+func TestSendDiscordEmbed_LegacyChannelBypassesTenantCheck(t *testing.T) {
+	f := &fakeEmbedSender{result: channels.DiscordSendEmbedResult{MessageID: "m1"}}
+	tool := NewSendDiscordEmbedTool()
+	tool.SetDiscordEmbedSender(f.fn)
+	tool.SetChannelTenantChecker(func(_ string) (uuid.UUID, bool) { return uuid.Nil, true })
+
+	// A context tenant is set; channel is legacy (uuid.Nil), so mismatch doesn't apply.
+	ctx := store.WithTenantID(embedCtx(), uuid.New())
+	res := tool.Execute(ctx, map[string]any{
+		"embeds": []any{map[string]any{"title": "x"}},
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("expected success on legacy channel, got %+v", res)
+	}
+	if !f.called {
+		t.Fatal("sender should run for legacy channel regardless of ctx tenant")
+	}
+}
+
 func TestSendDiscordEmbed_SenderError(t *testing.T) {
 	f := &fakeEmbedSender{err: errors.New("HTTP 403")}
 	tool := NewSendDiscordEmbedTool()

--- a/internal/tools/discord_embed_test.go
+++ b/internal/tools/discord_embed_test.go
@@ -1,0 +1,191 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+type fakeEmbedSender struct {
+	called   bool
+	gotCh    string
+	gotParam channels.DiscordSendEmbedParams
+	result   channels.DiscordSendEmbedResult
+	err      error
+}
+
+func (f *fakeEmbedSender) fn(_ context.Context, ch string, params channels.DiscordSendEmbedParams) (channels.DiscordSendEmbedResult, error) {
+	f.called = true
+	f.gotCh = ch
+	f.gotParam = params
+	return f.result, f.err
+}
+
+func embedCtx() context.Context {
+	ctx := context.Background()
+	ctx = WithToolChannel(ctx, "disc")
+	ctx = WithToolChatID(ctx, "1111")
+	ctx = WithToolPeerKind(ctx, "group")
+	return ctx
+}
+
+func TestSendDiscordEmbed_NoSender(t *testing.T) {
+	tool := NewSendDiscordEmbedTool()
+	res := tool.Execute(embedCtx(), map[string]any{
+		"embeds": []any{map[string]any{"title": "x"}},
+	})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result when sender unset, got %+v", res)
+	}
+}
+
+func TestSendDiscordEmbed_RequiresEmbeds(t *testing.T) {
+	f := &fakeEmbedSender{}
+	tool := NewSendDiscordEmbedTool()
+	tool.SetDiscordEmbedSender(f.fn)
+
+	for _, args := range []map[string]any{
+		{}, // missing
+		{"embeds": []any{}}, // empty
+	} {
+		res := tool.Execute(embedCtx(), args)
+		if res == nil || !res.IsError {
+			t.Errorf("args=%v: want error result, got %+v", args, res)
+		}
+		if f.called {
+			t.Errorf("args=%v: sender should not be called", args)
+		}
+	}
+}
+
+func TestSendDiscordEmbed_ContextFallback(t *testing.T) {
+	f := &fakeEmbedSender{result: channels.DiscordSendEmbedResult{MessageID: "m1", ChannelID: "1111"}}
+	tool := NewSendDiscordEmbedTool()
+	tool.SetDiscordEmbedSender(f.fn)
+
+	res := tool.Execute(embedCtx(), map[string]any{
+		"embeds": []any{map[string]any{"title": "Hi", "description": "there"}},
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %+v", res)
+	}
+	if !f.called {
+		t.Fatal("sender was not called")
+	}
+	if f.gotCh != "disc" {
+		t.Errorf("channel = %q, want disc", f.gotCh)
+	}
+	if f.gotParam.ChannelID != "1111" {
+		t.Errorf("channel_id = %q, want 1111 (from ctx)", f.gotParam.ChannelID)
+	}
+	if len(f.gotParam.Embeds) != 1 || f.gotParam.Embeds[0].Title != "Hi" {
+		t.Errorf("embeds decoded wrong: %+v", f.gotParam.Embeds)
+	}
+
+	var got channels.DiscordSendEmbedResult
+	if err := json.Unmarshal([]byte(res.ForLLM), &got); err != nil {
+		t.Fatalf("result JSON: %v", err)
+	}
+	if got.MessageID != "m1" {
+		t.Errorf("result message_id = %q", got.MessageID)
+	}
+}
+
+func TestSendDiscordEmbed_FullDecode(t *testing.T) {
+	f := &fakeEmbedSender{result: channels.DiscordSendEmbedResult{MessageID: "m1"}}
+	tool := NewSendDiscordEmbedTool()
+	tool.SetDiscordEmbedSender(f.fn)
+
+	res := tool.Execute(embedCtx(), map[string]any{
+		"channel_id": "2222",
+		"content":    "heads up",
+		"reply_to":   "m0",
+		"embeds": []any{
+			map[string]any{
+				"title":       "Status",
+				"description": "ok",
+				"url":         "https://example.com",
+				"color":       float64(0x2ECC71),
+				"timestamp":   "2026-04-21T15:04:05Z",
+				"author":      map[string]any{"name": "ci", "url": "https://ex.com/ci", "icon_url": "https://ex.com/i.png"},
+				"footer":      map[string]any{"text": "b42", "icon_url": "https://ex.com/f.png"},
+				"image":       map[string]any{"url": "https://ex.com/big.png"},
+				"thumbnail":   map[string]any{"url": "https://ex.com/th.png"},
+				"fields": []any{
+					map[string]any{"name": "env", "value": "prod", "inline": true},
+					map[string]any{"name": "dur", "value": "12s", "inline": true},
+				},
+			},
+		},
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %+v", res)
+	}
+	p := f.gotParam
+	if p.ChannelID != "2222" || p.Content != "heads up" || p.ReplyTo != "m0" {
+		t.Errorf("top-level params wrong: %+v", p)
+	}
+	if len(p.Embeds) != 1 {
+		t.Fatalf("embeds count = %d", len(p.Embeds))
+	}
+	e := p.Embeds[0]
+	if e.Title != "Status" || e.URL != "https://example.com" || e.Color != 0x2ECC71 {
+		t.Errorf("basic fields wrong: %+v", e)
+	}
+	if e.Author == nil || e.Author.Name != "ci" {
+		t.Error("author not decoded")
+	}
+	if e.Footer == nil || e.Footer.Text != "b42" {
+		t.Error("footer not decoded")
+	}
+	if e.Image == nil || e.Image.URL != "https://ex.com/big.png" {
+		t.Error("image not decoded")
+	}
+	if e.Thumbnail == nil || e.Thumbnail.URL != "https://ex.com/th.png" {
+		t.Error("thumbnail not decoded")
+	}
+	if len(e.Fields) != 2 || !e.Fields[0].Inline {
+		t.Errorf("fields not decoded: %+v", e.Fields)
+	}
+}
+
+func TestSendDiscordEmbed_TenantBlock(t *testing.T) {
+	f := &fakeEmbedSender{}
+	tool := NewSendDiscordEmbedTool()
+	tool.SetDiscordEmbedSender(f.fn)
+
+	chTenant := uuid.New()
+	tool.SetChannelTenantChecker(func(_ string) (uuid.UUID, bool) { return chTenant, true })
+
+	// Different tenant on context — should block.
+	ctx := store.WithTenantID(embedCtx(), uuid.New())
+	res := tool.Execute(ctx, map[string]any{
+		"embeds": []any{map[string]any{"title": "x"}},
+	})
+	if res == nil || !res.IsError || !strings.Contains(res.ForLLM, "not accessible") {
+		t.Fatalf("expected cross-tenant block, got %+v", res)
+	}
+	if f.called {
+		t.Fatal("sender should not be invoked on tenant block")
+	}
+}
+
+func TestSendDiscordEmbed_SenderError(t *testing.T) {
+	f := &fakeEmbedSender{err: errors.New("HTTP 403")}
+	tool := NewSendDiscordEmbedTool()
+	tool.SetDiscordEmbedSender(f.fn)
+
+	res := tool.Execute(embedCtx(), map[string]any{
+		"embeds": []any{map[string]any{"title": "x"}},
+	})
+	if res == nil || !res.IsError || !strings.Contains(res.ForLLM, "HTTP 403") {
+		t.Fatalf("expected wrapped error, got %+v", res)
+	}
+}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -20,7 +20,7 @@ var builtinToolGroups = map[string][]string{
 	"sessions":   {"sessions_list", "sessions_history", "sessions_send", "spawn", "session_status"},
 	"ui":         {"browser"},
 	"automation": {"cron"},
-	"messaging":  {"message", "create_forum_topic", "list_group_members"},
+	"messaging":  {"message", "create_forum_topic", "list_group_members", "send_discord_embed"},
 	"team":       {"team_tasks"},
 	// Composite group: all goclaw native tools (excludes MCP/custom plugins).
 	"goclaw": {
@@ -31,7 +31,7 @@ var builtinToolGroups = map[string][]string{
 		"sessions_list", "sessions_history", "sessions_send", "spawn", "session_status",
 		"delegate",
 		"cron", "datetime", "heartbeat",
-		"message", "create_forum_topic", "list_group_members",
+		"message", "create_forum_topic", "list_group_members", "send_discord_embed",
 		"read_image", "read_document", "read_audio", "read_video",
 		"create_image", "create_video", "create_audio",
 		"skill_search", "skill_manage", "publish_skill", "use_skill",


### PR DESCRIPTION
## Summary

Adds a new agent tool `send_discord_embed` that posts Discord rich embeds via `ChannelMessageSendComplex`, mirroring the `create_discord_thread` pattern (types on `channels`, `Manager.SendDiscordEmbed` dispatch, `*Aware` injection at gateway startup). Validates every Discord embed limit (256/4096/2048/1024/6000/25) in-process before the API call. Tool description ships with use-case recipes + concrete decimal-RGB values so the LLM knows when and how to reach for it.

## Review (added commit `7261cf8f`)

Pre-landing review caught a real correctness bug + two coverage gaps:

- **Correctness bug — fixed.** The 6000-char embed cap was counting `params.Content` in its sum. Discord's 6000 applies to embed text only; `content` has its own 2000-char cap (enforced separately). Under the previous code, a legitimate send like `content=1900 chars + embeds totaling 5500 chars` (7400 combined but only 5500 embed, well under 6000) was rejected with a spurious "combined embed text exceeds 6000 characters". Fixed by starting the counter at 0.
- **Coverage gaps — filled.** Added `TestSendDiscordEmbed_ChannelNotFound` (tenant checker returns `!exists`) and `TestSendDiscordEmbed_LegacyChannelBypassesTenantCheck` (legacy `uuid.Nil` tenant falls through the check). Both mirror the matching coverage in `create_discord_thread`'s test suite.

## Test plan

- [x] `go build ./...` + `go build -tags sqliteonly ./...` + `go vet ./...`
- [x] `go test ./internal/channels/discord/... ./internal/tools/` — all pass
- [x] New `TestSendEmbed_ContentDoesNotCountTowardEmbedCap` proves the 6000-cap fix with a concrete repro
- [ ] Manual: agent on Discord posts a multi-embed message with accompanying content near the 2000-char cap + embeds totaling 5000+ chars — confirm it goes through instead of failing validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)