### PR TITLE
fix(acp): handle session/request_permission protocol for Gemini CLI 0.38.x

### DIFF
--- a/internal/providers/acp/process.go
+++ b/internal/providers/acp/process.go
@@ -19,14 +19,16 @@ type ACPProcess struct {
 	cmd  *exec.Cmd
 	conn *Conn
 
-	agentCaps  AgentCaps
-	workDir    string
-	lastActive time.Time
-	inUse      atomic.Int32 // >0 means at least one prompt is active — reaper must skip
-	mu         sync.Mutex
-	ctx        context.Context
-	cancel     context.CancelFunc
-	exited     chan struct{} // closed when process exits
+	agentCaps     AgentCaps
+	workDir       string
+	mcpServersFn  func(context.Context) []McpServer // invoked on every session/new + session/load
+	promptTimeout time.Duration                     // overrides promptInactivityTimeout when non-zero
+	lastActive    time.Time
+	inUse         atomic.Int32 // >0 means at least one prompt is active — reaper must skip
+	mu            sync.Mutex
+	ctx           context.Context
+	cancel        context.CancelFunc
+	exited        chan struct{} // closed when process exits
 
 	// updateFns routes session/update notifications to the correct active prompt.
 	updateFns map[string]func(SessionUpdate)
@@ -37,6 +39,11 @@ type ACPProcess struct {
 func (p *ACPProcess) AgentCaps() AgentCaps {
 	return p.agentCaps
 }
+
+// WorkDir returns the process pool's base work directory. Callers building
+// per-session workspaces should join a session-specific segment under this
+// path and pass the result as the cwd argument to NewSession/LoadSession.
+func (p *ACPProcess) WorkDir() string { return p.workDir }
 
 // registerUpdateFn registers a callback for session/update notifications on sessionID.
 func (p *ACPProcess) registerUpdateFn(sid string, fn func(SessionUpdate)) {
@@ -107,16 +114,18 @@ func (p *ACPProcess) dispatchUpdate(update SessionUpdate) {
 // Typically a single shared process is used (poolKey = binary identifier),
 // and multiple ACP sessions are multiplexed over it.
 type ProcessPool struct {
-	processes   sync.Map // poolKey → *ACPProcess
-	spawnMu     sync.Map // poolKey → *sync.Mutex — prevents concurrent spawn
-	agentBinary string
-	agentArgs   []string
-	workDir     string
-	idleTTL     time.Duration
-	mu          sync.RWMutex // protects toolHandler
-	toolHandler RequestHandler
-	done        chan struct{}
-	closeOnce   sync.Once
+	processes     sync.Map // poolKey → *ACPProcess
+	spawnMu       sync.Map // poolKey → *sync.Mutex — prevents concurrent spawn
+	agentBinary   string
+	agentArgs     []string
+	workDir       string
+	mcpServersFn  func(context.Context) []McpServer // resolved per session/new + session/load
+	idleTTL       time.Duration
+	promptTimeout time.Duration
+	mu            sync.RWMutex // protects toolHandler, mcpServersFn, promptTimeout
+	toolHandler   RequestHandler
+	done          chan struct{}
+	closeOnce     sync.Once
 }
 
 // NewProcessPool creates a pool that spawns ACP agents as subprocesses.
@@ -130,6 +139,37 @@ func NewProcessPool(binary string, args []string, workDir string, idleTTL time.D
 	}
 	go pp.reapLoop()
 	return pp
+}
+
+// SetMcpServersFunc configures the callback used to build the MCP server list
+// on every session/new and session/load request. The callback receives the
+// request context (with agent/tenant IDs) so it can return per-agent servers
+// resolved from the MCP store. Must be called before GetOrSpawn; spawned
+// processes inherit the current value at spawn time.
+func (pp *ProcessPool) SetMcpServersFunc(fn func(context.Context) []McpServer) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+	pp.mcpServersFn = fn
+}
+
+func (pp *ProcessPool) getMcpServersFn() func(context.Context) []McpServer {
+	pp.mu.RLock()
+	defer pp.mu.RUnlock()
+	return pp.mcpServersFn
+}
+
+// SetPromptTimeout sets the inactivity timeout used by Prompt() watchdogs in
+// newly spawned processes. Existing processes are not affected.
+func (pp *ProcessPool) SetPromptTimeout(d time.Duration) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+	pp.promptTimeout = d
+}
+
+func (pp *ProcessPool) getPromptTimeout() time.Duration {
+	pp.mu.RLock()
+	defer pp.mu.RUnlock()
+	return pp.promptTimeout
 }
 
 // SetToolHandler sets the agent→client request handler (tool bridge).
@@ -176,7 +216,9 @@ func (pp *ProcessPool) spawn(ctx context.Context, poolKey string) (*ACPProcess, 
 
 	cmd := exec.CommandContext(procCtx, pp.agentBinary, pp.agentArgs...)
 	cmd.Dir = pp.workDir
-	cmd.Env = filterACPEnv(os.Environ())
+	cmd.Env = append(filterACPEnv(os.Environ()),
+		"GEMINI_TELEMETRY_ENABLED=false",
+	)
 	cmd.SysProcAttr = sysProcAttr()
 
 	stdinPipe, err := cmd.StdinPipe()
@@ -198,18 +240,20 @@ func (pp *ProcessPool) spawn(ctx context.Context, poolKey string) (*ACPProcess, 
 	}
 
 	proc := &ACPProcess{
-		cmd:        cmd,
-		lastActive: time.Now(),
-		ctx:        procCtx,
-		cancel:     cancel,
-		exited:     make(chan struct{}),
-		workDir:    pp.workDir,
+		cmd:           cmd,
+		lastActive:    time.Now(),
+		ctx:           procCtx,
+		cancel:        cancel,
+		exited:        make(chan struct{}),
+		workDir:       pp.workDir,
+		mcpServersFn:  pp.getMcpServersFn(),
+		promptTimeout: pp.getPromptTimeout(),
 	}
 
 	// Notification handler: log all notifications and dispatch session/update to callers
 	notifyHandler := func(method string, params json.RawMessage) {
 		slog.Info("acp: notification received", "method", method)
-		slog.Debug("acp: notification params", "method", method, "params", string(params))
+		slog.Info("acp: notification params", "method", method, "params", string(params))
 		if method == "session/update" {
 			var update SessionUpdate
 			if err := json.Unmarshal(params, &update); err != nil {
@@ -260,8 +304,8 @@ func (pp *ProcessPool) reapLoop() {
 				proc.mu.Unlock()
 				if idle {
 					slog.Info("acp: reaping idle process", "pool_key", key)
+					pp.processes.Delete(key) // delete before cancel so a concurrent GetOrSpawn sees no stale entry
 					proc.cancel()
-					pp.processes.Delete(key)
 				}
 				return true
 			})

--- a/internal/providers/acp/session.go
+++ b/internal/providers/acp/session.go
@@ -5,8 +5,14 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 )
+
+// promptInactivityTimeout is the maximum time Prompt() will wait without
+// receiving any session/update notification before cancelling the prompt.
+// Exposed as a package var so tests can shorten it.
+var promptInactivityTimeout = 10 * time.Minute
 
 // Initialize sends the ACP initialize request to establish capabilities.
 func (p *ACPProcess) Initialize(ctx context.Context) error {
@@ -14,7 +20,7 @@ func (p *ACPProcess) Initialize(ctx context.Context) error {
 	defer cancel()
 	req := InitializeRequest{
 		ProtocolVersion: 1,
-		ClientInfo:      ClientInfo{Name: "GoClaw", Version: "1.0"},
+		ClientInfo:      ClientInfo{Name: "", Version: "1.0"},
 		Capabilities:    ClientCaps{},
 	}
 	var resp InitializeResponse
@@ -26,51 +32,85 @@ func (p *ACPProcess) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// resolveCwd returns the provided override if non-empty, otherwise the
+// process pool's default work directory (falling back to CWD as last resort).
+func (p *ACPProcess) resolveCwd(override string) string {
+	if override != "" {
+		return override
+	}
+	if p.workDir != "" {
+		return p.workDir
+	}
+	cwd, _ := filepath.Abs(".")
+	return cwd
+}
+
 // NewSession creates a new ACP session and returns its session ID.
-func (p *ACPProcess) NewSession(ctx context.Context) (string, error) {
+// If cwd is non-empty it is used as the session working directory; otherwise
+// the process pool's workDir is used. Gemini CLI 0.36.x honors the per-session
+// cwd even when it differs from the subprocess spawn directory, enabling
+// per-goclaw-session workspace isolation.
+func (p *ACPProcess) NewSession(ctx context.Context, cwd string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
+	sessionCwd := p.resolveCwd(cwd)
 
-	cwd := p.workDir
-	if cwd == "" {
-		cwd, _ = filepath.Abs(".")
+	var servers []McpServer
+	if p.mcpServersFn != nil {
+		servers = p.mcpServersFn(ctx)
 	}
-
-	req := NewSessionRequest{
-		Cwd:        cwd,
-		McpServers: []string{},
+	if servers == nil {
+		servers = []McpServer{}
 	}
+	req := NewSessionRequest{Cwd: sessionCwd, McpServers: servers}
 	var resp NewSessionResponse
 	if err := p.conn.Call(ctx, "session/new", req, &resp); err != nil {
 		return "", fmt.Errorf("acp session/new: %w", err)
 	}
-	slog.Info("acp: session/new", "sid", resp.SessionID, "cwd", cwd)
+	slog.Info("acp: session/new", "sid", resp.SessionID, "cwd", sessionCwd, "mcpServers", len(servers))
+	for _, s := range servers {
+		switch sv := s.(type) {
+		case McpServerHTTP:
+			slog.Info("acp: mcp server (http)", "name", sv.Name, "url", sv.URL, "headers", len(sv.Headers))
+		case McpServerStdio:
+			slog.Info("acp: mcp server (stdio)", "name", sv.Name, "command", sv.Command, "args", sv.Args)
+		}
+	}
 	return resp.SessionID, nil
 }
 
 // LoadSession restores a previous ACP session by ID (used after process restart).
 // Returns the session ID to use going forward (may equal the requested ID).
 // Only call if AgentCaps().LoadSession is true.
-func (p *ACPProcess) LoadSession(ctx context.Context, sessionID string) (string, error) {
+// cwd has the same semantics as NewSession — pass the per-goclaw-session
+// directory so tool calls resolve paths against it.
+func (p *ACPProcess) LoadSession(ctx context.Context, sessionID, cwd string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
+	sessionCwd := p.resolveCwd(cwd)
 
-	cwd := p.workDir
-	if cwd == "" {
-		cwd, _ = filepath.Abs(".")
+	var servers []McpServer
+	if p.mcpServersFn != nil {
+		servers = p.mcpServersFn(ctx)
 	}
-
-	req := LoadSessionRequest{SessionID: sessionID, Cwd: cwd}
+	if servers == nil {
+		servers = []McpServer{}
+	}
+	req := LoadSessionRequest{SessionID: sessionID, Cwd: sessionCwd, McpServers: servers}
 	var resp LoadSessionResponse
 	if err := p.conn.Call(ctx, "session/load", req, &resp); err != nil {
 		return "", fmt.Errorf("acp session/load: %w", err)
 	}
-	slog.Info("acp: session/load", "sid", resp.SessionID)
+	slog.Info("acp: session/load", "sid", resp.SessionID, "cwd", sessionCwd)
 	return resp.SessionID, nil
 }
 
 // Prompt sends user content to sessionID and blocks until the agent completes,
 // invoking onUpdate for each session/update notification received.
+//
+// An inactivity watchdog cancels the prompt if no session/update arrives within
+// promptInactivityTimeout. This guards against silent hangs where the ACP agent
+// stops responding without closing the connection.
 func (p *ACPProcess) Prompt(ctx context.Context, sessionID string, content []ContentBlock, onUpdate func(SessionUpdate)) (*PromptResponse, error) {
 	p.inUse.Add(1)
 	defer p.inUse.Add(-1)
@@ -79,11 +119,61 @@ func (p *ACPProcess) Prompt(ctx context.Context, sessionID string, content []Con
 	p.lastActive = time.Now()
 	p.mu.Unlock()
 
-	p.registerUpdateFn(sessionID, onUpdate)
+	timeout := p.promptTimeout
+	if timeout <= 0 {
+		timeout = promptInactivityTimeout
+	}
+
+	// lastActivity is refreshed by every session/update; watchdog fires when stale.
+	var lastActivity atomic.Int64
+	lastActivity.Store(time.Now().UnixNano())
+
+	watchdogDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if time.Since(time.Unix(0, lastActivity.Load())) > timeout {
+					slog.Warn("acp: prompt inactivity timeout, cancelling",
+						"sid", sessionID, "timeout", timeout)
+					_ = p.conn.Notify("session/cancel", CancelNotification{SessionID: sessionID})
+					return
+				}
+			case <-watchdogDone:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Wrap onUpdate to refresh lastActivity on every notification.
+	p.registerUpdateFn(sessionID, func(update SessionUpdate) {
+		lastActivity.Store(time.Now().UnixNano())
+		if update.ToolCall != nil {
+			slog.Info("acp: tool call update", "sid", sessionID, "tool", update.ToolCall.Name, "status", update.ToolCall.Status, "id", update.ToolCall.ID)
+		} else if update.Kind != "" {
+			slog.Info("acp: session update", "sid", sessionID, "kind", update.Kind, "sessionUpdate", update.Update.SessionUpdate, "status", update.Update.Status)
+		}
+		if onUpdate != nil {
+			onUpdate(update)
+		}
+	})
 	defer p.unregisterUpdateFn(sessionID)
+	defer close(watchdogDone)
 
 	goclawSession := goclawSessionFromCtx(ctx)
-	slog.Info("acp: session/prompt", "session", goclawSession, "sid", sessionID)
+	var contentPreview string
+	if len(content) > 0 && content[0].Type == "text" {
+		if len(content[0].Text) > 200 {
+			contentPreview = content[0].Text[:200] + "..."
+		} else {
+			contentPreview = content[0].Text
+		}
+	}
+	slog.Info("acp: session/prompt", "session", goclawSession, "sid", sessionID, "blocks", len(content), "preview", contentPreview)
 	req := PromptRequest{
 		SessionID: sessionID,
 		Prompt:    content,

--- a/internal/providers/acp/tool_bridge.go
+++ b/internal/providers/acp/tool_bridge.go
@@ -57,34 +57,50 @@ func NewToolBridge(workspace string, opts ...ToolBridgeOption) *ToolBridge {
 // Handle dispatches agent→client requests by method name.
 // Implements the RequestHandler signature for Conn.
 func (tb *ToolBridge) Handle(ctx context.Context, method string, params json.RawMessage) (any, error) {
+	session := goclawSessionFromCtx(ctx)
 	switch method {
 	case "fs/readTextFile":
 		if tb.permMode == "deny-all" {
+			slog.Warn("security.tool_denied", "session", session, "tool", method, "reason", "deny-all")
 			return nil, fmt.Errorf("read denied by permission mode: %s", tb.permMode)
 		}
 		var req ReadTextFileRequest
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		return tb.readFile(req)
+		result, err := tb.readFile(req)
+		if err == nil {
+			slog.Info("security.tool_granted", "session", session, "tool", method, "path", req.Path)
+		}
+		return result, err
 	case "fs/writeTextFile":
 		if tb.permMode == "deny-all" || tb.permMode == "approve-reads" {
+			slog.Warn("security.tool_denied", "session", session, "tool", method, "reason", tb.permMode)
 			return nil, fmt.Errorf("write denied by permission mode: %s", tb.permMode)
 		}
 		var req WriteTextFileRequest
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		return tb.writeFile(req)
+		result, err := tb.writeFile(req)
+		if err == nil {
+			slog.Info("security.tool_granted", "session", session, "tool", method, "path", req.Path)
+		}
+		return result, err
 	case "terminal/create":
 		if tb.permMode == "deny-all" || tb.permMode == "approve-reads" {
+			slog.Warn("security.tool_denied", "session", session, "tool", method, "reason", tb.permMode)
 			return nil, fmt.Errorf("terminal denied by permission mode: %s", tb.permMode)
 		}
 		var req CreateTerminalRequest
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		return tb.createTerminal(req)
+		result, err := tb.createTerminal(req)
+		if err == nil {
+			slog.Info("security.tool_granted", "session", session, "tool", method, "command", req.Command)
+		}
+		return result, err
 	case "terminal/output":
 		var req TerminalOutputRequest
 		if err := json.Unmarshal(params, &req); err != nil {
@@ -105,6 +121,7 @@ func (tb *ToolBridge) Handle(ctx context.Context, method string, params json.Raw
 		return tb.waitForExit(ctx, req)
 	case "terminal/kill":
 		if tb.permMode == "deny-all" {
+			slog.Warn("security.tool_denied", "session", session, "tool", method, "reason", "deny-all")
 			return nil, fmt.Errorf("terminal kill denied by permission mode: %s", tb.permMode)
 		}
 		var req KillTerminalRequest
@@ -117,7 +134,13 @@ func (tb *ToolBridge) Handle(ctx context.Context, method string, params json.Raw
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		return tb.handlePermission(req)
+		return tb.handlePermission(ctx, req)
+	case "session/request_permission":
+		var req SessionRequestPermissionRequest
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, fmt.Errorf("invalid params: %w", err)
+		}
+		return tb.handleSessionPermission(ctx, req)
 	default:
 		return nil, fmt.Errorf("unknown method: %s", method)
 	}
@@ -151,21 +174,73 @@ func (tb *ToolBridge) writeFile(req WriteTextFileRequest) (*WriteTextFileRespons
 	return &WriteTextFileResponse{}, nil
 }
 
-// handlePermission responds to permission requests based on configured mode.
-func (tb *ToolBridge) handlePermission(req RequestPermissionRequest) (*RequestPermissionResponse, error) {
+// handleSessionPermission handles Gemini CLI's "session/request_permission" ACP method.
+// Gemini CLI expects a nested outcome object that differs from the generic "permission/request" format.
+// Responding with "proceed_always_server" adds the entire goclaw-bridge server to Gemini's
+// allowlist so all subsequent tool calls in the session skip the confirmation step.
+func (tb *ToolBridge) handleSessionPermission(ctx context.Context, req SessionRequestPermissionRequest) (*SessionRequestPermissionResponse, error) {
+	session := goclawSessionFromCtx(ctx)
+
+	available := make(map[string]bool, len(req.Options))
+	for _, opt := range req.Options {
+		available[opt.OptionID] = true
+	}
+
 	switch tb.permMode {
 	case "deny-all":
+		slog.Warn("security.tool_denied", "session", session, "tool", req.ToolCall.Title, "reason", "deny-all")
+		return &SessionRequestPermissionResponse{
+			Outcome: SessionPermOutcome{Outcome: "cancelled"},
+		}, nil
+	case "approve-reads":
+		lower := strings.ToLower(req.ToolCall.Title)
+		if strings.Contains(lower, "read") || strings.Contains(lower, "glob") ||
+			strings.Contains(lower, "grep") || strings.Contains(lower, "search") ||
+			strings.Contains(lower, "list") || strings.Contains(lower, "view") {
+			slog.Info("security.tool_granted", "session", session, "tool", req.ToolCall.Title, "mode", "approve-reads")
+			return &SessionRequestPermissionResponse{
+				Outcome: SessionPermOutcome{Outcome: "selected", OptionID: "proceed_once"},
+			}, nil
+		}
+		slog.Warn("security.tool_denied", "session", session, "tool", req.ToolCall.Title, "reason", "approve-reads:write-blocked")
+		return &SessionRequestPermissionResponse{
+			Outcome: SessionPermOutcome{Outcome: "cancelled"},
+		}, nil
+	default: // "approve-all"
+		// Prefer server-wide approval so all subsequent goclaw-bridge tool calls skip confirmation.
+		optionID := "proceed_once"
+		for _, pref := range []string{"proceed_always_server", "proceed_always_tool", "proceed_once"} {
+			if available[pref] {
+				optionID = pref
+				break
+			}
+		}
+		slog.Info("security.tool_granted", "session", session, "tool", req.ToolCall.Title, "mode", "approve-all", "optionId", optionID)
+		return &SessionRequestPermissionResponse{
+			Outcome: SessionPermOutcome{Outcome: "selected", OptionID: optionID},
+		}, nil
+	}
+}
+
+// handlePermission responds to permission requests based on configured mode.
+func (tb *ToolBridge) handlePermission(ctx context.Context, req RequestPermissionRequest) (*RequestPermissionResponse, error) {
+	session := goclawSessionFromCtx(ctx)
+	switch tb.permMode {
+	case "deny-all":
+		slog.Warn("security.tool_denied", "session", session, "tool", req.ToolName, "reason", "deny-all")
 		return &RequestPermissionResponse{Outcome: "denied"}, nil
 	case "approve-reads":
-		// Approve read-only tools, deny write/exec tools
 		lower := strings.ToLower(req.ToolName)
 		if strings.Contains(lower, "read") || strings.Contains(lower, "glob") ||
 			strings.Contains(lower, "grep") || strings.Contains(lower, "search") ||
 			strings.Contains(lower, "list") || strings.Contains(lower, "view") {
+			slog.Info("security.tool_granted", "session", session, "tool", req.ToolName, "mode", "approve-reads")
 			return &RequestPermissionResponse{Outcome: "approved"}, nil
 		}
+		slog.Warn("security.tool_denied", "session", session, "tool", req.ToolName, "reason", "approve-reads:write-blocked")
 		return &RequestPermissionResponse{Outcome: "denied"}, nil
 	default: // "approve-all" or unknown → approve
+		slog.Info("security.tool_granted", "session", session, "tool", req.ToolName, "mode", "approve-all")
 		return &RequestPermissionResponse{Outcome: "approved"}, nil
 	}
 }

--- a/internal/providers/acp/types.go
+++ b/internal/providers/acp/types.go
@@ -61,9 +61,57 @@ type MCPCaps struct {
 
 // --- Session Methods ---
 
+// McpServer is a discriminated-union transport descriptor for MCP servers.
+// Concrete types: McpServerHTTP, McpServerStdio (SSE unimplemented).
+// Per ACP spec (zed-industries/agent-client-protocol), the wire format is a
+// JSON object tagged by `type`; Go's encoding/json handles this via concrete
+// values held in the interface.
+type McpServer interface{ mcpServerKind() }
+
+// McpServerHTTP carries HTTP transport MCP config.
+// Headers is a {name,value} array — Gemini CLI 0.36.x rejects object-shaped
+// headers with schema error "expected array, received object", so we diverge
+// from the zed-industries ACP schema (which specifies object) to match the
+// implementation that actually consumes the payload.
+type McpServerHTTP struct {
+	Type    string         `json:"type"` // always "http"
+	Name    string         `json:"name"`
+	URL     string         `json:"url"`
+	Headers []McpServerKV  `json:"headers"`
+}
+
+func (McpServerHTTP) mcpServerKind() {}
+
+// McpServerStdio carries stdio transport MCP config.
+type McpServerStdio struct {
+	Type    string        `json:"type"` // always "stdio"
+	Name    string        `json:"name"`
+	Command string        `json:"command"`
+	Args    []string      `json:"args"`
+	Env     []McpServerKV `json:"env"`
+}
+
+func (McpServerStdio) mcpServerKind() {}
+
+// McpServerKV is a {name, value} pair used for both HTTP headers and stdio env.
+type McpServerKV struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Alias retained for backward compatibility with any caller that constructed
+// env entries by the older name. New code should use McpServerKV directly.
+type McpServerEnv = McpServerKV
+
+// NewHTTPMcpServer returns an HTTP-transport McpServer with an empty headers
+// slice (the field must be present per schema).
+func NewHTTPMcpServer(name, url string) McpServer {
+	return McpServerHTTP{Type: "http", Name: name, URL: url, Headers: []McpServerKV{}}
+}
+
 type NewSessionRequest struct {
-	Cwd        string   `json:"cwd"`
-	McpServers []string `json:"mcpServers"`
+	Cwd        string      `json:"cwd"`
+	McpServers []McpServer `json:"mcpServers"`
 }
 
 type NewSessionResponse struct {
@@ -71,9 +119,9 @@ type NewSessionResponse struct {
 }
 
 type LoadSessionRequest struct {
-	SessionID  string   `json:"sessionId"`
-	Cwd        string   `json:"cwd,omitempty"`
-	McpServers []string `json:"mcpServers"`
+	SessionID  string      `json:"sessionId"`
+	Cwd        string      `json:"cwd,omitempty"`
+	McpServers []McpServer `json:"mcpServers"`
 }
 
 type LoadSessionResponse struct {
@@ -205,4 +253,36 @@ type RequestPermissionRequest struct {
 
 type RequestPermissionResponse struct {
 	Outcome string `json:"outcome"` // "proceed_always", "approved", "denied"
+}
+
+// SessionRequestPermissionRequest is sent by Gemini CLI (method "session/request_permission")
+// to request approval before executing an MCP tool.
+type SessionRequestPermissionRequest struct {
+	SessionID string             `json:"sessionId"`
+	Options   []SessionPermOpt   `json:"options"`
+	ToolCall  SessionPermTool    `json:"toolCall"`
+}
+
+type SessionPermOpt struct {
+	OptionID string `json:"optionId"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+}
+
+type SessionPermTool struct {
+	ToolCallID string `json:"toolCallId"`
+	Status     string `json:"status"`
+	Title      string `json:"title"`
+	Kind       string `json:"kind,omitempty"`
+}
+
+// SessionRequestPermissionResponse matches Gemini CLI's RequestPermissionResponseSchema.
+// Wire format: {"outcome":{"outcome":"cancelled"}} or {"outcome":{"outcome":"selected","optionId":"..."}}
+type SessionRequestPermissionResponse struct {
+	Outcome SessionPermOutcome `json:"outcome"`
+}
+
+type SessionPermOutcome struct {
+	Outcome  string `json:"outcome"`           // "cancelled" or "selected"
+	OptionID string `json:"optionId,omitempty"` // required when outcome="selected"
 }

--- a/internal/providers/acp_provider.go
+++ b/internal/providers/acp_provider.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -23,12 +25,15 @@ type acpSessionEntry struct {
 // ACPProvider implements Provider by orchestrating ACP-compatible agent subprocesses.
 // One shared Gemini process is used; each goclaw conversation gets its own ACP session.
 type ACPProvider struct {
-	name         string
-	pool         *acp.ProcessPool
-	bridge       *acp.ToolBridge
-	defaultModel string
-	permMode     string
-	poolKey      string // key for the shared process in the pool (binary + args)
+	name           string
+	pool           *acp.ProcessPool
+	bridge         *acp.ToolBridge
+	defaultModel   string
+	permMode       string
+	poolKey        string // key for the shared process in the pool (binary + args)
+	mcpServersFn   func(context.Context) []acp.McpServer // resolved per session
+	sessionIdleTTL time.Duration                         // idle TTL for ACP session reaper
+	promptTimeout  time.Duration                         // inactivity timeout for Prompt() watchdog
 
 	acpSessions sync.Map // goclawSessionKey → *acpSessionEntry
 	sessionMu   sync.Map // goclawSessionKey → *sync.Mutex (prevents concurrent session creation)
@@ -67,22 +72,61 @@ func WithACPPermMode(mode string) ACPOption {
 	}
 }
 
+// WithACPSessionTTL overrides the idle TTL used by the session reaper.
+// When not set, defaults to the process pool's idleTTL.
+func WithACPSessionTTL(d time.Duration) ACPOption {
+	return func(p *ACPProvider) {
+		if d > 0 {
+			p.sessionIdleTTL = d
+		}
+	}
+}
+
+// WithACPPromptTimeout sets the inactivity timeout for Prompt() watchdogs.
+// Overrides the package-level promptInactivityTimeout (10 min default).
+func WithACPPromptTimeout(d time.Duration) ACPOption {
+	return func(p *ACPProvider) {
+		if d > 0 {
+			p.promptTimeout = d
+		}
+	}
+}
+
+// WithACPMcpServersFunc registers a callback that returns the MCP server list
+// to send on every session/new and session/load request. The callback receives
+// the request context so it can resolve per-agent servers (e.g. from the MCP
+// store based on agent ID in ctx). Return nil or an empty slice for no servers.
+func WithACPMcpServersFunc(fn func(context.Context) []acp.McpServer) ACPOption {
+	return func(p *ACPProvider) {
+		p.mcpServersFn = fn
+	}
+}
+
 // NewACPProvider creates a provider that orchestrates ACP agents as subprocesses.
 func NewACPProvider(binary string, args []string, workDir string, idleTTL time.Duration, denyPatterns []*regexp.Regexp, opts ...ACPOption) *ACPProvider {
-	// Pool key identifies the shared process: binary + args combination
-	poolKey := binary
-	if len(args) > 0 {
-		poolKey += "|" + strings.Join(args, " ")
-	}
-
 	p := &ACPProvider{
 		name:         "acp",
 		defaultModel: "claude",
-		poolKey:      poolKey,
 		done:         make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(p)
+	}
+
+	// poolKey uniquely identifies a subprocess configuration so that providers
+	// differing in any of the five dimensions always spawn separate processes.
+	// permMode is included explicitly; it is no longer injected into CLI args
+	// because ACP permission/request RPCs are handled entirely by ToolBridge.
+	p.poolKey = fmt.Sprintf("%s|%s|%s|%s|%s",
+		binary,
+		strings.Join(args, " "),
+		workDir,
+		idleTTL,
+		p.permMode,
+	)
+
+	if p.sessionIdleTTL == 0 {
+		p.sessionIdleTTL = idleTTL
 	}
 
 	var bridgeOpts []acp.ToolBridgeOption
@@ -96,15 +140,20 @@ func NewACPProvider(binary string, args []string, workDir string, idleTTL time.D
 
 	p.pool = acp.NewProcessPool(binary, args, workDir, idleTTL)
 	p.pool.SetToolHandler(p.bridge.Handle)
+	if p.mcpServersFn != nil {
+		p.pool.SetMcpServersFunc(p.mcpServersFn)
+	}
+	if p.promptTimeout > 0 {
+		p.pool.SetPromptTimeout(p.promptTimeout)
+	}
 
 	go p.sessionReaper()
 	return p
 }
 
-// sessionReaper removes ACP sessions idle for more than 30 minutes.
+// sessionReaper removes ACP sessions idle for more than sessionIdleTTL.
 // Sends session/cancel to release resources on the agent side before purging locally.
 func (p *ACPProvider) sessionReaper() {
-	const sessionIdleTTL = 30 * time.Minute
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 	for {
@@ -112,12 +161,13 @@ func (p *ACPProvider) sessionReaper() {
 		case <-ticker.C:
 			p.acpSessions.Range(func(key, value any) bool {
 				entry := value.(*acpSessionEntry)
-				if time.Since(entry.lastUsed) > sessionIdleTTL {
-					slog.Info("acp: expiring idle session", "goclaw_session", key, "sid", entry.id)
+				if time.Since(entry.lastUsed) > p.sessionIdleTTL {
+					slog.Info("acp: expiring idle session", "goclaw_session", key, "sid", entry.id, "ttl", p.sessionIdleTTL)
 					if entry.proc != nil {
 						_ = entry.proc.Cancel(entry.id)
 					}
 					p.acpSessions.Delete(key)
+					p.sessionMu.Delete(key)
 				}
 				return true
 			})
@@ -127,10 +177,59 @@ func (p *ACPProvider) sessionReaper() {
 	}
 }
 
+// ensureSessionDir creates and returns a per-goclaw-session workspace under
+// the process pool's base work directory. Mirrors the claude_cli provider's
+// ensureWorkDir pattern so acp-workspaces layout matches cli-workspaces:
+//
+//	<baseWorkDir>/agent-<name>-ws-direct-<uuid>/
+//
+// Falls back to the pool's workDir (shared) if the base is unset or MkdirAll
+// fails — safer than /tmp since the caller passes Authorization-protected
+// paths to the ACP agent.
+func (p *ACPProvider) ensureSessionDir(proc *acp.ACPProcess, goclawKey string) string {
+	base := proc.WorkDir()
+	if base == "" {
+		return ""
+	}
+	safe := sanitizePathSegment(goclawKey)
+	if safe == "" {
+		return base
+	}
+	dir := filepath.Join(base, safe)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Warn("acp: failed to create per-session workspace, using pool default",
+			"goclaw_session", goclawKey, "dir", dir, "error", err)
+		return base
+	}
+	return dir
+}
+
+// writeGeminiMD writes the system prompt to GEMINI.md in the session workspace.
+// Gemini CLI reads this file automatically from the session cwd (mirrors writeClaudeMD).
+// Skips write if content is unchanged. Returns true if the file was rewritten,
+// signalling the caller to invalidate the live ACP session so the next request
+// starts a fresh session with the updated instructions.
+func (p *ACPProvider) writeGeminiMD(sessionDir, systemPrompt string) bool {
+	if sessionDir == "" || systemPrompt == "" {
+		return false
+	}
+	path := filepath.Join(sessionDir, "GEMINI.md")
+	if existing, err := os.ReadFile(path); err == nil && string(existing) == systemPrompt {
+		return false
+	}
+	if err := os.WriteFile(path, []byte(systemPrompt), 0600); err != nil {
+		slog.Warn("acp: failed to write GEMINI.md", "path", path, "error", err)
+		return false
+	}
+	return true
+}
+
 // resolveSession returns the ACP session ID for a goclaw session key.
-// It creates a new session if none exists, or reloads it after a process respawn.
+// sessionDir is the pre-computed per-session workspace (caller must ensure it exists).
+// Returns isNew=true only when a brand-new session is created via session/new —
+// callers use this to inject full conversation history into the first prompt.
 // A per-key mutex prevents concurrent creation races for the same session.
-func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, goclawKey string) (string, error) {
+func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, sessionDir, goclawKey string) (sid string, isNew bool, err error) {
 	actual, _ := p.sessionMu.LoadOrStore(goclawKey, &sync.Mutex{})
 	mu := actual.(*sync.Mutex)
 	mu.Lock()
@@ -141,29 +240,29 @@ func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, 
 		if entry.proc == proc {
 			// Same process instance: session is still live, just update last-used
 			entry.lastUsed = time.Now()
-			return entry.id, nil
+			return entry.id, false, nil
 		}
 		// Process was respawned — try to restore the session
 		slog.Info("acp: process respawned, attempting session restore",
 			"goclaw_session", goclawKey, "old_sid", entry.id)
 		if proc.AgentCaps().LoadSession {
-			sid, err := proc.LoadSession(ctx, entry.id)
+			sid, err := proc.LoadSession(ctx, entry.id, sessionDir)
 			if err == nil {
 				p.acpSessions.Store(goclawKey, &acpSessionEntry{id: sid, proc: proc, lastUsed: time.Now()})
-				return sid, nil
+				return sid, false, nil
 			}
 			slog.Warn("acp: session/load failed, creating new session", "old_sid", entry.id, "error", err)
 		}
 		// session/load not supported or failed — fall through to create new
 	}
 
-	slog.Info("acp: creating new session", "goclaw_session", goclawKey, "pool_key", p.poolKey)
-	sid, err := proc.NewSession(ctx)
+	slog.Info("acp: creating new session", "goclaw_session", goclawKey, "pool_key", p.poolKey, "cwd", sessionDir)
+	sid, err = proc.NewSession(ctx, sessionDir)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	p.acpSessions.Store(goclawKey, &acpSessionEntry{id: sid, proc: proc, lastUsed: time.Now()})
-	return sid, nil
+	return sid, true, nil
 }
 
 func (p *ACPProvider) Name() string         { return p.name }
@@ -195,7 +294,15 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 		return nil, fmt.Errorf("acp: spawn failed: %w", err)
 	}
 
-	acpSessionID, err := p.resolveSession(ctx, proc, sessionKey)
+	sessionDir := p.ensureSessionDir(proc, sessionKey)
+	systemPrompt, _, _ := extractFromMessages(req.Messages)
+	if p.writeGeminiMD(sessionDir, systemPrompt) {
+		// System prompt changed — invalidate live session so next resolveSession
+		// creates a fresh one that loads the updated GEMINI.md.
+		p.acpSessions.Delete(sessionKey)
+	}
+
+	acpSessionID, isNew, err := p.resolveSession(ctx, proc, sessionDir, sessionKey)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +310,7 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 		defer p.purgeSession(sessionKey)
 	}
 
-	content := extractACPContent(req)
+	content := extractACPContent(req, isNew)
 	if len(content) == 0 {
 		return nil, fmt.Errorf("acp: no user message in request")
 	}
@@ -212,7 +319,10 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 
 	var buf strings.Builder
 	var updateCount int
-	promptResp, err := proc.Prompt(ctx, acpSessionID, content, func(update acp.SessionUpdate) {
+	cb := func(update acp.SessionUpdate) {
+		if update.ToolCall != nil {
+			slog.Info("acp: tool call (chat)", "name", update.ToolCall.Name, "status", update.ToolCall.Status, "id", update.ToolCall.ID)
+		}
 		if update.Message != nil {
 			for _, block := range update.Message.Content {
 				if block.Type == "text" {
@@ -221,7 +331,20 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 				}
 			}
 		}
-	})
+	}
+
+	const maxACPRetry = 2
+	var promptResp *acp.PromptResponse
+	for attempt := range maxACPRetry + 1 {
+		buf.Reset()
+		updateCount = 0
+		promptResp, err = proc.Prompt(ctx, acpSessionID, content, cb)
+		if err == nil || !isMalformedFunctionCall(err) {
+			break
+		}
+		slog.Warn("acp: malformed function call, retrying", "attempt", attempt+1, "session", sessionKey, "sid", acpSessionID)
+	}
+
 	if err != nil {
 		slog.Error("acp: chat error", "session", sessionKey, "sid", acpSessionID, "error", err)
 		return &ChatResponse{
@@ -230,12 +353,26 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 		}, err
 	}
 
+	if promptResp != nil && promptResp.StopReason == "cancelled" {
+		slog.Warn("acp: chat cancelled", "session", sessionKey, "sid", acpSessionID, "updates", updateCount)
+		errMsg := "[요청 취소] 응답 대기 중 타임아웃으로 취소됨"
+		if buf.Len() > 0 {
+			errMsg = buf.String() + "\n\n" + errMsg
+		}
+		return &ChatResponse{Content: errMsg, FinishReason: "stop"}, nil
+	}
+
+	outputText := buf.String()
 	slog.Info("acp: chat completed", "session", sessionKey, "sid", acpSessionID,
-		"stopReason", mapStopReason(promptResp), "updates", updateCount, "contentLen", buf.Len())
+		"stopReason", mapStopReason(promptResp), "updates", updateCount, "contentLen", len(outputText))
 	return &ChatResponse{
-		Content:      buf.String(),
+		Content:      outputText,
 		FinishReason: mapStopReason(promptResp),
-		Usage:        &Usage{},
+		Usage: &Usage{
+			PromptTokens:     acpInputTokens(req.Messages),
+			CompletionTokens: acpEstimateTokens(outputText),
+			TotalTokens:      acpInputTokens(req.Messages) + acpEstimateTokens(outputText),
+		},
 	}, nil
 }
 
@@ -251,7 +388,13 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 		return nil, fmt.Errorf("acp: spawn failed: %w", err)
 	}
 
-	acpSessionID, err := p.resolveSession(ctx, proc, sessionKey)
+	sessionDir := p.ensureSessionDir(proc, sessionKey)
+	systemPrompt, _, _ := extractFromMessages(req.Messages)
+	if p.writeGeminiMD(sessionDir, systemPrompt) {
+		p.acpSessions.Delete(sessionKey)
+	}
+
+	acpSessionID, isNew, err := p.resolveSession(ctx, proc, sessionDir, sessionKey)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +402,7 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 		defer p.purgeSession(sessionKey)
 	}
 
-	content := extractACPContent(req)
+	content := extractACPContent(req, isNew)
 	if len(content) == 0 {
 		return nil, fmt.Errorf("acp: no user message in request")
 	}
@@ -282,7 +425,7 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 
 	var buf strings.Builder
 	var updateCount int
-	promptResp, err := proc.Prompt(ctx, acpSessionID, content, func(update acp.SessionUpdate) {
+	streamCb := func(update acp.SessionUpdate) {
 		if update.Message != nil {
 			for _, block := range update.Message.Content {
 				if block.Type == "text" {
@@ -292,10 +435,21 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 				}
 			}
 		}
-		if update.ToolCall != nil && update.ToolCall.Status == "running" {
-			slog.Debug("acp: tool call", "name", update.ToolCall.Name)
+		if update.ToolCall != nil {
+			slog.Info("acp: tool call (stream)", "name", update.ToolCall.Name, "status", update.ToolCall.Status, "id", update.ToolCall.ID)
 		}
-	})
+	}
+
+	const maxACPRetry = 2
+	var promptResp *acp.PromptResponse
+	for attempt := range maxACPRetry + 1 {
+		promptResp, err = proc.Prompt(ctx, acpSessionID, content, streamCb)
+		if err == nil || !isMalformedFunctionCall(err) {
+			break
+		}
+		slog.Warn("acp: malformed function call, retrying", "attempt", attempt+1, "session", sessionKey, "sid", acpSessionID)
+	}
+
 	if err != nil {
 		slog.Error("acp: chat error", "session", sessionKey, "sid", acpSessionID, "error", err)
 		return &ChatResponse{
@@ -304,14 +458,31 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 		}, err
 	}
 
+	if promptResp != nil && promptResp.StopReason == "cancelled" {
+		slog.Warn("acp: chat stream cancelled", "session", sessionKey, "sid", acpSessionID, "updates", updateCount)
+		errMsg := "[요청 취소] 응답 대기 중 타임아웃으로 취소됨"
+		prefix := "\n\n"
+		if buf.Len() == 0 {
+			prefix = ""
+		}
+		onChunk(StreamChunk{Content: prefix + errMsg})
+		onChunk(StreamChunk{Done: true})
+		return &ChatResponse{Content: buf.String() + prefix + errMsg, FinishReason: "stop"}, nil
+	}
+
 	onChunk(StreamChunk{Done: true})
+	outputText := buf.String()
 	slog.Info("acp: chat stream completed", "session", sessionKey, "sid", acpSessionID,
-		"stopReason", mapStopReason(promptResp), "updates", updateCount, "contentLen", buf.Len())
+		"stopReason", mapStopReason(promptResp), "updates", updateCount, "contentLen", len(outputText))
 
 	return &ChatResponse{
-		Content:      buf.String(),
+		Content:      outputText,
 		FinishReason: mapStopReason(promptResp),
-		Usage:        &Usage{},
+		Usage: &Usage{
+			PromptTokens:     acpInputTokens(req.Messages),
+			CompletionTokens: acpEstimateTokens(outputText),
+			TotalTokens:      acpInputTokens(req.Messages) + acpEstimateTokens(outputText),
+		},
 	}, nil
 }
 
@@ -339,31 +510,85 @@ func (p *ACPProvider) Close() error {
 	return p.pool.Close()
 }
 
-// extractACPContent extracts user message + images from ChatRequest into ACP ContentBlocks.
-func extractACPContent(req ChatRequest) []acp.ContentBlock {
-	systemPrompt, userMsg, images := extractFromMessages(req.Messages)
-	if userMsg == "" {
+// acpAllowedMIME is the set of image MIME types accepted by ACP providers.
+var acpAllowedMIME = map[string]bool{
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/webp": true,
+	"image/gif":  true,
+}
+
+// acpMaxImageBytes is the maximum decoded image size accepted (5 MB).
+const acpMaxImageBytes = 5 * 1024 * 1024
+
+// appendACPImages appends validated image ContentBlocks to blocks.
+func appendACPImages(blocks []acp.ContentBlock, images []ImageContent) []acp.ContentBlock {
+	for _, img := range images {
+		if !acpAllowedMIME[img.MimeType] {
+			slog.Warn("acp: unsupported image MIME type, skipping", "mime", img.MimeType)
+			continue
+		}
+		if len(img.Data)*3/4 > acpMaxImageBytes {
+			slog.Warn("acp: image too large, skipping", "estimatedBytes", len(img.Data)*3/4, "limit", acpMaxImageBytes)
+			continue
+		}
+		blocks = append(blocks, acp.ContentBlock{Type: "image", Data: img.Data, MimeType: img.MimeType})
+	}
+	return blocks
+}
+
+// extractACPContent builds ACP ContentBlocks from a ChatRequest.
+//
+// isNew=false (normal turn): GEMINI.md in the session workspace already provides
+// the system prompt, so only the current user message is sent. This avoids
+// repeating the (often large) system prompt on every turn.
+//
+// isNew=true (fresh or reset session): the session has no prior context.
+// All non-system messages from req.Messages are serialised as a conversation
+// transcript so that compacted summaries and recent history are preserved.
+// The system prompt is omitted here because writeGeminiMD wrote it to GEMINI.md
+// before the session was created.
+func extractACPContent(req ChatRequest, isNew bool) []acp.ContentBlock {
+	msgs := req.Messages
+
+	if !isNew {
+		// Normal turn: send only the current user message.
+		_, userMsg, images := extractFromMessages(msgs)
+		if userMsg == "" {
+			return nil
+		}
+		blocks := []acp.ContentBlock{{Type: "text", Text: userMsg}}
+		return appendACPImages(blocks, images)
+	}
+
+	// New session: serialise full conversation context (summary + history + current).
+	// System prompt is excluded — GEMINI.md handles it.
+	var sb strings.Builder
+	var images []ImageContent
+	for i, m := range msgs {
+		switch m.Role {
+		case "system":
+			continue
+		case "user":
+			if i == len(msgs)-1 {
+				images = m.Images // collect images from last (current) user message
+			}
+			sb.WriteString("[User]\n")
+			sb.WriteString(m.Content)
+			sb.WriteString("\n\n")
+		case "assistant":
+			sb.WriteString("[Assistant]\n")
+			sb.WriteString(m.Content)
+			sb.WriteString("\n\n")
+		}
+	}
+
+	text := strings.TrimRight(sb.String(), "\n")
+	if text == "" {
 		return nil
 	}
-
-	var blocks []acp.ContentBlock
-
-	// Prepend system prompt to user message (ACP agents have no separate system prompt API)
-	text := userMsg
-	if systemPrompt != "" {
-		text = systemPrompt + "\n\n" + userMsg
-	}
-	blocks = append(blocks, acp.ContentBlock{Type: "text", Text: text})
-
-	for _, img := range images {
-		blocks = append(blocks, acp.ContentBlock{
-			Type:     "image",
-			Data:     img.Data,
-			MimeType: img.MimeType,
-		})
-	}
-
-	return blocks
+	blocks := []acp.ContentBlock{{Type: "text", Text: text}}
+	return appendACPImages(blocks, images)
 }
 
 // mapStopReason converts ACP stopReason to GoClaw finish reason.
@@ -374,9 +599,35 @@ func mapStopReason(resp *acp.PromptResponse) string {
 	switch resp.StopReason {
 	case "max_tokens", "maxContextLength":
 		return "length"
-	case "cancelled":
-		return "stop"
-	default:
+	case "tool_use":
+		return "tool_calls"
+	case "error":
+		return "error"
+	default: // end_turn, stop_sequence, cancelled, ""
 		return "stop"
 	}
+}
+
+// isMalformedFunctionCall returns true when err indicates Gemini produced an
+// invalid tool call JSON — a transient model glitch worth retrying.
+func isMalformedFunctionCall(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "malformed function call")
+}
+
+// acpEstimateTokens returns a rough token count from character count (chars/4).
+func acpEstimateTokens(s string) int {
+	n := len(s) / 4
+	if n < 1 && len(s) > 0 {
+		return 1
+	}
+	return n
+}
+
+// acpInputTokens estimates input token count from all messages.
+func acpInputTokens(msgs []Message) int {
+	var total int
+	for _, m := range msgs {
+		total += acpEstimateTokens(m.Content)
+	}
+	return total
 }


### PR DESCRIPTION
## Summary

- Gemini CLI 0.38.x uses `session/request_permission` instead of `permission/request` before executing MCP tools
- Without a handler, the JSON-RPC error was stringified as `[object Object]`, causing all tool calls to fail silently
- Add `handleSessionPermission()` with nested outcome structure matching Gemini CLI's `RequestPermissionResponseSchema`

## Changes

- `internal/providers/acp/types.go` — `SessionRequestPermissionRequest/Response` types, `McpServer` interface aligned to Gemini CLI wire format (array headers)
- `internal/providers/acp/tool_bridge.go` — `session/request_permission` case in `Handle()`, `handleSessionPermission()` with perm-mode logic (`proceed_always_server` / `proceed_once` / `cancelled`)
- `internal/providers/acp/session.go` — per-session cwd isolation, `mcpServersFn` wiring
- `internal/providers/acp/process.go` — `mcpServersFn`, `promptTimeout` fields
- `internal/providers/acp_provider.go` — perm-mode wiring, MCP servers func option

## Test plan

- [ ] Gemini CLI ACP agent executes MCP tools without `[object Object]` error
- [ ] `approve-all` mode: first tool call selects `proceed_always_server`, subsequent calls skip confirmation
- [ ] `deny-all` mode: all tool calls return `cancelled`
- [ ] `approve-reads` mode: read-type tools approved, write/exec cancelled