### PR TITLE
feat(pipeline): add tool call authorization mechanism

### DIFF
--- a/internal/agent/loop_pipeline_adapter.go
+++ b/internal/agent/loop_pipeline_adapter.go
@@ -137,6 +137,7 @@ func (l *Loop) buildPipelineDeps(req *RunRequest, bridgeRS *runState) pipeline.P
 		ExecuteToolCall:   cb.executeToolCall,
 		ExecuteToolRaw:    cb.executeToolRaw,
 		ProcessToolResult: cb.processToolResult,
+		AuthorizeToolCall: cb.authorizeToolCall,
 		CheckReadOnly:     cb.checkReadOnly,
 
 		// Observe: drain InjectCh

--- a/internal/agent/loop_pipeline_callbacks.go
+++ b/internal/agent/loop_pipeline_callbacks.go
@@ -54,6 +54,7 @@ func (l *Loop) pipelineCallbacks(req *RunRequest, bridgeRS *runState) pipelineCa
 		executeToolCall:    l.makeExecuteToolCall(req, bridgeRS),
 		executeToolRaw:     l.makeExecuteToolRaw(req),
 		processToolResult:  l.makeProcessToolResult(req, bridgeRS),
+		authorizeToolCall:  l.makeAuthorizeToolCall(),
 		checkReadOnly:      l.makeCheckReadOnly(req, bridgeRS),
 		sanitizeContent:    SanitizeAssistantContent,
 		flushMessages:      l.makeFlushMessages(req),
@@ -82,6 +83,7 @@ type pipelineCallbackSet struct {
 	executeToolCall    func(ctx context.Context, state *pipeline.RunState, tc providers.ToolCall) ([]providers.Message, error)
 	executeToolRaw     func(ctx context.Context, tc providers.ToolCall) (providers.Message, any, error)
 	processToolResult  func(ctx context.Context, state *pipeline.RunState, tc providers.ToolCall, rawMsg providers.Message, rawData any) []providers.Message
+	authorizeToolCall  func(ctx context.Context, state *pipeline.RunState, tc providers.ToolCall) (bool, string)
 	checkReadOnly      func(state *pipeline.RunState) (*providers.Message, bool)
 	sanitizeContent    func(string) string
 	flushMessages      func(ctx context.Context, sessionKey string, msgs []providers.Message) error
@@ -215,6 +217,33 @@ func (l *Loop) makeBuildFilteredTools(req *RunRequest) func(state *pipeline.RunS
 			}
 		}
 		return toolDefs, nil
+	}
+}
+
+// makeAuthorizeToolCall enforces runtime tool allowlist checks before execution.
+// This is a fail-closed guard in case a model emits a tool call that was not
+// present in the per-iteration tool definitions.
+func (l *Loop) makeAuthorizeToolCall() func(ctx context.Context, state *pipeline.RunState, tc providers.ToolCall) (bool, string) {
+	return func(_ context.Context, state *pipeline.RunState, tc providers.ToolCall) (bool, string) {
+		allowed := state.Tool.AllowedTools
+		if allowed == nil {
+			return true, ""
+		}
+		if allowed[tc.Name] {
+			return true, ""
+		}
+
+		// Preserve lazy activation for deferred tools (typically per-user MCP).
+		if l.tools != nil && l.tools.TryActivateDeferred(tc.Name) {
+			// Guard lazy activation with deny policy to prevent bypass.
+			if l.toolPolicy != nil && l.toolPolicy.IsDenied(tc.Name, l.agentToolPolicy) {
+				return false, "tool not allowed by policy: " + tc.Name
+			}
+			allowed[tc.Name] = true
+			return true, ""
+		}
+
+		return false, "tool not allowed by policy: " + tc.Name
 	}
 }
 

--- a/internal/pipeline/deps.go
+++ b/internal/pipeline/deps.go
@@ -89,6 +89,9 @@ type PipelineDeps struct {
 	ExecuteToolRaw func(ctx context.Context, tc providers.ToolCall) (providers.Message, any, error)
 	// ProcessToolResult processes a raw tool result with state mutation (sequential only).
 	ProcessToolResult func(ctx context.Context, state *RunState, tc providers.ToolCall, rawMsg providers.Message, rawData any) []providers.Message
+	// AuthorizeToolCall validates whether a tool call is allowed to execute.
+	// Used by ToolStage as a runtime guard against out-of-policy tool calls.
+	AuthorizeToolCall func(ctx context.Context, state *RunState, tc providers.ToolCall) (bool, string)
 	// CheckReadOnly checks read-only streak. Returns warning message (if any) and whether to break.
 	CheckReadOnly func(state *RunState) (*providers.Message, bool)
 

--- a/internal/pipeline/substates.go
+++ b/internal/pipeline/substates.go
@@ -45,6 +45,9 @@ type PruneState struct {
 
 // ToolState: owned by ToolStage.
 type ToolState struct {
+	// AllowedTools is the per-iteration execution allowlist built from tool
+	// definitions sent to the provider. Nil means "no runtime restriction".
+	AllowedTools   map[string]bool
 	LoopDetector   any // concrete type toolLoopState lives in agent; Phase 5 defines LoopDetector interface
 	TotalToolCalls int
 	AsyncToolCalls []string      // tool names that executed async (spawn)

--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -41,6 +41,13 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		if err != nil {
 			return fmt.Errorf("build tools: %w", err)
 		}
+		allowed := make(map[string]bool, len(toolDefs))
+		for _, td := range toolDefs {
+			allowed[td.Function.Name] = true
+		}
+		state.Tool.AllowedTools = allowed
+	} else {
+		state.Tool.AllowedTools = nil
 	}
 
 	// 3. Construct ChatRequest

--- a/internal/pipeline/tool_stage.go
+++ b/internal/pipeline/tool_stage.go
@@ -48,6 +48,19 @@ func (s *ToolStage) Execute(ctx context.Context, state *RunState) error {
 
 	// Sequential fallback: ExecuteToolCall handles both I/O and state mutation.
 	for _, tc := range toolCalls {
+		if s.deps.AuthorizeToolCall != nil {
+			if ok, reason := s.deps.AuthorizeToolCall(ctx, state, tc); !ok {
+				state.Messages.AppendPending(providers.Message{
+					Role:       "tool",
+					Content:    reason,
+					ToolCallID: tc.ID,
+					IsError:    true,
+				})
+				state.Tool.TotalToolCalls++
+				continue
+			}
+		}
+
 		// Hook: sync PreToolUse — block if hook denies. Builtin-source hooks may
 		// rewrite tc.Arguments via UpdatedToolInput (e.g. path-sanitizer); apply
 		// before ExecuteToolCall so the rewrite is authoritative.
@@ -114,10 +127,30 @@ func (s *ToolStage) executeParallel(ctx context.Context, state *RunState, toolCa
 		err     error
 	}
 
+	filteredCalls := make([]providers.ToolCall, 0, len(toolCalls))
+	for _, tc := range toolCalls {
+		if s.deps.AuthorizeToolCall != nil {
+			if ok, reason := s.deps.AuthorizeToolCall(ctx, state, tc); !ok {
+				state.Messages.AppendPending(providers.Message{
+					Role:       "tool",
+					Content:    reason,
+					ToolCallID: tc.ID,
+					IsError:    true,
+				})
+				state.Tool.TotalToolCalls++
+				continue
+			}
+		}
+		filteredCalls = append(filteredCalls, tc)
+	}
+	if len(filteredCalls) == 0 {
+		return nil
+	}
+
 	// Phase 1: parallel I/O (no state mutation)
-	results := make([]rawResult, len(toolCalls))
+	results := make([]rawResult, len(filteredCalls))
 	var wg sync.WaitGroup
-	for i, tc := range toolCalls {
+	for i, tc := range filteredCalls {
 		wg.Add(1)
 		go func(idx int, tc providers.ToolCall) {
 			defer wg.Done()

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -434,18 +434,31 @@ func unionWithSpec(reg *Registry, current []string, allTools []string, spec []st
 // IsDenied checks if a tool name is explicitly denied by global or agent policy.
 // Used to prevent lazy-activated deferred tools from bypassing the deny list.
 func (pe *PolicyEngine) IsDenied(name string, agentPolicy *config.ToolPolicySpec) bool {
+	candidates := map[string]struct{}{name: {}}
+	// Keep legacy alias compatibility (e.g. bash -> exec).
+	candidates[resolveAlias(name)] = struct{}{}
+	// Include registry alias mapping when available.
 	pe.mu.RLock()
 	reg := pe.registry
 	pe.mu.RUnlock()
+	if reg != nil {
+		if canonical, ok := reg.Aliases()[name]; ok && canonical != "" {
+			candidates[canonical] = struct{}{}
+		}
+	}
 
 	if pe.globalPolicy != nil {
-		if matchDenySpec(reg, name, pe.globalPolicy.Deny) {
-			return true
+		for candidate := range candidates {
+			if matchDenySpec(reg, candidate, pe.globalPolicy.Deny) {
+				return true
+			}
 		}
 	}
 	if agentPolicy != nil {
-		if matchDenySpec(reg, name, agentPolicy.Deny) {
-			return true
+		for candidate := range candidates {
+			if matchDenySpec(reg, candidate, agentPolicy.Deny) {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION

## Summary
Tool deny rules were only applied when building the model-visible tool list, not at execution time, so `exec` could still be called via exec/bash paths.

This fix adds per-iteration runtime authorization before every tool execution (sequential and parallel), keeps deferred tool activation but re-checks deny policy, and hardens IsDenied to include alias resolution (bash -> exec).

Result: denied tools are now blocked reliably at runtime, even if the model still attempts the call.

- Introduced `AuthorizeToolCall` function to validate tool calls against a runtime allowlist.
- Updated `ToolStage` to utilize the new authorization check before executing tool calls.
- Enhanced `PipelineDeps` and `ToolState` to support the new authorization logic.
- Implemented lazy activation for deferred tools with policy checks to prevent unauthorized access.
- Ensured that the `ThinkStage` initializes the allowed tools list based on tool definitions.


## Type
<!-- Check one -->
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [ ] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
