### PR TITLE
feat(codex-pool): split round-robin counter per modality (chat vs image)

### DIFF
--- a/internal/providers/chatgpt_oauth_router.go
+++ b/internal/providers/chatgpt_oauth_router.go
@@ -12,6 +12,13 @@ import (
 const chatGPTOAuthStrategyRoundRobin = "round_robin"
 const chatGPTOAuthStrategyPriorityOrder = "priority_order"
 
+// Modality keys used to scope round-robin counters so that chat and image
+// traffic rotate independently within the same pool. See registry.RoundRobinNext.
+const (
+	chatGPTOAuthModalityChat  = "chat"
+	chatGPTOAuthModalityImage = "image"
+)
+
 // ChatGPTOAuthRouter routes a ChatGPT OAuth-backed agent across multiple
 // authenticated Codex providers while keeping the agent's primary provider as
 // the preferred/default account.
@@ -46,7 +53,7 @@ func NewChatGPTOAuthRouter(
 }
 
 func (p *ChatGPTOAuthRouter) Name() string {
-	selection, err := p.orderedProviders(context.Background(), false)
+	selection, err := p.orderedProviders(context.Background(), chatGPTOAuthModalityChat, false)
 	if err != nil || len(selection) == 0 {
 		return p.defaultProviderName
 	}
@@ -54,7 +61,7 @@ func (p *ChatGPTOAuthRouter) Name() string {
 }
 
 func (p *ChatGPTOAuthRouter) DefaultModel() string {
-	selection, err := p.orderedProviders(context.Background(), false)
+	selection, err := p.orderedProviders(context.Background(), chatGPTOAuthModalityChat, false)
 	if err != nil || len(selection) == 0 {
 		return ""
 	}
@@ -70,7 +77,7 @@ func (p *ChatGPTOAuthRouter) HasRegisteredProviders() bool {
 // HasAvailableProviders reports whether at least one registered Codex provider is
 // route-eligible right now after auth/quota readiness filtering.
 func (p *ChatGPTOAuthRouter) HasAvailableProviders() bool {
-	_, err := p.orderedProviders(context.Background(), false)
+	_, err := p.orderedProviders(context.Background(), chatGPTOAuthModalityChat, false)
 	return err == nil
 }
 
@@ -87,7 +94,7 @@ func (p *ChatGPTOAuthRouter) ChatStream(ctx context.Context, req ChatRequest, on
 }
 
 func (p *ChatGPTOAuthRouter) call(ctx context.Context, fn func(Provider) (*ChatResponse, error)) (*ChatResponse, error) {
-	ordered, err := p.orderedProviders(ctx, true)
+	ordered, err := p.orderedProviders(ctx, chatGPTOAuthModalityChat, true)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +130,7 @@ func (p *ChatGPTOAuthRouter) call(ctx context.Context, fn func(Provider) (*ChatR
 	return nil, lastErr
 }
 
-func (p *ChatGPTOAuthRouter) orderedProviders(ctx context.Context, advance bool) ([]Provider, error) {
+func (p *ChatGPTOAuthRouter) orderedProviders(ctx context.Context, modality string, advance bool) ([]Provider, error) {
 	candidates := p.routeCandidates(ctx)
 	if len(candidates) == 0 {
 		return nil, fmt.Errorf("no authenticated chatgpt_oauth providers available")
@@ -162,8 +169,7 @@ func (p *ChatGPTOAuthRouter) orderedProviders(ctx context.Context, advance bool)
 		return ordered, nil
 	}
 
-	rrKey := compoundKey(p.tenantID, p.defaultProviderName)
-	start := p.registry.RoundRobinNext(rrKey, len(active), advance)
+	start := p.registry.RoundRobinNext(p.tenantID, p.defaultProviderName, modality, len(active), advance)
 
 	ordered := make([]Provider, 0, len(active)+len(fallback))
 	ordered = append(ordered, active[start:]...)

--- a/internal/providers/chatgpt_oauth_router_image.go
+++ b/internal/providers/chatgpt_oauth_router_image.go
@@ -21,7 +21,7 @@ var _ NativeImageProvider = (*ChatGPTOAuthRouter)(nil)
 // advance=true), regardless of which member ultimately serves the response.
 // This matches the Chat path semantics documented on call().
 func (p *ChatGPTOAuthRouter) GenerateImage(ctx context.Context, req NativeImageRequest) (*NativeImageResult, error) {
-	ordered, err := p.orderedProviders(ctx, true)
+	ordered, err := p.orderedProviders(ctx, chatGPTOAuthModalityImage, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/chatgpt_oauth_router_image_test.go
+++ b/internal/providers/chatgpt_oauth_router_image_test.go
@@ -1,11 +1,15 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/uuid"
@@ -63,6 +67,162 @@ var imageReq = NativeImageRequest{Prompt: "a cat", ImageModel: "gpt-image-2"}
 
 // b64img is a non-empty base64 string used as placeholder image data in test SSE responses.
 const b64img = "aW1hZ2VkYXRh" // "imagedata" — not a valid PNG, but parseNativeImageSSE accepts any non-empty b64
+
+// TestChatGPTOAuthRouterImage_ChatBurstDoesNotPerturbImageOrder is the regression
+// test for issue #1018. It uses the issue's exact worked example: chat bursts
+// interleaved between image calls on a 3-account pool.
+//
+// On the OLD shared-counter implementation the image hit sequence was skewed:
+//
+//	5 chat (counter 0→2) │ image1 start=2 → C, counter→0
+//	4 chat (counter 0→1) │ image2 start=1 → B, counter→2
+//	3 chat (counter 2→2) │ image3 start=2 → C, counter→0
+//	                         ─ hits: A=0, B=1, C=2 (skew)
+//
+// On the fixed per-modality implementation the image counter is untouched by
+// chat bursts and advances 0→1→2, giving exact sequence A, B, C (even).
+//
+// Critically, this scenario discriminates buggy vs. fixed code — unlike a test
+// that runs N-consecutive image calls on an N-member pool, which always hits
+// every member once regardless of the starting offset and cannot detect the bug.
+func TestChatGPTOAuthRouterImage_ChatBurstDoesNotPerturbImageOrder(t *testing.T) {
+	tenantID := uuid.New()
+	registry := NewRegistry(nil)
+
+	// Dual-purpose test servers: CodexProvider routes both chat and image to
+	// `{apiBase}/codex/responses` — the request body distinguishes them (image
+	// requests carry a `"type":"image_generation"` tool entry). Each server
+	// counts chat vs image hits based on body inspection.
+	var chatHits, imgHits [3]int
+	mkServer := func(i int) *httptest.Server {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			if bytes.Contains(body, []byte(`"image_generation"`)) {
+				imgHits[i]++
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(imageSSEResponse(b64img)))
+				return
+			}
+			chatHits[i]++
+			writeSSEDone(w)
+		}))
+		t.Cleanup(s.Close)
+		return s
+	}
+	srvA, srvB, srvC := mkServer(0), mkServer(1), mkServer(2)
+
+	registry.RegisterForTenant(tenantID, newImageCodexProvider("acct-a", srvA.URL))
+	registry.RegisterForTenant(tenantID, newImageCodexProvider("acct-b", srvB.URL))
+	registry.RegisterForTenant(tenantID, newImageCodexProvider("acct-c", srvC.URL))
+
+	router := NewChatGPTOAuthRouter(tenantID, registry, "acct-a", "round_robin", []string{"acct-b", "acct-c"})
+
+	// Interleaved pattern from issue #1018: 5 chat, 1 image, 4 chat, 1 image, 3 chat, 1 image.
+	pattern := []struct {
+		chatBurst int
+		image     bool
+	}{
+		{5, true},
+		{4, true},
+		{3, true},
+	}
+	imageOrder := make([]int, 0, 3) // records which server index served each image call
+	for _, step := range pattern {
+		for i := 0; i < step.chatBurst; i++ {
+			if _, err := router.Chat(context.Background(), ChatRequest{
+				Messages: []Message{{Role: "user", Content: "chat"}},
+			}); err != nil {
+				t.Fatalf("chat call failed: %v", err)
+			}
+		}
+		if step.image {
+			before := imgHits
+			if _, err := router.GenerateImage(context.Background(), imageReq); err != nil {
+				t.Fatalf("image call failed: %v", err)
+			}
+			for i := range imgHits {
+				if imgHits[i] > before[i] {
+					imageOrder = append(imageOrder, i)
+					break
+				}
+			}
+		}
+	}
+
+	// Post-fix expectation: image counter is independent, so image order is [A, B, C].
+	// Pre-fix (buggy) expectation with this input would be [C, B, C] — NOT all distinct.
+	wantOrder := []int{0, 1, 2}
+	if len(imageOrder) != 3 {
+		t.Fatalf("imageOrder length = %d, want 3 (hits=%v)", len(imageOrder), imgHits)
+	}
+	for i, got := range imageOrder {
+		if got != wantOrder[i] {
+			t.Fatalf("image call %d hit acct-%c, want acct-%c (order=%v, hits=%v)",
+				i, 'a'+byte(got), 'a'+byte(wantOrder[i]), imageOrder, imgHits)
+		}
+	}
+
+	// And each image server MUST have been hit exactly once (acceptance criterion from #1018).
+	for i, n := range imgHits {
+		if n != 1 {
+			t.Fatalf("image server acct-%c hit %d times, want 1 (hits=%v)", 'a'+byte(i), n, imgHits)
+		}
+	}
+}
+
+// TestChatGPTOAuthRouter_IntrospectionDoesNotAdvanceCounter guards the invariant
+// that Name(), DefaultModel(), and HasAvailableProviders() use advance=false when
+// calling orderedProviders — i.e. calling them never rotates live traffic offsets.
+// If someone flips those to advance=true in a refactor, this test fails fast.
+func TestChatGPTOAuthRouter_IntrospectionDoesNotAdvanceCounter(t *testing.T) {
+	tenantID := uuid.New()
+	registry := NewRegistry(nil)
+
+	var hitsA, hitsB, hitsC int
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hitsA++
+		writeSSEDone(w)
+	}))
+	t.Cleanup(serverA.Close)
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hitsB++
+		writeSSEDone(w)
+	}))
+	t.Cleanup(serverB.Close)
+	serverC := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hitsC++
+		writeSSEDone(w)
+	}))
+	t.Cleanup(serverC.Close)
+
+	pa := newImageCodexProvider("acct-a", serverA.URL)
+	pb := newImageCodexProvider("acct-b", serverB.URL)
+	pc := newImageCodexProvider("acct-c", serverC.URL)
+	registry.RegisterForTenant(tenantID, pa)
+	registry.RegisterForTenant(tenantID, pb)
+	registry.RegisterForTenant(tenantID, pc)
+
+	router := NewChatGPTOAuthRouter(tenantID, registry, "acct-a", "round_robin", []string{"acct-b", "acct-c"})
+
+	// Call introspection 20 times — counter must stay at 0.
+	for i := 0; i < 20; i++ {
+		_ = router.Name()
+		_ = router.DefaultModel()
+		_ = router.HasAvailableProviders()
+	}
+
+	// One real chat call — must hit acct-a (counter was never advanced).
+	if _, err := router.Chat(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	}); err != nil {
+		t.Fatalf("chat failed: %v", err)
+	}
+	if hitsA != 1 || hitsB != 0 || hitsC != 0 {
+		t.Fatalf("introspection leaked counter advance: hitsA=%d hitsB=%d hitsC=%d, want 1/0/0",
+			hitsA, hitsB, hitsC)
+	}
+}
 
 // TestChatGPTOAuthRouterImage_RoundRobin_RotatesAcrossCalls verifies that 2 successive
 // GenerateImage calls each hit a different pool member (round-robin distribution).
@@ -238,5 +398,89 @@ func TestChatGPTOAuthRouterImage_RoundRobinAdvancesPerCall(t *testing.T) {
 	}
 	if hitsB != 1 {
 		t.Fatalf("hitsB = %d, want 1", hitsB)
+	}
+}
+
+// TestChatGPTOAuthRouter_ChatAndImageConcurrent_CountersIndependent is the
+// concurrent stress proof of issue #1018's core thesis: chat and image
+// rotation counters must not corrupt each other under parallel load.
+//
+// On a 3-member pool, N chat calls and N image calls run concurrently;
+// with independent per-modality counters both modalities MUST distribute
+// ~evenly (each server ±1 of N/3 for its modality). Any shared state would
+// show either a data race (caught by -race) or visible skew.
+func TestChatGPTOAuthRouter_ChatAndImageConcurrent_CountersIndependent(t *testing.T) {
+	tenantID := uuid.New()
+	registry := NewRegistry(nil)
+
+	var chatHits, imgHits [3]int64
+	mkServer := func(i int) *httptest.Server {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			if bytes.Contains(body, []byte(`"image_generation"`)) {
+				atomic.AddInt64(&imgHits[i], 1)
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(imageSSEResponse(b64img)))
+				return
+			}
+			atomic.AddInt64(&chatHits[i], 1)
+			writeSSEDone(w)
+		}))
+		t.Cleanup(s.Close)
+		return s
+	}
+	srvA, srvB, srvC := mkServer(0), mkServer(1), mkServer(2)
+
+	registry.RegisterForTenant(tenantID, newImageCodexProvider("acct-a", srvA.URL))
+	registry.RegisterForTenant(tenantID, newImageCodexProvider("acct-b", srvB.URL))
+	registry.RegisterForTenant(tenantID, newImageCodexProvider("acct-c", srvC.URL))
+
+	router := NewChatGPTOAuthRouter(tenantID, registry, "acct-a", "round_robin", []string{"acct-b", "acct-c"})
+
+	const perModality = 90 // divisible by 3 so even distribution is achievable
+	var wg sync.WaitGroup
+	wg.Add(perModality * 2)
+	for i := 0; i < perModality; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := router.Chat(context.Background(), ChatRequest{
+				Messages: []Message{{Role: "user", Content: "c"}},
+			}); err != nil {
+				t.Errorf("chat failed: %v", err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if _, err := router.GenerateImage(context.Background(), imageReq); err != nil {
+				t.Errorf("image failed: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Total hits per modality must equal perModality.
+	totalChat := chatHits[0] + chatHits[1] + chatHits[2]
+	totalImg := imgHits[0] + imgHits[1] + imgHits[2]
+	if totalChat != perModality {
+		t.Fatalf("total chat hits = %d, want %d", totalChat, perModality)
+	}
+	if totalImg != perModality {
+		t.Fatalf("total image hits = %d, want %d", totalImg, perModality)
+	}
+	// Each server should get exactly perModality/3 hits per modality for a pure
+	// round-robin under no failover. Allow slack for scheduling but assert no
+	// member is starved and none is over-served beyond a small tolerance.
+	expected := int64(perModality / 3)
+	const slack = int64(5) // generous — any real bug produces much larger skew
+	for i := 0; i < 3; i++ {
+		if chatHits[i] < expected-slack || chatHits[i] > expected+slack {
+			t.Errorf("chat server %d hits = %d, want ~%d (±%d); all=%v",
+				i, chatHits[i], expected, slack, chatHits)
+		}
+		if imgHits[i] < expected-slack || imgHits[i] > expected+slack {
+			t.Errorf("image server %d hits = %d, want ~%d (±%d); all=%v",
+				i, imgHits[i], expected, slack, imgHits)
+		}
 	}
 }

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -21,8 +21,10 @@ type Registry struct {
 	mu            sync.RWMutex
 	tenantFromCtx func(context.Context) uuid.UUID // injected to avoid circular import with store
 
-	// roundRobinCounters stores shared round-robin state keyed by "tenantID/providerName"
-	// so that ChatGPTOAuthRouter instances (created per-request) share rotation state.
+	// roundRobinCounters stores shared round-robin state keyed by "tenantID/providerName/modality"
+	// so that ChatGPTOAuthRouter instances (created per-request) share rotation state
+	// within a modality (e.g. chat) while keeping distinct modalities (e.g. image)
+	// rotating on independent counters — see RoundRobinNext.
 	roundRobinMu       sync.Mutex
 	roundRobinCounters map[string]int
 }
@@ -37,10 +39,17 @@ func NewRegistry(tenantFromCtx func(context.Context) uuid.UUID) *Registry {
 	}
 }
 
-// RoundRobinNext returns the current round-robin index for the given key and
-// optionally advances it. Used by ChatGPTOAuthRouter to persist rotation state
-// across per-request router instances.
-func (r *Registry) RoundRobinNext(key string, poolSize int, advance bool) int {
+// RoundRobinNext returns the current round-robin index for the given
+// (tenant, base provider, modality) triple and optionally advances it.
+// Used by ChatGPTOAuthRouter to persist rotation state across per-request
+// router instances. The modality segment (e.g. "chat", "image") keeps
+// independent counters per modality so that bursty traffic on one modality
+// cannot skew the offset used by another.
+func (r *Registry) RoundRobinNext(tenantID uuid.UUID, baseProviderName, modality string, poolSize int, advance bool) int {
+	if poolSize <= 0 {
+		return 0
+	}
+	key := roundRobinKey(tenantID, baseProviderName, modality)
 	r.roundRobinMu.Lock()
 	defer r.roundRobinMu.Unlock()
 	idx := r.roundRobinCounters[key] % poolSize
@@ -48,6 +57,11 @@ func (r *Registry) RoundRobinNext(key string, poolSize int, advance bool) int {
 		r.roundRobinCounters[key] = (idx + 1) % poolSize
 	}
 	return idx
+}
+
+// roundRobinKey builds the compound key for a tenant-scoped, per-modality counter.
+func roundRobinKey(tenantID uuid.UUID, baseProviderName, modality string) string {
+	return tenantID.String() + "/" + baseProviderName + "/" + modality
 }
 
 // compoundKey returns "tenantID/name" for registry lookup.


### PR DESCRIPTION
## Summary

- Add a `modality` segment to the Codex-pool round-robin counter key so chat and image traffic rotate independently within the same pool.
- `Registry.RoundRobinNext` now takes `(tenantID, baseProviderName, modality, poolSize, advance)` and keys state on `tenantID/baseProviderName/modality`.
- `ChatGPTOAuthRouter` threads `"chat"` through Chat/ChatStream and `"image"` through GenerateImage.

Closes #1018

## Root Cause

Before this change, `Registry.RoundRobinNext` used a single counter per `(tenantID, baseProviderName)` and was advanced once per call from **both** `ChatGPTOAuthRouter.Chat` and `ChatGPTOAuthRouter.GenerateImage`. On small pools (2-3 accounts) with bursty mixed traffic, chat bursts shifted the shared offset so image calls landed on a skewed subset of members over short windows (see issue body for the 3-account worked example).

## What changed

| File | Change |
|------|--------|
| `internal/providers/registry.go` | `RoundRobinNext` signature now `(tenantID, baseProviderName, modality, poolSize, advance)`; compound key is `tenantID/baseProviderName/modality`; zero `poolSize` guarded; struct doc comment updated |
| `internal/providers/chatgpt_oauth_router.go` | `orderedProviders` accepts a modality arg; `Chat`/`ChatStream` and introspection paths pass `"chat"`; modality constants added |
| `internal/providers/chatgpt_oauth_router_image.go` | `GenerateImage` passes `"image"` |
| `internal/providers/chatgpt_oauth_router_image_test.go` | Three new/replacement tests — see Test Coverage below |

## Test Coverage (post red-team)

| Test | What it guards |
|------|----------------|
| `TestChatGPTOAuthRouterImage_ChatBurstDoesNotPerturbImageOrder` | Regression: uses the issue's exact interleaved worked example (5 chat → 1 image → 4 chat → 1 image → 3 chat → 1 image). Buggy path yields order `[C, B, C]`; fixed path yields `[A, B, C]`. A naive "N consecutive image calls on N-member pool" test was rejected as tautological — modulo-N arithmetic makes it pass on both buggy and fixed code. |
| `TestChatGPTOAuthRouter_IntrospectionDoesNotAdvanceCounter` | 20× interleaved `Name()` / `DefaultModel()` / `HasAvailableProviders()` calls followed by one `Chat` — must still hit `acct-a`. Protects `advance=false` invariant from silent refactor regressions. |
| `TestChatGPTOAuthRouter_ChatAndImageConcurrent_CountersIndependent` | 90 chat + 90 image goroutines in parallel; each modality must distribute ~evenly across all 3 servers (±5 slack). Combined with `-race`, proves the modality-split invariant holds under load. |

## Validation

- [x] `go build ./...` (PG) passes
- [x] `go build -tags sqliteonly ./...` (Desktop/Lite) passes
- [x] `go vet ./internal/providers/...` clean
- [x] `go test -race ./internal/providers/... -count=1` — 723 tests pass
- [x] Pre-existing `TestChatGPTOAuthRouterRoundRobin` unchanged and passes (chat-only rotation semantics preserved)
- [x] New interleaved regression test verified to fail against the pre-fix counter arithmetic (trace in test doc comment)

## Red-Team Findings (resolved)

- **[Critical]** Original regression test was tautological on a 3-member pool with 3 sequential image calls — replaced with interleaved scenario above.
- **[Medium]** No guard on introspection-path `advance=false` invariant — new `IntrospectionDoesNotAdvanceCounter` test added.
- **[Medium]** No concurrent proof of counter independence — new concurrent test added, race-clean.
- **[Trivial]** Stale doc comment on `Registry.roundRobinCounters` — updated.

## Deferred (not blocking)

- Pool-size=1 boundary: `orderedProviders` early-returns before invoking `RoundRobinNext` when `len(active) == 1`, so modality key is never written in that path. Not a correctness bug; YAGNI.
- Multi-tenant isolation test: structurally guaranteed by the tenant segment in the compound key; existing code-paths already exercise tenant isolation.
- `ChatGPTOAuthRoutingObservation.SetPool` does not record modality; observations are per-request (either chat or image, never both in one record) so no diagnostic signal is lost.

## Notes

- Signature keeps `poolSize` and `advance` params — issue text illustrated a 3-arg shape but callers still need both for atomic offset pick + advance under the registry mutex. The essential change is the compound key.
- `Name()`, `DefaultModel()`, `HasAvailableProviders()` introspection paths pass `"chat"` by convention; `advance=false` means no counter mutation and thus no cross-modality leakage.