### PR TITLE
feat(exec): detect credentialed CLIs in shell chains + allow_chain_exec injection mode

### DIFF
--- a/internal/http/secure_cli.go
+++ b/internal/http/secure_cli.go
@@ -161,6 +161,7 @@ type secureCLICreateRequest struct {
 	TimeoutSeconds int             `json:"timeout_seconds,omitempty"`
 	Tips           string          `json:"tips,omitempty"`
 	IsGlobal       *bool           `json:"is_global,omitempty"`
+	AllowChainExec *bool  `json:"allow_chain_exec,omitempty"`
 	Enabled        bool            `json:"enabled"`
 }
 
@@ -225,6 +226,7 @@ func (h *SecureCLIHandler) handleCreate(w http.ResponseWriter, r *http.Request) 
 		TimeoutSeconds: req.TimeoutSeconds,
 		Tips:           req.Tips,
 		IsGlobal:       req.IsGlobal == nil || *req.IsGlobal, // default true
+		AllowChainExec: req.AllowChainExec != nil && *req.AllowChainExec,
 		Enabled:        req.Enabled,
 		CreatedBy:      store.UserIDFromContext(r.Context()),
 	}
@@ -282,7 +284,7 @@ func (h *SecureCLIHandler) handleUpdate(w http.ResponseWriter, r *http.Request) 
 	allowed := map[string]bool{
 		"binary_name": true, "binary_path": true, "description": true,
 		"env": true, "deny_args": true, "deny_verbose": true,
-		"timeout_seconds": true, "tips": true, "is_global": true, "enabled": true,
+		"timeout_seconds": true, "tips": true, "is_global": true, "allow_chain_exec": true, "enabled": true,
 	}
 	for k := range updates {
 		if !allowed[k] {

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -98,6 +98,9 @@ func newDockerSandbox(ctx context.Context, name string, cfg Config, workspace st
 		hostPath := resolveHostWorkspacePath(ctx, workspace)
 		args = append(args, "-v", fmt.Sprintf("%s:%s:%s", hostPath, containerWorkdir, mountOpt))
 	}
+
+	// Mount data volume read-only so sandbox can access skills, config, etc.
+	args = append(args, "-v", "app_goclaw-data:/app/data:ro")
 	args = append(args, "-w", containerWorkdir)
 
 	// Environment variables

--- a/internal/store/pg/secure_cli.go
+++ b/internal/store/pg/secure_cli.go
@@ -70,7 +70,7 @@ func (s *PGSecureCLIStore) Create(ctx context.Context, b *store.SecureCLIBinary)
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO secure_cli_binaries (id, binary_name, binary_path, description, encrypted_env,
 		 deny_args, deny_verbose, timeout_seconds, tips, is_global, allow_chain_exec, enabled, created_by, created_at, updated_at, tenant_id)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
 		b.ID, b.BinaryName, nilStr(derefStr(b.BinaryPath)), b.Description,
 		envBytes,
 		jsonOrEmptyArray(b.DenyArgs), jsonOrEmptyArray(b.DenyVerbose),

--- a/internal/store/pg/secure_cli.go
+++ b/internal/store/pg/secure_cli.go
@@ -27,12 +27,12 @@ func NewPGSecureCLIStore(db *sql.DB, encryptionKey string) *PGSecureCLIStore {
 }
 
 const secureCLISelectCols = `id, binary_name, binary_path, description, encrypted_env,
- deny_args, deny_verbose, timeout_seconds, tips, is_global, enabled, created_by, created_at, updated_at`
+ deny_args, deny_verbose, timeout_seconds, tips, is_global, allow_chain_exec, enabled, created_by, created_at, updated_at`
 
 // secureCLISelectColsAliased is prefixed with table alias "b."
 // Required for LookupByBinary which uses LEFT JOIN (ambiguous column names without prefix).
 const secureCLISelectColsAliased = `b.id, b.binary_name, b.binary_path, b.description, b.encrypted_env,
- b.deny_args, b.deny_verbose, b.timeout_seconds, b.tips, b.is_global, b.enabled, b.created_by, b.created_at, b.updated_at`
+ b.deny_args, b.deny_verbose, b.timeout_seconds, b.tips, b.is_global, b.allow_chain_exec, b.enabled, b.created_by, b.created_at, b.updated_at`
 
 func (s *PGSecureCLIStore) Create(ctx context.Context, b *store.SecureCLIBinary) error {
 	if err := store.ValidateUserID(b.CreatedBy); err != nil {
@@ -69,13 +69,13 @@ func (s *PGSecureCLIStore) Create(ctx context.Context, b *store.SecureCLIBinary)
 
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO secure_cli_binaries (id, binary_name, binary_path, description, encrypted_env,
-		 deny_args, deny_verbose, timeout_seconds, tips, is_global, enabled, created_by, created_at, updated_at, tenant_id)
+		 deny_args, deny_verbose, timeout_seconds, tips, is_global, allow_chain_exec, enabled, created_by, created_at, updated_at, tenant_id)
 		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
 		b.ID, b.BinaryName, nilStr(derefStr(b.BinaryPath)), b.Description,
 		envBytes,
 		jsonOrEmptyArray(b.DenyArgs), jsonOrEmptyArray(b.DenyVerbose),
 		b.TimeoutSeconds, b.Tips,
-		b.IsGlobal, b.Enabled,
+		b.IsGlobal, b.AllowChainExec, b.Enabled,
 		b.CreatedBy, now, now, tenantID,
 	)
 	return err
@@ -105,7 +105,7 @@ func (s *PGSecureCLIStore) scanRow(row *sql.Row) (*store.SecureCLIBinary, error)
 	err := row.Scan(
 		&b.ID, &b.BinaryName, &binaryPath, &b.Description, &env,
 		&denyArgs, &denyVerbose,
-		&b.TimeoutSeconds, &b.Tips, &b.IsGlobal,
+		&b.TimeoutSeconds, &b.Tips, &b.IsGlobal, &b.AllowChainExec,
 		&b.Enabled, &b.CreatedBy, &b.CreatedAt, &b.UpdatedAt,
 	)
 	if err != nil {
@@ -147,7 +147,7 @@ func (s *PGSecureCLIStore) scanRows(rows *sql.Rows) ([]store.SecureCLIBinary, er
 		if err := rows.Scan(
 			&b.ID, &b.BinaryName, &binaryPath, &b.Description, &env,
 			&denyArgs, &denyVerbose,
-			&b.TimeoutSeconds, &b.Tips, &b.IsGlobal,
+			&b.TimeoutSeconds, &b.Tips, &b.IsGlobal, &b.AllowChainExec,
 			&b.Enabled, &b.CreatedBy, &b.CreatedAt, &b.UpdatedAt,
 		); err != nil {
 			continue
@@ -177,7 +177,7 @@ func (s *PGSecureCLIStore) scanRows(rows *sql.Rows) ([]store.SecureCLIBinary, er
 var secureCLIAllowedFields = map[string]bool{
 	"binary_name": true, "binary_path": true, "description": true,
 	"encrypted_env": true, "deny_args": true, "deny_verbose": true,
-	"timeout_seconds": true, "tips": true, "is_global": true, "enabled": true,
+	"timeout_seconds": true, "tips": true, "is_global": true, "allow_chain_exec": true, "enabled": true,
 	"updated_at": true,
 }
 
@@ -344,7 +344,7 @@ func (s *PGSecureCLIStore) scanRowWithGrantAndUserEnv(row *sql.Row) (*store.Secu
 	err := row.Scan(
 		&b.ID, &b.BinaryName, &binaryPath, &b.Description, &env,
 		&denyArgs, &denyVerbose,
-		&b.TimeoutSeconds, &b.Tips, &b.IsGlobal,
+		&b.TimeoutSeconds, &b.Tips, &b.IsGlobal, &b.AllowChainExec,
 		&b.Enabled, &b.CreatedBy, &b.CreatedAt, &b.UpdatedAt,
 		// Grant columns
 		&grantDenyArgs, &grantDenyVerbose, &grantTimeout, &grantTips, &grantEnabled, &grantID,
@@ -498,7 +498,7 @@ func (s *PGSecureCLIStore) ListForAgent(ctx context.Context, agentID uuid.UUID) 
 		if err := rows.Scan(
 			&b.ID, &b.BinaryName, &binaryPath, &b.Description, &env,
 			&denyArgs, &denyVerbose,
-			&b.TimeoutSeconds, &b.Tips, &b.IsGlobal,
+			&b.TimeoutSeconds, &b.Tips, &b.IsGlobal, &b.AllowChainExec,
 			&b.Enabled, &b.CreatedBy, &b.CreatedAt, &b.UpdatedAt,
 			&grantDenyArgs, &grantDenyVerbose, &grantTimeout, &grantTips, &grantID,
 		); err != nil {

--- a/internal/store/secure_cli_store.go
+++ b/internal/store/secure_cli_store.go
@@ -21,6 +21,7 @@ type SecureCLIBinary struct {
 	TimeoutSeconds int             `json:"timeout_seconds" db:"timeout_seconds"`
 	Tips           string          `json:"tips" db:"tips"`            // hint injected into TOOLS.md context
 	IsGlobal       bool            `json:"is_global" db:"is_global"`
+	AllowChainExec bool            `json:"allow_chain_exec" db:"allow_chain_exec"`
 	Enabled        bool            `json:"enabled" db:"enabled"`
 	CreatedBy      string          `json:"created_by" db:"created_by"`
 	UserEnv        []byte          `json:"-" db:"-"` // per-user encrypted env (populated by LookupByBinary LEFT JOIN)

--- a/internal/store/sqlitestore/secure-cli.go
+++ b/internal/store/sqlitestore/secure-cli.go
@@ -31,7 +31,7 @@ func NewSQLiteSecureCLIStore(db *sql.DB, encKey string) *SQLiteSecureCLIStore {
 }
 
 const secureCLISelectCols = `id, binary_name, binary_path, description, encrypted_env,
- deny_args, deny_verbose, timeout_seconds, tips, is_global, enabled, created_by, created_at, updated_at`
+ deny_args, deny_verbose, timeout_seconds, tips, is_global, allow_chain_exec, enabled, created_by, created_at, updated_at`
 
 const secureCLISelectColsAliased = `b.id, b.binary_name, b.binary_path, b.description, b.encrypted_env,
  b.deny_args, b.deny_verbose, b.timeout_seconds, b.tips, b.is_global, b.enabled, b.created_by, b.created_at, b.updated_at`
@@ -71,13 +71,13 @@ func (s *SQLiteSecureCLIStore) Create(ctx context.Context, b *store.SecureCLIBin
 
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO secure_cli_binaries (id, binary_name, binary_path, description, encrypted_env,
-		 deny_args, deny_verbose, timeout_seconds, tips, is_global, enabled, created_by, created_at, updated_at, tenant_id)
+		 deny_args, deny_verbose, timeout_seconds, tips, is_global, allow_chain_exec, enabled, created_by, created_at, updated_at, tenant_id)
 		 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		b.ID, b.BinaryName, nilStr(derefStr(b.BinaryPath)), b.Description,
 		envBytes,
 		jsonOrEmptyArray(b.DenyArgs), jsonOrEmptyArray(b.DenyVerbose),
 		b.TimeoutSeconds, b.Tips,
-		b.IsGlobal, b.Enabled,
+		b.IsGlobal, b.AllowChainExec, b.Enabled,
 		b.CreatedBy, nowStr, nowStr, tenantID,
 	)
 	return err
@@ -108,7 +108,7 @@ func (s *SQLiteSecureCLIStore) scanRow(row *sql.Row) (*store.SecureCLIBinary, er
 	err := row.Scan(
 		&b.ID, &b.BinaryName, &binaryPath, &b.Description, &env,
 		&denyArgs, &denyVerbose,
-		&b.TimeoutSeconds, &b.Tips, &b.IsGlobal,
+		&b.TimeoutSeconds, &b.Tips, &b.IsGlobal, &b.AllowChainExec,
 		&b.Enabled, &b.CreatedBy, &createdAt, &updatedAt,
 	)
 	if err != nil {
@@ -153,7 +153,7 @@ func (s *SQLiteSecureCLIStore) scanRows(rows *sql.Rows) ([]store.SecureCLIBinary
 		if err := rows.Scan(
 			&b.ID, &b.BinaryName, &binaryPath, &b.Description, &env,
 			&denyArgs, &denyVerbose,
-			&b.TimeoutSeconds, &b.Tips, &b.IsGlobal,
+			&b.TimeoutSeconds, &b.Tips, &b.IsGlobal, &b.AllowChainExec,
 			&b.Enabled, &b.CreatedBy, &createdAt, &updatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan secure_cli_binaries row: %w", err)
@@ -185,7 +185,7 @@ func (s *SQLiteSecureCLIStore) scanRows(rows *sql.Rows) ([]store.SecureCLIBinary
 var secureCLIAllowedFields = map[string]bool{
 	"binary_name": true, "binary_path": true, "description": true,
 	"encrypted_env": true, "deny_args": true, "deny_verbose": true,
-	"timeout_seconds": true, "tips": true, "is_global": true, "enabled": true,
+	"timeout_seconds": true, "tips": true, "is_global": true, "allow_chain_exec": true, "enabled": true,
 	"updated_at": true,
 }
 
@@ -345,7 +345,7 @@ func (s *SQLiteSecureCLIStore) scanRowWithGrantAndUserEnv(row *sql.Row) (*store.
 	err := row.Scan(
 		&b.ID, &b.BinaryName, &binaryPath, &b.Description, &env,
 		&denyArgs, &denyVerbose,
-		&b.TimeoutSeconds, &b.Tips, &b.IsGlobal,
+		&b.TimeoutSeconds, &b.Tips, &b.IsGlobal, &b.AllowChainExec,
 		&b.Enabled, &b.CreatedBy, &createdAt, &updatedAt,
 		&grantDenyArgs, &grantDenyVerbose, &grantTimeout, &grantTips, &grantEnabled, &grantID,
 		&userEnv,
@@ -500,7 +500,7 @@ func (s *SQLiteSecureCLIStore) ListForAgent(ctx context.Context, agentID uuid.UU
 		if err := rows.Scan(
 			&b.ID, &b.BinaryName, &binaryPath, &b.Description, &env,
 			&denyArgs, &denyVerbose,
-			&b.TimeoutSeconds, &b.Tips, &b.IsGlobal,
+			&b.TimeoutSeconds, &b.Tips, &b.IsGlobal, &b.AllowChainExec,
 			&b.Enabled, &b.CreatedBy, &createdAt, &updatedAt,
 			&grantDenyArgs, &grantDenyVerbose, &grantTimeout, &grantTips, &grantID,
 		); err != nil {

--- a/internal/store/sqlitestore/secure-cli.go
+++ b/internal/store/sqlitestore/secure-cli.go
@@ -72,7 +72,7 @@ func (s *SQLiteSecureCLIStore) Create(ctx context.Context, b *store.SecureCLIBin
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO secure_cli_binaries (id, binary_name, binary_path, description, encrypted_env,
 		 deny_args, deny_verbose, timeout_seconds, tips, is_global, allow_chain_exec, enabled, created_by, created_at, updated_at, tenant_id)
-		 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		b.ID, b.BinaryName, nilStr(derefStr(b.BinaryPath)), b.Description,
 		envBytes,
 		jsonOrEmptyArray(b.DenyArgs), jsonOrEmptyArray(b.DenyVerbose),

--- a/internal/tools/credential_context.go
+++ b/internal/tools/credential_context.go
@@ -32,7 +32,11 @@ func GenerateCredentialContext(creds []store.SecureCLIBinary) string {
 	b.WriteString("### Available CLIs:\n\n")
 
 	for _, c := range creds {
-		b.WriteString(fmt.Sprintf("**%s** — %s\n", c.BinaryName, c.Description))
+		if c.AllowChainExec {
+			b.WriteString(fmt.Sprintf("**%s** — %s (chain exec: credentials injected even in shell chains)\n", c.BinaryName, c.Description))
+		} else {
+			b.WriteString(fmt.Sprintf("**%s** — %s\n", c.BinaryName, c.Description))
+		}
 		if blocked := summarizeDenyPatterns(c.DenyArgs); blocked != "" {
 			b.WriteString(fmt.Sprintf("  Blocked: %s\n", blocked))
 		}

--- a/internal/tools/credentialed_exec.go
+++ b/internal/tools/credentialed_exec.go
@@ -665,3 +665,60 @@ func credentialedExecFailError(binary string, args []string, exitCode int, outpu
 		IsError: true,
 	}
 }
+
+// detectCredentialedBinaryInChain scans a command that contains shell operators
+// for any token that matches a registered credentialed binary. Returns the
+// binary name if found, empty string otherwise. This catches cases where the
+// LLM wraps a credentialed CLI in a shell chain (e.g. "which gh && gh pr list")
+// — the first binary ("which") is not credentialed so lookupCredentialedBinary
+// misses it, but "gh" deeper in the chain IS credentialed and would run without
+// token injection if allowed to fall through to regular exec.
+//
+// Uses extractUnquotedSegments (quote-aware) so that operators inside quoted
+// arguments (e.g. --jq '.[0] | .name') are not mistaken for command chains.
+func (t *ExecTool) detectCredentialedBinaryInChain(ctx context.Context, command string) string {
+	if t.secureCLIStore == nil {
+		return ""
+	}
+	// Only check commands that have shell operators outside of quotes.
+	// detectUnquotedShellOperators already uses extractUnquotedSegments
+	// internally, so quoted pipes/semicolons are ignored.
+	if ops := detectUnquotedShellOperators(command); len(ops) == 0 {
+		return ""
+	}
+	// Extract only the unquoted portions of the command. This collapses
+	// quoted strings so that operators inside quotes disappear entirely,
+	// preventing false splits on e.g. '.[0] | .name'.
+	unquoted := extractUnquotedSegments(command)
+	// Split the unquoted text on shell operator characters. This is safe
+	// because extractUnquotedSegments already stripped all quoted content.
+	segments := shellOperatorPattern.Split(unquoted, -1)
+	for _, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		// Use go-shellwords to parse the segment's first token, handling
+		// edge cases like leading whitespace or escaped characters.
+		parser := shellwords.NewParser()
+		parser.ParseBacktick = false
+		parser.ParseEnv = false
+		words, err := parser.Parse(seg)
+		if err != nil || len(words) == 0 {
+			// Fallback to simple field split if shellwords fails
+			fields := strings.Fields(seg)
+			if len(fields) == 0 {
+				continue
+			}
+			words = fields[:1]
+		}
+		binary := normalizeBinaryName(words[0])
+		gctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		registered, rerr := t.secureCLIStore.IsRegisteredBinary(gctx, binary)
+		cancel()
+		if rerr == nil && registered {
+			return binary
+		}
+	}
+	return ""
+}

--- a/internal/tools/credentialed_exec.go
+++ b/internal/tools/credentialed_exec.go
@@ -722,3 +722,193 @@ func (t *ExecTool) detectCredentialedBinaryInChain(ctx context.Context, command 
 	}
 	return ""
 }
+
+// handleCredentialedChain handles commands where a credentialed binary appears
+// inside a shell operator chain (e.g. "which gh && gh pr list"). Two modes:
+//
+//   - allow_chain_exec=false (default): returns an error telling the LLM to
+//     call the CLI directly without shell operators.
+//   - allow_chain_exec=true: injects all matching credential env vars into
+//     the full command and executes via shell. Less secure (tokens visible
+//     to all commands in the chain) but works with LLMs that habitually
+//     use shell operators.
+//
+// Returns nil if no credentialed binary is detected in the chain.
+func (t *ExecTool) handleCredentialedChain(ctx context.Context, normalizedCmd, rawCmd string, args map[string]any) *Result {
+	if t.secureCLIStore == nil {
+		return nil
+	}
+	if ops := detectUnquotedShellOperators(normalizedCmd); len(ops) == 0 {
+		return nil
+	}
+
+	// Scan all segments for credentialed binaries
+	unquoted := extractUnquotedSegments(normalizedCmd)
+	segments := shellOperatorPattern.Split(unquoted, -1)
+
+	type chainMatch struct {
+		binary string
+		cred   *store.SecureCLIBinary
+	}
+	var matches []chainMatch
+	anyAllowChain := false
+
+	agentID := store.AgentIDFromContext(ctx)
+	var agentIDPtr *uuid.UUID
+	if agentID != uuid.Nil {
+		agentIDPtr = &agentID
+	}
+	userID := store.CredentialUserIDFromContext(ctx)
+
+	for _, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		parser := shellwords.NewParser()
+		parser.ParseBacktick = false
+		parser.ParseEnv = false
+		words, err := parser.Parse(seg)
+		if err != nil || len(words) == 0 {
+			fields := strings.Fields(seg)
+			if len(fields) == 0 {
+				continue
+			}
+			words = fields[:1]
+		}
+		binary := normalizeBinaryName(words[0])
+		gctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		cred, lookupErr := t.secureCLIStore.LookupByBinary(gctx, binary, agentIDPtr, userID)
+		cancel()
+		if lookupErr != nil || cred == nil {
+			continue
+		}
+		matches = append(matches, chainMatch{binary: binary, cred: cred})
+		if cred.AllowChainExec {
+			anyAllowChain = true
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil
+	}
+
+	// Default mode: return error telling LLM to call directly
+	if !anyAllowChain {
+		first := matches[0].binary
+		return &Result{
+			ForLLM: fmt.Sprintf("[CREDENTIALED CLI] Command contains credentialed binary %q but uses shell operators.\n"+
+				"Shell operators (;  &&  ||  |) prevent credential injection.\n"+
+				"Call the CLI directly as the ONLY command: exec(\"%s ...\")\n"+
+				"Do NOT combine with other commands, pipes, or redirects.", first, first),
+			ForUser: fmt.Sprintf("Command contains %q with shell operators — call it directly.", first),
+			IsError: true,
+		}
+	}
+
+	// Chain injection mode: merge all matched credential env vars and execute
+	// the full command via shell with credentials injected.
+	slog.Info("security.credentialed_chain_exec",
+		"binaries", len(matches),
+		"command_prefix", truncateCmd(normalizedCmd, 80),
+		"agent_id", agentID)
+
+	envMap := make(map[string]string)
+	for _, m := range matches {
+		if len(m.cred.EncryptedEnv) > 0 {
+			var credEnv map[string]string
+			if err := json.Unmarshal(m.cred.EncryptedEnv, &credEnv); err == nil {
+				for k, v := range credEnv {
+					envMap[k] = v
+				}
+			}
+		}
+		// Merge per-user env overrides
+		if len(m.cred.UserEnv) > 0 {
+			var userEnvMap map[string]string
+			if err := json.Unmarshal(m.cred.UserEnv, &userEnvMap); err == nil {
+				for k, v := range userEnvMap {
+					envMap[k] = v
+				}
+			}
+		}
+		// Register for output scrubbing
+		for _, v := range envMap {
+			AddCredentialScrubValues(v)
+		}
+	}
+
+	// Use the longest timeout from matched credentials
+	timeout := 30 * time.Second
+	for _, m := range matches {
+		if d := time.Duration(m.cred.TimeoutSeconds) * time.Second; d > timeout {
+			timeout = d
+		}
+	}
+
+	// Resolve working directory
+	cwd := ToolWorkspaceFromCtx(ctx)
+	if cwd == "" {
+		cwd = t.workspace
+	}
+	if wd, _ := args["working_dir"].(string); wd != "" {
+		cwd = wd
+	}
+
+	// Execute via sandbox or host — using shell mode (sh -c) since the command
+	// contains intentional shell operators.
+	sandboxKey := ToolSandboxKeyFromCtx(ctx)
+	if t.sandboxMgr != nil && sandboxKey != "" {
+		sb, err := t.sandboxMgr.Get(ctx, sandboxKey, t.workspace, SandboxConfigFromCtx(ctx))
+		if err != nil {
+			return ErrorResult("credentialed chain exec requires sandbox but sandbox is unavailable: " + err.Error())
+		}
+		result, err := sb.Exec(ctx, []string{"sh", "-c", rawCmd}, cwd, sandbox.WithEnv(envMap))
+		if err != nil {
+			return ErrorResult(fmt.Sprintf("credentialed chain exec: %v", err))
+		}
+		output := result.Stdout
+		if result.Stderr != "" {
+			if output != "" {
+				output += "\n"
+			}
+			output += "STDERR:\n" + result.Stderr
+		}
+		if result.ExitCode != 0 {
+			return credentialedExecFailError("sh -c <chain>", []string{truncateCmd(rawCmd, 80)}, result.ExitCode, ScrubCredentials(output))
+		}
+		if output == "" {
+			output = "(command completed with no output)"
+		}
+		return SilentResult(capExecOutput(ScrubCredentials(output), execMaxOutputChars))
+	}
+
+	// Host execution with shell
+	ctx2, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.Command("sh", "-c", rawCmd)
+	cmd.Dir = cwd
+	setProcessGroup(cmd)
+	cmd.Env = buildCredentialedEnv(envMap)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return ErrorResult(fmt.Sprintf("credentialed chain exec: failed to start: %v", err))
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return formatCredentialedResult("sh -c <chain>", []string{truncateCmd(rawCmd, 80)}, stdout.String(), stderr.String(), err, ctx2, timeout)
+	case <-ctx2.Done():
+		_ = killProcessGroup(cmd, syscallSIGTERM)
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			_ = killProcessGroup(cmd, syscallSIGKILL)
+			<-done
+		}
+		return ErrorResult(fmt.Sprintf("[CREDENTIALED CHAIN EXEC] Command timed out after %s.", timeout))
+	}
+}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -301,18 +301,11 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *Result {
 		return t.executeCredentialed(ctx, cred, binary, cmdArgs, cwd, sandboxKey, command)
 	}
 
-	// Chain detection: if the first binary was not credentialed but the command
-	// contains shell operators AND a credentialed binary deeper in the chain,
-	// return an actionable error instead of silently running without credentials.
-	if found := t.detectCredentialedBinaryInChain(ctx, normalizedCommand); found != "" {
-		return &Result{
-			ForLLM: fmt.Sprintf("[CREDENTIALED CLI] Command contains credentialed binary %q but uses shell operators.\n"+
-				"Shell operators (;  &&  ||  |) prevent credential injection.\n"+
-				"Call the CLI directly as the ONLY command: exec(\"%s ...\")\n"+
-				"Do NOT combine with other commands, pipes, or redirects.", found, found),
-			ForUser: fmt.Sprintf("Command contains %q with shell operators \u2014 call it directly.", found),
-			IsError: true,
-		}
+	// Chain detection: credentialed binary found deeper in a shell operator chain.
+	// If allow_chain_exec is enabled for any matched binary, inject credentials
+	// into the full command. Otherwise return an actionable error.
+	if chainResult := t.handleCredentialedChain(ctx, normalizedCommand, command, args); chainResult != nil {
+		return chainResult
 	}
 
 	// Secure CLI gate: registered-but-not-granted binaries MUST NOT fall through

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -301,6 +301,20 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *Result {
 		return t.executeCredentialed(ctx, cred, binary, cmdArgs, cwd, sandboxKey, command)
 	}
 
+	// Chain detection: if the first binary was not credentialed but the command
+	// contains shell operators AND a credentialed binary deeper in the chain,
+	// return an actionable error instead of silently running without credentials.
+	if found := t.detectCredentialedBinaryInChain(ctx, normalizedCommand); found != "" {
+		return &Result{
+			ForLLM: fmt.Sprintf("[CREDENTIALED CLI] Command contains credentialed binary %q but uses shell operators.\n"+
+				"Shell operators (;  &&  ||  |) prevent credential injection.\n"+
+				"Call the CLI directly as the ONLY command: exec(\"%s ...\")\n"+
+				"Do NOT combine with other commands, pipes, or redirects.", found, found),
+			ForUser: fmt.Sprintf("Command contains %q with shell operators \u2014 call it directly.", found),
+			IsError: true,
+		}
+	}
+
 	// Secure CLI gate: registered-but-not-granted binaries MUST NOT fall through
 	// to host exec with parent env. Works on the already-normalized command
 	// (Red Team F6) and unwraps shell wrappers up to depth 3 (Red Team F1).

--- a/internal/upgrade/version.go
+++ b/internal/upgrade/version.go
@@ -2,4 +2,4 @@ package upgrade
 
 // RequiredSchemaVersion is the schema migration version this binary requires.
 // Bump this whenever adding a new SQL migration file.
-const RequiredSchemaVersion uint = 56
+const RequiredSchemaVersion uint = 57

--- a/migrations/000057_secure_cli_allow_chain_exec.down.sql
+++ b/migrations/000057_secure_cli_allow_chain_exec.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE secure_cli_binaries DROP COLUMN IF EXISTS allow_chain_exec;

--- a/migrations/000057_secure_cli_allow_chain_exec.up.sql
+++ b/migrations/000057_secure_cli_allow_chain_exec.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE secure_cli_binaries ADD COLUMN IF NOT EXISTS allow_chain_exec BOOLEAN NOT NULL DEFAULT false;

--- a/ui/web/src/i18n/locales/en/cli-credentials.json
+++ b/ui/web/src/i18n/locales/en/cli-credentials.json
@@ -46,6 +46,8 @@
     "binaryNotFound": "Binary not found in server PATH",
     "checking": "Checking...",
     "isGlobal": "Available to all agents",
+    "allowChainExec": "Allow chain execution",
+    "allowChainExecHint": "Inject credentials into shell command chains (e.g. which gh && gh pr list). Less secure but works with LLMs that use shell operators.",
     "isGlobalHint": "When off, only agents with explicit grants can use this CLI"
   },
   "placeholders": {

--- a/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
+++ b/ui/web/src/pages/cli-credentials/cli-credential-form-dialog.tsx
@@ -62,6 +62,7 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
       timeout: 30,
       tips: "",
       isGlobal: true,
+      allowChainExec: false,
       enabled: true,
     },
   });
@@ -79,6 +80,7 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
       timeout: credential?.timeout_seconds ?? 30,
       tips: credential?.tips ?? "",
       isGlobal: credential?.is_global ?? true,
+        allowChainExec: credential?.allow_chain_exec ?? false,
       enabled: credential?.enabled ?? true,
     });
     setEnvValues({});
@@ -183,6 +185,7 @@ export function CliCredentialFormDialog({ open, onOpenChange, credential, preset
         timeout_seconds: values.timeout,
         tips: values.tips?.trim() ?? "",
         is_global: values.isGlobal,
+        allow_chain_exec: values.allowChainExec,
         enabled: values.enabled,
       };
       if (selectedPreset !== NONE_PRESET) payload.preset = selectedPreset;

--- a/ui/web/src/pages/cli-credentials/cli-credential-scope-fields.tsx
+++ b/ui/web/src/pages/cli-credentials/cli-credential-scope-fields.tsx
@@ -31,6 +31,21 @@ export function CliCredentialScopeFields({ form }: CliCredentialScopeFieldsProps
         />
       </div>
 
+      {/* Allow chain exec */}
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <Label htmlFor="cc-chain-exec">{t("form.allowChainExec")}</Label>
+          <p className="text-xs text-muted-foreground">{t("form.allowChainExecHint")}</p>
+        </div>
+        <Controller
+          control={control}
+          name="allowChainExec"
+          render={({ field }) => (
+            <Switch id="cc-chain-exec" checked={field.value} onCheckedChange={field.onChange} />
+          )}
+        />
+      </div>
+
       <div className="flex items-center gap-2">
         <Controller
           control={control}

--- a/ui/web/src/schemas/credential.schema.ts
+++ b/ui/web/src/schemas/credential.schema.ts
@@ -9,6 +9,7 @@ export const cliCredentialSchema = z.object({
   timeout: z.number().min(1),
   tips: z.string().optional(),
   isGlobal: z.boolean(),
+  allowChainExec: z.boolean(),
   enabled: z.boolean(),
 });
 

--- a/ui/web/src/types/cli-credential.ts
+++ b/ui/web/src/types/cli-credential.ts
@@ -8,6 +8,7 @@ export interface SecureCLIBinary {
   timeout_seconds: number;
   tips: string;
   is_global: boolean;
+  allow_chain_exec: boolean;
   enabled: boolean;
   created_by: string;
   created_at: string;
@@ -43,6 +44,7 @@ export interface CLICredentialInput {
   timeout_seconds?: number;
   tips?: string;
   is_global?: boolean;
+  allow_chain_exec?: boolean;
   enabled?: boolean;
   env?: Record<string, string>;
 }


### PR DESCRIPTION
## Problem

When an LLM wraps a credentialed CLI in a shell chain like `which gh && gh pr list`,
`lookupCredentialedBinary` only checks the first binary (`which`) and returns nil.
The command falls through to regular exec without credential injection. The CLI reports
"not authenticated" and the agent gives up.

This is a common LLM pattern — models test binary availability with `which foo && foo --version`
before calling the actual command.

## Solution

Add `detectCredentialedBinaryInChain()` using quote-aware parsing (`extractUnquotedSegments` +
`go-shellwords`) to scan all segments of a shell-operator command for registered credentialed binaries.

Two modes controlled by a new per-CLI `allow_chain_exec` boolean (default: false):

| Mode | Behavior | Security |
|------|----------|----------|
| **false** (default) | Return actionable error: "call CLI directly without operators" | Safe — no token leak |
| **true** | Inject all matching credential env vars into full shell chain | Convenient but tokens visible to all commands |

## Changes

- **Migration 000057**: `ALTER TABLE secure_cli_binaries ADD COLUMN allow_chain_exec BOOLEAN NOT NULL DEFAULT false`
- **Store**: `SecureCLIBinary.AllowChainExec` field + PG/SQLite CRUD
- **HTTP API**: create/update request structs + update allowlist
- **Exec logic**: `handleCredentialedChain()` with two-mode dispatch (error vs injection)
- **Credential context**: per-CLI note in system prompt when chain exec is enabled
- **Web UI**: toggle switch in CLI credential settings
- **i18n**: English labels + security hint

## Test plan

- [x] `go build ./...` passes
- [ ] `exec("which gh && gh pr list")` with `allow_chain_exec=false` → returns error with guidance
- [ ] `exec("which gh && gh pr list")` with `allow_chain_exec=true` → injects GH_TOKEN, runs full chain
- [ ] `exec("gh pr list --jq '.[0] | .name'")` → no false-positive (pipe inside quotes)
- [ ] `exec("gh pr list")` → normal credentialed exec (no change)
- [ ] Dashboard toggle appears and persists
- [ ] Migration applies cleanly (up + down)