### PR TITLE
fix(cron): always reset session before cron runs — stateless flag inverted

### DIFF
--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -88,8 +88,11 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 		// Reset session before each cron run to prevent tool errors from previous
 		// runs from polluting the context and blocking future executions (#294).
 		// Save() persists the empty session to DB so stale data won't reload after restart.
-		// Stateless jobs skip this — they intentionally carry no session history.
-		if !job.Stateless {
+		// Always reset cron sessions to prevent message accumulation across runs.
+		// Stateless jobs especially need this — the agent loop persists messages
+		// to the session regardless of the stateless flag, so without a reset
+		// the session grows indefinitely.
+		{
 			sessionMgr.Reset(cronCtx, sessionKey)
 			sessionMgr.Save(cronCtx, sessionKey)
 		}


### PR DESCRIPTION
## Summary

Cron jobs with `stateless=true` accumulate unbounded session history because the reset logic is inverted.

**Current code** (`cmd/gateway_cron.go:92`):
```go
if !job.Stateless {
    sessionMgr.Reset(cronCtx, sessionKey)
    sessionMgr.Save(cronCtx, sessionKey)
}
```

This resets **non-stateless** jobs but **skips** stateless ones. The agent loop always persists messages to the session key regardless of the stateless flag, so stateless cron sessions grow indefinitely.

**Observed in production:** A stateless cron job accumulated 230KB of messages over ~10 runs. The model saw stale context from previous runs, causing it to skip data collection ("already done").

**Fix:** Remove the condition — always reset before cron execution. This is consistent with the intent of #294 (which added the reset to prevent error accumulation) and ensures stateless jobs actually start fresh.

## Test plan

- [x] Verified in production: deleting the accumulated session + running with reset fixed the behavior
- [ ] Stateless cron job starts with empty message history each run
- [ ] Non-stateless cron jobs still work (they were already being reset per #294)