### PR TITLE
fix(sandbox): sanitize @ in container names for WhatsApp LID chat IDs

### DIFF
--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -432,6 +432,7 @@ func sanitizeKey(key string) string {
 		"/", "-",
 		" ", "-",
 		".", "-",
+		"@", "-",
 	).Replace(key)
 
 	if len(safe) > 50 {

--- a/internal/sandbox/docker_test.go
+++ b/internal/sandbox/docker_test.go
@@ -97,6 +97,7 @@ func TestSanitizeKey(t *testing.T) {
 		{"simple", "simple"},
 		{"has/slash", "has-slash"},
 		{"has space", "has-space"},
+		{"agent:chloe:whatsapp:551152861098:5@s.whatsapp.net", "agent-chloe-whatsapp-551152861098-5-s-whatsapp-net"},
 		{strings.Repeat("x", 100), strings.Repeat("x", 50)},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

`sanitizeKey()` in `internal/sandbox/docker.go` replaces `:`, `/`, ` `, `.` with `-` but misses `@`. WhatsApp LID-format chat IDs like `551152861098:5@s.whatsapp.net` produce container names containing `@`, which Docker rejects as invalid.

- Add `"@", "-"` to the `strings.NewReplacer` call
- Add test case with a realistic WhatsApp LID key

## Test plan

- [x] `go test ./internal/sandbox/ -run TestSanitizeKey` passes
- [ ] WhatsApp-triggered agent sessions create sandbox containers successfully

Fixes #1029