### PR TITLE
fix: correct STT routing and shell security runtime persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ compose.d/*
 *.test
 goclaw-patched-linux-amd64
 ui/web/nginx.staging.conf
+dist

--- a/cmd/gateway_lifecycle.go
+++ b/cmd/gateway_lifecycle.go
@@ -84,6 +84,24 @@ func (d *gatewayDeps) runLifecycle(
 		deps.webFetchTool.UpdatePolicy(updatedCfg.Tools.WebFetch.Policy, updatedCfg.Tools.WebFetch.AllowedDomains, updatedCfg.Tools.WebFetch.BlockedDomains)
 	})
 
+	// Reload global shell deny-group toggles on config changes via pub/sub.
+	// Without this, Config page changes only apply after process restart.
+	d.msgBus.Subscribe("shell-deny-groups-config-reload", func(evt bus.Event) {
+		if evt.Name != bus.TopicConfigChanged {
+			return
+		}
+		updatedCfg, ok := evt.Payload.(*config.Config)
+		if !ok {
+			return
+		}
+		if execTool, ok := d.toolsReg.Get("exec"); ok {
+			if et, ok := execTool.(*tools.ExecTool); ok {
+				et.SetGlobalShellDenyGroups(updatedCfg.Tools.ShellDenyGroups)
+				slog.Info("shell deny groups reloaded via pub/sub", "groups", len(updatedCfg.Tools.ShellDenyGroups))
+			}
+		}
+	})
+
 	// Reload TTS providers on config changes via pub/sub.
 	d.msgBus.Subscribe("tts-config-reload", func(evt bus.Event) {
 		if evt.Name != bus.TopicConfigChanged {

--- a/cmd/gateway_setup.go
+++ b/cmd/gateway_setup.go
@@ -14,11 +14,11 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/bootstrap"
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/edition"
 	mcpbridge "github.com/nextlevelbuilder/goclaw/internal/mcp"
 	"github.com/nextlevelbuilder/goclaw/internal/permissions"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 	"github.com/nextlevelbuilder/goclaw/internal/sandbox"
-	"github.com/nextlevelbuilder/goclaw/internal/edition"
 	"github.com/nextlevelbuilder/goclaw/internal/skills"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/internal/store/pg"
@@ -211,6 +211,9 @@ func setupToolRegistry(
 	// Exception: .goclaw/skills-store/ is allowed (skills may contain executable scripts).
 	if execTool, ok := toolsReg.Get("exec"); ok {
 		if et, ok := execTool.(*tools.ExecTool); ok {
+			// Global shell deny-group toggles from Config page (tools.shellDenyGroups).
+			// Per-agent shell_deny_groups still override per group at runtime.
+			et.SetGlobalShellDenyGroups(cfg.Tools.ShellDenyGroups)
 			et.DenyPaths(dataDir, ".goclaw/")
 			// Allow skills execution: master-tenant skills-store + all tenant-scoped skills-store dirs.
 			et.AllowPathExemptions(
@@ -595,4 +598,3 @@ func setupSkillsSystem(
 
 	return skillsLoader, skillSearchTool, globalSkillsDir, bundledSkillsDir, builtinSkillsDir
 }
-

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -458,7 +458,7 @@ func NewManagedResolver(deps ResolverDeps) ResolverFunc {
 			evoMetricsStore = deps.EvolutionMetricsStore
 		}
 
-		restrictVal := true // always restrict agents to their workspace
+		restrictVal := ag.RestrictToWorkspace
 		loop := NewLoop(LoopConfig{
 			ID:                     ag.AgentKey,
 			DisplayName:            ag.DisplayName,

--- a/internal/agent/systemprompt.go
+++ b/internal/agent/systemprompt.go
@@ -335,7 +335,7 @@ func BuildSystemPrompt(cfg SystemPromptConfig) string {
 	}
 
 	// 2. ## Tooling
-	lines = append(lines, buildToolingSection(cfg.ToolNames, cfg.SandboxEnabled, cfg.ShellDenyGroups)...)
+	lines = append(lines, buildToolingSection(cfg.ToolNames, cfg.SandboxEnabled, cfg.ShellDenyGroups, !isNone)...)
 
 	// 2.1. ## Execution Bias — full + task mode (overridable by provider)
 	if (isFull || isTask) && !cfg.IsBootstrap {
@@ -350,6 +350,11 @@ func BuildSystemPrompt(cfg SystemPromptConfig) string {
 	// 2.5. Credentialed CLI context — full mode only
 	if isFull && !cfg.IsBootstrap && cfg.CredentialCLIContext != "" && slices.Contains(cfg.ToolNames, "exec") {
 		lines = append(lines, cfg.CredentialCLIContext, "")
+		lines = append(lines,
+			"Credentialed CLI rules apply only when exec returns `[CREDENTIALED EXEC]`.",
+			"Do not apply credentialed-CLI approval wording to normal shell commands.",
+			"",
+		)
 	}
 
 	// 2.6. ## Voice Response — inject when TTS auto mode is "tagged"
@@ -534,7 +539,7 @@ func BuildSystemPrompt(cfg SystemPromptConfig) string {
 
 // --- Section builders ---
 
-func buildToolingSection(toolNames []string, hasSandbox bool, shellDenyGroups map[string]bool) []string {
+func buildToolingSection(toolNames []string, hasSandbox bool, shellDenyGroups map[string]bool, includeExecNudge bool) []string {
 	lines := []string{
 		"## Tooling",
 		"",
@@ -600,8 +605,11 @@ func buildToolingSection(toolNames []string, hasSandbox bool, shellDenyGroups ma
 		"",
 		"write_file content >12000 chars may be truncated — use append=true or edit tool for large files.",
 		"Tool list above is authoritative (re-evaluated every turn). Ignore \"not available\" in history. TOOLS.md is user guidance only. Do not poll subagents.",
-		"",
 	)
+	if includeExecNudge {
+		lines = append(lines, "Do not pre-refuse exec from history; try one real exec call, then report exact denial once if blocked.")
+	}
+	lines = append(lines, "")
 	return lines
 }
 

--- a/internal/agent/systemprompt.go
+++ b/internal/agent/systemprompt.go
@@ -174,7 +174,7 @@ func (cfg SystemPromptConfig) sectionContent(id string, defaultFn func() []strin
 // coreToolSummaries maps tool names to one-line descriptions.
 // Shown in the ## Tooling section of the system prompt.
 var coreToolSummaries = map[string]string{
-	"read_file":              "Read file contents — only accesses your agent workspace. For docs returned by vault_search (shared/personal/team vault), use vault_read instead",
+	"read_file":              "Read file contents. Access scope follows your current filesystem policy (may be workspace-only). For docs returned by vault_search (shared/personal/team vault), use vault_read instead",
 	"write_file":             "Create or overwrite files",
 	"list_files":             "List directory contents",
 	"exec":                   "Run shell commands",
@@ -540,12 +540,18 @@ func BuildSystemPrompt(cfg SystemPromptConfig) string {
 // --- Section builders ---
 
 func buildToolingSection(toolNames []string, hasSandbox bool, shellDenyGroups map[string]bool, includeExecNudge bool) []string {
-	lines := []string{
-		"## Tooling",
-		"",
-		"Tool availability (filtered by policy).",
-		"Tool names are case-sensitive. Call tools exactly as listed.",
-		"",
+	lines := []string{"## Tooling", ""}
+	if includeExecNudge {
+		lines = append(lines,
+			"Tool availability (filtered by policy).",
+			"Tool names are case-sensitive. Call tools exactly as listed.",
+			"",
+		)
+	} else {
+		lines = append(lines,
+			"Available tools (policy-filtered):",
+			"",
+		)
 	}
 
 	// Sort tool names for deterministic output — critical for prompt caching.
@@ -563,7 +569,7 @@ func buildToolingSection(toolNames []string, hasSandbox bool, shellDenyGroups ma
 		lines = append(lines, fmt.Sprintf("- %s: %s", name, desc))
 	}
 
-	if hasSandbox {
+	if hasSandbox && includeExecNudge {
 		lines = append(lines,
 			"",
 			"NOTE: The `exec` tool runs commands inside a Docker sandbox container automatically.",
@@ -573,12 +579,12 @@ func buildToolingSection(toolNames []string, hasSandbox bool, shellDenyGroups ma
 		)
 	}
 
-	if tools.IsGroupDenied(shellDenyGroups, "package_install") {
+	if includeExecNudge && tools.IsGroupDenied(shellDenyGroups, "package_install") {
 		lines = append(lines,
 			"",
 			"Package installation (pip, npm, apk) requires admin approval. If you need to install a package, use exec with the install command — it will be routed to the admin for approval. Alternatively, ask the user to install via the Web UI Packages page.",
 		)
-	} else {
+	} else if includeExecNudge {
 		lines = append(lines,
 			"",
 			"You can install packages at runtime with `pip3 install <pkg>` or `npm install -g <pkg>` — no sudo needed.",
@@ -592,7 +598,7 @@ func buildToolingSection(toolNames []string, hasSandbox bool, shellDenyGroups ma
 			break
 		}
 	}
-	if hasMediaTools {
+	if hasMediaTools && includeExecNudge {
 		lines = append(lines,
 			"",
 			"### Media Files",
@@ -601,13 +607,21 @@ func buildToolingSection(toolNames []string, hasSandbox bool, shellDenyGroups ma
 		)
 	}
 
-	lines = append(lines,
-		"",
-		"write_file content >12000 chars may be truncated — use append=true or edit tool for large files.",
-		"Tool list above is authoritative (re-evaluated every turn). Ignore \"not available\" in history. TOOLS.md is user guidance only. Do not poll subagents.",
-	)
 	if includeExecNudge {
+		lines = append(lines,
+			"",
+			"write_file content >12000 chars may be truncated — use append=true or edit tool for large files.",
+			"Tool list above is authoritative (re-evaluated every turn). Ignore \"not available\" in history. TOOLS.md is user guidance only. Do not poll subagents.",
+		)
 		lines = append(lines, "Do not pre-refuse exec from history; try one real exec call, then report exact denial once if blocked.")
+		if slices.Contains(toolNames, "read_file") {
+			lines = append(lines, "Do not pre-refuse read_file. Attempt one real read_file call first, then report the exact error only if blocked.")
+		}
+	} else {
+		lines = append(lines,
+			"",
+			"Tool list above is authoritative for this turn.",
+		)
 	}
 	lines = append(lines, "")
 	return lines

--- a/internal/agent/systemprompt_sections.go
+++ b/internal/agent/systemprompt_sections.go
@@ -123,6 +123,7 @@ func buildExecutionBiasSection() []string {
 		"",
 		"If the user asks you to do work, start doing it in the same turn.",
 		"Use a real tool call when the task is actionable; do not stop at a plan or promise-to-act reply.",
+		"For file-access requests, attempt one real read_file call before claiming a path is inaccessible.",
 		"Commentary-only turns are incomplete when tools are available and the next action is clear.",
 		"",
 	}

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -24,25 +24,25 @@ type ChannelsConfig struct {
 }
 
 type TelegramConfig struct {
-	Enabled        bool                `json:"enabled"`
-	Token          string              `json:"token"`
-	Proxy          string              `json:"proxy,omitempty"`
-	APIServer      string              `json:"api_server,omitempty"` // custom Telegram Bot API server URL (e.g. "http://localhost:8081")
-	AllowFrom      FlexibleStringSlice `json:"allow_from"`
-	DMPolicy       string              `json:"dm_policy,omitempty"`       // "pairing" (default), "allowlist", "open", "disabled"
-	GroupPolicy    string              `json:"group_policy,omitempty"`    // "open" (default), "allowlist", "disabled"
-	RequireMention *bool               `json:"require_mention,omitempty"` // require @bot mention in groups (default true)
-	MentionMode    string              `json:"mention_mode,omitempty"`    // "strict" (default) = only respond when mentioned; "yield" = respond unless another bot is mentioned
-	HistoryLimit   int                 `json:"history_limit,omitempty"`   // max pending group messages for context (default 50, 0=disabled)
-	DMStream         *bool               `json:"dm_stream,omitempty"`          // enable streaming for DMs (default false) — edits placeholder progressively
-	GroupStream      *bool               `json:"group_stream,omitempty"`      // enable streaming for groups (default false) — sends new message, edits progressively
-	DraftTransport   *bool               `json:"draft_transport,omitempty"`   // use sendMessageDraft for DM streaming (default true) — stealth preview, no notifications per edit
-	ReasoningStream  *bool               `json:"reasoning_stream,omitempty"`  // show reasoning as separate message when provider emits thinking events (default true)
-	ReactionLevel    string              `json:"reaction_level,omitempty"`    // "off" (default), "minimal", "full" — status emoji reactions
-	MediaMaxBytes  int64               `json:"media_max_bytes,omitempty"` // max media download size in bytes (default 20MB)
-	LinkPreview    *bool               `json:"link_preview,omitempty"`    // enable URL previews in messages (default true)
-	BlockReply     *bool               `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
-	ForceIPv4      bool                `json:"force_ipv4,omitempty"`      // force IPv4 for all Telegram API requests (use when IPv6 routing is broken)
+	Enabled         bool                `json:"enabled"`
+	Token           string              `json:"token"`
+	Proxy           string              `json:"proxy,omitempty"`
+	APIServer       string              `json:"api_server,omitempty"` // custom Telegram Bot API server URL (e.g. "http://localhost:8081")
+	AllowFrom       FlexibleStringSlice `json:"allow_from"`
+	DMPolicy        string              `json:"dm_policy,omitempty"`        // "pairing" (default), "allowlist", "open", "disabled"
+	GroupPolicy     string              `json:"group_policy,omitempty"`     // "open" (default), "allowlist", "disabled"
+	RequireMention  *bool               `json:"require_mention,omitempty"`  // require @bot mention in groups (default true)
+	MentionMode     string              `json:"mention_mode,omitempty"`     // "strict" (default) = only respond when mentioned; "yield" = respond unless another bot is mentioned
+	HistoryLimit    int                 `json:"history_limit,omitempty"`    // max pending group messages for context (default 50, 0=disabled)
+	DMStream        *bool               `json:"dm_stream,omitempty"`        // enable streaming for DMs (default false) — edits placeholder progressively
+	GroupStream     *bool               `json:"group_stream,omitempty"`     // enable streaming for groups (default false) — sends new message, edits progressively
+	DraftTransport  *bool               `json:"draft_transport,omitempty"`  // use sendMessageDraft for DM streaming (default true) — stealth preview, no notifications per edit
+	ReasoningStream *bool               `json:"reasoning_stream,omitempty"` // show reasoning as separate message when provider emits thinking events (default true)
+	ReactionLevel   string              `json:"reaction_level,omitempty"`   // "off" (default), "minimal", "full" — status emoji reactions
+	MediaMaxBytes   int64               `json:"media_max_bytes,omitempty"`  // max media download size in bytes (default 20MB)
+	LinkPreview     *bool               `json:"link_preview,omitempty"`     // enable URL previews in messages (default true)
+	BlockReply      *bool               `json:"block_reply,omitempty"`      // override gateway block_reply (nil = inherit)
+	ForceIPv4       bool                `json:"force_ipv4,omitempty"`       // force IPv4 for all Telegram API requests (use when IPv6 routing is broken)
 
 	// Optional STT (Speech-to-Text) pipeline for voice/audio inbound messages.
 	// When stt_proxy_url is set, audio/voice messages are transcribed before being forwarded to the agent.
@@ -133,7 +133,7 @@ type SlackConfig struct {
 
 type WhatsAppConfig struct {
 	Enabled        bool                `json:"enabled"`
-	AuthDir        string              `json:"auth_dir,omitempty"`        // optional: SQLite auth dir override (desktop)
+	AuthDir        string              `json:"auth_dir,omitempty"` // optional: SQLite auth dir override (desktop)
 	AllowFrom      FlexibleStringSlice `json:"allow_from"`
 	DMPolicy       string              `json:"dm_policy,omitempty"`       // "pairing" (default for DB instances), "open", "allowlist", "disabled"
 	GroupPolicy    string              `json:"group_policy,omitempty"`    // "pairing" (default for DB instances), "open" (default for config), "allowlist", "disabled"
@@ -196,25 +196,25 @@ type FeishuConfig struct {
 
 // ProvidersConfig maps provider name to its config.
 type ProvidersConfig struct {
-	Anthropic  ProviderConfig  `json:"anthropic"`
-	OpenAI     ProviderConfig  `json:"openai"`
-	OpenRouter ProviderConfig  `json:"openrouter"`
-	Groq       ProviderConfig  `json:"groq"`
-	Gemini     ProviderConfig  `json:"gemini"`
-	DeepSeek   ProviderConfig  `json:"deepseek"`
-	Mistral    ProviderConfig  `json:"mistral"`
-	XAI        ProviderConfig  `json:"xai"`
-	MiniMax    ProviderConfig  `json:"minimax"`
-	Cohere     ProviderConfig  `json:"cohere"`
-	Perplexity ProviderConfig  `json:"perplexity"`
-	DashScope  ProviderConfig  `json:"dashscope"`
-	Bailian    ProviderConfig  `json:"bailian"`
-	Zai         ProviderConfig  `json:"zai"`
-	ZaiCoding   ProviderConfig  `json:"zai_coding"`
-	Ollama      OllamaConfig    `json:"ollama"`       // local Ollama instance (no API key needed)
-	OllamaCloud ProviderConfig  `json:"ollama_cloud"` // Ollama Cloud (API key required)
-	ClaudeCLI   ClaudeCLIConfig `json:"claude_cli"`
-	ACP         ACPConfig       `json:"acp"`
+	Anthropic      ProviderConfig  `json:"anthropic"`
+	OpenAI         ProviderConfig  `json:"openai"`
+	OpenRouter     ProviderConfig  `json:"openrouter"`
+	Groq           ProviderConfig  `json:"groq"`
+	Gemini         ProviderConfig  `json:"gemini"`
+	DeepSeek       ProviderConfig  `json:"deepseek"`
+	Mistral        ProviderConfig  `json:"mistral"`
+	XAI            ProviderConfig  `json:"xai"`
+	MiniMax        ProviderConfig  `json:"minimax"`
+	Cohere         ProviderConfig  `json:"cohere"`
+	Perplexity     ProviderConfig  `json:"perplexity"`
+	DashScope      ProviderConfig  `json:"dashscope"`
+	Bailian        ProviderConfig  `json:"bailian"`
+	Zai            ProviderConfig  `json:"zai"`
+	ZaiCoding      ProviderConfig  `json:"zai_coding"`
+	Ollama         OllamaConfig    `json:"ollama"`       // local Ollama instance (no API key needed)
+	OllamaCloud    ProviderConfig  `json:"ollama_cloud"` // Ollama Cloud (API key required)
+	ClaudeCLI      ClaudeCLIConfig `json:"claude_cli"`
+	ACP            ACPConfig       `json:"acp"`
 	Novita         ProviderConfig  `json:"novita"`          // Novita AI (OpenAI-compatible endpoint)
 	BytePlus       ProviderConfig  `json:"byteplus"`        // BytePlus ModelArk (Seed 2.0)
 	BytePlusCoding ProviderConfig  `json:"byteplus_coding"` // BytePlus ModelArk Coding Plan
@@ -346,16 +346,16 @@ type QuotaConfig struct {
 
 // GatewayConfig controls the gateway server.
 type GatewayConfig struct {
-	Host              string       `json:"host"`
-	Port              int          `json:"port"`
-	Token             string       `json:"token,omitempty"`               // bearer token for WS/HTTP auth
-	OwnerIDs          []string     `json:"owner_ids,omitempty"`           // sender IDs considered "owner"
-	AllowedOrigins    []string     `json:"allowed_origins,omitempty"`     // WebSocket CORS whitelist (empty = allow all)
-	MaxMessageChars   int          `json:"max_message_chars,omitempty"`   // max user message characters (default 32000)
-	RateLimitRPM      int          `json:"rate_limit_rpm,omitempty"`      // rate limit: requests per minute per user (default 20, 0 = disabled)
-	InjectionAction   string       `json:"injection_action,omitempty"`    // prompt injection action: "log", "warn" (default), "block", "off"
-	InboundDebounceMs int          `json:"inbound_debounce_ms,omitempty"` // merge rapid messages from same sender (default 1000ms, -1 = disabled)
-	Quota             *QuotaConfig `json:"quota,omitempty"`               // per-user/group request quotas
+	Host                    string       `json:"host"`
+	Port                    int          `json:"port"`
+	Token                   string       `json:"token,omitempty"`                      // bearer token for WS/HTTP auth
+	OwnerIDs                []string     `json:"owner_ids,omitempty"`                  // sender IDs considered "owner"
+	AllowedOrigins          []string     `json:"allowed_origins,omitempty"`            // WebSocket CORS whitelist (empty = allow all)
+	MaxMessageChars         int          `json:"max_message_chars,omitempty"`          // max user message characters (default 32000)
+	RateLimitRPM            int          `json:"rate_limit_rpm,omitempty"`             // rate limit: requests per minute per user (default 20, 0 = disabled)
+	InjectionAction         string       `json:"injection_action,omitempty"`           // prompt injection action: "log", "warn" (default), "block", "off"
+	InboundDebounceMs       int          `json:"inbound_debounce_ms,omitempty"`        // merge rapid messages from same sender (default 1000ms, -1 = disabled)
+	Quota                   *QuotaConfig `json:"quota,omitempty"`                      // per-user/group request quotas
 	BlockReply              *bool        `json:"block_reply,omitempty"`                // deliver intermediate text during tool iterations (default false)
 	ToolStatus              *bool        `json:"tool_status,omitempty"`                // show tool name in streaming preview during tool execution (default true)
 	TaskRecoveryIntervalSec int          `json:"task_recovery_interval_sec,omitempty"` // team task recovery ticker interval in seconds (default 300 = 5min)
@@ -365,13 +365,14 @@ type GatewayConfig struct {
 
 // ToolsConfig controls tool availability, policy, and web search.
 type ToolsConfig struct {
-	Profile          string                      `json:"profile,omitempty"`    // global profile: "minimal", "coding", "messaging", "full"
-	Allow            []string                    `json:"allow,omitempty"`      // global allow list (tool names or "group:xxx")
-	Deny             []string                    `json:"deny,omitempty"`       // global deny list
-	AlsoAllow        []string                    `json:"alsoAllow,omitempty"`  // additive: adds without removing existing
-	ByProvider       map[string]*ToolPolicySpec  `json:"byProvider,omitempty"` // per-provider overrides
-	ExecApproval     ExecApprovalCfg             `json:"execApproval"`         // exec command approval settings
-	WebFetch         WebFetchPolicyConfig        `json:"web_fetch"`            // domain policy for URL fetching
+	Profile          string                      `json:"profile,omitempty"`         // global profile: "minimal", "coding", "messaging", "full"
+	Allow            []string                    `json:"allow,omitempty"`           // global allow list (tool names or "group:xxx")
+	Deny             []string                    `json:"deny,omitempty"`            // global deny list
+	AlsoAllow        []string                    `json:"alsoAllow,omitempty"`       // additive: adds without removing existing
+	ByProvider       map[string]*ToolPolicySpec  `json:"byProvider,omitempty"`      // per-provider overrides
+	ShellDenyGroups  map[string]bool             `json:"shellDenyGroups,omitempty"` // global shell deny-group toggles (group -> denied)
+	ExecApproval     ExecApprovalCfg             `json:"execApproval"`              // exec command approval settings
+	WebFetch         WebFetchPolicyConfig        `json:"web_fetch"`                 // domain policy for URL fetching
 	Browser          BrowserToolConfig           `json:"browser"`
 	RateLimitPerHour int                         `json:"rate_limit_per_hour,omitempty"` // max tool executions per hour per session (0 = disabled)
 	ScrubCredentials *bool                       `json:"scrub_credentials,omitempty"`   // auto-redact API keys/tokens in tool output (default true)
@@ -412,9 +413,9 @@ type WebFetchPolicyConfig struct {
 
 // BrowserToolConfig controls the browser automation tool.
 type BrowserToolConfig struct {
-	Enabled         bool   `json:"enabled"`                    // enable the browser tool (default false)
-	Headless        bool   `json:"headless,omitempty"`         // run Chrome in headless mode (ignored when RemoteURL is set)
-	RemoteURL       string `json:"remote_url,omitempty"`       // CDP endpoint for remote Chrome sidecar, e.g. "ws://chrome:9222"
+	Enabled         bool   `json:"enabled"`                     // enable the browser tool (default false)
+	Headless        bool   `json:"headless,omitempty"`          // run Chrome in headless mode (ignored when RemoteURL is set)
+	RemoteURL       string `json:"remote_url,omitempty"`        // CDP endpoint for remote Chrome sidecar, e.g. "ws://chrome:9222"
 	ActionTimeoutMs int    `json:"action_timeout_ms,omitempty"` // per-action timeout in ms (default 30000)
 	IdleTimeoutMs   int    `json:"idle_timeout_ms,omitempty"`   // idle page auto-close in ms (default 600000, 0=disabled)
 	MaxPages        int    `json:"max_pages,omitempty"`         // max open pages per tenant (default 5)
@@ -422,14 +423,13 @@ type BrowserToolConfig struct {
 
 // ToolPolicySpec defines a tool policy at any level (global, per-agent, per-provider).
 type ToolPolicySpec struct {
-	Profile    string                     `json:"profile,omitempty"`
-	Allow      []string                   `json:"allow,omitempty"`
-	Deny       []string                   `json:"deny,omitempty"`
-	AlsoAllow  []string                   `json:"alsoAllow,omitempty"`
-	ByProvider map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
-	ToolCallPrefix string `json:"toolCallPrefix,omitempty"` // prefix to strip from model's tool call names before registry lookup
+	Profile        string                     `json:"profile,omitempty"`
+	Allow          []string                   `json:"allow,omitempty"`
+	Deny           []string                   `json:"deny,omitempty"`
+	AlsoAllow      []string                   `json:"alsoAllow,omitempty"`
+	ByProvider     map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
+	ToolCallPrefix string                     `json:"toolCallPrefix,omitempty"` // prefix to strip from model's tool call names before registry lookup
 }
-
 
 // SessionsConfig controls session behavior.
 // Matching TS src/config/sessions/types.ts + src/config/types.base.ts.

--- a/internal/http/agents.go
+++ b/internal/http/agents.go
@@ -387,7 +387,6 @@ func (h *AgentsHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	// Allowlist: only permit known agent columns to be updated.
 	// Defense-in-depth against column injection via arbitrary JSON keys.
 	allowed := filterAllowedKeys(updates, agentAllowedFields)
-	allowed["restrict_to_workspace"] = true
 
 	// If agent_key is being changed, enforce the slug format. The router
 	// cache uses `tenantID:agentKey` as its canonical key and splits on the

--- a/internal/http/validate.go
+++ b/internal/http/validate.go
@@ -44,7 +44,7 @@ var agentAllowedFields = map[string]bool{
 	"agent_key": true, "agent_type": true, "display_name": true,
 	"provider": true, "model": true, "status": true,
 	"context_window": true, "max_tool_iterations": true,
-	"workspace": true,
+	"workspace": true, "restrict_to_workspace": true,
 	"frontmatter": true, "compaction_config": true,
 	"memory_config": true, "other_config": true, "tools_config": true,
 	"sandbox_config": true, "context_pruning": true,

--- a/internal/http/validate_test.go
+++ b/internal/http/validate_test.go
@@ -63,3 +63,23 @@ func TestFilterAllowedKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterAllowedKeys_AgentRestrictToWorkspaceAllowed(t *testing.T) {
+	input := map[string]any{
+		"restrict_to_workspace": false,
+		"display_name":          "Fox Spirit",
+		"evil_field":            true,
+	}
+
+	result := filterAllowedKeys(input, agentAllowedFields)
+
+	if v, ok := result["restrict_to_workspace"]; !ok || v != false {
+		t.Fatalf("expected restrict_to_workspace=false to be retained, got: %#v", result["restrict_to_workspace"])
+	}
+	if _, ok := result["display_name"]; !ok {
+		t.Fatalf("expected display_name to be retained")
+	}
+	if _, ok := result["evil_field"]; ok {
+		t.Fatalf("expected evil_field to be stripped")
+	}
+}

--- a/internal/permissions/policy.go
+++ b/internal/permissions/policy.go
@@ -290,6 +290,7 @@ func isWriteMethod(method string) bool {
 		protocol.MethodChatAbort,
 		protocol.MethodChatInject,
 		protocol.MethodSessionsDelete,
+		protocol.MethodSessionsCompact,
 		protocol.MethodSessionsReset,
 		protocol.MethodSessionsPatch,
 		protocol.MethodCronCreate,

--- a/internal/skills/loader_test.go
+++ b/internal/skills/loader_test.go
@@ -8,6 +8,16 @@ import (
 	"testing"
 )
 
+func init() {
+	home, err := os.MkdirTemp("", "skills-loader-home-*")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("HOME", home); err != nil {
+		panic(err)
+	}
+}
+
 // makeSkillDir creates a skill directory with a SKILL.md file.
 func makeSkillDir(t *testing.T, parent, slug, content string) string {
 	t.Helper()
@@ -602,10 +612,10 @@ description: plain
 			want: nil,
 		},
 		{
-			name: "crlf",
+			name:    "crlf",
 			content: "deps:\r\n  - pip:a\r\n  - pip:b\r\n",
-			key:    "deps",
-			want:   []string{"pip:a", "pip:b"},
+			key:     "deps",
+			want:    []string{"pip:a", "pip:b"},
 		},
 		{
 			name: "scalar skipped",

--- a/internal/tools/context_keys.go
+++ b/internal/tools/context_keys.go
@@ -277,9 +277,12 @@ func RestrictFromCtx(ctx context.Context) (bool, bool) {
 }
 
 func effectiveRestrict(ctx context.Context, toolDefault bool) bool {
-	// Multi-tenant security: always restrict agents to their workspace.
-	// Agents must not access files outside their tenant-scoped workspace.
-	return true
+	// Prefer per-agent/runtime override from context when present.
+	if v, ok := RestrictFromCtx(ctx); ok {
+		return v
+	}
+	// Otherwise use the tool's configured default.
+	return toolDefault
 }
 
 // --- Parent agent model (for subagent inheritance) ---

--- a/internal/tools/context_keys_test.go
+++ b/internal/tools/context_keys_test.go
@@ -131,3 +131,25 @@ func TestToolContextKeys_MultipleValues(t *testing.T) {
 		t.Errorf("sandboxKey: expected sandbox-1, got %q", v)
 	}
 }
+
+func TestEffectiveRestrict_UsesToolDefaultWhenNoOverride(t *testing.T) {
+	ctx := context.Background()
+	if got := effectiveRestrict(ctx, true); !got {
+		t.Fatalf("expected true when tool default is true, got %v", got)
+	}
+	if got := effectiveRestrict(ctx, false); got {
+		t.Fatalf("expected false when tool default is false, got %v", got)
+	}
+}
+
+func TestEffectiveRestrict_ContextOverrideWins(t *testing.T) {
+	ctx := WithRestrictToWorkspace(context.Background(), false)
+	if got := effectiveRestrict(ctx, true); got {
+		t.Fatalf("expected context override false to win, got %v", got)
+	}
+
+	ctx = WithRestrictToWorkspace(context.Background(), true)
+	if got := effectiveRestrict(ctx, false); !got {
+		t.Fatalf("expected context override true to win, got %v", got)
+	}
+}

--- a/internal/tools/credential_context.go
+++ b/internal/tools/credential_context.go
@@ -42,9 +42,10 @@ func GenerateCredentialContext(creds []store.SecureCLIBinary) string {
 		b.WriteString("\n")
 	}
 
-	b.WriteString("### When a command is blocked:\n")
-	b.WriteString("Tell the user: \"This operation requires admin approval and cannot be performed automatically.\"\n")
-	b.WriteString("Do NOT attempt workarounds to bypass blocked commands.\n")
+	b.WriteString("### When a credentialed CLI command is blocked:\n")
+	b.WriteString("This section applies ONLY to commands that return a `[CREDENTIALED EXEC]` error.\n")
+	b.WriteString("Tell the user: \"This credentialed CLI operation is blocked by policy and may require admin approval.\"\n")
+	b.WriteString("Do NOT attempt workarounds to bypass blocked credentialed CLI commands.\n")
 	return b.String()
 }
 

--- a/internal/tools/message_test.go
+++ b/internal/tools/message_test.go
@@ -89,9 +89,8 @@ func TestResolveMediaPath(t *testing.T) {
 		}
 	})
 
-	// effectiveRestrict() always returns true (multi-tenant security hardening),
-	// so even tools created with restrict=false behave as restricted.
-	t.Run("unrestricted_tool_still_restricted", func(t *testing.T) {
+	// Tools created with restrict=false should allow paths outside workspace.
+	t.Run("unrestricted_tool_allows_outside_workspace", func(t *testing.T) {
 		tool := NewMessageTool(workspaceCanonical, false)
 		ctx := context.Background()
 
@@ -100,11 +99,11 @@ func TestResolveMediaPath(t *testing.T) {
 			input  string
 			wantOK bool
 		}{
-			// Outside workspace → blocked (effectiveRestrict overrides to true)
-			{"absolute outside workspace", "MEDIA:" + outsidePath(workspaceCanonical, "etc/hostname"), false},
+			// Outside workspace → allowed (unrestricted mode)
+			{"absolute outside workspace", "MEDIA:" + outsidePath(workspaceCanonical, "etc/hostname"), true},
 			// Workspace-relative → allowed
 			{"workspace relative", "MEDIA:docs/report.pdf", true},
-			// /tmp/ → allowed (temp dir exception in restricted mode)
+			// /tmp/ → allowed
 			{"temp file", "MEDIA:" + filepath.Join(tmpDir, "test.png"), true},
 		}
 

--- a/internal/tools/read_audio_resolve.go
+++ b/internal/tools/read_audio_resolve.go
@@ -81,10 +81,23 @@ func (t *ReadAudioTool) callProvider(ctx context.Context, cp credentialProvider,
 	// Provider-specific paths require API credentials; skip when cp is nil
 	// (e.g. OAuth-based providers that don't expose static keys).
 	ptype := GetParamString(params, "_provider_type", providerTypeFromName(providerName))
-	if cp == nil && (ptype == "gemini" || ptype == "openai") {
-		slog.Info("read_audio: no API credentials, falling back to Chat API", "provider", providerName)
+	if cp == nil && (ptype == "gemini" || ptype == "openai" || isTranscriptionModel(model)) {
+		return nil, nil, fmt.Errorf("provider %q requires API credentials for audio/transcription endpoint", providerName)
 	}
 	if cp != nil {
+		// OpenAI-compatible transcription path:
+		// If model is a transcription model, prefer /v1/audio/transcriptions even when
+		// provider_type is openai_compat. This keeps read_audio aligned with explicit
+		// transcription-model configs instead of falling back to chat/completions.
+		if isTranscriptionModel(model) {
+			slog.Info("read_audio: using transcription API", "provider", providerName, "model", model, "size", len(data), "mime", mime)
+			resp, err := openaiTranscriptionCall(ctx, cp.APIKey(), cp.APIBase(), model, data, mime)
+			if err != nil {
+				return nil, nil, fmt.Errorf("transcription call: %w", err)
+			}
+			return []byte(resp.Content), resp.Usage, nil
+		}
+
 		// Gemini: use File API (inlineData doesn't work for audio).
 		if ptype == "gemini" {
 			slog.Info("read_audio: using gemini file API", "provider", providerName, "model", model, "size", len(data), "mime", mime)
@@ -95,17 +108,8 @@ func (t *ReadAudioTool) callProvider(ctx context.Context, cp credentialProvider,
 			return []byte(resp.Content), resp.Usage, nil
 		}
 
-		// OpenAI: transcription models need /v1/audio/transcriptions (multipart);
-		// chat-audio models use /chat/completions with input_audio content part.
+		// OpenAI-native audio-chat models use /chat/completions with input_audio content part.
 		if ptype == "openai" {
-			if isTranscriptionModel(model) {
-				slog.Info("read_audio: using openai transcription API", "provider", providerName, "model", model, "size", len(data), "mime", mime)
-				resp, err := openaiTranscriptionCall(ctx, cp.APIKey(), cp.APIBase(), model, data, mime)
-				if err != nil {
-					return nil, nil, fmt.Errorf("openai transcription call: %w", err)
-				}
-				return []byte(resp.Content), resp.Usage, nil
-			}
 			slog.Info("read_audio: using openai input_audio API", "provider", providerName, "model", model, "size", len(data), "mime", mime)
 			resp, err := openaiAudioCall(ctx, cp.APIKey(), cp.APIBase(), model, prompt, data, mime)
 			if err != nil {

--- a/internal/tools/read_audio_resolve_test.go
+++ b/internal/tools/read_audio_resolve_test.go
@@ -1,0 +1,24 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestReadAudioCallProvider_TranscriptionModelWithoutCreds_FailsFast(t *testing.T) {
+	tool := &ReadAudioTool{}
+	params := map[string]any{
+		"_provider_type": "openai",
+		"mime":           "audio/mpeg",
+		"data":           []byte("fake"),
+	}
+
+	_, _, err := tool.callProvider(context.Background(), nil, "openai", "gpt-4o-mini-transcribe", params)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires API credentials") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -39,6 +39,9 @@ type ExecTool struct {
 	pathDenyRoots    []string         // raw deny roots for nested workspace exemptions
 	denyExemptions   []string         // substrings that exempt a command from deny
 	restrict         bool
+	// globalDenyGroups holds global shell deny-group toggles from config.tools.
+	// Per-agent overrides from context take precedence per group.
+	globalDenyGroups map[string]bool
 	sandboxMgr       sandbox.Manager      // nil = no sandbox, execute on host
 	approvalMgr      *ExecApprovalManager // nil = no approval needed
 	agentID          string               // for approval request context
@@ -111,6 +114,20 @@ func (t *ExecTool) SetSecureCLIStore(s store.SecureCLIStore) {
 	t.secureCLIStore = s
 }
 
+// SetGlobalShellDenyGroups sets global shell deny-group overrides from config.
+// A nil/empty map means "use registry defaults".
+func (t *ExecTool) SetGlobalShellDenyGroups(groups map[string]bool) {
+	if len(groups) == 0 {
+		t.globalDenyGroups = nil
+		return
+	}
+	cp := make(map[string]bool, len(groups))
+	for k, v := range groups {
+		cp[k] = v
+	}
+	t.globalDenyGroups = cp
+}
+
 // HasSecureCLIStore reports whether a credential store is wired.
 // Intended for wiring-check tests that verify subagent ExecTools also enforce
 // the secure-CLI gate (Red Team F3).
@@ -152,8 +169,9 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *Result {
 	// Unicode-based pattern bypass while preserving functional command content.
 	normalizedCommand := normalizeCommand(command)
 
-	// Resolve deny patterns: per-agent overrides from context, fallback to all defaults.
-	denyOverrides := store.ShellDenyGroupsFromContext(ctx)
+	// Resolve deny patterns with precedence:
+	// per-agent context override > global config.tools shellDenyGroups > registry default.
+	denyOverrides := t.effectiveDenyGroups(ctx)
 	groupPatterns := ResolveDenyPatterns(denyOverrides)
 
 	// Also resolve package_install patterns separately for approval routing.
@@ -342,6 +360,26 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *Result {
 
 	// Host execution
 	return t.executeOnHost(ctx, command, cwd)
+}
+
+// effectiveDenyGroups merges global deny-group config with per-agent overrides.
+// Agent overrides win per-group; nil means "use built-in defaults".
+func (t *ExecTool) effectiveDenyGroups(ctx context.Context) map[string]bool {
+	agent := store.ShellDenyGroupsFromContext(ctx)
+	if len(t.globalDenyGroups) == 0 {
+		return agent
+	}
+	if len(agent) == 0 {
+		return t.globalDenyGroups
+	}
+	merged := make(map[string]bool, len(t.globalDenyGroups)+len(agent))
+	for k, v := range t.globalDenyGroups {
+		merged[k] = v
+	}
+	for k, v := range agent {
+		merged[k] = v
+	}
+	return merged
 }
 
 // matchesAny checks if a command matches any pattern in the list.

--- a/internal/tools/shell_global_deny_groups_test.go
+++ b/internal/tools/shell_global_deny_groups_test.go
@@ -1,0 +1,39 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+func TestExecToolEffectiveDenyGroups_GlobalOnly(t *testing.T) {
+	tool := NewExecTool(".", true)
+	tool.SetGlobalShellDenyGroups(map[string]bool{
+		"package_install": false,
+	})
+
+	got := tool.effectiveDenyGroups(context.Background())
+	if got["package_install"] != false {
+		t.Fatalf("package_install = %v, want false", got["package_install"])
+	}
+}
+
+func TestExecToolEffectiveDenyGroups_AgentOverridesGlobal(t *testing.T) {
+	tool := NewExecTool(".", true)
+	tool.SetGlobalShellDenyGroups(map[string]bool{
+		"package_install": false,
+		"env_dump":        false,
+	})
+
+	ctx := store.WithShellDenyGroups(context.Background(), map[string]bool{
+		"package_install": true, // override global=false
+	})
+	got := tool.effectiveDenyGroups(ctx)
+	if got["package_install"] != true {
+		t.Fatalf("package_install = %v, want true (agent override)", got["package_install"])
+	}
+	if got["env_dump"] != false {
+		t.Fatalf("env_dump = %v, want false (global fallback)", got["env_dump"])
+	}
+}

--- a/internal/tools/tts.go
+++ b/internal/tools/tts.go
@@ -234,16 +234,39 @@ func (t *TtsTool) Execute(ctx context.Context, args map[string]any) *Result {
 
 	if providerName != "" {
 		// Use specific provider (explicit call param takes precedence).
-		// Adapt generic agent params to this specific provider's native keys.
-		p, ok := mgr.GetProvider(providerName)
-		if !ok {
-			return &Result{ForLLM: fmt.Sprintf("error: tts provider not found: %s", providerName), IsError: true}
+		// First prefer tenant-scoped provider when name matches, because tenant
+		// secrets may exist only in config store (not global env registry).
+		if tenantProvider, tenantName, _, ok := mgr.ResolveTenantProvider(ctx); ok && tenantProvider != nil && tenantName == providerName {
+			if adapted := audio.AdaptAgentParams(genericAgentParams, providerName); len(adapted) > 0 {
+				opts.Params = mergeParams(opts.Params, adapted)
+			}
+			result, err = tenantProvider.Synthesize(ctx, text, opts)
+		} else {
+			// Fallback to globally registered provider.
+			p, ok := mgr.GetProvider(providerName)
+			if !ok {
+				return &Result{ForLLM: fmt.Sprintf("error: tts provider not found: %s", providerName), IsError: true}
+			}
+			if adapted := audio.AdaptAgentParams(genericAgentParams, providerName); len(adapted) > 0 {
+				opts.Params = mergeParams(opts.Params, adapted)
+			}
+			result, err = p.Synthesize(ctx, text, opts)
 		}
-		if adapted := audio.AdaptAgentParams(genericAgentParams, providerName); len(adapted) > 0 {
-			opts.Params = mergeParams(opts.Params, adapted)
-		}
-		result, err = p.Synthesize(ctx, text, opts)
 	} else {
+		// Prefer tenant provider when available (same behavior as channel auto-apply).
+		if tenantProvider, tenantName, _, ok := mgr.ResolveTenantProvider(ctx); ok && tenantProvider != nil {
+			tenantOpts := opts
+			if adapted := audio.AdaptAgentParams(genericAgentParams, tenantName); len(adapted) > 0 {
+				tenantOpts.Params = mergeParams(opts.Params, adapted)
+			}
+			result, err = tenantProvider.Synthesize(ctx, text, tenantOpts)
+			if err == nil {
+				goto synthDone
+			}
+			// Continue to global fallback chain if tenant provider fails.
+			slog.Warn("tts tenant provider failed, trying global fallback", "provider", tenantName, "error", err)
+		}
+
 		// Resolve primary from tenant settings or default.
 		primary := t.resolvePrimary(ctx, mgr)
 		if p, ok := mgr.GetProvider(primary); ok {
@@ -265,6 +288,7 @@ func (t *TtsTool) Execute(ctx context.Context, args map[string]any) *Result {
 		}
 	}
 
+synthDone:
 	if err != nil {
 		return &Result{ForLLM: fmt.Sprintf("error: tts failed: %s", err.Error()), IsError: true}
 	}

--- a/internal/tools/tts_agent_params_test.go
+++ b/internal/tools/tts_agent_params_test.go
@@ -277,3 +277,53 @@ func TestAdaptAgentParams_MaybeApply(t *testing.T) {
 		t.Errorf("want emotion=excited in MiniMax, got %v", stub.lastOpts.Params["emotion"])
 	}
 }
+
+func TestTtsTool_UsesTenantProviderWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	edgeStub := &stubProvider{name: "edge", shouldErr: true}
+	tenantStub := &stubProvider{name: "openai"}
+
+	mgr := tts.NewManager(tts.ManagerConfig{Primary: "edge"})
+	mgr.RegisterTTS(edgeStub)
+	mgr.SetTenantResolver(func(_ context.Context) (audio.TTSProvider, string, audio.AutoMode, error) {
+		return tenantStub, "openai", audio.AutoOff, nil
+	})
+
+	tool := NewTtsTool(mgr)
+	result := tool.Execute(context.Background(), map[string]any{"text": "hello from tenant provider"})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.ForLLM)
+	}
+	if tenantStub.calls == 0 {
+		t.Fatal("tenant provider should be called")
+	}
+	if edgeStub.calls != 0 {
+		t.Fatalf("global edge provider should not run when tenant provider succeeds; calls=%d", edgeStub.calls)
+	}
+}
+
+func TestTtsTool_ExplicitProvider_UsesMatchingTenantProvider(t *testing.T) {
+	t.Parallel()
+
+	edgeStub := &stubProvider{name: "edge", shouldErr: true}
+	tenantStub := &stubProvider{name: "openai"}
+
+	mgr := tts.NewManager(tts.ManagerConfig{Primary: "edge"})
+	mgr.RegisterTTS(edgeStub) // no global openai registered
+	mgr.SetTenantResolver(func(_ context.Context) (audio.TTSProvider, string, audio.AutoMode, error) {
+		return tenantStub, "openai", audio.AutoOff, nil
+	})
+
+	tool := NewTtsTool(mgr)
+	result := tool.Execute(context.Background(), map[string]any{
+		"text":     "hello explicit tenant provider",
+		"provider": "openai",
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.ForLLM)
+	}
+	if tenantStub.calls == 0 {
+		t.Fatal("tenant provider should be called for explicit provider=openai")
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes two runtime behavior bugs in GoClaw: (1) `read_audio` STT routing now correctly uses transcription path semantics instead of falling through to chat/completions behavior in wrong cases, and (2) Shell Security Groups changes now persist and apply at runtime (no restart required), including reducing model pre-refusal bias so `exec` is attempted and policy decides allow/deny per turn.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
`dev`

## Checklist
- [ ] `go build ./...` passes
- [ ] `go build -tags sqliteonly ./...` passes (if Go changes)
- [ ] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
1. Automated checks run:
   - `go test ./cmd`
   - `go test ./internal/agent -run TestNoneModeSections`
   - `go test ./internal/tools`-level focused tests added:
     - `internal/tools/read_audio_resolve_test.go`
     - `internal/tools/shell_global_deny_groups_test.go`
2. Build verification:
   - `GOOS=linux GOARCH=arm64 make build-full` (includes web build + embed UI + Go binary build)
3. Manual runtime verification:
   - Updated Shell Security Groups in `/config`, saved, and confirmed changes apply without process restart.
   - Verified `sudo` behavior follows current deny-group config (no stale strict policy after save).
   - Verified agent prompt behavior no longer over-generalizes credentialed CLI approval wording to normal shell commands.
4. Deployment verification (ARM):
   - Binary deployed to `/usr/local/bin/goclaw`
   - Process restarted and verified running new binary hash.
