### PR TITLE
fix(provider/cursor): persist chat ID to disk for session continuity across restarts

### DIFF
--- a/cmd/gateway_consumer_handlers.go
+++ b/cmd/gateway_consumer_handlers.go
@@ -413,6 +413,7 @@ func handleResetCommand(
 	deps.SessStore.Reset(ctx, sessionKey)
 	deps.SessStore.Save(ctx, sessionKey)
 	providers.ResetCLISession("", sessionKey)
+	providers.ResetCursorCLISession("", sessionKey)
 	slog.Info("inbound: /reset command", "session", sessionKey)
 
 	return true

--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -198,6 +198,23 @@ func registerProviders(registry *providers.Registry, cfg *config.Config, modelRe
 		slog.Info("registered provider", "name", "claude-cli")
 	}
 
+	// Cursor CLI provider (subscription-based, no API key needed)
+	if cfg.Providers.CursorCLI.CLIPath != "" {
+		cliPath := cfg.Providers.CursorCLI.CLIPath
+		var opts []providers.CursorCLIOption
+		if cfg.Providers.CursorCLI.Model != "" {
+			opts = append(opts, providers.WithCursorCLIModel(cfg.Providers.CursorCLI.Model))
+		}
+		if cfg.Providers.CursorCLI.Mode != "" {
+			opts = append(opts, providers.WithCursorCLIMode(cfg.Providers.CursorCLI.Mode))
+		}
+		if cfg.Providers.CursorCLI.BaseWorkDir != "" {
+			opts = append(opts, providers.WithCursorCLIWorkDir(cfg.Providers.CursorCLI.BaseWorkDir))
+		}
+		registry.Register(providers.NewCursorCLIProvider(cliPath, opts...))
+		slog.Info("registered provider", "name", "cursor-cli")
+	}
+
 	// ACP provider (config-based) — orchestrates any ACP-compatible agent binary
 	if cfg.Providers.ACP.Binary != "" {
 		registerACPFromConfig(registry, cfg.Providers.ACP)
@@ -304,6 +321,35 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 				cliOpts = append(cliOpts, providers.WithClaudeCLIMCPConfigData(mcpData))
 			}
 			registry.RegisterForTenant(p.TenantID, providers.NewClaudeCLIProvider(cliPath, cliOpts...))
+			slog.Info("registered provider from DB", "name", p.Name)
+			continue
+		}
+		// Cursor CLI doesn't need API key
+		if p.ProviderType == store.ProviderCursorCLI {
+			cliPath := p.APIBase // reuse APIBase field for CLI path
+			if cliPath == "" {
+				cliPath = "agent"
+			}
+			if cliPath != "agent" && !filepath.IsAbs(cliPath) {
+				slog.Warn("security.cursor_cli: invalid path from DB, using default", "path", cliPath)
+				cliPath = "agent"
+			}
+			if _, err := exec.LookPath(cliPath); err != nil {
+				slog.Warn("cursor-cli: binary not found, skipping", "path", cliPath, "error", err)
+				continue
+			}
+			var cliOpts []providers.CursorCLIOption
+			cliOpts = append(cliOpts, providers.WithCursorCLIName(p.Name))
+			// Parse settings JSONB for extra config (mode)
+			var settings struct {
+				Mode string `json:"mode"`
+			}
+			if p.Settings != nil {
+				if err := json.Unmarshal(p.Settings, &settings); err == nil && settings.Mode != "" {
+					cliOpts = append(cliOpts, providers.WithCursorCLIMode(settings.Mode))
+				}
+			}
+			registry.RegisterForTenant(p.TenantID, providers.NewCursorCLIProvider(cliPath, cliOpts...))
 			slog.Info("registered provider from DB", "name", p.Name)
 			continue
 		}

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -24,25 +24,25 @@ type ChannelsConfig struct {
 }
 
 type TelegramConfig struct {
-	Enabled        bool                `json:"enabled"`
-	Token          string              `json:"token"`
-	Proxy          string              `json:"proxy,omitempty"`
-	APIServer      string              `json:"api_server,omitempty"` // custom Telegram Bot API server URL (e.g. "http://localhost:8081")
-	AllowFrom      FlexibleStringSlice `json:"allow_from"`
-	DMPolicy       string              `json:"dm_policy,omitempty"`       // "pairing" (default), "allowlist", "open", "disabled"
-	GroupPolicy    string              `json:"group_policy,omitempty"`    // "open" (default), "allowlist", "disabled"
-	RequireMention *bool               `json:"require_mention,omitempty"` // require @bot mention in groups (default true)
-	MentionMode    string              `json:"mention_mode,omitempty"`    // "strict" (default) = only respond when mentioned; "yield" = respond unless another bot is mentioned
-	HistoryLimit   int                 `json:"history_limit,omitempty"`   // max pending group messages for context (default 50, 0=disabled)
-	DMStream         *bool               `json:"dm_stream,omitempty"`          // enable streaming for DMs (default false) — edits placeholder progressively
-	GroupStream      *bool               `json:"group_stream,omitempty"`      // enable streaming for groups (default false) — sends new message, edits progressively
-	DraftTransport   *bool               `json:"draft_transport,omitempty"`   // use sendMessageDraft for DM streaming (default true) — stealth preview, no notifications per edit
-	ReasoningStream  *bool               `json:"reasoning_stream,omitempty"`  // show reasoning as separate message when provider emits thinking events (default true)
-	ReactionLevel    string              `json:"reaction_level,omitempty"`    // "off" (default), "minimal", "full" — status emoji reactions
-	MediaMaxBytes  int64               `json:"media_max_bytes,omitempty"` // max media download size in bytes (default 20MB)
-	LinkPreview    *bool               `json:"link_preview,omitempty"`    // enable URL previews in messages (default true)
-	BlockReply     *bool               `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
-	ForceIPv4      bool                `json:"force_ipv4,omitempty"`      // force IPv4 for all Telegram API requests (use when IPv6 routing is broken)
+	Enabled         bool                `json:"enabled"`
+	Token           string              `json:"token"`
+	Proxy           string              `json:"proxy,omitempty"`
+	APIServer       string              `json:"api_server,omitempty"` // custom Telegram Bot API server URL (e.g. "http://localhost:8081")
+	AllowFrom       FlexibleStringSlice `json:"allow_from"`
+	DMPolicy        string              `json:"dm_policy,omitempty"`        // "pairing" (default), "allowlist", "open", "disabled"
+	GroupPolicy     string              `json:"group_policy,omitempty"`     // "open" (default), "allowlist", "disabled"
+	RequireMention  *bool               `json:"require_mention,omitempty"`  // require @bot mention in groups (default true)
+	MentionMode     string              `json:"mention_mode,omitempty"`     // "strict" (default) = only respond when mentioned; "yield" = respond unless another bot is mentioned
+	HistoryLimit    int                 `json:"history_limit,omitempty"`    // max pending group messages for context (default 50, 0=disabled)
+	DMStream        *bool               `json:"dm_stream,omitempty"`        // enable streaming for DMs (default false) — edits placeholder progressively
+	GroupStream     *bool               `json:"group_stream,omitempty"`     // enable streaming for groups (default false) — sends new message, edits progressively
+	DraftTransport  *bool               `json:"draft_transport,omitempty"`  // use sendMessageDraft for DM streaming (default true) — stealth preview, no notifications per edit
+	ReasoningStream *bool               `json:"reasoning_stream,omitempty"` // show reasoning as separate message when provider emits thinking events (default true)
+	ReactionLevel   string              `json:"reaction_level,omitempty"`   // "off" (default), "minimal", "full" — status emoji reactions
+	MediaMaxBytes   int64               `json:"media_max_bytes,omitempty"`  // max media download size in bytes (default 20MB)
+	LinkPreview     *bool               `json:"link_preview,omitempty"`     // enable URL previews in messages (default true)
+	BlockReply      *bool               `json:"block_reply,omitempty"`      // override gateway block_reply (nil = inherit)
+	ForceIPv4       bool                `json:"force_ipv4,omitempty"`       // force IPv4 for all Telegram API requests (use when IPv6 routing is broken)
 
 	// Optional STT (Speech-to-Text) pipeline for voice/audio inbound messages.
 	// When stt_proxy_url is set, audio/voice messages are transcribed before being forwarded to the agent.
@@ -133,7 +133,7 @@ type SlackConfig struct {
 
 type WhatsAppConfig struct {
 	Enabled        bool                `json:"enabled"`
-	AuthDir        string              `json:"auth_dir,omitempty"`        // optional: SQLite auth dir override (desktop)
+	AuthDir        string              `json:"auth_dir,omitempty"` // optional: SQLite auth dir override (desktop)
 	AllowFrom      FlexibleStringSlice `json:"allow_from"`
 	DMPolicy       string              `json:"dm_policy,omitempty"`       // "pairing" (default for DB instances), "open", "allowlist", "disabled"
 	GroupPolicy    string              `json:"group_policy,omitempty"`    // "pairing" (default for DB instances), "open" (default for config), "allowlist", "disabled"
@@ -196,25 +196,26 @@ type FeishuConfig struct {
 
 // ProvidersConfig maps provider name to its config.
 type ProvidersConfig struct {
-	Anthropic  ProviderConfig  `json:"anthropic"`
-	OpenAI     ProviderConfig  `json:"openai"`
-	OpenRouter ProviderConfig  `json:"openrouter"`
-	Groq       ProviderConfig  `json:"groq"`
-	Gemini     ProviderConfig  `json:"gemini"`
-	DeepSeek   ProviderConfig  `json:"deepseek"`
-	Mistral    ProviderConfig  `json:"mistral"`
-	XAI        ProviderConfig  `json:"xai"`
-	MiniMax    ProviderConfig  `json:"minimax"`
-	Cohere     ProviderConfig  `json:"cohere"`
-	Perplexity ProviderConfig  `json:"perplexity"`
-	DashScope  ProviderConfig  `json:"dashscope"`
-	Bailian    ProviderConfig  `json:"bailian"`
-	Zai         ProviderConfig  `json:"zai"`
-	ZaiCoding   ProviderConfig  `json:"zai_coding"`
-	Ollama      OllamaConfig    `json:"ollama"`       // local Ollama instance (no API key needed)
-	OllamaCloud ProviderConfig  `json:"ollama_cloud"` // Ollama Cloud (API key required)
-	ClaudeCLI   ClaudeCLIConfig `json:"claude_cli"`
-	ACP         ACPConfig       `json:"acp"`
+	Anthropic      ProviderConfig  `json:"anthropic"`
+	OpenAI         ProviderConfig  `json:"openai"`
+	OpenRouter     ProviderConfig  `json:"openrouter"`
+	Groq           ProviderConfig  `json:"groq"`
+	Gemini         ProviderConfig  `json:"gemini"`
+	DeepSeek       ProviderConfig  `json:"deepseek"`
+	Mistral        ProviderConfig  `json:"mistral"`
+	XAI            ProviderConfig  `json:"xai"`
+	MiniMax        ProviderConfig  `json:"minimax"`
+	Cohere         ProviderConfig  `json:"cohere"`
+	Perplexity     ProviderConfig  `json:"perplexity"`
+	DashScope      ProviderConfig  `json:"dashscope"`
+	Bailian        ProviderConfig  `json:"bailian"`
+	Zai            ProviderConfig  `json:"zai"`
+	ZaiCoding      ProviderConfig  `json:"zai_coding"`
+	Ollama         OllamaConfig    `json:"ollama"`       // local Ollama instance (no API key needed)
+	OllamaCloud    ProviderConfig  `json:"ollama_cloud"` // Ollama Cloud (API key required)
+	ClaudeCLI      ClaudeCLIConfig `json:"claude_cli"`
+	CursorCLI      CursorCLIConfig `json:"cursor_cli"`
+	ACP            ACPConfig       `json:"acp"`
 	Novita         ProviderConfig  `json:"novita"`          // Novita AI (OpenAI-compatible endpoint)
 	BytePlus       ProviderConfig  `json:"byteplus"`        // BytePlus ModelArk (Seed 2.0)
 	BytePlusCoding ProviderConfig  `json:"byteplus_coding"` // BytePlus ModelArk Coding Plan
@@ -232,6 +233,14 @@ type ClaudeCLIConfig struct {
 	Model       string `json:"model" yaml:"model"`                 // default model alias (default: "sonnet")
 	BaseWorkDir string `json:"base_work_dir" yaml:"base_work_dir"` // base dir for agent workspaces
 	PermMode    string `json:"perm_mode" yaml:"perm_mode"`         // permission mode (default: "bypassPermissions")
+}
+
+// CursorCLIConfig configures the Cursor CLI provider (uses subscription, not API key).
+type CursorCLIConfig struct {
+	CLIPath     string `json:"cli_path" yaml:"cli_path"`           // path to cursor agent binary (default: "agent")
+	Model       string `json:"model" yaml:"model"`                 // default model alias
+	Mode        string `json:"mode" yaml:"mode"`                   // working mode: "agent", "plan", "ask" (default: "agent")
+	BaseWorkDir string `json:"base_work_dir" yaml:"base_work_dir"` // base dir for agent workspaces
 }
 
 // ACPConfig configures the ACP (Agent Client Protocol) provider.
@@ -318,6 +327,7 @@ func (c *Config) HasAnyProvider() bool {
 		p.Ollama.Host != "" ||
 		p.OllamaCloud.APIKey != "" ||
 		p.ClaudeCLI.CLIPath != "" ||
+		p.CursorCLI.CLIPath != "" ||
 		p.ACP.Binary != "" ||
 		p.Novita.APIKey != "" ||
 		p.BytePlus.APIKey != "" ||
@@ -346,16 +356,16 @@ type QuotaConfig struct {
 
 // GatewayConfig controls the gateway server.
 type GatewayConfig struct {
-	Host              string       `json:"host"`
-	Port              int          `json:"port"`
-	Token             string       `json:"token,omitempty"`               // bearer token for WS/HTTP auth
-	OwnerIDs          []string     `json:"owner_ids,omitempty"`           // sender IDs considered "owner"
-	AllowedOrigins    []string     `json:"allowed_origins,omitempty"`     // WebSocket CORS whitelist (empty = allow all)
-	MaxMessageChars   int          `json:"max_message_chars,omitempty"`   // max user message characters (default 32000)
-	RateLimitRPM      int          `json:"rate_limit_rpm,omitempty"`      // rate limit: requests per minute per user (default 20, 0 = disabled)
-	InjectionAction   string       `json:"injection_action,omitempty"`    // prompt injection action: "log", "warn" (default), "block", "off"
-	InboundDebounceMs int          `json:"inbound_debounce_ms,omitempty"` // merge rapid messages from same sender (default 1000ms, -1 = disabled)
-	Quota             *QuotaConfig `json:"quota,omitempty"`               // per-user/group request quotas
+	Host                    string       `json:"host"`
+	Port                    int          `json:"port"`
+	Token                   string       `json:"token,omitempty"`                      // bearer token for WS/HTTP auth
+	OwnerIDs                []string     `json:"owner_ids,omitempty"`                  // sender IDs considered "owner"
+	AllowedOrigins          []string     `json:"allowed_origins,omitempty"`            // WebSocket CORS whitelist (empty = allow all)
+	MaxMessageChars         int          `json:"max_message_chars,omitempty"`          // max user message characters (default 32000)
+	RateLimitRPM            int          `json:"rate_limit_rpm,omitempty"`             // rate limit: requests per minute per user (default 20, 0 = disabled)
+	InjectionAction         string       `json:"injection_action,omitempty"`           // prompt injection action: "log", "warn" (default), "block", "off"
+	InboundDebounceMs       int          `json:"inbound_debounce_ms,omitempty"`        // merge rapid messages from same sender (default 1000ms, -1 = disabled)
+	Quota                   *QuotaConfig `json:"quota,omitempty"`                      // per-user/group request quotas
 	BlockReply              *bool        `json:"block_reply,omitempty"`                // deliver intermediate text during tool iterations (default false)
 	ToolStatus              *bool        `json:"tool_status,omitempty"`                // show tool name in streaming preview during tool execution (default true)
 	TaskRecoveryIntervalSec int          `json:"task_recovery_interval_sec,omitempty"` // team task recovery ticker interval in seconds (default 300 = 5min)
@@ -412,9 +422,9 @@ type WebFetchPolicyConfig struct {
 
 // BrowserToolConfig controls the browser automation tool.
 type BrowserToolConfig struct {
-	Enabled         bool   `json:"enabled"`                    // enable the browser tool (default false)
-	Headless        bool   `json:"headless,omitempty"`         // run Chrome in headless mode (ignored when RemoteURL is set)
-	RemoteURL       string `json:"remote_url,omitempty"`       // CDP endpoint for remote Chrome sidecar, e.g. "ws://chrome:9222"
+	Enabled         bool   `json:"enabled"`                     // enable the browser tool (default false)
+	Headless        bool   `json:"headless,omitempty"`          // run Chrome in headless mode (ignored when RemoteURL is set)
+	RemoteURL       string `json:"remote_url,omitempty"`        // CDP endpoint for remote Chrome sidecar, e.g. "ws://chrome:9222"
 	ActionTimeoutMs int    `json:"action_timeout_ms,omitempty"` // per-action timeout in ms (default 30000)
 	IdleTimeoutMs   int    `json:"idle_timeout_ms,omitempty"`   // idle page auto-close in ms (default 600000, 0=disabled)
 	MaxPages        int    `json:"max_pages,omitempty"`         // max open pages per tenant (default 5)
@@ -422,12 +432,12 @@ type BrowserToolConfig struct {
 
 // ToolPolicySpec defines a tool policy at any level (global, per-agent, per-provider).
 type ToolPolicySpec struct {
-	Profile    string                     `json:"profile,omitempty"`
-	Allow      []string                   `json:"allow,omitempty"`
-	Deny       []string                   `json:"deny,omitempty"`
-	AlsoAllow  []string                   `json:"alsoAllow,omitempty"`
-	ByProvider map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
-	ToolCallPrefix string `json:"toolCallPrefix,omitempty"` // prefix to strip from model's tool call names before registry lookup
+	Profile        string                     `json:"profile,omitempty"`
+	Allow          []string                   `json:"allow,omitempty"`
+	Deny           []string                   `json:"deny,omitempty"`
+	AlsoAllow      []string                   `json:"alsoAllow,omitempty"`
+	ByProvider     map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
+	ToolCallPrefix string                     `json:"toolCallPrefix,omitempty"` // prefix to strip from model's tool call names before registry lookup
 }
 
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -151,6 +151,12 @@ func (c *Config) applyEnvOverrides() {
 	envStr("GOCLAW_CLAUDE_CLI_MODEL", &c.Providers.ClaudeCLI.Model)
 	envStr("GOCLAW_CLAUDE_CLI_WORK_DIR", &c.Providers.ClaudeCLI.BaseWorkDir)
 
+	// Cursor CLI provider
+	envStr("GOCLAW_CURSOR_CLI_PATH", &c.Providers.CursorCLI.CLIPath)
+	envStr("GOCLAW_CURSOR_CLI_MODEL", &c.Providers.CursorCLI.Model)
+	envStr("GOCLAW_CURSOR_CLI_MODE", &c.Providers.CursorCLI.Mode)
+	envStr("GOCLAW_CURSOR_CLI_WORK_DIR", &c.Providers.CursorCLI.BaseWorkDir)
+
 	// Default provider/model: env is fallback only (applied when config has no value).
 	// The onboard wizard sets these in .env for initial bootstrap; once the user
 	// saves a provider/model via the Dashboard, the config-file value wins.
@@ -276,7 +282,6 @@ func (c *Config) applyEnvOverrides() {
 		c.Tools.Browser.Enabled = true
 	}
 }
-
 
 // Save writes the config to a JSON file.
 func Save(path string, cfg *Config) error {

--- a/internal/http/provider_models.go
+++ b/internal/http/provider_models.go
@@ -15,8 +15,8 @@ import (
 
 // ModelInfo is a normalized model entry returned by the list-models endpoint.
 type ModelInfo struct {
-	ID        string                        `json:"id"`
-	Name      string                        `json:"name,omitempty"`
+	ID        string                         `json:"id"`
+	Name      string                         `json:"name,omitempty"`
 	Reasoning *providers.ReasoningCapability `json:"reasoning,omitempty"`
 }
 
@@ -53,6 +53,18 @@ func (h *ProvidersHandler) handleListProviderModels(w http.ResponseWriter, r *ht
 	// Claude CLI doesn't need an API key — return hardcoded models
 	if p.ProviderType == store.ProviderClaudeCLI {
 		respond(claudeCLIModels())
+		return
+	}
+
+	// Cursor CLI doesn't need an API key — query models directly from the CLI.
+	if p.ProviderType == store.ProviderCursorCLI {
+		models, err := cursorCLIModels(p.APIBase)
+		if err != nil {
+			slog.Warn("providers.models.cursor_cli", "provider", p.Name, "error", err)
+			respond([]ModelInfo{})
+			return
+		}
+		respond(models)
 		return
 	}
 

--- a/internal/http/provider_models_catalog.go
+++ b/internal/http/provider_models_catalog.go
@@ -1,5 +1,13 @@
 package http
 
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
 // bailianModels returns a hardcoded list of models available on the
 // Bailian Coding platform (coding-intl.dashscope.aliyuncs.com).
 // The platform does not expose a /v1/models endpoint.
@@ -70,6 +78,72 @@ func claudeCLIModels() []ModelInfo {
 		{ID: "opus", Name: "Opus"},
 		{ID: "haiku", Name: "Haiku"},
 	}
+}
+
+var (
+	cursorANSICSI = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+	cursorANSIOSC = regexp.MustCompile(`\x1b\][^\x07]*(?:\x07|\x1b\\)`)
+)
+
+// cursorCLIModels fetches model aliases by invoking `agent models`.
+func cursorCLIModels(cliPath string) ([]ModelInfo, error) {
+	if strings.TrimSpace(cliPath) == "" {
+		cliPath = "agent"
+	}
+	cmd := exec.Command(cliPath, "models")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("cursor-cli models command failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	models := parseCursorCLIModelsOutput(out)
+	if len(models) == 0 {
+		return nil, fmt.Errorf("cursor-cli models command returned no models")
+	}
+	return models, nil
+}
+
+func parseCursorCLIModelsOutput(out []byte) []ModelInfo {
+	text := strings.ReplaceAll(string(out), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	models := make([]ModelInfo, 0, len(lines))
+	seen := make(map[string]struct{}, len(lines))
+	for _, raw := range lines {
+		line := strings.TrimSpace(stripCursorANSI(raw))
+		if line == "" || line == "Available models" || strings.HasPrefix(line, "Tip:") {
+			continue
+		}
+		id, name, ok := parseCursorCLIModelLine(line)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		models = append(models, ModelInfo{ID: id, Name: name})
+	}
+	return models
+}
+
+func parseCursorCLIModelLine(line string) (id string, name string, ok bool) {
+	left, right, found := strings.Cut(line, " - ")
+	if !found {
+		return "", "", false
+	}
+	id = strings.TrimSpace(left)
+	name = strings.TrimSpace(right)
+	if id == "" || name == "" {
+		return "", "", false
+	}
+	return id, name, true
+}
+
+func stripCursorANSI(s string) string {
+	b := []byte(s)
+	b = cursorANSIOSC.ReplaceAll(b, nil)
+	b = cursorANSICSI.ReplaceAll(b, nil)
+	b = bytes.ReplaceAll(b, []byte{0x1b}, nil)
+	return string(b)
 }
 
 // acpModels returns the model aliases for ACP-compatible coding agents.

--- a/internal/http/provider_models_catalog_test.go
+++ b/internal/http/provider_models_catalog_test.go
@@ -1,0 +1,57 @@
+package http
+
+import "testing"
+
+func TestParseCursorCLIModelsOutputPlain(t *testing.T) {
+	out := []byte(`Available models
+
+auto - Auto (current)
+composer-2-fast - Composer 2 Fast (default)
+gpt-5.3-codex - Codex 5.3
+
+Tip: use --model <id>`)
+
+	models := parseCursorCLIModelsOutput(out)
+	if len(models) != 3 {
+		t.Fatalf("models len = %d, want 3", len(models))
+	}
+	if models[0].ID != "auto" || models[0].Name != "Auto (current)" {
+		t.Fatalf("models[0] = %#v, want auto / Auto (current)", models[0])
+	}
+	if models[2].ID != "gpt-5.3-codex" || models[2].Name != "Codex 5.3" {
+		t.Fatalf("models[2] = %#v, want gpt-5.3-codex / Codex 5.3", models[2])
+	}
+}
+
+func TestParseCursorCLIModelsOutputANSI(t *testing.T) {
+	out := []byte("\x1b[1mAvailable models\x1b[0m\n\n" +
+		"\x1b[32mauto\x1b[0m - Auto (current)\n" +
+		"\x1b[36mgpt-5.4-high\x1b[0m - \x1b[1mGPT-5.4 1M High\x1b[0m\n" +
+		"\x1b]8;;https://example.com\x07ignored-link\x1b]8;;\x07\n" +
+		"Tip: use --model <id>\n")
+
+	models := parseCursorCLIModelsOutput(out)
+	if len(models) != 2 {
+		t.Fatalf("models len = %d, want 2", len(models))
+	}
+	if models[1].ID != "gpt-5.4-high" || models[1].Name != "GPT-5.4 1M High" {
+		t.Fatalf("models[1] = %#v, want gpt-5.4-high / GPT-5.4 1M High", models[1])
+	}
+}
+
+func TestParseCursorCLIModelsOutputSkipsInvalidAndDuplicateLines(t *testing.T) {
+	out := []byte(`Available models
+auto - Auto (current)
+invalid line without separator
+auto - Auto (current)
+gpt-5.4-high - GPT-5.4 1M High
+`)
+
+	models := parseCursorCLIModelsOutput(out)
+	if len(models) != 2 {
+		t.Fatalf("models len = %d, want 2", len(models))
+	}
+	if models[0].ID != "auto" || models[1].ID != "gpt-5.4-high" {
+		t.Fatalf("models = %#v, want auto then gpt-5.4-high", models)
+	}
+}

--- a/internal/http/provider_verify.go
+++ b/internal/http/provider_verify.go
@@ -79,6 +79,20 @@ func (h *ProvidersHandler) handleVerifyProvider(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Cursor CLI: validate binary exists and accept any model (CLI handles model validation)
+	if p.ProviderType == store.ProviderCursorCLI {
+		cliPath := p.APIBase
+		if cliPath == "" {
+			cliPath = "agent"
+		}
+		if _, err := exec.LookPath(cliPath); err != nil {
+			writeJSON(w, http.StatusOK, map[string]any{"valid": false, "error": "Cursor agent binary not found: " + cliPath})
+		} else {
+			writeJSON(w, http.StatusOK, map[string]any{"valid": true})
+		}
+		return
+	}
+
 	if h.providerReg == nil {
 		writeJSON(w, http.StatusOK, map[string]any{"valid": false, "error": "no provider registry available"})
 		return
@@ -155,6 +169,48 @@ func (h *ProvidersHandler) handleClaudeCLIAuthStatus(w http.ResponseWriter, r *h
 		"logged_in":         status.LoggedIn,
 		"email":             status.Email,
 		"subscription_type": status.SubscriptionType,
+		"in_docker":         inDocker,
+	})
+}
+
+// handleCursorCLIAuthStatus checks whether the Cursor CLI is authenticated on the server.
+//
+//	GET /v1/providers/cursor-cli/auth-status
+//	Response: {"authenticated": true, "email": "..."}
+//	     or: {"authenticated": false, "error": "..."}
+func (h *ProvidersHandler) handleCursorCLIAuthStatus(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	// Try to find CLI path from existing Cursor CLI provider in DB
+	cliPath := "agent"
+	if existing, err := h.store.ListProviders(r.Context()); err == nil {
+		for _, p := range existing {
+			if p.ProviderType == store.ProviderCursorCLI && p.APIBase != "" {
+				cliPath = p.APIBase
+				break
+			}
+		}
+	}
+
+	inDocker := config.InDocker()
+
+	status, err := providers.CheckCursorAuthStatus(ctx, cliPath)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"authenticated": false,
+			"error":         err.Error(),
+			"in_docker":     inDocker,
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"authenticated":     status.IsAuthenticated,
+		"status":            status.Status,
+		"has_access_token":  status.HasAccessToken,
+		"has_refresh_token": status.HasRefreshToken,
+		"email":             status.UserInfo.Email,
 		"in_docker":         inDocker,
 	})
 }

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -35,9 +35,9 @@ type ProvidersHandler struct {
 	cliMu           sync.Mutex                       // serializes Claude CLI provider create to prevent duplicates
 	msgBus          *bus.MessageBus
 	sysConfigStore  store.SystemConfigStore
-	tracingStore    store.TracingStore        // optional: for provider-scoped pool activity
-	agents          store.AgentCRUDStore      // optional: for provider pool activity agent lookup
-	modelReg        providers.ModelRegistry   // optional: forward-compat model resolver for Anthropic
+	tracingStore    store.TracingStore      // optional: for provider-scoped pool activity
+	agents          store.AgentCRUDStore    // optional: for provider pool activity agent lookup
+	modelReg        providers.ModelRegistry // optional: forward-compat model resolver for Anthropic
 }
 
 // NewProvidersHandler creates a handler for provider management endpoints.
@@ -141,6 +141,7 @@ func (h *ProvidersHandler) RegisterRoutes(mux *http.ServeMux) {
 
 	// Claude CLI auth status (global — not per-provider)
 	mux.HandleFunc("GET /v1/providers/claude-cli/auth-status", h.auth(h.handleClaudeCLIAuthStatus))
+	mux.HandleFunc("GET /v1/providers/cursor-cli/auth-status", h.auth(h.handleCursorCLIAuthStatus))
 }
 
 func (h *ProvidersHandler) auth(next http.HandlerFunc) http.HandlerFunc {
@@ -191,6 +192,25 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) {
 			cliOpts = append(cliOpts, providers.WithClaudeCLIMCPConfigData(mcpData))
 		}
 		h.providerReg.RegisterForTenant(p.TenantID, providers.NewClaudeCLIProvider(cliPath, cliOpts...))
+		return
+	}
+	// Cursor CLI doesn't need an API key — register immediately
+	if p.ProviderType == store.ProviderCursorCLI {
+		cliPath := p.APIBase
+		if cliPath == "" {
+			cliPath = "agent"
+		}
+		var cliOpts []providers.CursorCLIOption
+		cliOpts = append(cliOpts, providers.WithCursorCLIName(p.Name))
+		var settings struct {
+			Mode string `json:"mode"`
+		}
+		if p.Settings != nil {
+			if err := json.Unmarshal(p.Settings, &settings); err == nil && settings.Mode != "" {
+				cliOpts = append(cliOpts, providers.WithCursorCLIMode(settings.Mode))
+			}
+		}
+		h.providerReg.RegisterForTenant(p.TenantID, providers.NewCursorCLIProvider(cliPath, cliOpts...))
 		return
 	}
 	// Ollama doesn't need an API key — handle before the key guard (same as startup).
@@ -269,6 +289,7 @@ func normalizeOllamaAPIBase(p *store.LLMProviderData) {
 var localProviderTypes = map[string]bool{
 	store.ProviderOllama:    true,
 	store.ProviderClaudeCLI: true,
+	store.ProviderCursorCLI: true,
 	store.ProviderACP:       true,
 }
 
@@ -363,6 +384,21 @@ func (h *ProvidersHandler) handleCreateProvider(w http.ResponseWriter, r *http.R
 			if ep.ProviderType == store.ProviderClaudeCLI {
 				writeJSON(w, http.StatusConflict, map[string]string{
 					"error": i18n.T(locale, i18n.MsgAlreadyExists, "Claude CLI provider", "only one is allowed per instance"),
+				})
+				return
+			}
+		}
+	}
+	// Same guard for Cursor CLI
+	if p.ProviderType == store.ProviderCursorCLI {
+		h.cliMu.Lock()
+		defer h.cliMu.Unlock()
+
+		existing, _ := h.store.ListProviders(r.Context())
+		for _, ep := range existing {
+			if ep.ProviderType == store.ProviderCursorCLI {
+				writeJSON(w, http.StatusConflict, map[string]string{
+					"error": i18n.T(locale, i18n.MsgAlreadyExists, "Cursor CLI provider", "only one is allowed per instance"),
 				})
 				return
 			}

--- a/internal/providers/cursor_cli.go
+++ b/internal/providers/cursor_cli.go
@@ -1,0 +1,111 @@
+package providers
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+)
+
+// CursorCLIProvider implements Provider by shelling out to the Cursor `agent` CLI binary.
+// It drives the headless Cursor Agent CLI to process prompts with streaming output.
+type CursorCLIProvider struct {
+	name         string // provider name (default: "cursor-cli")
+	cliPath      string // path to agent binary (default: "agent")
+	defaultModel string // default model alias
+	defaultMode  string // default mode: "agent", "plan", "ask"
+	baseWorkDir  string // base dir for agent workspaces
+	mu           sync.Mutex
+	sessionMu    sync.Map // key: string, value: *sync.Mutex
+}
+
+// CursorCLIOption configures the provider.
+type CursorCLIOption func(*CursorCLIProvider)
+
+// WithCursorCLIName overrides the provider name.
+func WithCursorCLIName(name string) CursorCLIOption {
+	return func(p *CursorCLIProvider) {
+		if name != "" {
+			p.name = name
+		}
+	}
+}
+
+// WithCursorCLIModel sets the default model alias.
+func WithCursorCLIModel(model string) CursorCLIOption {
+	return func(p *CursorCLIProvider) {
+		if model != "" {
+			p.defaultModel = model
+		}
+	}
+}
+
+// WithCursorCLIMode sets the default working mode.
+func WithCursorCLIMode(mode string) CursorCLIOption {
+	return func(p *CursorCLIProvider) {
+		if mode != "" {
+			p.defaultMode = mode
+		}
+	}
+}
+
+// WithCursorCLIWorkDir sets the base work directory.
+func WithCursorCLIWorkDir(dir string) CursorCLIOption {
+	return func(p *CursorCLIProvider) {
+		if dir != "" {
+			p.baseWorkDir = dir
+		}
+	}
+}
+
+// NewCursorCLIProvider creates a provider that invokes the Cursor agent CLI.
+func NewCursorCLIProvider(cliPath string, opts ...CursorCLIOption) *CursorCLIProvider {
+	if cliPath == "" {
+		cliPath = "agent"
+	}
+	p := &CursorCLIProvider{
+		name:         "cursor-cli",
+		cliPath:      cliPath,
+		defaultModel: "",
+		defaultMode:  "agent",
+		baseWorkDir:  defaultCursorWorkDir(),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+func (p *CursorCLIProvider) Name() string         { return p.name }
+func (p *CursorCLIProvider) DefaultModel() string { return p.defaultModel }
+
+// Capabilities implements CapabilitiesAware for pipeline code-path selection.
+func (p *CursorCLIProvider) Capabilities() ProviderCapabilities {
+	return ProviderCapabilities{
+		Streaming:        true,
+		ToolCalling:      true,
+		StreamWithTools:  true,
+		Thinking:         false,
+		Vision:           false,
+		CacheControl:     false,
+		MaxContextWindow: 200_000,
+		TokenizerID:      "cl100k_base",
+	}
+}
+
+// Close implements io.Closer (no-op for Cursor CLI — no temp files managed here).
+func (p *CursorCLIProvider) Close() error {
+	return nil
+}
+
+func defaultCursorWorkDir() string {
+	return filepath.Join(config.ResolvedDataDirFromEnv(), "cursor-workspaces")
+}
+
+// lockSession acquires a per-session mutex to prevent concurrent CLI calls on the same session.
+func (p *CursorCLIProvider) lockSession(sessionKey string) func() {
+	actual, _ := p.sessionMu.LoadOrStore(sessionKey, &sync.Mutex{})
+	m := actual.(*sync.Mutex)
+	m.Lock()
+	return m.Unlock
+}

--- a/internal/providers/cursor_cli.go
+++ b/internal/providers/cursor_cli.go
@@ -19,6 +19,15 @@ type CursorCLIProvider struct {
 	sessionMu    sync.Map // key: string, value: *sync.Mutex
 }
 
+// cursorChatIDRegistries maps baseWorkDir -> *sync.Map (sessionKey -> cursorChatID).
+// Package-level so ResetCursorCLISession can invalidate entries without a provider pointer.
+var cursorChatIDRegistries sync.Map // key: string, value: *sync.Map
+
+func getCursorChatIDRegistry(baseWorkDir string) *sync.Map {
+	actual, _ := cursorChatIDRegistries.LoadOrStore(baseWorkDir, &sync.Map{})
+	return actual.(*sync.Map)
+}
+
 // CursorCLIOption configures the provider.
 type CursorCLIOption func(*CursorCLIProvider)
 

--- a/internal/providers/cursor_cli_auth.go
+++ b/internal/providers/cursor_cli_auth.go
@@ -1,0 +1,44 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// CursorAuthStatus holds the parsed result of `agent whoami --format json`.
+type CursorAuthStatus struct {
+	Status          string `json:"status"`
+	IsAuthenticated bool   `json:"isAuthenticated"`
+	HasAccessToken  bool   `json:"hasAccessToken"`
+	HasRefreshToken bool   `json:"hasRefreshToken"`
+	UserInfo        struct {
+		Email string `json:"email,omitempty"`
+	} `json:"userInfo"`
+}
+
+// CheckCursorAuthStatus runs `agent whoami --format json` using the given CLI
+// path and returns the parsed authentication status.
+func CheckCursorAuthStatus(ctx context.Context, cliPath string) (*CursorAuthStatus, error) {
+	if cliPath == "" {
+		cliPath = "agent"
+	}
+
+	resolvedPath, err := exec.LookPath(cliPath)
+	if err != nil {
+		return nil, fmt.Errorf("cursor agent binary not found at %q: %w", cliPath, err)
+	}
+
+	cmd := exec.CommandContext(ctx, resolvedPath, "whoami", "--format", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("cursor whoami failed: %w", err)
+	}
+
+	var status CursorAuthStatus
+	if err := json.Unmarshal(output, &status); err != nil {
+		return nil, fmt.Errorf("failed to parse cursor auth status: %w", err)
+	}
+	return &status, nil
+}

--- a/internal/providers/cursor_cli_chat.go
+++ b/internal/providers/cursor_cli_chat.go
@@ -1,0 +1,268 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Chat runs the Cursor CLI synchronously and returns the final response.
+func (p *CursorCLIProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	systemPrompt, userMsg, _ := extractFromMessages(req.Messages)
+	sessionKey := extractStringOpt(req.Options, OptSessionKey)
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+
+	unlock := p.lockSession(sessionKey)
+	defer unlock()
+
+	workDir := p.ensureWorkDir(sessionKey)
+	args := p.buildArgs(model, workDir, sessionKey, false)
+
+	// Prepend system prompt to user message if present
+	prompt := userMsg
+	if systemPrompt != "" {
+		prompt = systemPrompt + "\n\n" + userMsg
+	}
+	args = append(args, prompt)
+
+	cmd := exec.CommandContext(ctx, p.cliPath, args...)
+	cmd.Dir = workDir
+	cmd.Env = filterCursorEnv(os.Environ())
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	slog.Debug("cursor-cli exec", "cmd", fmt.Sprintf("%s %s", p.cliPath, strings.Join(args, " ")), "workdir", workDir)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("cursor-cli: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return p.parseJSONResponse(output)
+}
+
+// ChatStream runs the Cursor CLI with stream-json output, calling onChunk for each text delta.
+func (p *CursorCLIProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk func(StreamChunk)) (*ChatResponse, error) {
+	systemPrompt, userMsg, _ := extractFromMessages(req.Messages)
+	sessionKey := extractStringOpt(req.Options, OptSessionKey)
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+
+	slog.Debug("cursor-cli: acquiring session lock", "session_key", sessionKey)
+	unlock := p.lockSession(sessionKey)
+	defer func() {
+		unlock()
+		slog.Debug("cursor-cli: session lock released", "session_key", sessionKey)
+	}()
+
+	workDir := p.ensureWorkDir(sessionKey)
+	args := p.buildArgs(model, workDir, sessionKey, true)
+
+	prompt := userMsg
+	if systemPrompt != "" {
+		prompt = systemPrompt + "\n\n" + userMsg
+	}
+	args = append(args, prompt)
+
+	cmd := exec.CommandContext(ctx, p.cliPath, args...)
+	cmd.WaitDelay = 5 * time.Second
+	cmd.Dir = workDir
+	cmd.Env = filterCursorEnv(os.Environ())
+
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("cursor-cli stdout pipe: %w", err)
+	}
+
+	fullCmd := fmt.Sprintf("%s %s", p.cliPath, strings.Join(args, " "))
+	slog.Debug("cursor-cli stream exec", "cmd", fullCmd, "workdir", workDir)
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("cursor-cli start: %w", err)
+	}
+
+	var debugFile *os.File
+	if os.Getenv("GOCLAW_DEBUG") == "1" {
+		debugLogPath := filepath.Join(workDir, "cursor-debug.log")
+		debugFile, _ = os.OpenFile(debugLogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if debugFile != nil {
+			fmt.Fprintf(debugFile, "=== CMD: %s\n=== WORKDIR: %s\n=== TIME: %s\n\n", fullCmd, workDir, time.Now().Format(time.RFC3339))
+			defer debugFile.Close()
+		}
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, StdioScanBufInit), StdioScanBufMax)
+
+	var finalResp ChatResponse
+	var contentBuf strings.Builder
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			break
+		}
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if debugFile != nil {
+			fmt.Fprintf(debugFile, "%s\n", line)
+		}
+		if line[0] != '{' {
+			continue
+		}
+
+		var ev cursorStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			slog.Debug("cursor-cli: skip malformed stream line", "error", err)
+			continue
+		}
+
+		switch ev.Type {
+		case "assistant":
+			text := extractCursorText(ev.Message)
+			if text != "" {
+				contentBuf.WriteString(text)
+				onChunk(StreamChunk{Content: text})
+			}
+
+		case "result":
+			finalResp.Content = contentBuf.String()
+			finalResp.FinishReason = "stop"
+			if ev.IsError {
+				finalResp.FinishReason = "error"
+			}
+			if ev.Usage != nil {
+				finalResp.Usage = &Usage{
+					PromptTokens:     ev.Usage.InputTokens,
+					CompletionTokens: ev.Usage.OutputTokens,
+					TotalTokens:      ev.Usage.InputTokens + ev.Usage.OutputTokens,
+				}
+			}
+
+		case "tool_call":
+			// Cursor tool calls are emitted but not executed by GoClaw — the CLI handles them internally.
+			// We emit them as content placeholders so the stream doesn't stall.
+			if ev.Subtype == "started" {
+				text := "[Using tool]"
+				contentBuf.WriteString(text)
+				onChunk(StreamChunk{Content: text})
+			}
+		}
+	}
+
+	if ctx.Err() != nil {
+		_ = cmd.Wait()
+		return nil, ctx.Err()
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("cursor-cli: stream read error: %w", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if debugFile != nil {
+			fmt.Fprintf(debugFile, "\n=== STDERR:\n%s\n=== EXIT ERROR: %v\n", stderrBuf.String(), err)
+		}
+		if finalResp.Content != "" {
+			return &finalResp, nil
+		}
+		return nil, fmt.Errorf("cursor-cli: %w (stderr: %s)", err, stderrBuf.String())
+	}
+	if debugFile != nil && stderrBuf.Len() > 0 {
+		fmt.Fprintf(debugFile, "\n=== STDERR:\n%s\n", stderrBuf.String())
+	}
+
+	if finalResp.Content == "" {
+		finalResp.Content = contentBuf.String()
+		finalResp.FinishReason = "stop"
+	}
+
+	onChunk(StreamChunk{Done: true})
+	return &finalResp, nil
+}
+
+func (p *CursorCLIProvider) parseJSONResponse(output []byte) (*ChatResponse, error) {
+	var final ChatResponse
+	var contentBuf strings.Builder
+
+	for _, line := range bytes.Split(output, []byte("\n")) {
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var ev cursorStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+		switch ev.Type {
+		case "assistant":
+			text := extractCursorText(ev.Message)
+			if text != "" {
+				contentBuf.WriteString(text)
+			}
+		case "result":
+			final.Content = contentBuf.String()
+			final.FinishReason = "stop"
+			if ev.IsError {
+				final.FinishReason = "error"
+			}
+			if ev.Usage != nil {
+				final.Usage = &Usage{
+					PromptTokens:     ev.Usage.InputTokens,
+					CompletionTokens: ev.Usage.OutputTokens,
+					TotalTokens:      ev.Usage.InputTokens + ev.Usage.OutputTokens,
+				}
+			}
+		}
+	}
+
+	if final.Content == "" {
+		final.Content = contentBuf.String()
+		final.FinishReason = "stop"
+	}
+	return &final, nil
+}
+
+func extractCursorText(msg *cursorStreamMsg) string {
+	if msg == nil {
+		return ""
+	}
+	var parts []string
+	for _, block := range msg.Content {
+		if block.Type == "text" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// filterCursorEnv removes CURSOR* env vars to prevent nested session conflicts.
+func filterCursorEnv(environ []string) []string {
+	var filtered []string
+	for _, e := range environ {
+		key := e
+		if before, _, ok := strings.Cut(e, "="); ok {
+			key = before
+		}
+		if strings.HasPrefix(key, "CURSOR") {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
+}

--- a/internal/providers/cursor_cli_chat.go
+++ b/internal/providers/cursor_cli_chat.go
@@ -27,7 +27,17 @@ func (p *CursorCLIProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRes
 	defer unlock()
 
 	workDir := p.ensureWorkDir(sessionKey)
-	args := p.buildArgs(model, workDir, sessionKey, false)
+
+	var chatID string
+	if sessionKey != "" {
+		var err error
+		chatID, err = p.getOrCreateChatID(ctx, sessionKey)
+		if err != nil {
+			slog.Warn("cursor-cli: failed to get/create chat ID, starting fresh chat", "session_key", sessionKey, "error", err)
+			chatID = ""
+		}
+	}
+	args := p.buildArgs(model, workDir, chatID, false)
 
 	// Prepend system prompt to user message if present
 	prompt := userMsg
@@ -69,7 +79,17 @@ func (p *CursorCLIProvider) ChatStream(ctx context.Context, req ChatRequest, onC
 	}()
 
 	workDir := p.ensureWorkDir(sessionKey)
-	args := p.buildArgs(model, workDir, sessionKey, true)
+
+	var chatID string
+	if sessionKey != "" {
+		var err error
+		chatID, err = p.getOrCreateChatID(ctx, sessionKey)
+		if err != nil {
+			slog.Warn("cursor-cli: failed to get/create chat ID, starting fresh chat", "session_key", sessionKey, "error", err)
+			chatID = ""
+		}
+	}
+	args := p.buildArgs(model, workDir, chatID, true)
 
 	prompt := userMsg
 	if systemPrompt != "" {

--- a/internal/providers/cursor_cli_session.go
+++ b/internal/providers/cursor_cli_session.go
@@ -1,0 +1,110 @@
+package providers
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// validCursorModes lists accepted working modes for the Cursor CLI.
+var validCursorModes = map[string]bool{
+	"agent": true,
+	"plan":  true,
+	"ask":   true,
+}
+
+func (p *CursorCLIProvider) buildArgs(model, workDir, sessionKey string, streaming bool) []string {
+	args := []string{
+		"-p",
+		"--force",
+		"--trust",
+		"--workspace", workDir,
+	}
+	if streaming {
+		args = append(args, "--output-format", "stream-json")
+	}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	mode := p.defaultMode
+	if !validCursorModes[mode] {
+		mode = "agent"
+	}
+	if mode != "agent" {
+		args = append(args, "--mode", mode)
+	}
+	if sessionKey != "" {
+		// Cursor Agent CLI versions may not support `--session-id`.
+		// For compatibility, only attempt `--resume` when a transcript for this
+		// deterministic session ID already exists.
+		sid := deriveCursorSessionUUID(sessionKey).String()
+		if cursorSessionFileExists(workDir, sid) {
+			args = append(args, "--resume", sid)
+		}
+	}
+	return args
+}
+
+func (p *CursorCLIProvider) ensureWorkDir(sessionKey string) string {
+	safe := sanitizePathSegment(sessionKey)
+	dir := filepath.Join(p.baseWorkDir, safe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		slog.Warn("cursor-cli: failed to create workdir", "dir", dir, "error", err)
+		return os.TempDir()
+	}
+	return dir
+}
+
+func deriveCursorSessionUUID(sessionKey string) uuid.UUID {
+	if sessionKey == "" {
+		return uuid.New()
+	}
+	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte("cursor:"+sessionKey))
+}
+
+func cursorSessionFileExists(workDir, sessionID string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	// Cursor stores sessions at: ~/.cursor/projects/<encoded-path>/agent-transcripts/<session-id>/<session-id>.jsonl
+	// Path encoding: replace path separators and special chars with "-"
+	resolved, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		resolved = workDir
+	}
+	encoded := strings.NewReplacer(string(filepath.Separator), "-", "_", "-", ".", "-", ":", "-", " ", "-").Replace(resolved)
+	encoded = strings.Trim(encoded, "-")
+	sessionFile := filepath.Join(home, ".cursor", "projects", encoded, "agent-transcripts", sessionID, sessionID+".jsonl")
+	_, err = os.Stat(sessionFile)
+	return err == nil
+}
+
+// ResetCursorCLISession deletes the Cursor CLI session file for a given session key.
+func ResetCursorCLISession(baseWorkDir, sessionKey string) {
+	if baseWorkDir == "" {
+		baseWorkDir = defaultCursorWorkDir()
+	}
+	safe := sanitizePathSegment(sessionKey)
+	workDir := filepath.Join(baseWorkDir, safe)
+	sessionID := deriveCursorSessionUUID(sessionKey).String()
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		resolved, err := filepath.EvalSymlinks(workDir)
+		if err != nil {
+			resolved = workDir
+		}
+		encoded := strings.NewReplacer(string(filepath.Separator), "-", "_", "-", ".", "-", ":", "-", " ", "-").Replace(resolved)
+		encoded = strings.Trim(encoded, "-")
+		sessionFile := filepath.Join(home, ".cursor", "projects", encoded, "agent-transcripts", sessionID, sessionID+".jsonl")
+		if err := os.Remove(sessionFile); err == nil {
+			slog.Info("cursor-cli: deleted session file on /reset", "path", sessionFile)
+		}
+	}
+}

--- a/internal/providers/cursor_cli_session.go
+++ b/internal/providers/cursor_cli_session.go
@@ -1,12 +1,13 @@
 package providers
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 // validCursorModes lists accepted working modes for the Cursor CLI.
@@ -16,7 +17,7 @@ var validCursorModes = map[string]bool{
 	"ask":   true,
 }
 
-func (p *CursorCLIProvider) buildArgs(model, workDir, sessionKey string, streaming bool) []string {
+func (p *CursorCLIProvider) buildArgs(model, workDir, chatID string, streaming bool) []string {
 	args := []string{
 		"-p",
 		"--force",
@@ -36,14 +37,8 @@ func (p *CursorCLIProvider) buildArgs(model, workDir, sessionKey string, streami
 	if mode != "agent" {
 		args = append(args, "--mode", mode)
 	}
-	if sessionKey != "" {
-		// Cursor Agent CLI versions may not support `--session-id`.
-		// For compatibility, only attempt `--resume` when a transcript for this
-		// deterministic session ID already exists.
-		sid := deriveCursorSessionUUID(sessionKey).String()
-		if cursorSessionFileExists(workDir, sid) {
-			args = append(args, "--resume", sid)
-		}
+	if chatID != "" {
+		args = append(args, "--resume", chatID)
 	}
 	return args
 }
@@ -60,51 +55,72 @@ func (p *CursorCLIProvider) ensureWorkDir(sessionKey string) string {
 	return dir
 }
 
-func deriveCursorSessionUUID(sessionKey string) uuid.UUID {
+func (p *CursorCLIProvider) getOrCreateChatID(ctx context.Context, sessionKey string) (string, error) {
 	if sessionKey == "" {
-		return uuid.New()
+		return "", nil
 	}
-	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte("cursor:"+sessionKey))
+
+	registry := getCursorChatIDRegistry(p.baseWorkDir)
+	if cached, ok := registry.Load(sessionKey); ok {
+		return cached.(string), nil
+	}
+
+	workDir := p.ensureWorkDir(sessionKey)
+	chatIDFile := filepath.Join(workDir, ".cursor", "chatid")
+	if data, err := os.ReadFile(chatIDFile); err == nil {
+		chatID := strings.TrimSpace(string(data))
+		if chatID != "" {
+			registry.Store(sessionKey, chatID)
+			return chatID, nil
+		}
+	}
+
+	chatID, err := p.createChat(ctx)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(chatIDFile), 0755); err == nil {
+		if err := os.WriteFile(chatIDFile, []byte(chatID), 0600); err != nil {
+			slog.Warn("cursor-cli: failed to write chat ID file", "path", chatIDFile, "error", err)
+		}
+	}
+	registry.Store(sessionKey, chatID)
+	slog.Info("cursor-cli: created new chat", "session_key", sessionKey, "chat_id", chatID)
+	return chatID, nil
 }
 
-func cursorSessionFileExists(workDir, sessionID string) bool {
-	home, err := os.UserHomeDir()
+func (p *CursorCLIProvider) createChat(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, p.cliPath, "create-chat")
+	cmd.Env = filterCursorEnv(os.Environ())
+
+	output, err := cmd.Output()
 	if err != nil {
-		return false
+		return "", fmt.Errorf("cursor-cli create-chat: %w", err)
 	}
-	// Cursor stores sessions at: ~/.cursor/projects/<encoded-path>/agent-transcripts/<session-id>/<session-id>.jsonl
-	// Path encoding: replace path separators and special chars with "-"
-	resolved, err := filepath.EvalSymlinks(workDir)
-	if err != nil {
-		resolved = workDir
+
+	chatID := strings.TrimSpace(string(output))
+	if chatID == "" {
+		return "", fmt.Errorf("cursor-cli create-chat: empty response")
 	}
-	encoded := strings.NewReplacer(string(filepath.Separator), "-", "_", "-", ".", "-", ":", "-", " ", "-").Replace(resolved)
-	encoded = strings.Trim(encoded, "-")
-	sessionFile := filepath.Join(home, ".cursor", "projects", encoded, "agent-transcripts", sessionID, sessionID+".jsonl")
-	_, err = os.Stat(sessionFile)
-	return err == nil
+	return chatID, nil
 }
 
-// ResetCursorCLISession deletes the Cursor CLI session file for a given session key.
+// ResetCursorCLISession deletes the Cursor CLI session state for a given session key.
+// Called on /reset so the next message starts a fresh chat.
 func ResetCursorCLISession(baseWorkDir, sessionKey string) {
 	if baseWorkDir == "" {
 		baseWorkDir = defaultCursorWorkDir()
 	}
+
+	registry := getCursorChatIDRegistry(baseWorkDir)
+	if _, ok := registry.Load(sessionKey); ok {
+		registry.Delete(sessionKey)
+	}
+
 	safe := sanitizePathSegment(sessionKey)
 	workDir := filepath.Join(baseWorkDir, safe)
-	sessionID := deriveCursorSessionUUID(sessionKey).String()
-
-	home, err := os.UserHomeDir()
-	if err == nil {
-		resolved, err := filepath.EvalSymlinks(workDir)
-		if err != nil {
-			resolved = workDir
-		}
-		encoded := strings.NewReplacer(string(filepath.Separator), "-", "_", "-", ".", "-", ":", "-", " ", "-").Replace(resolved)
-		encoded = strings.Trim(encoded, "-")
-		sessionFile := filepath.Join(home, ".cursor", "projects", encoded, "agent-transcripts", sessionID, sessionID+".jsonl")
-		if err := os.Remove(sessionFile); err == nil {
-			slog.Info("cursor-cli: deleted session file on /reset", "path", sessionFile)
-		}
+	chatIDFile := filepath.Join(workDir, ".cursor", "chatid")
+	if err := os.Remove(chatIDFile); err == nil {
+		slog.Info("cursor-cli: cleared chat ID on /reset", "session_key", sessionKey)
 	}
 }

--- a/internal/providers/cursor_cli_session_test.go
+++ b/internal/providers/cursor_cli_session_test.go
@@ -1,0 +1,18 @@
+package providers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCursorBuildArgsDoesNotUseSessionIDFlag(t *testing.T) {
+	p := NewCursorCLIProvider("agent")
+	workDir := t.TempDir()
+
+	args := p.buildArgs("gpt-5.4", workDir, "session-key", false)
+	joined := strings.Join(args, " ")
+
+	if strings.Contains(joined, "--session-id") {
+		t.Fatalf("buildArgs() includes unsupported --session-id flag: %q", joined)
+	}
+}

--- a/internal/providers/cursor_cli_session_test.go
+++ b/internal/providers/cursor_cli_session_test.go
@@ -9,10 +9,34 @@ func TestCursorBuildArgsDoesNotUseSessionIDFlag(t *testing.T) {
 	p := NewCursorCLIProvider("agent")
 	workDir := t.TempDir()
 
-	args := p.buildArgs("gpt-5.4", workDir, "session-key", false)
+	args := p.buildArgs("gpt-5.4", workDir, "", false)
 	joined := strings.Join(args, " ")
 
 	if strings.Contains(joined, "--session-id") {
 		t.Fatalf("buildArgs() includes unsupported --session-id flag: %q", joined)
+	}
+}
+
+func TestCursorBuildArgsWithChatID(t *testing.T) {
+	p := NewCursorCLIProvider("agent")
+	workDir := t.TempDir()
+
+	args := p.buildArgs("gpt-5.4", workDir, "chat-abc123", false)
+	joined := strings.Join(args, " ")
+
+	if !strings.Contains(joined, "--resume chat-abc123") {
+		t.Fatalf("buildArgs() should include --resume with chat ID: %q", joined)
+	}
+}
+
+func TestCursorBuildArgsWithoutChatID(t *testing.T) {
+	p := NewCursorCLIProvider("agent")
+	workDir := t.TempDir()
+
+	args := p.buildArgs("gpt-5.4", workDir, "", false)
+	joined := strings.Join(args, " ")
+
+	if strings.Contains(joined, "--resume") {
+		t.Fatalf("buildArgs() should not include --resume when chatID is empty: %q", joined)
 	}
 }

--- a/internal/providers/cursor_cli_types.go
+++ b/internal/providers/cursor_cli_types.go
@@ -1,0 +1,32 @@
+package providers
+
+// cursorStreamEvent is a single line from `agent --output-format stream-json`.
+type cursorStreamEvent struct {
+	Type      string                 `json:"type"`              // "system", "user", "assistant", "tool_call", "result"
+	Subtype   string                 `json:"subtype,omitempty"` // e.g. "init", "started", "completed", "failed"
+	SessionID string                 `json:"session_id,omitempty"`
+	Message   *cursorStreamMsg       `json:"message,omitempty"`   // for type="assistant"
+	CallID    string                 `json:"call_id,omitempty"`   // for type="tool_call"
+	ToolCall  map[string]interface{} `json:"tool_call,omitempty"` // for type="tool_call"
+	Result    string                 `json:"result,omitempty"`    // for type="result"
+	IsError   bool                   `json:"is_error,omitempty"`
+	Usage     *cursorUsage           `json:"usage,omitempty"`
+}
+
+// cursorStreamMsg wraps content blocks inside an assistant message event.
+type cursorStreamMsg struct {
+	Content []cursorContentBlock `json:"content"`
+}
+
+// cursorContentBlock is a single content block (text).
+type cursorContentBlock struct {
+	Type string `json:"type"` // "text"
+	Text string `json:"text,omitempty"`
+}
+
+// cursorUsage maps Cursor CLI usage counters.
+type cursorUsage struct {
+	InputTokens     int `json:"inputTokens,omitempty"`
+	OutputTokens    int `json:"outputTokens,omitempty"`
+	CacheReadTokens int `json:"cacheReadTokens,omitempty"`
+}

--- a/internal/store/provider_store.go
+++ b/internal/store/provider_store.go
@@ -24,12 +24,13 @@ const (
 	ProviderBailian         = "bailian"
 	ProviderChatGPTOAuth    = "chatgpt_oauth"
 	ProviderClaudeCLI       = "claude_cli"
+	ProviderCursorCLI       = "cursor_cli"
 	ProviderYesScale        = "yescale"
 	ProviderZai             = "zai"
 	ProviderZaiCoding       = "zai_coding"
-	ProviderOllama          = "ollama"       // local or self-hosted Ollama (no API key)
-	ProviderOllamaCloud     = "ollama_cloud" // Ollama Cloud (Bearer token required)
-	ProviderACP             = "acp"          // ACP (Agent Client Protocol) agent subprocess
+	ProviderOllama          = "ollama"          // local or self-hosted Ollama (no API key)
+	ProviderOllamaCloud     = "ollama_cloud"    // Ollama Cloud (Bearer token required)
+	ProviderACP             = "acp"             // ACP (Agent Client Protocol) agent subprocess
 	ProviderNovita          = "novita"          // Novita AI (OpenAI-compatible endpoint)
 	ProviderBytePlus        = "byteplus"        // BytePlus ModelArk (Seed 2.0 models)
 	ProviderBytePlusCoding  = "byteplus_coding" // BytePlus ModelArk Coding Plan
@@ -61,6 +62,7 @@ var ValidProviderTypes = map[string]bool{
 	ProviderBailian:         true,
 	ProviderChatGPTOAuth:    true,
 	ProviderClaudeCLI:       true,
+	ProviderCursorCLI:       true,
 	ProviderYesScale:        true,
 	ProviderZai:             true,
 	ProviderZaiCoding:       true,
@@ -178,6 +180,7 @@ var NoEmbeddingTypes = map[string]bool{
 	ProviderAnthropicNative: true, // uses x-api-key auth, not Bearer; no embedding models
 	ProviderACP:             true,
 	ProviderClaudeCLI:       true,
+	ProviderCursorCLI:       true,
 	ProviderChatGPTOAuth:    true,
 }
 

--- a/ui/web/src/constants/providers.ts
+++ b/ui/web/src/constants/providers.ts
@@ -35,6 +35,7 @@ export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: "ollama", label: "Ollama (Local)", apiBase: "http://localhost:11434/v1", placeholder: "" },
   { value: "ollama_cloud", label: "Ollama Cloud", apiBase: "https://ollama.com/v1", placeholder: "" },
   { value: "claude_cli", label: "Claude CLI (Local)", apiBase: "", placeholder: "" },
+  { value: "cursor_cli", label: "Cursor CLI (Local)", apiBase: "", placeholder: "" },
   { value: "acp", label: "ACP Agent (Subprocess)", apiBase: "", placeholder: "claude" },
 ];
 

--- a/ui/web/src/i18n/locales/en/providers.json
+++ b/ui/web/src/i18n/locales/en/providers.json
@@ -168,7 +168,7 @@
   },
   "cli": {
     "description": "Claude CLI uses your local",
-    "descriptionSuffix": "binary. No API key needed.",
+    "descriptionSuffix": "binary. API key is only needed when Cursor is not authenticated.",
     "checkingAuth": "Checking authentication...",
     "authenticatedAs": "Authenticated as",
     "switchAccount": "Switch account?",
@@ -178,6 +178,24 @@
     "notAuthenticated": "Not authenticated",
     "runOnServer": "Run on the server terminal:",
     "recheckButton": "Re-check"
+  },
+  "cursor": {
+    "description": "Cursor CLI uses your local",
+    "descriptionSuffix": "binary. No API key needed.",
+    "checkingAuth": "Checking authentication...",
+    "authenticated": "Authenticated",
+    "authenticatedAs": "Authenticated as",
+    "notAuthenticated": "Not authenticated",
+    "runOnServer": "Run on the server terminal:",
+    "recheckButton": "Re-check",
+    "mode": "Working Mode",
+    "modeAgent": "Agent",
+    "modePlan": "Plan",
+    "modeAsk": "Ask",
+    "modeHint": "Agent: full tool access. Plan: read-only planning. Ask: Q&A without edits.",
+    "apiKey": "CURSOR_AGENTS_API_KEY",
+    "apiKeyPlaceholder": "Optional — leave empty if Cursor is authenticated",
+    "apiKeyHint": "Set this env var if Cursor CLI is not yet authenticated"
   },
   "detail": {
     "title": "Provider Details",
@@ -190,6 +208,8 @@
     "acpConfigDesc": "Agent subprocess settings",
     "cliConfig": "Claude CLI",
     "cliConfigDesc": "Local CLI authentication",
+    "cursorCliConfig": "Cursor CLI",
+    "cursorCliConfigDesc": "Local Cursor CLI authentication",
     "oauthConfig": "ChatGPT Subscription (OAuth)",
     "oauthConfigDesc": "Manage sign-in for this named OpenAI/Codex account",
     "nameReadonly": "Provider identifier, cannot be changed",

--- a/ui/web/src/i18n/locales/vi/providers.json
+++ b/ui/web/src/i18n/locales/vi/providers.json
@@ -184,6 +184,24 @@
     "runOnServer": "Chạy trên terminal máy chủ:",
     "recheckButton": "Kiểm tra lại"
   },
+  "cursor": {
+    "description": "Cursor CLI sử dụng tệp nhị phân",
+    "descriptionSuffix": "cục bộ của bạn. Không cần API key.",
+    "checkingAuth": "Đang kiểm tra xác thực...",
+    "authenticated": "Đã xác thực",
+    "authenticatedAs": "Đã xác thực là",
+    "notAuthenticated": "Chưa xác thực",
+    "runOnServer": "Chạy trên terminal máy chủ:",
+    "recheckButton": "Kiểm tra lại",
+    "mode": "Chế độ làm việc",
+    "modeAgent": "Agent",
+    "modePlan": "Kế hoạch",
+    "modeAsk": "Hỏi đáp",
+    "modeHint": "Agent: truy cập công cụ đầy đủ. Plan: lập kế hoạch chỉ đọc. Ask: hỏi đáp không chỉnh sửa.",
+    "apiKey": "CURSOR_AGENTS_API_KEY",
+    "apiKeyPlaceholder": "Tùy chọn — để trống nếu Cursor đã xác thực",
+    "apiKeyHint": "Đặt biến môi trường này nếu Cursor CLI chưa xác thực"
+  },
   "detail": {
     "advanced": "Nâng cao",
     "identity": "Danh tính",
@@ -194,6 +212,8 @@
     "acpConfigDesc": "Cài đặt tiến trình con agent",
     "cliConfig": "Claude CLI",
     "cliConfigDesc": "Xác thực CLI cục bộ",
+    "cursorCliConfig": "Cursor CLI",
+    "cursorCliConfigDesc": "Xác thực Cursor CLI cục bộ",
     "oauthConfig": "ChatGPT Subscription (OAuth)",
     "oauthConfigDesc": "Quản lý đăng nhập cho tài khoản OpenAI/Codex có bí danh này",
     "nameReadonly": "Định danh provider, không thể thay đổi",

--- a/ui/web/src/i18n/locales/zh/providers.json
+++ b/ui/web/src/i18n/locales/zh/providers.json
@@ -202,6 +202,24 @@
     "runOnServer": "在服务器终端运行：",
     "recheckButton": "重新检查"
   },
+  "cursor": {
+    "description": "Cursor CLI 使用本地",
+    "descriptionSuffix": "二进制文件。无需 API 密钥。",
+    "checkingAuth": "正在检查认证...",
+    "authenticated": "已认证",
+    "authenticatedAs": "已认证为",
+    "notAuthenticated": "未认证",
+    "runOnServer": "在服务器终端运行：",
+    "recheckButton": "重新检查",
+    "mode": "工作模式",
+    "modeAgent": "Agent",
+    "modePlan": "规划",
+    "modeAsk": "问答",
+    "modeHint": "Agent：完整工具访问。Plan：只读规划。Ask：不修改的问答。",
+    "apiKey": "CURSOR_AGENTS_API_KEY",
+    "apiKeyPlaceholder": "可选 — 如已验证则留空",
+    "apiKeyHint": "如果 Cursor CLI 尚未验证，请设置此环境变量"
+  },
   "detail": {
     "advanced": "高级设置",
     "identity": "身份",
@@ -212,6 +230,8 @@
     "acpConfigDesc": "Agent子进程设置",
     "cliConfig": "Claude CLI",
     "cliConfigDesc": "本地CLI认证",
+    "cursorCliConfig": "Cursor CLI",
+    "cursorCliConfigDesc": "本地 Cursor CLI 认证",
     "oauthConfig": "ChatGPT Subscription (OAuth)",
     "oauthConfigDesc": "管理这个具名 OpenAI/Codex 账户的登录状态",
     "nameReadonly": "Provider标识符，无法更改",

--- a/ui/web/src/pages/providers/provider-cursor-section.tsx
+++ b/ui/web/src/pages/providers/provider-cursor-section.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useHttp } from "@/hooks/use-ws";
+import { AlertTriangle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
+
+interface CursorAuthStatus {
+  authenticated: boolean;
+  email?: string;
+  error?: string;
+  in_docker?: boolean;
+}
+
+interface CursorCLISectionProps {
+  open: boolean;
+  mode: string;
+  onModeChange: (v: string) => void;
+  apiKey: string;
+  onApiKeyChange: (v: string) => void;
+}
+
+export function CursorCLISection({
+  open,
+  mode,
+  onModeChange,
+  apiKey,
+  onApiKeyChange,
+}: CursorCLISectionProps) {
+  const { t } = useTranslation("providers");
+  const http = useHttp();
+  const [authStatus, setAuthStatus] = useState<CursorAuthStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const checkAuth = useCallback(() => {
+    setLoading(true);
+    http
+      .get<CursorAuthStatus>("/v1/providers/cursor-cli/auth-status")
+      .then(setAuthStatus)
+      .catch(() => setAuthStatus({ authenticated: false, error: "Failed to check auth status" }))
+      .finally(() => setLoading(false));
+  }, [http]);
+
+  useEffect(() => {
+    if (open) {
+      checkAuth();
+      return;
+    }
+    setAuthStatus(null);
+  }, [open, checkAuth]);
+
+  const isAuthenticated = authStatus?.authenticated === true;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        {t("cursor.description")} <code className="rounded bg-muted px-1 py-0.5">agent</code> {t("cursor.descriptionSuffix")}
+      </p>
+
+      <div className="space-y-2">
+        <Label>{t("cursor.mode")}</Label>
+        <Select value={mode} onValueChange={onModeChange}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="agent">{t("cursor.modeAgent")}</SelectItem>
+            <SelectItem value="plan">{t("cursor.modePlan")}</SelectItem>
+            <SelectItem value="ask">{t("cursor.modeAsk")}</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">{t("cursor.modeHint")}</p>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {t("cursor.checkingAuth")}
+        </div>
+      ) : isAuthenticated ? (
+        <div className="flex items-center justify-between rounded-md border border-green-200 bg-green-50 px-3 py-2 dark:border-green-800 dark:bg-green-950">
+          <div className="flex items-center gap-2">
+            <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+            <p className="text-sm text-green-700 dark:text-green-300">
+              {t("cursor.authenticatedAs")} <strong>{authStatus?.email || t("cursor.authenticated")}</strong>
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-green-700 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
+            onClick={checkAuth}
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-800 dark:bg-amber-950">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+              <p className="text-sm font-medium text-amber-700 dark:text-amber-300">
+                {t("cursor.notAuthenticated")}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-amber-700 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-300"
+              onClick={checkAuth}
+            >
+              <RefreshCw className="h-3.5 w-3.5 mr-1" />
+              <span className="text-xs">{t("cursor.recheckButton")}</span>
+            </Button>
+          </div>
+          <p className="text-sm text-amber-600 dark:text-amber-400">{t("cursor.runOnServer")}</p>
+          <code className="block rounded bg-amber-100 px-2 py-1 text-xs font-mono dark:bg-amber-900 dark:text-amber-300">
+            {authStatus?.in_docker ? "docker compose exec goclaw agent login" : "agent login"}
+          </code>
+          {authStatus?.error && (
+            <p className="text-xs text-amber-500">{authStatus.error}</p>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="cursorApiKey">{t("cursor.apiKey")}</Label>
+            <Input
+              id="cursorApiKey"
+              type="password"
+              value={apiKey}
+              onChange={(e) => onApiKeyChange(e.target.value)}
+              placeholder={t("cursor.apiKeyPlaceholder")}
+              className="text-base md:text-sm"
+            />
+            <p className="text-xs text-muted-foreground">{t("cursor.apiKeyHint")}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-detail/provider-advanced-dialog.tsx
@@ -20,6 +20,7 @@ import {
 import { ConfigGroupHeader } from "@/components/shared/config-group-header";
 import { PROVIDER_TYPES } from "@/constants/providers";
 import { CLISection } from "../provider-cli-section";
+import { CursorCLISection } from "../provider-cursor-section";
 import { OAuthSection } from "../provider-oauth-section";
 import type { ProviderData, ProviderInput } from "@/types/provider";
 
@@ -39,6 +40,8 @@ function deriveState(provider: ProviderData) {
     acpIdleTTL: (s?.idle_ttl as string) || "",
     acpPermMode: (s?.perm_mode as string) || "approve-all",
     acpWorkDir: (s?.work_dir as string) || "",
+    cursorMode: (s?.mode as string) || "agent",
+    cursorApiKey: "",
   };
 }
 
@@ -51,7 +54,9 @@ export function ProviderAdvancedDialog({
   const { t } = useTranslation("providers");
 
   const isACP = provider.provider_type === "acp";
-  const isCLI = provider.provider_type === "claude_cli";
+  const isClaudeCLI = provider.provider_type === "claude_cli";
+  const isCursorCLI = provider.provider_type === "cursor_cli";
+  const isCLI = isClaudeCLI || isCursorCLI;
   const isOAuth = provider.provider_type === "chatgpt_oauth";
   const isStandard = !isACP && !isCLI && !isOAuth;
 
@@ -64,6 +69,8 @@ export function ProviderAdvancedDialog({
   const [acpIdleTTL, setAcpIdleTTL] = useState(init.acpIdleTTL);
   const [acpPermMode, setAcpPermMode] = useState(init.acpPermMode);
   const [acpWorkDir, setAcpWorkDir] = useState(init.acpWorkDir);
+  const [cursorMode, setCursorMode] = useState(init.cursorMode);
+  const [cursorApiKey, setCursorApiKey] = useState(init.cursorApiKey);
 
   // Re-sync when dialog opens
   useEffect(() => {
@@ -75,6 +82,8 @@ export function ProviderAdvancedDialog({
     setAcpIdleTTL(s.acpIdleTTL);
     setAcpPermMode(s.acpPermMode);
     setAcpWorkDir(s.acpWorkDir);
+    setCursorMode(s.cursorMode);
+    setCursorApiKey(s.cursorApiKey);
      
   }, [open, provider]);
 
@@ -96,6 +105,13 @@ export function ProviderAdvancedDialog({
         if (acpPermMode) settings.perm_mode = acpPermMode;
         if (acpWorkDir.trim()) settings.work_dir = acpWorkDir.trim();
         if (Object.keys(settings).length > 0) data.settings = settings;
+      } else if (isCursorCLI) {
+        const settings = { ...(provider.settings ?? {}) } as Record<string, unknown>;
+        settings.mode = cursorMode || "agent";
+        if (cursorApiKey.trim()) {
+          settings.api_key = cursorApiKey.trim();
+        }
+        data.settings = settings;
       } else if (isStandard) {
         data.api_base = apiBase.trim() || undefined;
       }
@@ -230,14 +246,24 @@ export function ProviderAdvancedDialog({
             </>
           )}
 
-          {/* Claude CLI */}
+          {/* Local CLI */}
           {isCLI && (
             <>
               <ConfigGroupHeader
-                title={t("detail.cliConfig")}
-                description={t("detail.cliConfigDesc")}
+                title={isCursorCLI ? t("detail.cursorCliConfig") : t("detail.cliConfig")}
+                description={isCursorCLI ? t("detail.cursorCliConfigDesc") : t("detail.cliConfigDesc")}
               />
-              <CLISection open={open} />
+              {isCursorCLI ? (
+                <CursorCLISection
+                  open={open}
+                  mode={cursorMode}
+                  onModeChange={setCursorMode}
+                  apiKey={cursorApiKey}
+                  onApiKeyChange={setCursorApiKey}
+                />
+              ) : (
+                <CLISection open={open} />
+              )}
             </>
           )}
 

--- a/ui/web/src/pages/providers/provider-detail/provider-overview-helpers.ts
+++ b/ui/web/src/pages/providers/provider-detail/provider-overview-helpers.ts
@@ -3,11 +3,12 @@ import type { ChatGPTOAuthRoutingConfig } from "@/types/agent";
 import { normalizeReasoningEffort, normalizeReasoningFallback } from "@/types/provider";
 
 // Provider types that don't use API keys
-export const NO_API_KEY_TYPES = new Set(["claude_cli", "acp", "chatgpt_oauth"]);
+export const NO_API_KEY_TYPES = new Set(["claude_cli", "cursor_cli", "acp", "chatgpt_oauth"]);
 
 // Provider types that don't support embedding
 export const NO_EMBEDDING_TYPES = new Set([
   "claude_cli",
+  "cursor_cli",
   "acp",
   "chatgpt_oauth",
   "anthropic_native",

--- a/ui/web/src/pages/providers/provider-form-dialog.tsx
+++ b/ui/web/src/pages/providers/provider-form-dialog.tsx
@@ -27,6 +27,7 @@ import { slugify } from "@/lib/slug";
 import { DEFAULT_CODEX_OAUTH_ALIAS, PROVIDER_TYPES, suggestUniqueProviderAlias } from "@/constants/providers";
 import { OAuthSection } from "./provider-oauth-section";
 import { CLISection } from "./provider-cli-section";
+import { CursorCLISection } from "./provider-cursor-section";
 import { ACPSection } from "./provider-acp-section";
 import { ProviderStandardFormFields } from "./provider-standard-form-fields";
 import { Loader2 } from "lucide-react";
@@ -67,8 +68,10 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
   const name = watch("name");
 
   const hasClaudeCLI = existingProviders.some((p) => p.provider_type === "claude_cli");
+  const hasCursorCLI = existingProviders.some((p) => p.provider_type === "cursor_cli");
   const isOAuth = providerType === "chatgpt_oauth";
   const isCLI = providerType === "claude_cli";
+  const isCursorCLI = providerType === "cursor_cli";
   const isACP = providerType === "acp";
 
   // Reset form when dialog opens
@@ -86,6 +89,8 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
         acpIdleTTL: "",
         acpPermMode: "approve-all",
         acpWorkDir: "",
+        cursorMode: "agent",
+        cursorApiKey: "",
       });
     }
   }, [open, reset]);
@@ -106,6 +111,14 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
       if (data.acpIdleTTL?.trim()) settings.idle_ttl = data.acpIdleTTL.trim();
       if (data.acpPermMode) settings.perm_mode = data.acpPermMode;
       if (data.acpWorkDir?.trim()) settings.work_dir = data.acpWorkDir.trim();
+      if (Object.keys(settings).length > 0) payload.settings = settings;
+    }
+
+    if (isCursorCLI) {
+      payload.api_base = data.cursorBinary || undefined;
+      const settings: Record<string, unknown> = {};
+      if (data.cursorMode) settings.mode = data.cursorMode;
+      if (data.cursorApiKey) settings.api_key = data.cursorApiKey;
       if (Object.keys(settings).length > 0) payload.settings = settings;
     }
 
@@ -141,6 +154,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
           <ProviderTypeSelect
             value={providerType}
             hasClaudeCLI={hasClaudeCLI}
+            hasCursorCLI={hasCursorCLI}
             alreadyAddedLabel={t("form.alreadyAdded")}
             providerTypeLabel={t("form.providerType")}
             onChange={handleProviderTypeChange}
@@ -208,6 +222,16 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
 
               {isCLI && <CLISection open={open} />}
 
+              {isCursorCLI && (
+                <CursorCLISection
+                  open={open}
+                  mode={watch("cursorMode") || "agent"}
+                  onModeChange={(v) => setValue("cursorMode", v)}
+                  apiKey={watch("cursorApiKey") || ""}
+                  onApiKeyChange={(v) => setValue("cursorApiKey", v)}
+                />
+              )}
+
               {isACP && (
                 <ACPSection
                   binary={watch("acpBinary") || ""}
@@ -223,7 +247,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
                 />
               )}
 
-              {!isCLI && !isACP && (
+              {!isCLI && !isCursorCLI && !isACP && (
                 <ProviderStandardFormFields
                   register={register}
                   errors={errors}
@@ -232,7 +256,7 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
                 />
               )}
 
-              {(isCLI || isACP) && (
+              {(isCLI || isCursorCLI || isACP) && (
                 <>
                   <div className="flex items-center justify-between">
                     <Label htmlFor="enabled">{t("form.enabled")}</Label>
@@ -277,9 +301,10 @@ export function ProviderFormDialog({ open, onOpenChange, onSubmit, existingProvi
   );
 }
 
-function ProviderTypeSelect({ value, hasClaudeCLI, alreadyAddedLabel, providerTypeLabel, onChange }: {
+function ProviderTypeSelect({ value, hasClaudeCLI, hasCursorCLI, alreadyAddedLabel, providerTypeLabel, onChange }: {
   value: string;
   hasClaudeCLI: boolean;
+  hasCursorCLI: boolean;
   alreadyAddedLabel: string;
   providerTypeLabel: string;
   onChange: (value: string) => void;
@@ -296,10 +321,13 @@ function ProviderTypeSelect({ value, hasClaudeCLI, alreadyAddedLabel, providerTy
             <SelectItem
               key={pt.value}
               value={pt.value}
-              disabled={pt.value === "claude_cli" && hasClaudeCLI}
+              disabled={(pt.value === "claude_cli" && hasClaudeCLI) || (pt.value === "cursor_cli" && hasCursorCLI)}
             >
               {pt.label}
               {pt.value === "claude_cli" && hasClaudeCLI && (
+                <span className="ml-1 text-xs opacity-60">{alreadyAddedLabel}</span>
+              )}
+              {pt.value === "cursor_cli" && hasCursorCLI && (
                 <span className="ml-1 text-xs opacity-60">{alreadyAddedLabel}</span>
               )}
             </SelectItem>

--- a/ui/web/src/pages/providers/provider-utils.tsx
+++ b/ui/web/src/pages/providers/provider-utils.tsx
@@ -12,6 +12,7 @@ const SPECIAL_VARIANTS: Record<string, BadgeVariant> = {
   anthropic_native: "default",
   chatgpt_oauth: "default",
   claude_cli: "outline",
+  cursor_cli: "outline",
   acp: "outline",
 };
 
@@ -123,7 +124,7 @@ export function ProviderApiKeyBadge({
       </span>
     );
   }
-  if (provider.provider_type === "claude_cli") {
+  if (provider.provider_type === "claude_cli" || provider.provider_type === "cursor_cli") {
     return (
       <span className="flex items-center gap-1 text-xs-plus text-emerald-600 dark:text-emerald-400">
         <ShieldCheck className="h-3 w-3" />{t("card.authenticated")}

--- a/ui/web/src/pages/setup/hooks/use-bootstrap-status.ts
+++ b/ui/web/src/pages/setup/hooks/use-bootstrap-status.ts
@@ -30,6 +30,7 @@ export function useBootstrapStatus() {
     const hasProvider = providers.some((provider) => provider.enabled && (
       provider.api_key === "***"
       || provider.provider_type === "claude_cli"
+      || provider.provider_type === "cursor_cli"
       || provider.provider_type === "ollama"
       || (provider.provider_type === "chatgpt_oauth" && readyOAuthProviders.has(provider.name))
     ));

--- a/ui/web/src/pages/setup/setup-page.tsx
+++ b/ui/web/src/pages/setup/setup-page.tsx
@@ -122,6 +122,7 @@ export function SetupPage() {
   const activeProvider = createdProvider ?? providers.find((provider) => provider.enabled && (
     provider.api_key === "***"
     || provider.provider_type === "claude_cli"
+    || provider.provider_type === "cursor_cli"
     || provider.provider_type === "ollama"
     || (provider.provider_type === "chatgpt_oauth" && readyOAuthProviders.has(provider.name))
   )) ?? null;

--- a/ui/web/src/pages/setup/step-provider.tsx
+++ b/ui/web/src/pages/setup/step-provider.tsx
@@ -44,7 +44,7 @@ export function StepProvider({ onComplete, existingProvider }: StepProviderProps
   const [error, setError] = useState("");
 
   const isOAuth = providerType === "chatgpt_oauth";
-  const isCLI = providerType === "claude_cli";
+  const isCLI = providerType === "claude_cli" || providerType === "cursor_cli";
   // Local Ollama uses no API key — the server accepts any non-empty Bearer value internally
   const isOllama = providerType === "ollama";
 

--- a/ui/web/src/schemas/provider.schema.ts
+++ b/ui/web/src/schemas/provider.schema.ts
@@ -17,6 +17,10 @@ export const providerCreateSchema = z.object({
   acpIdleTTL: z.string().optional(),
   acpPermMode: z.string().optional(),
   acpWorkDir: z.string().optional(),
+  // Cursor CLI-specific fields
+  cursorBinary: z.string().optional(),
+  cursorMode: z.string().optional(),
+  cursorApiKey: z.string().optional(),
 });
 
 export type ProviderCreateFormData = z.infer<typeof providerCreateSchema>;


### PR DESCRIPTION
## Summary

- **Problem**: Cursor CLI agent sessions weren't persisting across server restarts — chat ID was stored only in-memory
- **Solution**: Persist chat ID to `<workDir>/.cursor/chatid` file
- **Flow**: Check memory cache → check disk → call `agent create-chat` if missing → write to disk
- **Reset**: `/reset` clears both memory and disk file so next message creates a new chat

### Changes

1. `cursor_cli.go` — add `sync.Map` registry to track sessionKey → chatID per baseWorkDir
2. `cursor_cli_session.go` — refactored `buildArgs(chatID)` to take explicit chatID; added `getOrCreateChatID()`, `createChat()`, `ResetCursorCLISession()` 
3. `cursor_cli_chat.go` — call `getOrCreateChatID()` before building args in both `Chat()` and `ChatStream()`
4. `gateway_consumer_handlers.go` — call `ResetCursorCLISession()` on `/reset`
5. Updated tests

## Test

```bash
go build ./... && go test ./internal/providers/ -run TestCursor -v
```