### PR TITLE
fix(discord): remove redundant allowlist gate blocking pairing/allowlist policies (#985)

### DIFF
--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -58,15 +58,6 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 		}
 	}
 
-	// Check allowlist (for "open" policy, still apply allowlist if configured)
-	if !c.IsAllowed(senderID) {
-		slog.Debug("discord message rejected by allowlist",
-			"user_id", senderID,
-			"username", senderName,
-		)
-		return
-	}
-
 	// Handle bot commands (writer management, etc.) before further processing.
 	if c.tryHandleCommand(m) {
 		return


### PR DESCRIPTION
## Summary
- Fixes #985 — Discord channel failed when DM Policy or Group Policy was set to "Pairing" or "Allowlist only"; only "Open (Accept All)" worked.
- Root cause: `handleMessage` ran a redundant `IsAllowed(senderID)` check **after** `checkDMPolicy` / `checkGroupPolicy`, creating a double-gate. `BaseChannel.CheckDMPolicy` / `CheckGroupPolicy` already handle allowlist + pairing correctly and return `PolicyAllow` for paired users. The extra post-gate then rejected paired users who were not individually in the allowlist.
- Fix aligns Discord with Telegram's pattern (no post-policy allowlist re-check). 9 lines removed, no new code.

## Test plan
- [x] `go build ./...` and `go build -tags sqliteonly ./...` pass
- [x] `go vet ./...` clean
- [x] `go test ./internal/channels/...` all green (policy semantics covered by `internal/channels/policy_test.go`)
- [ ] Manual: Discord DM policy = "pairing" → unpaired user gets pairing code DM, paired user's messages reach agent
- [ ] Manual: Discord DM policy = "allowlist" with allowlist → only allowlisted users pass
- [ ] Manual: Discord Group policy = "pairing" → group pairing flow works end-to-end

Closes #985