### PR TITLE
feat: configurable MCP stdio command allowlist

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -144,6 +144,16 @@ func runGateway() {
 
 	pgStores, traceCollector, snapshotWorker := setupStoresAndTracing(cfg, dataDir, msgBus)
 
+	// Rebuild TTS manager after DB secrets are loaded — setupToolRegistry runs
+	// before setupStoresAndTracing, so providers whose API keys live only in the
+	// config_secrets table (e.g. ElevenLabs) were not registered on first pass.
+	if newTTS := setupTTS(cfg); newTTS != nil {
+		setupAudioExtras(cfg, newTTS)
+		ttsTool.UpdateManager(newTTS)
+		audioMgr = newTTS
+		slog.Info("tts rebuilt after DB secrets loaded", "provider", newTTS.PrimaryProvider(), "auto", string(newTTS.AutoMode()))
+	}
+
 	// Recover from crashes: flip ghost 'summoning' rows to 'summon_failed'.
 	// Summon goroutines don't survive process restart; stale DB rows would trap the UI.
 	if pgStores.Agents != nil {

--- a/cmd/gateway_lifecycle.go
+++ b/cmd/gateway_lifecycle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/edition"
 	"github.com/nextlevelbuilder/goclaw/internal/heartbeat"
+	mcpbridge "github.com/nextlevelbuilder/goclaw/internal/mcp"
 	"github.com/nextlevelbuilder/goclaw/internal/sandbox"
 	"github.com/nextlevelbuilder/goclaw/internal/scheduler"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
@@ -109,6 +110,19 @@ func (d *gatewayDeps) runLifecycle(
 			d.ttsHandler.UpdateManager(newMgr)
 		}
 		slog.Info("tts config reloaded", "provider", newMgr.PrimaryProvider(), "auto", string(newMgr.AutoMode()))
+	})
+
+	// Reload MCP extra allowed commands on config changes via pub/sub.
+	d.msgBus.Subscribe("mcp-commands-reload", func(evt bus.Event) {
+		if evt.Name != bus.TopicConfigChanged {
+			return
+		}
+		updatedCfg, ok := evt.Payload.(*config.Config)
+		if !ok {
+			return
+		}
+		mcpbridge.SetExtraAllowedCommands(updatedCfg.Tools.AllowedCommands)
+		slog.Info("MCP extra commands reloaded", "commands", updatedCfg.Tools.AllowedCommands)
 	})
 
 	// Note: vault enrichment provider is resolved per-tenant at runtime,

--- a/cmd/gateway_setup.go
+++ b/cmd/gateway_setup.go
@@ -161,6 +161,12 @@ func setupToolRegistry(
 		slog.Info("credential scrubbing disabled")
 	}
 
+	// MCP extra allowed commands (extends the hardcoded allowlist for stdio transport)
+	if len(cfg.Tools.AllowedCommands) > 0 {
+		mcpbridge.SetExtraAllowedCommands(cfg.Tools.AllowedCommands)
+		slog.Info("MCP extra commands allowed", "commands", cfg.Tools.AllowedCommands)
+	}
+
 	// MCP servers (config-based: shared across all agents)
 	if len(cfg.Tools.McpServers) > 0 {
 		mcpMgr = mcpbridge.NewManager(toolsReg, mcpbridge.WithConfigs(cfg.Tools.McpServers))

--- a/docs/03-tools-system.md
+++ b/docs/03-tools-system.md
@@ -410,6 +410,18 @@ GoClaw integrates with Model Context Protocol (MCP) servers. The MCP Manager con
 | `sse` | Connect to SSE endpoint via URL |
 | `streamable-http` | Connect to HTTP streaming endpoint |
 
+**Command allowlist (stdio transport):** For security, only well-known runtime commands are permitted by default: `node`, `npx`, `npm`, `python`, `python3`, `ruby`, `go`, `cargo`, `java`, `dotnet`, `php`, `uvx`, `uv`, `pipx`, `deno`, `bun`. To use custom binaries (e.g. `mcp-cldkctl`), add them to `tools.allowed_commands` in config:
+
+```json5
+{
+  "tools": {
+    "allowed_commands": ["mcp-cldkctl", "my-custom-mcp"]
+  }
+}
+```
+
+This can also be configured via the web UI: **Settings → Tools → MCP Allowed Commands**. Changes take effect immediately without restart.
+
 **Reliability:** Health checks every 30 seconds. Reconnection via exponential backoff (2s initial, 60s max, 10 attempts).
 
 **Access control:**

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -376,6 +376,7 @@ type ToolsConfig struct {
 	RateLimitPerHour int                         `json:"rate_limit_per_hour,omitempty"` // max tool executions per hour per session (0 = disabled)
 	ScrubCredentials *bool                       `json:"scrub_credentials,omitempty"`   // auto-redact API keys/tokens in tool output (default true)
 	McpServers       map[string]*MCPServerConfig `json:"mcp_servers,omitempty"`         // external MCP server connections
+	AllowedCommands  []string                    `json:"allowed_commands,omitempty"`    // extra commands allowed for MCP stdio transport
 }
 
 // MCPServerConfig configures a single external MCP server connection.

--- a/internal/mcp/validation.go
+++ b/internal/mcp/validation.go
@@ -20,6 +20,17 @@ var allowedCommands = map[string]bool{
 	"deno": true, "bun": true,
 }
 
+// extraAllowedCommands holds user-configured commands added via config.json "tools.allowed_commands".
+var extraAllowedCommands map[string]bool
+
+// SetExtraAllowedCommands populates the extra command allowlist from config.
+func SetExtraAllowedCommands(cmds []string) {
+	extraAllowedCommands = make(map[string]bool, len(cmds))
+	for _, cmd := range cmds {
+		extraAllowedCommands[cmd] = true
+	}
+}
+
 // Shell metacharacters that indicate injection attempt.
 var shellMetaChars = regexp.MustCompile(`[;|&$` + "`" + `(){}[\]<>]`)
 
@@ -79,14 +90,14 @@ func ValidateCommand(cmd string) error {
 
 	// Allow absolute paths to known commands
 	if strings.HasPrefix(cmd, "/") {
-		if !allowedCommands[basename] {
+		if !allowedCommands[basename] && !extraAllowedCommands[basename] {
 			return fmt.Errorf("command %q not in allowlist", basename)
 		}
 		return nil
 	}
 
 	// Bare command must be in allowlist
-	if !allowedCommands[cmd] {
+	if !allowedCommands[cmd] && !extraAllowedCommands[cmd] {
 		return fmt.Errorf("command %q not in allowlist (allowed: node, npx, python, python3, ruby, go, java, uvx, uv, pipx, deno, bun)", cmd)
 	}
 	return nil

--- a/ui/web/src/i18n/locales/en/config.json
+++ b/ui/web/src/i18n/locales/en/config.json
@@ -209,6 +209,10 @@
   "tools.execAskModeTip": "When to prompt the user for approval before executing a command.",
   "tools.execAllowlistLabel": "Allowed Commands (one pattern per line)",
   "tools.scrubCredentials": "Scrub Credentials",
+  "tools.mcpCommands": "MCP Allowed Commands",
+  "tools.mcpCommandsLabel": "Extra Commands",
+  "tools.mcpCommandsTip": "Custom binary names allowed as MCP server commands (stdio transport). Default runtimes (node, python, etc.) are always allowed.",
+  "tools.mcpCommandsPlaceholder": "Type command name and press Enter",
 
   "tts.title": "Text-to-Speech",
   "tts.configured": "Configured",

--- a/ui/web/src/i18n/locales/vi/config.json
+++ b/ui/web/src/i18n/locales/vi/config.json
@@ -209,6 +209,10 @@
   "tools.execAskModeTip": "Khi nào nhắc người dùng phê duyệt trước khi thực thi lệnh.",
   "tools.execAllowlistLabel": "Lệnh được phép (mỗi dòng một mẫu)",
   "tools.scrubCredentials": "Ẩn thông tin xác thực",
+  "tools.mcpCommands": "Lệnh MCP được phép",
+  "tools.mcpCommandsLabel": "Lệnh bổ sung",
+  "tools.mcpCommandsTip": "Tên binary tùy chỉnh được phép làm lệnh MCP server (stdio transport). Các runtime mặc định (node, python, v.v.) luôn được phép.",
+  "tools.mcpCommandsPlaceholder": "Nhập tên lệnh và nhấn Enter",
 
   "tts.title": "Chuyển văn bản thành giọng nói",
   "tts.configured": "Đã cấu hình",

--- a/ui/web/src/i18n/locales/zh/config.json
+++ b/ui/web/src/i18n/locales/zh/config.json
@@ -209,6 +209,10 @@
   "tools.execAskModeTip": "在执行命令之前何时提示用户审批。",
   "tools.execAllowlistLabel": "允许的命令（每行一个模式）",
   "tools.scrubCredentials": "擦除凭证",
+  "tools.mcpCommands": "MCP 允许的命令",
+  "tools.mcpCommandsLabel": "额外命令",
+  "tools.mcpCommandsTip": "允许作为 MCP 服务器命令（stdio 传输）的自定义二进制文件名称。默认运行时（node、python 等）始终允许。",
+  "tools.mcpCommandsPlaceholder": "输入命令名称后按 Enter",
 
   "tts.title": "文字转语音",
   "tts.configured": "已配置",

--- a/ui/web/src/pages/config/config-page.tsx
+++ b/ui/web/src/pages/config/config-page.tsx
@@ -16,6 +16,7 @@ import { AiDefaultsSection } from "./sections/ai-defaults-section";
 import { QuotaSection } from "./sections/quota-section";
 import { ToolsProfileSection } from "./sections/tools-profile-section";
 import { ToolsExecSection } from "./sections/tools-exec-section";
+import { McpCommandsSection } from "./sections/mcp-commands-section";
 import { ShellSecuritySection } from "./sections/shell-security-section";
 import { TtsSection } from "./sections/tts-section";
 import { CronSection } from "./sections/cron-section";
@@ -144,6 +145,11 @@ export function ConfigPage() {
             saving={saving}
           />
           <ShellSecuritySection
+            data={config.tools as any}
+            onSave={(v) => patch({ tools: v })}
+            saving={saving}
+          />
+          <McpCommandsSection
             data={config.tools as any}
             onSave={(v) => patch({ tools: v })}
             saving={saving}

--- a/ui/web/src/pages/config/sections/mcp-commands-section.tsx
+++ b/ui/web/src/pages/config/sections/mcp-commands-section.tsx
@@ -1,0 +1,68 @@
+import { useState, useEffect } from "react";
+import { Save } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { InfoLabel } from "@/components/shared/info-label";
+import { TagInput } from "@/components/shared/tag-input";
+
+type ToolsData = Record<string, any>;
+
+interface Props {
+  data: ToolsData | undefined;
+  onSave: (value: ToolsData) => Promise<void>;
+  saving: boolean;
+}
+
+export function McpCommandsSection({ data, onSave, saving }: Props) {
+  const { t } = useTranslation("config");
+  const [draft, setDraft] = useState<ToolsData>(data ?? {});
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    setDraft(data ?? {});
+    setDirty(false);
+  }, [data]);
+
+  if (!data) return null;
+
+  const commands: string[] = draft.allowed_commands ?? [];
+
+  const update = (patch: Record<string, any>) => {
+    setDraft((prev) => ({ ...prev, ...patch }));
+    setDirty(true);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">{t("tools.mcpCommands")}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-1.5">
+          <InfoLabel tip={t("tools.mcpCommandsTip")}>
+            {t("tools.mcpCommandsLabel")}
+          </InfoLabel>
+          <TagInput
+            value={commands}
+            onChange={(v) => update({ allowed_commands: v })}
+            placeholder={t("tools.mcpCommandsPlaceholder")}
+          />
+        </div>
+
+        {dirty && (
+          <div className="flex justify-end pt-2">
+            <Button size="sm" onClick={() => onSave(draft)} disabled={saving} className="gap-1.5">
+              <Save className="h-3.5 w-3.5" /> {saving ? t("saving") : t("save")}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- Add configurable `tools.allowed_commands` field to extend the MCP stdio transport command allowlist beyond the hardcoded defaults (node, npx, python, etc.)
- Hot-reload support: config changes via UI take effect immediately without restart
- Web UI section under **Settings → Tools → MCP Allowed Commands** with i18n (en/vi/zh)
- Documentation added to `docs/03-tools-system.md`

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] Web UI build passes (`pnpm build`)
- [ ] Add a custom command via Settings → Tools → MCP Allowed Commands, then create an MCP server with that command — validation passes
- [ ] Remove the custom command from config, try saving — validation rejects as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)