### PR TITLE
fix(telegram): surface agent errors + balance markdown/HTML across chunks

### DIFF
--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -396,7 +396,11 @@ func processNormalMessage(
 	})
 
 	// Handle result asynchronously to not block the flush callback.
-	go func(agentKey, channel, chatID, session, rID, peerKind, inboundContent string, meta map[string]string, blockReplyEnabled bool, ptd *tools.PendingTeamDispatch) {
+	inboundLocale := msg.Metadata["locale"]
+	if inboundLocale == "" {
+		inboundLocale = "en"
+	}
+	go func(agentKey, channel, chatID, session, rID, peerKind, inboundContent, locale string, meta map[string]string, blockReplyEnabled bool, ptd *tools.PendingTeamDispatch) {
 		outcome := <-outCh
 
 		// Release team create lock — tasks already visible in DB, other goroutines can list.
@@ -430,13 +434,17 @@ func processNormalMessage(
 				return
 			}
 			slog.Error("inbound: agent run failed", "error", outcome.Err, "channel", channel)
-			// Suppress technical error text on public-facing channels (FB, Telegram, etc.)
-			// Empty Content still triggers placeholder/typing cleanup downstream.
+			// On external channels (Telegram, FB, Zalo, etc.) the raw technical error text
+			// is noise to end-users. But publishing empty Content was silently
+			// abandoning the user with a stopped typing indicator and no explanation —
+			// users had no way to tell whether the bot died or was still thinking.
+			// Surface a localized, generic fallback so they know to retry.
 			errContent := formatAgentError(outcome.Err)
 			if deps.ChannelMgr != nil {
 				if ct := deps.ChannelMgr.ChannelTypeForName(channel); isExternalChannel(ct) {
-					slog.Info("inbound: suppressed error for external channel", "channel", channel, "type", ct)
-					errContent = ""
+					errContent = i18n.T(locale, i18n.MsgAgentErrorGeneric)
+					slog.Info("inbound: sent generic fallback for external channel error",
+						"channel", channel, "type", ct, "locale", locale)
 				}
 			}
 			deps.MsgBus.PublishOutbound(bus.OutboundMessage{
@@ -505,5 +513,5 @@ func processNormalMessage(
 		if deps.TeamStore != nil && channel != tools.ChannelSystem && channel != tools.ChannelTeammate && channel != tools.ChannelDashboard {
 			go autoSetFollowup(ctx, deps.TeamStore, deps.AgentStore, agentKey, channel, chatID, replyContent)
 		}
-	}(agentID, msg.Channel, msg.ChatID, sessionKey, runID, peerKind, msg.Content, outMeta, blockReply, ptd)
+	}(agentID, msg.Channel, msg.ChatID, sessionKey, runID, peerKind, msg.Content, inboundLocale, outMeta, blockReply, ptd)
 }

--- a/internal/channels/telegram/format.go
+++ b/internal/channels/telegram/format.go
@@ -49,6 +49,15 @@ func markdownToTelegramHTML(text string) string {
 	// by escapeHTML() and displayed as literal "<b>bold</b>" text.
 	text = htmlTagToMarkdown(text)
 
+	// Balance unclosed bold/italic markers BEFORE formatting. When the LLM gets
+	// cut off mid-bold (max_tokens truncation, finish_reason=length, stream
+	// terminate), the raw content ends with "... : **70" and the non-greedy
+	// regex below silently passes it through as literal `**`. Users then see
+	// `• Anh thực nhận: **70` on Telegram. Stripping the lone marker is
+	// cleaner than appending a closing one (which would bold a partial word).
+	text = balanceMarkdownMarker(text, "**")
+	text = balanceMarkdownMarker(text, "__")
+
 	// Extract markdown tables FIRST — uses dedicated \x00TB placeholders.
 	// Tables render as <pre> (monospace block) WITHOUT <code> wrapper,
 	// so Telegram shows them as preformatted text, not as "code" with copy button.
@@ -448,5 +457,125 @@ func chunkHTML(text string, maxLen int) []string {
 		remaining = strings.TrimLeft(remaining[cutAt:], " \n")
 	}
 
-	return chunks
+	return balanceChunkTags(chunks)
+}
+
+// balanceMarkdownMarker strips the last unclosed marker pair (e.g. "**" or "__").
+// Telegram's non-greedy bold regex silently drops unmatched markers, so the
+// literal "**" leaks through to the rendered message. When the LLM is cut off
+// mid-bold, we'd rather lose the bold styling than render a literal "**".
+func balanceMarkdownMarker(text, marker string) string {
+	if !strings.Contains(text, marker) {
+		return text
+	}
+	if strings.Count(text, marker)%2 == 0 {
+		return text
+	}
+	last := strings.LastIndex(text, marker)
+	if last < 0 {
+		return text
+	}
+	return text[:last] + text[last+len(marker):]
+}
+
+// inlineFormattingTags enumerates Telegram HTML tags that can legitimately span
+// cross-chunk if the content is long. We close them at the end of the chunk
+// and re-open them at the start of the next so each chunk is a valid Telegram
+// HTML fragment.
+var inlineFormattingTags = []string{"b", "i", "u", "s", "code"}
+
+// balanceChunkTags closes any still-open inline formatting tags at the end of
+// each chunk and re-opens them at the start of the next. Without this, a
+// paragraph like `<b>foo\n\nbar</b>` split at `\n\n` would produce chunk 1
+// `<b>foo` (unclosed, Telegram rejects) and chunk 2 `bar</b>` (orphan close).
+func balanceChunkTags(chunks []string) []string {
+	if len(chunks) <= 1 {
+		return chunks
+	}
+	out := make([]string, 0, len(chunks))
+	var carry []string // tag names still open, to re-open at start of next chunk
+	for _, chunk := range chunks {
+		if len(carry) > 0 {
+			var b strings.Builder
+			for _, name := range carry {
+				b.WriteString("<")
+				b.WriteString(name)
+				b.WriteString(">")
+			}
+			b.WriteString(chunk)
+			chunk = b.String()
+		}
+		closed, stillOpen := closeUnclosedInlineTags(chunk)
+		out = append(out, closed)
+		carry = stillOpen
+	}
+	return out
+}
+
+// closeUnclosedInlineTags scans chunk, appends close tags for any unclosed
+// inline formatting tag, and returns the list of tag names that were unclosed
+// (so they can be re-opened in the next chunk). Tags with attributes (like
+// `<a href>`) and non-inline tags (`<pre>`, `<code class=...>`) are ignored —
+// the chunkHTML boundary logic already avoids splitting inside a tag.
+func closeUnclosedInlineTags(chunk string) (string, []string) {
+	var stack []string
+	i := 0
+	for i < len(chunk) {
+		lt := strings.IndexByte(chunk[i:], '<')
+		if lt < 0 {
+			break
+		}
+		i += lt
+		gt := strings.IndexByte(chunk[i:], '>')
+		if gt < 0 {
+			break
+		}
+		raw := chunk[i+1 : i+gt]
+		i += gt + 1
+		isClose := strings.HasPrefix(raw, "/")
+		if isClose {
+			raw = raw[1:]
+		}
+		// Tag name is everything up to the first space (strips attrs on opens).
+		name := strings.ToLower(strings.TrimSpace(raw))
+		if sp := strings.IndexByte(name, ' '); sp >= 0 {
+			name = name[:sp]
+		}
+		if !isInlineFormattingTag(name) {
+			continue
+		}
+		if isClose {
+			// Pop the most recent matching open from the stack.
+			for j := len(stack) - 1; j >= 0; j-- {
+				if stack[j] == name {
+					stack = append(stack[:j], stack[j+1:]...)
+					break
+				}
+			}
+		} else {
+			stack = append(stack, name)
+		}
+	}
+	if len(stack) == 0 {
+		return chunk, nil
+	}
+	var b strings.Builder
+	b.WriteString(chunk)
+	// Close in reverse order to maintain proper nesting.
+	for j := len(stack) - 1; j >= 0; j-- {
+		b.WriteString("</")
+		b.WriteString(stack[j])
+		b.WriteString(">")
+	}
+	// Reopen list preserves original nesting order.
+	return b.String(), append([]string(nil), stack...)
+}
+
+func isInlineFormattingTag(name string) bool {
+	for _, t := range inlineFormattingTags {
+		if t == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/channels/telegram/format_balance_test.go
+++ b/internal/channels/telegram/format_balance_test.go
@@ -1,0 +1,141 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBalanceMarkdownMarker_Bold(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"balanced", "hello **world** ok", "hello **world** ok"},
+		{"unclosed at end (the Gia Hân bug)", "• Anh thực nhận: **70", "• Anh thực nhận: 70"},
+		{"empty", "", ""},
+		{"no marker", "plain text", "plain text"},
+		{"one pair only", "**bold**", "**bold**"},
+		{"three markers — strip last", "**a**b**c", "**a**bc"},
+		{"unclosed with surrounding text", "start **oops end", "start oops end"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := balanceMarkdownMarker(tt.input, "**")
+			if got != tt.want {
+				t.Errorf("balanceMarkdownMarker(%q, **) = %q; want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBalanceMarkdownMarker_Underline(t *testing.T) {
+	// __x__ is also bold in Telegram markdown. Ensure the same parity logic applies.
+	got := balanceMarkdownMarker("hey __unclosed", "__")
+	if got != "hey unclosed" {
+		t.Errorf("balanceMarkdownMarker underline: got %q", got)
+	}
+}
+
+func TestMarkdownToTelegramHTML_UnclosedBold(t *testing.T) {
+	// Reproduces the Gia Hân bug: LLM output cut mid-bold → previously leaked
+	// literal `**70` to user; now balancer strips the dangling marker.
+	in := "• Tên liên hệ: Bryan\n• Anh thực nhận: **70"
+	out := markdownToTelegramHTML(in)
+	if strings.Contains(out, "**") {
+		t.Fatalf("markdownToTelegramHTML should strip unclosed **, got: %q", out)
+	}
+}
+
+func TestCloseUnclosedInlineTags(t *testing.T) {
+	tests := []struct {
+		name        string
+		chunk       string
+		wantClosed  string
+		wantReopen  []string
+	}{
+		{
+			name:       "no tags",
+			chunk:      "plain text",
+			wantClosed: "plain text",
+			wantReopen: nil,
+		},
+		{
+			name:       "balanced bold",
+			chunk:      "a <b>bold</b> b",
+			wantClosed: "a <b>bold</b> b",
+			wantReopen: nil,
+		},
+		{
+			name:       "unclosed bold — close and mark for reopen",
+			chunk:      "start <b>bold text",
+			wantClosed: "start <b>bold text</b>",
+			wantReopen: []string{"b"},
+		},
+		{
+			name:       "nested unclosed",
+			chunk:      "<b>bold <i>italic text",
+			wantClosed: "<b>bold <i>italic text</i></b>",
+			wantReopen: []string{"b", "i"},
+		},
+		{
+			name:       "code with attribute is still tracked",
+			chunk:      "use <code>foo",
+			wantClosed: "use <code>foo</code>",
+			wantReopen: []string{"code"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotClosed, gotReopen := closeUnclosedInlineTags(tt.chunk)
+			if gotClosed != tt.wantClosed {
+				t.Errorf("closed mismatch:\n  got:  %q\n  want: %q", gotClosed, tt.wantClosed)
+			}
+			if !equalStrings(gotReopen, tt.wantReopen) {
+				t.Errorf("reopen mismatch: got %v, want %v", gotReopen, tt.wantReopen)
+			}
+		})
+	}
+}
+
+func TestChunkHTML_BalancesTagsAcrossChunks(t *testing.T) {
+	// A long bold paragraph split across chunks. Before the fix, chunk 1 ended
+	// with an unclosed `<b>` and chunk 2 had an orphan `</b>` — Telegram rejects.
+	// After the fix: chunk 1 is closed, chunk 2 re-opens.
+	left := "<b>" + strings.Repeat("a", 100)
+	right := strings.Repeat("b", 100) + "</b>"
+	text := left + "\n\n" + right
+
+	chunks := chunkHTML(text, 120)
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		opens := strings.Count(c, "<b>")
+		closes := strings.Count(c, "</b>")
+		if opens != closes {
+			t.Errorf("chunk %d has unbalanced <b>: opens=%d closes=%d\n  content: %q", i, opens, closes, c)
+		}
+	}
+}
+
+func TestChunkHTML_PreservesBalancedSingleChunk(t *testing.T) {
+	// Single chunk that already balances should pass through unchanged.
+	text := "<b>short and balanced</b>"
+	chunks := chunkHTML(text, 4096)
+	if len(chunks) != 1 || chunks[0] != text {
+		t.Errorf("single chunk should pass through unchanged, got: %v", chunks)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/i18n/catalog_en.go
+++ b/internal/i18n/catalog_en.go
@@ -143,6 +143,7 @@ func init() {
 		MsgStatusPhaseDefault:  "Phase: Processing...",
 		MsgCancelledReply:      "✋ Cancelled. What would you like to do next?",
 		MsgInjectedAck:         "Got it, I'll incorporate that into what I'm working on.",
+		MsgAgentErrorGeneric:   "😔 Something went wrong processing your message. Please try again in a moment.",
 
 		// Knowledge Graph
 		MsgEntityIDRequired:       "entity_id is required",

--- a/internal/i18n/catalog_vi.go
+++ b/internal/i18n/catalog_vi.go
@@ -143,6 +143,7 @@ func init() {
 		MsgStatusPhaseDefault:  "Giai đoạn: Đang xử lý...",
 		MsgCancelledReply:      "✋ Đã hủy. Bạn muốn làm gì tiếp?",
 		MsgInjectedAck:         "Đã nhận, tôi sẽ xử lý trong tác vụ hiện tại.",
+		MsgAgentErrorGeneric:   "😔 Em gặp lỗi khi xử lý tin này, anh/chị thử gửi lại sau chút xíu nhé.",
 
 		// Knowledge Graph
 		MsgEntityIDRequired:       "entity_id là bắt buộc",

--- a/internal/i18n/catalog_zh.go
+++ b/internal/i18n/catalog_zh.go
@@ -143,6 +143,7 @@ func init() {
 		MsgStatusPhaseDefault:  "阶段：处理中...",
 		MsgCancelledReply:      "✋ 已取消。您接下来想做什么？",
 		MsgInjectedAck:         "收到，我会在当前任务中处理。",
+		MsgAgentErrorGeneric:   "😔 处理消息时出现问题，请稍后重试。",
 
 		// Knowledge Graph
 		MsgEntityIDRequired:       "entity_id 是必填项",

--- a/internal/i18n/keys.go
+++ b/internal/i18n/keys.go
@@ -144,6 +144,7 @@ const (
 	MsgStatusPhaseDefault  = "status.phase_default"   // "Phase: Processing..."
 	MsgCancelledReply      = "status.cancelled"       // "✋ Cancelled. What would you like to do next?"
 	MsgInjectedAck         = "status.injected_ack"    // "Got it, I'll incorporate that into what I'm working on."
+	MsgAgentErrorGeneric   = "status.agent_error"     // user-facing fallback when agent run errors on external channel
 
 	// --- Knowledge Graph ---
 	MsgEntityIDRequired           = "error.entity_id_required"            // "entity_id is required"

--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 )
@@ -75,6 +76,20 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 	// args on allowlisted mutating tools. Nullary tools (datetime, heartbeat) skip
 	// the heuristic so their legitimate empty-args calls pass through.
 	// Text-only truncation (no tool calls) is a valid long answer — deliver it.
+	// But log when it happens so operators can see max_tokens pressure — text-only
+	// truncation can still present to the user as a cut message (e.g. bold marker
+	// left unclosed). The telegram formatter strips dangling `**` defensively.
+	if resp.FinishReason == "length" && len(resp.ToolCalls) == 0 {
+		slog.Warn("think_stage: response truncated (finish_reason=length, text-only)",
+			"content_len", len(resp.Content),
+			"completion_tokens", func() int {
+				if resp.Usage != nil {
+					return resp.Usage.CompletionTokens
+				}
+				return 0
+			}(),
+		)
+	}
 	truncated := len(resp.ToolCalls) > 0 && (resp.FinishReason == "length" ||
 		(resp.FinishReason == "tool_calls" && toolCallsHaveMissingRequiredArgs(resp.ToolCalls)))
 	parseErr := !truncated && toolCallsHaveParseErrors(resp.ToolCalls)


### PR DESCRIPTION
## Summary

Infrastructure fixes for two Telegram-agent bugs observed while debugging a Vietnamese rideshare bot ("Gia Hân"). Both bugs affect **any agent on an external channel**, not just the specific one.

- **Silent error suppression**: agent-run errors on external channels (Telegram, Facebook, Zalo, …) were turned into empty outbound messages. Typing indicator stopped, no reply was sent, and users had no clue whether the bot died or was still thinking. Now surfaces a localized generic fallback (vi/en/zh).
- **Cut output / unclosed markdown**: when an LLM response was truncated (max_tokens hit, `finish_reason=length`, stream cut) mid-bold, the raw text ended with `**70` and the non-greedy regex silently passed it through as literal `**` — users saw `• Anh thực nhận: **70`. Pre-sanitize unpaired `**`/`__` before formatting.
- **Cross-chunk HTML tag balance**: `chunkHTML` previously avoided cuts inside a tag but did not balance inline formatting (`<b>/<i>/<u>/<s>/<code>`) across chunk boundaries — a long `<b>foo\n\nbar</b>` split at `\n\n` produced chunk 1 with unclosed `<b>` (Telegram rejects) and chunk 2 with orphan `</b>`. Now each chunk auto-closes unclosed tags and the next chunk re-opens them.
- **Observability**: `ThinkStage` now logs a warning when `finish_reason=length` hits text-only responses (no tool calls) — previously invisible to operators, though it still reaches the user as a cut message.

## Why it matters

From user bug report reproducing in production on the "Gia Hân" Telegram agent:
> Gia Hân đang typing... nhưng không gửi được reply  
> • Tên liên hệ: \*\*  
> • Anh thực nhận: \*\*70

Both symptoms are explained by the two code bugs above; fixing the markdown/HTML balance removes the literal `**` leak, and fixing the silent-error path means the user gets an actionable fallback instead of a stopped typing indicator with no message.

## Files changed

| Path | What |
|------|------|
| \`cmd/gateway_consumer_normal.go\` | Replace silent \`errContent=\"\"\` with localized \`i18n.T(locale, MsgAgentErrorGeneric)\` for external channels. Thread \`locale\` into the result goroutine. |
| \`internal/i18n/{keys,catalog_en,catalog_vi,catalog_zh}.go\` | Add \`MsgAgentErrorGeneric\` with en/vi/zh translations. |
| \`internal/channels/telegram/format.go\` | \`balanceMarkdownMarker\` strips unpaired \`**\`/\`__\` before format. \`balanceChunkTags\` + \`closeUnclosedInlineTags\` auto-close/reopen inline HTML tags across chunks. |
| \`internal/pipeline/think_stage.go\` | Warn log on \`finish_reason=length\` for text-only responses. |
| \`internal/channels/telegram/format_balance_test.go\` | **New** — 9 cases covering unclosed markers, cross-chunk tag balance, exact reproduction of the Gia Hân \`**70\` bug. |

## Test plan

- [x] \`go build ./...\` (PG variant)
- [x] \`go build -tags sqliteonly ./...\` (desktop variant)
- [x] \`go vet ./...\`
- [x] \`go test ./internal/channels/telegram/... ./internal/i18n/... ./internal/pipeline/...\` — all pass, 9 new cases included
- [ ] Manual: trigger an agent error on a Telegram chat (e.g. revoke provider key) and confirm user receives the localized fallback instead of silence
- [ ] Manual: send a long bold paragraph that spans two Telegram chunks, confirm both render without broken markdown
- [ ] Manual: trigger a \`max_tokens\`-capped response and confirm no literal \`**\` reaches the message

## Out of scope (flagged for follow-up)

The companion bugs in the user's report about "Gia Hân forgets the 125\$ it just acknowledged" and "fills customer data from an earlier trip into a new parse" are **prompt-engineering issues on that specific agent**, not gateway bugs — the history is passed correctly and USER.md is loaded. They need prompt-level rule changes applied in the agent's context files, not code changes.

Possible follow-up code changes worth discussing separately:
- Reduce \`defaultContextCacheTTL\` in \`internal/tools/context_file_interceptor.go\` from 5m → 1m so USER.md writes become visible faster.
- Bump \`DefaultMaxTokens\` in \`internal/config/defaults.go\` from 8192 to e.g. 16384 (cross-tenant impact, needs agreement).
- Re-start the typing indicator when a queued message (maxConcurrent=1 DM) actually dequeues, instead of only at handler ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)