### PR TITLE
feat(providers): add Cursor CLI agent provider

### DIFF
--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -198,6 +198,23 @@ func registerProviders(registry *providers.Registry, cfg *config.Config, modelRe
 		slog.Info("registered provider", "name", "claude-cli")
 	}
 
+	// Cursor CLI provider (subscription-based, no API key needed)
+	if cfg.Providers.CursorCLI.CLIPath != "" {
+		cliPath := cfg.Providers.CursorCLI.CLIPath
+		var opts []providers.CursorCLIOption
+		if cfg.Providers.CursorCLI.Model != "" {
+			opts = append(opts, providers.WithCursorCLIModel(cfg.Providers.CursorCLI.Model))
+		}
+		if cfg.Providers.CursorCLI.Mode != "" {
+			opts = append(opts, providers.WithCursorCLIMode(cfg.Providers.CursorCLI.Mode))
+		}
+		if cfg.Providers.CursorCLI.BaseWorkDir != "" {
+			opts = append(opts, providers.WithCursorCLIWorkDir(cfg.Providers.CursorCLI.BaseWorkDir))
+		}
+		registry.Register(providers.NewCursorCLIProvider(cliPath, opts...))
+		slog.Info("registered provider", "name", "cursor-cli")
+	}
+
 	// ACP provider (config-based) — orchestrates any ACP-compatible agent binary
 	if cfg.Providers.ACP.Binary != "" {
 		registerACPFromConfig(registry, cfg.Providers.ACP)
@@ -304,6 +321,35 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 				cliOpts = append(cliOpts, providers.WithClaudeCLIMCPConfigData(mcpData))
 			}
 			registry.RegisterForTenant(p.TenantID, providers.NewClaudeCLIProvider(cliPath, cliOpts...))
+			slog.Info("registered provider from DB", "name", p.Name)
+			continue
+		}
+		// Cursor CLI doesn't need API key
+		if p.ProviderType == store.ProviderCursorCLI {
+			cliPath := p.APIBase // reuse APIBase field for CLI path
+			if cliPath == "" {
+				cliPath = "agent"
+			}
+			if cliPath != "agent" && !filepath.IsAbs(cliPath) {
+				slog.Warn("security.cursor_cli: invalid path from DB, using default", "path", cliPath)
+				cliPath = "agent"
+			}
+			if _, err := exec.LookPath(cliPath); err != nil {
+				slog.Warn("cursor-cli: binary not found, skipping", "path", cliPath, "error", err)
+				continue
+			}
+			var cliOpts []providers.CursorCLIOption
+			cliOpts = append(cliOpts, providers.WithCursorCLIName(p.Name))
+			// Parse settings JSONB for extra config (mode)
+			var settings struct {
+				Mode string `json:"mode"`
+			}
+			if p.Settings != nil {
+				if err := json.Unmarshal(p.Settings, &settings); err == nil && settings.Mode != "" {
+					cliOpts = append(cliOpts, providers.WithCursorCLIMode(settings.Mode))
+				}
+			}
+			registry.RegisterForTenant(p.TenantID, providers.NewCursorCLIProvider(cliPath, cliOpts...))
 			slog.Info("registered provider from DB", "name", p.Name)
 			continue
 		}

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -24,25 +24,25 @@ type ChannelsConfig struct {
 }
 
 type TelegramConfig struct {
-	Enabled        bool                `json:"enabled"`
-	Token          string              `json:"token"`
-	Proxy          string              `json:"proxy,omitempty"`
-	APIServer      string              `json:"api_server,omitempty"` // custom Telegram Bot API server URL (e.g. "http://localhost:8081")
-	AllowFrom      FlexibleStringSlice `json:"allow_from"`
-	DMPolicy       string              `json:"dm_policy,omitempty"`       // "pairing" (default), "allowlist", "open", "disabled"
-	GroupPolicy    string              `json:"group_policy,omitempty"`    // "open" (default), "allowlist", "disabled"
-	RequireMention *bool               `json:"require_mention,omitempty"` // require @bot mention in groups (default true)
-	MentionMode    string              `json:"mention_mode,omitempty"`    // "strict" (default) = only respond when mentioned; "yield" = respond unless another bot is mentioned
-	HistoryLimit   int                 `json:"history_limit,omitempty"`   // max pending group messages for context (default 50, 0=disabled)
-	DMStream         *bool               `json:"dm_stream,omitempty"`          // enable streaming for DMs (default false) — edits placeholder progressively
-	GroupStream      *bool               `json:"group_stream,omitempty"`      // enable streaming for groups (default false) — sends new message, edits progressively
-	DraftTransport   *bool               `json:"draft_transport,omitempty"`   // use sendMessageDraft for DM streaming (default true) — stealth preview, no notifications per edit
-	ReasoningStream  *bool               `json:"reasoning_stream,omitempty"`  // show reasoning as separate message when provider emits thinking events (default true)
-	ReactionLevel    string              `json:"reaction_level,omitempty"`    // "off" (default), "minimal", "full" — status emoji reactions
-	MediaMaxBytes  int64               `json:"media_max_bytes,omitempty"` // max media download size in bytes (default 20MB)
-	LinkPreview    *bool               `json:"link_preview,omitempty"`    // enable URL previews in messages (default true)
-	BlockReply     *bool               `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
-	ForceIPv4      bool                `json:"force_ipv4,omitempty"`      // force IPv4 for all Telegram API requests (use when IPv6 routing is broken)
+	Enabled         bool                `json:"enabled"`
+	Token           string              `json:"token"`
+	Proxy           string              `json:"proxy,omitempty"`
+	APIServer       string              `json:"api_server,omitempty"` // custom Telegram Bot API server URL (e.g. "http://localhost:8081")
+	AllowFrom       FlexibleStringSlice `json:"allow_from"`
+	DMPolicy        string              `json:"dm_policy,omitempty"`        // "pairing" (default), "allowlist", "open", "disabled"
+	GroupPolicy     string              `json:"group_policy,omitempty"`     // "open" (default), "allowlist", "disabled"
+	RequireMention  *bool               `json:"require_mention,omitempty"`  // require @bot mention in groups (default true)
+	MentionMode     string              `json:"mention_mode,omitempty"`     // "strict" (default) = only respond when mentioned; "yield" = respond unless another bot is mentioned
+	HistoryLimit    int                 `json:"history_limit,omitempty"`    // max pending group messages for context (default 50, 0=disabled)
+	DMStream        *bool               `json:"dm_stream,omitempty"`        // enable streaming for DMs (default false) — edits placeholder progressively
+	GroupStream     *bool               `json:"group_stream,omitempty"`     // enable streaming for groups (default false) — sends new message, edits progressively
+	DraftTransport  *bool               `json:"draft_transport,omitempty"`  // use sendMessageDraft for DM streaming (default true) — stealth preview, no notifications per edit
+	ReasoningStream *bool               `json:"reasoning_stream,omitempty"` // show reasoning as separate message when provider emits thinking events (default true)
+	ReactionLevel   string              `json:"reaction_level,omitempty"`   // "off" (default), "minimal", "full" — status emoji reactions
+	MediaMaxBytes   int64               `json:"media_max_bytes,omitempty"`  // max media download size in bytes (default 20MB)
+	LinkPreview     *bool               `json:"link_preview,omitempty"`     // enable URL previews in messages (default true)
+	BlockReply      *bool               `json:"block_reply,omitempty"`      // override gateway block_reply (nil = inherit)
+	ForceIPv4       bool                `json:"force_ipv4,omitempty"`       // force IPv4 for all Telegram API requests (use when IPv6 routing is broken)
 
 	// Optional STT (Speech-to-Text) pipeline for voice/audio inbound messages.
 	// When stt_proxy_url is set, audio/voice messages are transcribed before being forwarded to the agent.
@@ -133,7 +133,7 @@ type SlackConfig struct {
 
 type WhatsAppConfig struct {
 	Enabled        bool                `json:"enabled"`
-	AuthDir        string              `json:"auth_dir,omitempty"`        // optional: SQLite auth dir override (desktop)
+	AuthDir        string              `json:"auth_dir,omitempty"` // optional: SQLite auth dir override (desktop)
 	AllowFrom      FlexibleStringSlice `json:"allow_from"`
 	DMPolicy       string              `json:"dm_policy,omitempty"`       // "pairing" (default for DB instances), "open", "allowlist", "disabled"
 	GroupPolicy    string              `json:"group_policy,omitempty"`    // "pairing" (default for DB instances), "open" (default for config), "allowlist", "disabled"
@@ -196,25 +196,26 @@ type FeishuConfig struct {
 
 // ProvidersConfig maps provider name to its config.
 type ProvidersConfig struct {
-	Anthropic  ProviderConfig  `json:"anthropic"`
-	OpenAI     ProviderConfig  `json:"openai"`
-	OpenRouter ProviderConfig  `json:"openrouter"`
-	Groq       ProviderConfig  `json:"groq"`
-	Gemini     ProviderConfig  `json:"gemini"`
-	DeepSeek   ProviderConfig  `json:"deepseek"`
-	Mistral    ProviderConfig  `json:"mistral"`
-	XAI        ProviderConfig  `json:"xai"`
-	MiniMax    ProviderConfig  `json:"minimax"`
-	Cohere     ProviderConfig  `json:"cohere"`
-	Perplexity ProviderConfig  `json:"perplexity"`
-	DashScope  ProviderConfig  `json:"dashscope"`
-	Bailian    ProviderConfig  `json:"bailian"`
-	Zai         ProviderConfig  `json:"zai"`
-	ZaiCoding   ProviderConfig  `json:"zai_coding"`
-	Ollama      OllamaConfig    `json:"ollama"`       // local Ollama instance (no API key needed)
-	OllamaCloud ProviderConfig  `json:"ollama_cloud"` // Ollama Cloud (API key required)
-	ClaudeCLI   ClaudeCLIConfig `json:"claude_cli"`
-	ACP         ACPConfig       `json:"acp"`
+	Anthropic      ProviderConfig  `json:"anthropic"`
+	OpenAI         ProviderConfig  `json:"openai"`
+	OpenRouter     ProviderConfig  `json:"openrouter"`
+	Groq           ProviderConfig  `json:"groq"`
+	Gemini         ProviderConfig  `json:"gemini"`
+	DeepSeek       ProviderConfig  `json:"deepseek"`
+	Mistral        ProviderConfig  `json:"mistral"`
+	XAI            ProviderConfig  `json:"xai"`
+	MiniMax        ProviderConfig  `json:"minimax"`
+	Cohere         ProviderConfig  `json:"cohere"`
+	Perplexity     ProviderConfig  `json:"perplexity"`
+	DashScope      ProviderConfig  `json:"dashscope"`
+	Bailian        ProviderConfig  `json:"bailian"`
+	Zai            ProviderConfig  `json:"zai"`
+	ZaiCoding      ProviderConfig  `json:"zai_coding"`
+	Ollama         OllamaConfig    `json:"ollama"`       // local Ollama instance (no API key needed)
+	OllamaCloud    ProviderConfig  `json:"ollama_cloud"` // Ollama Cloud (API key required)
+	ClaudeCLI      ClaudeCLIConfig `json:"claude_cli"`
+	CursorCLI      CursorCLIConfig `json:"cursor_cli"`
+	ACP            ACPConfig       `json:"acp"`
 	Novita         ProviderConfig  `json:"novita"`          // Novita AI (OpenAI-compatible endpoint)
 	BytePlus       ProviderConfig  `json:"byteplus"`        // BytePlus ModelArk (Seed 2.0)
 	BytePlusCoding ProviderConfig  `json:"byteplus_coding"` // BytePlus ModelArk Coding Plan
@@ -232,6 +233,14 @@ type ClaudeCLIConfig struct {
 	Model       string `json:"model" yaml:"model"`                 // default model alias (default: "sonnet")
 	BaseWorkDir string `json:"base_work_dir" yaml:"base_work_dir"` // base dir for agent workspaces
 	PermMode    string `json:"perm_mode" yaml:"perm_mode"`         // permission mode (default: "bypassPermissions")
+}
+
+// CursorCLIConfig configures the Cursor CLI provider (uses subscription, not API key).
+type CursorCLIConfig struct {
+	CLIPath     string `json:"cli_path" yaml:"cli_path"`           // path to cursor agent binary (default: "agent")
+	Model       string `json:"model" yaml:"model"`                 // default model alias
+	Mode        string `json:"mode" yaml:"mode"`                   // working mode: "agent", "plan", "ask" (default: "agent")
+	BaseWorkDir string `json:"base_work_dir" yaml:"base_work_dir"` // base dir for agent workspaces
 }
 
 // ACPConfig configures the ACP (Agent Client Protocol) provider.
@@ -318,6 +327,7 @@ func (c *Config) HasAnyProvider() bool {
 		p.Ollama.Host != "" ||
 		p.OllamaCloud.APIKey != "" ||
 		p.ClaudeCLI.CLIPath != "" ||
+		p.CursorCLI.CLIPath != "" ||
 		p.ACP.Binary != "" ||
 		p.Novita.APIKey != "" ||
 		p.BytePlus.APIKey != "" ||
@@ -346,16 +356,16 @@ type QuotaConfig struct {
 
 // GatewayConfig controls the gateway server.
 type GatewayConfig struct {
-	Host              string       `json:"host"`
-	Port              int          `json:"port"`
-	Token             string       `json:"token,omitempty"`               // bearer token for WS/HTTP auth
-	OwnerIDs          []string     `json:"owner_ids,omitempty"`           // sender IDs considered "owner"
-	AllowedOrigins    []string     `json:"allowed_origins,omitempty"`     // WebSocket CORS whitelist (empty = allow all)
-	MaxMessageChars   int          `json:"max_message_chars,omitempty"`   // max user message characters (default 32000)
-	RateLimitRPM      int          `json:"rate_limit_rpm,omitempty"`      // rate limit: requests per minute per user (default 20, 0 = disabled)
-	InjectionAction   string       `json:"injection_action,omitempty"`    // prompt injection action: "log", "warn" (default), "block", "off"
-	InboundDebounceMs int          `json:"inbound_debounce_ms,omitempty"` // merge rapid messages from same sender (default 1000ms, -1 = disabled)
-	Quota             *QuotaConfig `json:"quota,omitempty"`               // per-user/group request quotas
+	Host                    string       `json:"host"`
+	Port                    int          `json:"port"`
+	Token                   string       `json:"token,omitempty"`                      // bearer token for WS/HTTP auth
+	OwnerIDs                []string     `json:"owner_ids,omitempty"`                  // sender IDs considered "owner"
+	AllowedOrigins          []string     `json:"allowed_origins,omitempty"`            // WebSocket CORS whitelist (empty = allow all)
+	MaxMessageChars         int          `json:"max_message_chars,omitempty"`          // max user message characters (default 32000)
+	RateLimitRPM            int          `json:"rate_limit_rpm,omitempty"`             // rate limit: requests per minute per user (default 20, 0 = disabled)
+	InjectionAction         string       `json:"injection_action,omitempty"`           // prompt injection action: "log", "warn" (default), "block", "off"
+	InboundDebounceMs       int          `json:"inbound_debounce_ms,omitempty"`        // merge rapid messages from same sender (default 1000ms, -1 = disabled)
+	Quota                   *QuotaConfig `json:"quota,omitempty"`                      // per-user/group request quotas
 	BlockReply              *bool        `json:"block_reply,omitempty"`                // deliver intermediate text during tool iterations (default false)
 	ToolStatus              *bool        `json:"tool_status,omitempty"`                // show tool name in streaming preview during tool execution (default true)
 	TaskRecoveryIntervalSec int          `json:"task_recovery_interval_sec,omitempty"` // team task recovery ticker interval in seconds (default 300 = 5min)
@@ -413,9 +423,9 @@ type WebFetchPolicyConfig struct {
 
 // BrowserToolConfig controls the browser automation tool.
 type BrowserToolConfig struct {
-	Enabled         bool   `json:"enabled"`                    // enable the browser tool (default false)
-	Headless        bool   `json:"headless,omitempty"`         // run Chrome in headless mode (ignored when RemoteURL is set)
-	RemoteURL       string `json:"remote_url,omitempty"`       // CDP endpoint for remote Chrome sidecar, e.g. "ws://chrome:9222"
+	Enabled         bool   `json:"enabled"`                     // enable the browser tool (default false)
+	Headless        bool   `json:"headless,omitempty"`          // run Chrome in headless mode (ignored when RemoteURL is set)
+	RemoteURL       string `json:"remote_url,omitempty"`        // CDP endpoint for remote Chrome sidecar, e.g. "ws://chrome:9222"
 	ActionTimeoutMs int    `json:"action_timeout_ms,omitempty"` // per-action timeout in ms (default 30000)
 	IdleTimeoutMs   int    `json:"idle_timeout_ms,omitempty"`   // idle page auto-close in ms (default 600000, 0=disabled)
 	MaxPages        int    `json:"max_pages,omitempty"`         // max open pages per tenant (default 5)
@@ -423,12 +433,12 @@ type BrowserToolConfig struct {
 
 // ToolPolicySpec defines a tool policy at any level (global, per-agent, per-provider).
 type ToolPolicySpec struct {
-	Profile    string                     `json:"profile,omitempty"`
-	Allow      []string                   `json:"allow,omitempty"`
-	Deny       []string                   `json:"deny,omitempty"`
-	AlsoAllow  []string                   `json:"alsoAllow,omitempty"`
-	ByProvider map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
-	ToolCallPrefix string `json:"toolCallPrefix,omitempty"` // prefix to strip from model's tool call names before registry lookup
+	Profile        string                     `json:"profile,omitempty"`
+	Allow          []string                   `json:"allow,omitempty"`
+	Deny           []string                   `json:"deny,omitempty"`
+	AlsoAllow      []string                   `json:"alsoAllow,omitempty"`
+	ByProvider     map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
+	ToolCallPrefix string                     `json:"toolCallPrefix,omitempty"` // prefix to strip from model's tool call names before registry lookup
 }
 
 type WebToolsConfig struct {

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -154,6 +154,12 @@ func (c *Config) applyEnvOverrides() {
 	envStr("GOCLAW_CLAUDE_CLI_MODEL", &c.Providers.ClaudeCLI.Model)
 	envStr("GOCLAW_CLAUDE_CLI_WORK_DIR", &c.Providers.ClaudeCLI.BaseWorkDir)
 
+	// Cursor CLI provider
+	envStr("GOCLAW_CURSOR_CLI_PATH", &c.Providers.CursorCLI.CLIPath)
+	envStr("GOCLAW_CURSOR_CLI_MODEL", &c.Providers.CursorCLI.Model)
+	envStr("GOCLAW_CURSOR_CLI_MODE", &c.Providers.CursorCLI.Mode)
+	envStr("GOCLAW_CURSOR_CLI_WORK_DIR", &c.Providers.CursorCLI.BaseWorkDir)
+
 	// Default provider/model: env is fallback only (applied when config has no value).
 	// The onboard wizard sets these in .env for initial bootstrap; once the user
 	// saves a provider/model via the Dashboard, the config-file value wins.
@@ -279,7 +285,6 @@ func (c *Config) applyEnvOverrides() {
 		c.Tools.Browser.Enabled = true
 	}
 }
-
 
 // Save writes the config to a JSON file.
 func Save(path string, cfg *Config) error {

--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -15,8 +15,8 @@ import (
 
 // ModelInfo is a normalized model entry returned by the list-models endpoint.
 type ModelInfo struct {
-	ID        string                        `json:"id"`
-	Name      string                        `json:"name,omitempty"`
+	ID        string                         `json:"id"`
+	Name      string                         `json:"name,omitempty"`
 	Reasoning *providers.ReasoningCapability `json:"reasoning,omitempty"`
 }
 
@@ -53,6 +53,12 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 	// Claude CLI doesn't need an API key — return hardcoded models
 	if p.ProviderType == store.ProviderClaudeCLI {
 		respond(claudeCLIModels())
+		return
+	}
+
+	// Cursor CLI doesn't need an API key — return hardcoded models
+	if p.ProviderType == store.ProviderCursorCLI {
+		respond(cursorCLIModels())
 		return
 	}
 

--- a/internal/http/provider_models_catalog.go
+++ b/internal/http/provider_models_catalog.go
@@ -72,6 +72,17 @@ func claudeCLIModels() []ModelInfo {
 	}
 }
 
+// cursorCLIModels returns the model aliases accepted by the Cursor Agent CLI.
+func cursorCLIModels() []ModelInfo {
+	return []ModelInfo{
+		{ID: "claude-sonnet-4-6", Name: "Claude Sonnet 4.6"},
+		{ID: "claude-opus-4-6", Name: "Claude Opus 4.6"},
+		{ID: "gpt-5.4", Name: "GPT-5.4"},
+		{ID: "gpt-5.3-codex", Name: "GPT-5.3 Codex"},
+		{ID: "o4-mini", Name: "O4 Mini"},
+	}
+}
+
 // acpModels returns the model aliases for ACP-compatible coding agents.
 func acpModels() []ModelInfo {
 	return []ModelInfo{

--- a/internal/http/provider_verify.go
+++ b/internal/http/provider_verify.go
@@ -79,6 +79,20 @@ func (h *ProvidersHandler) handleVerifyProvider(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Cursor CLI: validate binary exists and accept any model (CLI handles model validation)
+	if p.ProviderType == store.ProviderCursorCLI {
+		cliPath := p.APIBase
+		if cliPath == "" {
+			cliPath = "agent"
+		}
+		if _, err := exec.LookPath(cliPath); err != nil {
+			writeJSON(w, http.StatusOK, map[string]any{"valid": false, "error": "Cursor agent binary not found: " + cliPath})
+		} else {
+			writeJSON(w, http.StatusOK, map[string]any{"valid": true})
+		}
+		return
+	}
+
 	if h.providerReg == nil {
 		writeJSON(w, http.StatusOK, map[string]any{"valid": false, "error": "no provider registry available"})
 		return

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -172,6 +172,25 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 		h.providerReg.RegisterForTenant(p.TenantID, providers.NewClaudeCLIProvider(cliPath, cliOpts...))
 		return
 	}
+	// Cursor CLI doesn't need an API key — register immediately
+	if p.ProviderType == store.ProviderCursorCLI {
+		cliPath := p.APIBase
+		if cliPath == "" {
+			cliPath = "agent"
+		}
+		var cliOpts []providers.CursorCLIOption
+		cliOpts = append(cliOpts, providers.WithCursorCLIName(p.Name))
+		var settings struct {
+			Mode string `json:"mode"`
+		}
+		if p.Settings != nil {
+			if err := json.Unmarshal(p.Settings, &settings); err == nil && settings.Mode != "" {
+				cliOpts = append(cliOpts, providers.WithCursorCLIMode(settings.Mode))
+			}
+		}
+		h.providerReg.RegisterForTenant(p.TenantID, providers.NewCursorCLIProvider(cliPath, cliOpts...))
+		return
+	}
 	// Ollama doesn't need an API key — handle before the key guard (same as startup).
 	// In Docker, swap localhost → host.docker.internal so the container can reach the host.
 	// api_base is stored with /v1 (normalized at write time), so no suffix appending needed.
@@ -242,6 +261,7 @@ func normalizeOllamaAPIBase(p *store.LLMProviderData) {
 var localProviderTypes = map[string]bool{
 	store.ProviderOllama:    true,
 	store.ProviderClaudeCLI: true,
+	store.ProviderCursorCLI: true,
 	store.ProviderACP:       true,
 }
 
@@ -336,6 +356,21 @@ func (h *ProvidersHandler) handleCreateProvider(w http.ResponseWriter, r *http.R
 			if ep.ProviderType == store.ProviderClaudeCLI {
 				writeJSON(w, http.StatusConflict, map[string]string{
 					"error": i18n.T(locale, i18n.MsgAlreadyExists, "Claude CLI provider", "only one is allowed per instance"),
+				})
+				return
+			}
+		}
+	}
+	// Same guard for Cursor CLI
+	if p.ProviderType == store.ProviderCursorCLI {
+		h.cliMu.Lock()
+		defer h.cliMu.Unlock()
+
+		existing, _ := h.store.ListProviders(r.Context())
+		for _, ep := range existing {
+			if ep.ProviderType == store.ProviderCursorCLI {
+				writeJSON(w, http.StatusConflict, map[string]string{
+					"error": i18n.T(locale, i18n.MsgAlreadyExists, "Cursor CLI provider", "only one is allowed per instance"),
 				})
 				return
 			}

--- a/internal/providers/cursor_cli.go
+++ b/internal/providers/cursor_cli.go
@@ -1,0 +1,111 @@
+package providers
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+)
+
+// CursorCLIProvider implements Provider by shelling out to the Cursor `agent` CLI binary.
+// It drives the headless Cursor Agent CLI to process prompts with streaming output.
+type CursorCLIProvider struct {
+	name         string // provider name (default: "cursor-cli")
+	cliPath      string // path to agent binary (default: "agent")
+	defaultModel string // default model alias
+	defaultMode  string // default mode: "agent", "plan", "ask"
+	baseWorkDir  string // base dir for agent workspaces
+	mu           sync.Mutex
+	sessionMu    sync.Map // key: string, value: *sync.Mutex
+}
+
+// CursorCLIOption configures the provider.
+type CursorCLIOption func(*CursorCLIProvider)
+
+// WithCursorCLIName overrides the provider name.
+func WithCursorCLIName(name string) CursorCLIOption {
+	return func(p *CursorCLIProvider) {
+		if name != "" {
+			p.name = name
+		}
+	}
+}
+
+// WithCursorCLIModel sets the default model alias.
+func WithCursorCLIModel(model string) CursorCLIOption {
+	return func(p *CursorCLIProvider) {
+		if model != "" {
+			p.defaultModel = model
+		}
+	}
+}
+
+// WithCursorCLIMode sets the default working mode.
+func WithCursorCLIMode(mode string) CursorCLIOption {
+	return func(p *CursorCLIProvider) {
+		if mode != "" {
+			p.defaultMode = mode
+		}
+	}
+}
+
+// WithCursorCLIWorkDir sets the base work directory.
+func WithCursorCLIWorkDir(dir string) CursorCLIOption {
+	return func(p *CursorCLIProvider) {
+		if dir != "" {
+			p.baseWorkDir = dir
+		}
+	}
+}
+
+// NewCursorCLIProvider creates a provider that invokes the Cursor agent CLI.
+func NewCursorCLIProvider(cliPath string, opts ...CursorCLIOption) *CursorCLIProvider {
+	if cliPath == "" {
+		cliPath = "agent"
+	}
+	p := &CursorCLIProvider{
+		name:         "cursor-cli",
+		cliPath:      cliPath,
+		defaultModel: "",
+		defaultMode:  "agent",
+		baseWorkDir:  defaultCursorWorkDir(),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+func (p *CursorCLIProvider) Name() string         { return p.name }
+func (p *CursorCLIProvider) DefaultModel() string { return p.defaultModel }
+
+// Capabilities implements CapabilitiesAware for pipeline code-path selection.
+func (p *CursorCLIProvider) Capabilities() ProviderCapabilities {
+	return ProviderCapabilities{
+		Streaming:        true,
+		ToolCalling:      true,
+		StreamWithTools:  true,
+		Thinking:         false,
+		Vision:           false,
+		CacheControl:     false,
+		MaxContextWindow: 200_000,
+		TokenizerID:      "cl100k_base",
+	}
+}
+
+// Close implements io.Closer (no-op for Cursor CLI — no temp files managed here).
+func (p *CursorCLIProvider) Close() error {
+	return nil
+}
+
+func defaultCursorWorkDir() string {
+	return filepath.Join(config.ResolvedDataDirFromEnv(), "cursor-workspaces")
+}
+
+// lockSession acquires a per-session mutex to prevent concurrent CLI calls on the same session.
+func (p *CursorCLIProvider) lockSession(sessionKey string) func() {
+	actual, _ := p.sessionMu.LoadOrStore(sessionKey, &sync.Mutex{})
+	m := actual.(*sync.Mutex)
+	m.Lock()
+	return m.Unlock
+}

--- a/internal/providers/cursor_cli_chat.go
+++ b/internal/providers/cursor_cli_chat.go
@@ -1,0 +1,268 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Chat runs the Cursor CLI synchronously and returns the final response.
+func (p *CursorCLIProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	systemPrompt, userMsg, _ := extractFromMessages(req.Messages)
+	sessionKey := extractStringOpt(req.Options, OptSessionKey)
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+
+	unlock := p.lockSession(sessionKey)
+	defer unlock()
+
+	workDir := p.ensureWorkDir(sessionKey)
+	args := p.buildArgs(model, workDir, sessionKey, false)
+
+	// Prepend system prompt to user message if present
+	prompt := userMsg
+	if systemPrompt != "" {
+		prompt = systemPrompt + "\n\n" + userMsg
+	}
+	args = append(args, prompt)
+
+	cmd := exec.CommandContext(ctx, p.cliPath, args...)
+	cmd.Dir = workDir
+	cmd.Env = filterCursorEnv(os.Environ())
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	slog.Debug("cursor-cli exec", "cmd", fmt.Sprintf("%s %s", p.cliPath, strings.Join(args, " ")), "workdir", workDir)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("cursor-cli: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return p.parseJSONResponse(output)
+}
+
+// ChatStream runs the Cursor CLI with stream-json output, calling onChunk for each text delta.
+func (p *CursorCLIProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk func(StreamChunk)) (*ChatResponse, error) {
+	systemPrompt, userMsg, _ := extractFromMessages(req.Messages)
+	sessionKey := extractStringOpt(req.Options, OptSessionKey)
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+
+	slog.Debug("cursor-cli: acquiring session lock", "session_key", sessionKey)
+	unlock := p.lockSession(sessionKey)
+	defer func() {
+		unlock()
+		slog.Debug("cursor-cli: session lock released", "session_key", sessionKey)
+	}()
+
+	workDir := p.ensureWorkDir(sessionKey)
+	args := p.buildArgs(model, workDir, sessionKey, true)
+
+	prompt := userMsg
+	if systemPrompt != "" {
+		prompt = systemPrompt + "\n\n" + userMsg
+	}
+	args = append(args, prompt)
+
+	cmd := exec.CommandContext(ctx, p.cliPath, args...)
+	cmd.WaitDelay = 5 * time.Second
+	cmd.Dir = workDir
+	cmd.Env = filterCursorEnv(os.Environ())
+
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("cursor-cli stdout pipe: %w", err)
+	}
+
+	fullCmd := fmt.Sprintf("%s %s", p.cliPath, strings.Join(args, " "))
+	slog.Debug("cursor-cli stream exec", "cmd", fullCmd, "workdir", workDir)
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("cursor-cli start: %w", err)
+	}
+
+	var debugFile *os.File
+	if os.Getenv("GOCLAW_DEBUG") == "1" {
+		debugLogPath := filepath.Join(workDir, "cursor-debug.log")
+		debugFile, _ = os.OpenFile(debugLogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if debugFile != nil {
+			fmt.Fprintf(debugFile, "=== CMD: %s\n=== WORKDIR: %s\n=== TIME: %s\n\n", fullCmd, workDir, time.Now().Format(time.RFC3339))
+			defer debugFile.Close()
+		}
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, StdioScanBufInit), StdioScanBufMax)
+
+	var finalResp ChatResponse
+	var contentBuf strings.Builder
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			break
+		}
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if debugFile != nil {
+			fmt.Fprintf(debugFile, "%s\n", line)
+		}
+		if line[0] != '{' {
+			continue
+		}
+
+		var ev cursorStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			slog.Debug("cursor-cli: skip malformed stream line", "error", err)
+			continue
+		}
+
+		switch ev.Type {
+		case "assistant":
+			text := extractCursorText(ev.Message)
+			if text != "" {
+				contentBuf.WriteString(text)
+				onChunk(StreamChunk{Content: text})
+			}
+
+		case "result":
+			finalResp.Content = contentBuf.String()
+			finalResp.FinishReason = "stop"
+			if ev.IsError {
+				finalResp.FinishReason = "error"
+			}
+			if ev.Usage != nil {
+				finalResp.Usage = &Usage{
+					PromptTokens:     ev.Usage.InputTokens,
+					CompletionTokens: ev.Usage.OutputTokens,
+					TotalTokens:      ev.Usage.InputTokens + ev.Usage.OutputTokens,
+				}
+			}
+
+		case "tool_call":
+			// Cursor tool calls are emitted but not executed by GoClaw — the CLI handles them internally.
+			// We emit them as content placeholders so the stream doesn't stall.
+			if ev.Subtype == "started" {
+				text := "[Using tool]"
+				contentBuf.WriteString(text)
+				onChunk(StreamChunk{Content: text})
+			}
+		}
+	}
+
+	if ctx.Err() != nil {
+		_ = cmd.Wait()
+		return nil, ctx.Err()
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("cursor-cli: stream read error: %w", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if debugFile != nil {
+			fmt.Fprintf(debugFile, "\n=== STDERR:\n%s\n=== EXIT ERROR: %v\n", stderrBuf.String(), err)
+		}
+		if finalResp.Content != "" {
+			return &finalResp, nil
+		}
+		return nil, fmt.Errorf("cursor-cli: %w (stderr: %s)", err, stderrBuf.String())
+	}
+	if debugFile != nil && stderrBuf.Len() > 0 {
+		fmt.Fprintf(debugFile, "\n=== STDERR:\n%s\n", stderrBuf.String())
+	}
+
+	if finalResp.Content == "" {
+		finalResp.Content = contentBuf.String()
+		finalResp.FinishReason = "stop"
+	}
+
+	onChunk(StreamChunk{Done: true})
+	return &finalResp, nil
+}
+
+func (p *CursorCLIProvider) parseJSONResponse(output []byte) (*ChatResponse, error) {
+	var final ChatResponse
+	var contentBuf strings.Builder
+
+	for _, line := range bytes.Split(output, []byte("\n")) {
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var ev cursorStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+		switch ev.Type {
+		case "assistant":
+			text := extractCursorText(ev.Message)
+			if text != "" {
+				contentBuf.WriteString(text)
+			}
+		case "result":
+			final.Content = contentBuf.String()
+			final.FinishReason = "stop"
+			if ev.IsError {
+				final.FinishReason = "error"
+			}
+			if ev.Usage != nil {
+				final.Usage = &Usage{
+					PromptTokens:     ev.Usage.InputTokens,
+					CompletionTokens: ev.Usage.OutputTokens,
+					TotalTokens:      ev.Usage.InputTokens + ev.Usage.OutputTokens,
+				}
+			}
+		}
+	}
+
+	if final.Content == "" {
+		final.Content = contentBuf.String()
+		final.FinishReason = "stop"
+	}
+	return &final, nil
+}
+
+func extractCursorText(msg *cursorStreamMsg) string {
+	if msg == nil {
+		return ""
+	}
+	var parts []string
+	for _, block := range msg.Content {
+		if block.Type == "text" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// filterCursorEnv removes CURSOR* env vars to prevent nested session conflicts.
+func filterCursorEnv(environ []string) []string {
+	var filtered []string
+	for _, e := range environ {
+		key := e
+		if before, _, ok := strings.Cut(e, "="); ok {
+			key = before
+		}
+		if strings.HasPrefix(key, "CURSOR") {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
+}

--- a/internal/providers/cursor_cli_session.go
+++ b/internal/providers/cursor_cli_session.go
@@ -1,0 +1,110 @@
+package providers
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// validCursorModes lists accepted working modes for the Cursor CLI.
+var validCursorModes = map[string]bool{
+	"agent": true,
+	"plan":  true,
+	"ask":   true,
+}
+
+func (p *CursorCLIProvider) buildArgs(model, workDir, sessionKey string, streaming bool) []string {
+	args := []string{
+		"-p",
+		"--force",
+		"--trust",
+		"--workspace", workDir,
+	}
+	if streaming {
+		args = append(args, "--output-format", "stream-json")
+	}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	mode := p.defaultMode
+	if !validCursorModes[mode] {
+		mode = "agent"
+	}
+	if mode != "agent" {
+		args = append(args, "--mode", mode)
+	}
+	if sessionKey != "" {
+		// Use deterministic session ID for resume support
+		sid := deriveCursorSessionUUID(sessionKey).String()
+		if cursorSessionFileExists(workDir, sid) {
+			args = append(args, "--resume", sid)
+		} else {
+			args = append(args, "--session-id", sid)
+		}
+	}
+	return args
+}
+
+func (p *CursorCLIProvider) ensureWorkDir(sessionKey string) string {
+	safe := sanitizePathSegment(sessionKey)
+	dir := filepath.Join(p.baseWorkDir, safe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		slog.Warn("cursor-cli: failed to create workdir", "dir", dir, "error", err)
+		return os.TempDir()
+	}
+	return dir
+}
+
+func deriveCursorSessionUUID(sessionKey string) uuid.UUID {
+	if sessionKey == "" {
+		return uuid.New()
+	}
+	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte("cursor:"+sessionKey))
+}
+
+func cursorSessionFileExists(workDir, sessionID string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	// Cursor stores sessions at: ~/.cursor/projects/<encoded-path>/agent-transcripts/<session-id>/<session-id>.jsonl
+	// Path encoding: replace path separators and special chars with "-"
+	resolved, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		resolved = workDir
+	}
+	encoded := strings.NewReplacer(string(filepath.Separator), "-", "_", "-", ".", "-", ":", "-", " ", "-").Replace(resolved)
+	encoded = strings.Trim(encoded, "-")
+	sessionFile := filepath.Join(home, ".cursor", "projects", encoded, "agent-transcripts", sessionID, sessionID+".jsonl")
+	_, err = os.Stat(sessionFile)
+	return err == nil
+}
+
+// ResetCursorCLISession deletes the Cursor CLI session file for a given session key.
+func ResetCursorCLISession(baseWorkDir, sessionKey string) {
+	if baseWorkDir == "" {
+		baseWorkDir = defaultCursorWorkDir()
+	}
+	safe := sanitizePathSegment(sessionKey)
+	workDir := filepath.Join(baseWorkDir, safe)
+	sessionID := deriveCursorSessionUUID(sessionKey).String()
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		resolved, err := filepath.EvalSymlinks(workDir)
+		if err != nil {
+			resolved = workDir
+		}
+		encoded := strings.NewReplacer(string(filepath.Separator), "-", "_", "-", ".", "-", ":", "-", " ", "-").Replace(resolved)
+		encoded = strings.Trim(encoded, "-")
+		sessionFile := filepath.Join(home, ".cursor", "projects", encoded, "agent-transcripts", sessionID, sessionID+".jsonl")
+		if err := os.Remove(sessionFile); err == nil {
+			slog.Info("cursor-cli: deleted session file on /reset", "path", sessionFile)
+		}
+	}
+}

--- a/internal/providers/cursor_cli_types.go
+++ b/internal/providers/cursor_cli_types.go
@@ -1,0 +1,32 @@
+package providers
+
+// cursorStreamEvent is a single line from `agent --output-format stream-json`.
+type cursorStreamEvent struct {
+	Type      string                 `json:"type"`              // "system", "user", "assistant", "tool_call", "result"
+	Subtype   string                 `json:"subtype,omitempty"` // e.g. "init", "started", "completed", "failed"
+	SessionID string                 `json:"session_id,omitempty"`
+	Message   *cursorStreamMsg       `json:"message,omitempty"`   // for type="assistant"
+	CallID    string                 `json:"call_id,omitempty"`   // for type="tool_call"
+	ToolCall  map[string]interface{} `json:"tool_call,omitempty"` // for type="tool_call"
+	Result    string                 `json:"result,omitempty"`    // for type="result"
+	IsError   bool                   `json:"is_error,omitempty"`
+	Usage     *cursorUsage           `json:"usage,omitempty"`
+}
+
+// cursorStreamMsg wraps content blocks inside an assistant message event.
+type cursorStreamMsg struct {
+	Content []cursorContentBlock `json:"content"`
+}
+
+// cursorContentBlock is a single content block (text).
+type cursorContentBlock struct {
+	Type string `json:"type"` // "text"
+	Text string `json:"text,omitempty"`
+}
+
+// cursorUsage maps Cursor CLI usage counters.
+type cursorUsage struct {
+	InputTokens     int `json:"inputTokens,omitempty"`
+	OutputTokens    int `json:"outputTokens,omitempty"`
+	CacheReadTokens int `json:"cacheReadTokens,omitempty"`
+}

--- a/internal/store/provider_store.go
+++ b/internal/store/provider_store.go
@@ -24,12 +24,13 @@ const (
 	ProviderBailian         = "bailian"
 	ProviderChatGPTOAuth    = "chatgpt_oauth"
 	ProviderClaudeCLI       = "claude_cli"
+	ProviderCursorCLI       = "cursor_cli"
 	ProviderYesScale        = "yescale"
 	ProviderZai             = "zai"
 	ProviderZaiCoding       = "zai_coding"
-	ProviderOllama          = "ollama"       // local or self-hosted Ollama (no API key)
-	ProviderOllamaCloud     = "ollama_cloud" // Ollama Cloud (Bearer token required)
-	ProviderACP             = "acp"          // ACP (Agent Client Protocol) agent subprocess
+	ProviderOllama          = "ollama"          // local or self-hosted Ollama (no API key)
+	ProviderOllamaCloud     = "ollama_cloud"    // Ollama Cloud (Bearer token required)
+	ProviderACP             = "acp"             // ACP (Agent Client Protocol) agent subprocess
 	ProviderNovita          = "novita"          // Novita AI (OpenAI-compatible endpoint)
 	ProviderBytePlus        = "byteplus"        // BytePlus ModelArk (Seed 2.0 models)
 	ProviderBytePlusCoding  = "byteplus_coding" // BytePlus ModelArk Coding Plan
@@ -61,6 +62,7 @@ var ValidProviderTypes = map[string]bool{
 	ProviderBailian:         true,
 	ProviderChatGPTOAuth:    true,
 	ProviderClaudeCLI:       true,
+	ProviderCursorCLI:       true,
 	ProviderYesScale:        true,
 	ProviderZai:             true,
 	ProviderZaiCoding:       true,
@@ -178,6 +180,7 @@ var NoEmbeddingTypes = map[string]bool{
 	ProviderAnthropicNative: true, // uses x-api-key auth, not Bearer; no embedding models
 	ProviderACP:             true,
 	ProviderClaudeCLI:       true,
+	ProviderCursorCLI:       true,
 	ProviderChatGPTOAuth:    true,
 }
 

--- a/ui/web/src/constants/providers.ts
+++ b/ui/web/src/constants/providers.ts
@@ -35,6 +35,7 @@ export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: "ollama", label: "Ollama (Local)", apiBase: "http://localhost:11434/v1", placeholder: "" },
   { value: "ollama_cloud", label: "Ollama Cloud", apiBase: "https://ollama.com/v1", placeholder: "" },
   { value: "claude_cli", label: "Claude CLI (Local)", apiBase: "", placeholder: "" },
+  { value: "cursor_cli", label: "Cursor CLI (Local)", apiBase: "", placeholder: "" },
   { value: "acp", label: "ACP Agent (Subprocess)", apiBase: "", placeholder: "claude" },
 ];
 

--- a/ui/web/src/i18n/locales/en/providers.json
+++ b/ui/web/src/i18n/locales/en/providers.json
@@ -179,6 +179,15 @@
     "runOnServer": "Run on the server terminal:",
     "recheckButton": "Re-check"
   },
+  "cursor": {
+    "description": "Cursor CLI uses your local",
+    "descriptionSuffix": "binary. No API key needed.",
+    "mode": "Working Mode",
+    "modeAgent": "Agent",
+    "modePlan": "Plan",
+    "modeAsk": "Ask",
+    "modeHint": "Agent: full tool access. Plan: read-only planning. Ask: Q&A without edits."
+  },
   "detail": {
     "title": "Provider Details",
     "advanced": "Advanced",

--- a/ui/web/src/i18n/locales/vi/providers.json
+++ b/ui/web/src/i18n/locales/vi/providers.json
@@ -184,6 +184,15 @@
     "runOnServer": "Chạy trên terminal máy chủ:",
     "recheckButton": "Kiểm tra lại"
   },
+  "cursor": {
+    "description": "Cursor CLI sử dụng tệp nhị phân",
+    "descriptionSuffix": "cục bộ của bạn. Không cần API key.",
+    "mode": "Chế độ làm việc",
+    "modeAgent": "Agent",
+    "modePlan": "Kế hoạch",
+    "modeAsk": "Hỏi đáp",
+    "modeHint": "Agent: truy cập công cụ đầy đủ. Plan: lập kế hoạch chỉ đọc. Ask: hỏi đáp không chỉnh sửa."
+  },
   "detail": {
     "advanced": "Nâng cao",
     "identity": "Danh tính",

--- a/ui/web/src/i18n/locales/zh/providers.json
+++ b/ui/web/src/i18n/locales/zh/providers.json
@@ -202,6 +202,15 @@
     "runOnServer": "在服务器终端运行：",
     "recheckButton": "重新检查"
   },
+  "cursor": {
+    "description": "Cursor CLI 使用本地",
+    "descriptionSuffix": "二进制文件。无需 API 密钥。",
+    "mode": "工作模式",
+    "modeAgent": "Agent",
+    "modePlan": "规划",
+    "modeAsk": "问答",
+    "modeHint": "Agent：完整工具访问。Plan：只读规划。Ask：不修改的问答。"
+  },
   "detail": {
     "advanced": "高级设置",
     "identity": "身份",

--- a/ui/web/src/pages/providers/provider-cursor-section.tsx
+++ b/ui/web/src/pages/providers/provider-cursor-section.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from "react-i18next";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+
+interface CursorCLISectionProps {
+  mode: string;
+  onModeChange: (v: string) => void;
+}
+
+export function CursorCLISection({ mode, onModeChange }: CursorCLISectionProps) {
+  const { t } = useTranslation("providers");
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        {t("cursor.description")} <code className="rounded bg-muted px-1 py-0.5">agent</code> {t("cursor.descriptionSuffix")}
+      </p>
+
+      <div className="space-y-2">
+        <Label>{t("cursor.mode")}</Label>
+        <Select value={mode} onValueChange={onModeChange}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="agent">{t("cursor.modeAgent")}</SelectItem>
+            <SelectItem value="plan">{t("cursor.modePlan")}</SelectItem>
+            <SelectItem value="ask">{t("cursor.modeAsk")}</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">{t("cursor.modeHint")}</p>
+      </div>
+    </div>
+  );
+}

--- a/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
@@ -51,7 +51,7 @@ export function ProviderAdvancedDialog({
   const { t } = useTranslation("providers");
 
   const isACP = provider.provider_type === "acp";
-  const isCLI = provider.provider_type === "claude_cli";
+  const isCLI = provider.provider_type === "claude_cli" || provider.provider_type === "cursor_cli";
   const isOAuth = provider.provider_type === "chatgpt_oauth";
   const isStandard = !isACP && !isCLI && !isOAuth;
 

--- a/ui/web/src/pages/providers/provider-detail/provider-overview-helpers.ts
+++ b/ui/web/src/pages/providers/provider-detail/provider-overview-helpers.ts
@@ -3,11 +3,12 @@ import type { ChatGPTOAuthRoutingConfig } from "@/types/agent";
 import { normalizeReasoningEffort, normalizeReasoningFallback } from "@/types/provider";
 
 // Provider types that don't use API keys
-export const NO_API_KEY_TYPES = new Set(["claude_cli", "acp", "chatgpt_oauth"]);
+export const NO_API_KEY_TYPES = new Set(["claude_cli", "cursor_cli", "acp", "chatgpt_oauth"]);
 
 // Provider types that don't support embedding
 export const NO_EMBEDDING_TYPES = new Set([
   "claude_cli",
+  "cursor_cli",
   "acp",
   "chatgpt_oauth",
   "anthropic_native",

--- a/ui/web/src/pages/providers/provider-form-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-form-dialog.tsx
@@ -27,6 +27,7 @@ import { slugify } from "@/lib/slug";
 import { DEFAULT_CODEX_OAUTH_ALIAS, PROVIDER_TYPES, suggestUniqueProviderAlias } from "@/constants/providers";
 import { OAuthSection } from "./provider-oauth-section";
 import { CLISection } from "./provider-cli-section";
+import { CursorCLISection } from "./provider-cursor-section";
 import { ACPSection } from "./provider-acp-section";
 import { ProviderStandardFormFields } from "./provider-standard-form-fields";
 import { Loader2 } from "lucide-react";
@@ -67,8 +68,10 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
   const name = watch("name");
 
   const hasClaudeCLI = existingProviders.some((p) => p.provider_type === "claude_cli");
+  const hasCursorCLI = existingProviders.some((p) => p.provider_type === "cursor_cli");
   const isOAuth = providerType === "chatgpt_oauth";
   const isCLI = providerType === "claude_cli";
+  const isCursorCLI = providerType === "cursor_cli";
   const isACP = providerType === "acp";
 
   // Reset form when dialog opens
@@ -86,6 +89,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
         acpIdleTTL: "",
         acpPermMode: "approve-all",
         acpWorkDir: "",
+        cursorMode: "agent",
       });
     }
   }, [open, reset]);
@@ -106,6 +110,13 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
       if (data.acpIdleTTL?.trim()) settings.idle_ttl = data.acpIdleTTL.trim();
       if (data.acpPermMode) settings.perm_mode = data.acpPermMode;
       if (data.acpWorkDir?.trim()) settings.work_dir = data.acpWorkDir.trim();
+      if (Object.keys(settings).length > 0) payload.settings = settings;
+    }
+
+    if (isCursorCLI) {
+      payload.api_base = data.cursorBinary || undefined;
+      const settings: Record<string, unknown> = {};
+      if (data.cursorMode) settings.mode = data.cursorMode;
       if (Object.keys(settings).length > 0) payload.settings = settings;
     }
 
@@ -141,6 +152,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
           <ProviderTypeSelect
             value={providerType}
             hasClaudeCLI={hasClaudeCLI}
+            hasCursorCLI={hasCursorCLI}
             alreadyAddedLabel={t("form.alreadyAdded")}
             providerTypeLabel={t("form.providerType")}
             onChange={handleProviderTypeChange}
@@ -208,6 +220,13 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
 
               {isCLI && <CLISection open={open} />}
 
+              {isCursorCLI && (
+                <CursorCLISection
+                  mode={watch("cursorMode") || "agent"}
+                  onModeChange={(v) => setValue("cursorMode", v)}
+                />
+              )}
+
               {isACP && (
                 <ACPSection
                   binary={watch("acpBinary") || ""}
@@ -223,7 +242,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
                 />
               )}
 
-              {!isCLI && !isACP && (
+              {!isCLI && !isCursorCLI && !isACP && (
                 <ProviderStandardFormFields
                   register={register}
                   errors={errors}
@@ -232,7 +251,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
                 />
               )}
 
-              {(isCLI || isACP) && (
+              {(isCLI || isCursorCLI || isACP) && (
                 <>
                   <div className="flex items-center justify-between">
                     <Label htmlFor="enabled">{t("form.enabled")}</Label>
@@ -277,9 +296,10 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
   );
 }
 
-function ProviderTypeSelect({ value, hasClaudeCLI, alreadyAddedLabel, providerTypeLabel, onChange }: {
+function ProviderTypeSelect({ value, hasClaudeCLI, hasCursorCLI, alreadyAddedLabel, providerTypeLabel, onChange }: {
   value: string;
   hasClaudeCLI: boolean;
+  hasCursorCLI: boolean;
   alreadyAddedLabel: string;
   providerTypeLabel: string;
   onChange: (value: string) => void;
@@ -296,10 +316,13 @@ function ProviderTypeSelect({ value, hasClaudeCLI, alreadyAddedLabel, providerTy
             <SelectItem
               key={pt.value}
               value={pt.value}
-              disabled={pt.value === "claude_cli" && hasClaudeCLI}
+              disabled={(pt.value === "claude_cli" && hasClaudeCLI) || (pt.value === "cursor_cli" && hasCursorCLI)}
             >
               {pt.label}
               {pt.value === "claude_cli" && hasClaudeCLI && (
+                <span className="ml-1 text-xs opacity-60">{alreadyAddedLabel}</span>
+              )}
+              {pt.value === "cursor_cli" && hasCursorCLI && (
                 <span className="ml-1 text-xs opacity-60">{alreadyAddedLabel}</span>
               )}
             </SelectItem>

--- a/ui/web/src/pages/providers/provider-utils.tsx
+++ b/ui/web/src/pages/providers/provider-utils.tsx
@@ -12,6 +12,7 @@ const SPECIAL_VARIANTS: Record<string, BadgeVariant> = {
   anthropic_native: "default",
   chatgpt_oauth: "default",
   claude_cli: "outline",
+  cursor_cli: "outline",
   acp: "outline",
 };
 
@@ -123,7 +124,7 @@ export function ProviderApiKeyBadge({
       </span>
     );
   }
-  if (provider.provider_type === "claude_cli") {
+  if (provider.provider_type === "claude_cli" || provider.provider_type === "cursor_cli") {
     return (
       <span className="flex items-center gap-1 text-xs-plus text-emerald-600 dark:text-emerald-400">
         <ShieldCheck className="h-3 w-3" />{t("card.authenticated")}

--- a/ui/web/src/pages/setup/hooks/use-bootstrap-status.ts
+++ b/ui/web/src/pages/setup/hooks/use-bootstrap-status.ts
@@ -30,6 +30,7 @@ export function useBootstrapStatus() {
     const hasProvider = providers.some((provider) => provider.enabled && (
       provider.api_key === "***"
       || provider.provider_type === "claude_cli"
+      || provider.provider_type === "cursor_cli"
       || provider.provider_type === "ollama"
       || (provider.provider_type === "chatgpt_oauth" && readyOAuthProviders.has(provider.name))
     ));

--- a/ui/web/src/pages/setup/setup-page.tsx
+++ b/ui/web/src/pages/setup/setup-page.tsx
@@ -122,6 +122,7 @@ export function SetupPage() {
   const activeProvider = createdProvider ?? providers.find((provider) => provider.enabled && (
     provider.api_key === "***"
     || provider.provider_type === "claude_cli"
+    || provider.provider_type === "cursor_cli"
     || provider.provider_type === "ollama"
     || (provider.provider_type === "chatgpt_oauth" && readyOAuthProviders.has(provider.name))
   )) ?? null;

--- a/ui/web/src/pages/setup/step-provider.tsx
+++ b/ui/web/src/pages/setup/step-provider.tsx
@@ -44,7 +44,7 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
   const [error, setError] = useState("");
 
   const isOAuth = providerType === "chatgpt_oauth";
-  const isCLI = providerType === "claude_cli";
+  const isCLI = providerType === "claude_cli" || providerType === "cursor_cli";
   // Local Ollama uses no API key — the server accepts any non-empty Bearer value internally
   const isOllama = providerType === "ollama";
 

--- a/ui/web/src/schemas/provider.schema.ts
+++ b/ui/web/src/schemas/provider.schema.ts
@@ -17,6 +17,9 @@ export const providerCreateSchema = z.object({
   acpIdleTTL: z.string().optional(),
   acpPermMode: z.string().optional(),
   acpWorkDir: z.string().optional(),
+  // Cursor CLI-specific fields
+  cursorBinary: z.string().optional(),
+  cursorMode: z.string().optional(),
 });
 
 export type ProviderCreateFormData = z.infer<typeof providerCreateSchema>;


### PR DESCRIPTION
## Summary

Adds first-class **Cursor** as a daemon agent provider by driving the headless Cursor Agent CLI (`agent`), so GoClaw can list Cursor alongside other providers, spawn Cursor-backed sessions, and stream output into the existing agent pipeline.

## What changed

- **Backend**: `CursorCLIProvider` / session implementation (`agent -p --force`, stream-json), provider manifest + registry wiring, `extra.cursor` settings on provider config (mode via JSONB), and model catalog.
- **CLI modes**: Supports `agent`, `plan`, and `ask` working modes passed via `--mode` flag.
- **Model selection**: When creating a new agent with the Cursor provider, users can select from the Cursor model catalog instead of falling back to a default.
- **Session persistence**: Uses deterministic session IDs with `--resume` / `--session-id` flags, storing transcripts in `~/.cursor/projects/`.
- **Frontend**: `cursor_cli` provider type in constants/schemas, provider form dialog with mode selector, i18n keys for en/vi/zh, setup flow support.

## Testing

- `go build ./...` (PG build)
- `go build -tags sqliteonly ./...` (Desktop/SQLite build)
- `go vet ./...`

## Notes

Inspired by how [Paseo PR #280](https://github.com/getpaseo/paseo/pull/280) handles the Cursor agent through CLI.