### PR TITLE
Prepare Docker deployment for TOSE

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,9 @@ tests/
 openclaw-go
 *.exe
 tmp/
+backups/
+data/
+goclaw-volumes*.tar.gz
 .claude/
 .vscode/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ goclaw-lite-*.zip
 .mcp.json
 tmp
 .claude/
+backups/
+data/
+goclaw-volumes*.tar.gz
 
 deploy-*.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # ENABLE_EMBEDUI controls whether the web UI is built and embedded.
 # Must be declared before first FROM to use in stage selector.
-ARG ENABLE_EMBEDUI=false
+ARG ENABLE_EMBEDUI=true
 
 # ── Stage 0: Build Web UI ──
 # BuildKit skips this stage entirely when ENABLE_EMBEDUI=false
@@ -39,7 +39,7 @@ COPY . .
 ARG ENABLE_OTEL=false
 ARG ENABLE_TSNET=false
 ARG ENABLE_REDIS=false
-ARG ENABLE_EMBEDUI=false
+ARG ENABLE_EMBEDUI=true
 ARG VERSION=
 
 # Copy web UI dist — from web-builder when ENABLE_EMBEDUI=true, empty dir otherwise.
@@ -70,8 +70,8 @@ RUN set -eux; \
 FROM alpine:3.23
 
 ARG ENABLE_SANDBOX=false
-ARG ENABLE_PYTHON=false
-ARG ENABLE_NODE=false
+ARG ENABLE_PYTHON=true
+ARG ENABLE_NODE=true
 ARG ENABLE_FULL_SKILLS=false
 ARG ENABLE_CLAUDE_CLI=false
 
@@ -143,12 +143,12 @@ RUN chmod +x /app/docker-entrypoint.sh && \
 # .runtime has split ownership: root owns the dir (so pkg-helper can write apk-packages),
 # while pip/npm subdirs are goclaw-owned (runtime installs by the app process).
 # Symlink .claude → data volume so Claude CLI credentials persist across container recreates.
-RUN mkdir -p /app/workspace /app/data/.runtime/pip /app/data/.runtime/npm-global/lib \
+RUN mkdir -p /app/workspace /app/data/skills /app/data/.runtime/pip /app/data/.runtime/npm-global/lib \
         /app/data/.runtime/pip-cache /app/data/.runtime/bin /app/data/.claude /app/skills \
         /app/tsnet-state /app/.goclaw \
     && ln -s /app/data/.claude /app/.claude \
     && touch /app/data/.runtime/apk-packages \
-    && chown -R goclaw:goclaw /app/workspace /app/skills /app/tsnet-state /app/.goclaw \
+    && chown -R goclaw:goclaw /app/workspace /app/skills /app/data/skills /app/tsnet-state /app/.goclaw \
     && chown goclaw:goclaw /app/bundled-skills /app/data \
     && chown root:goclaw /app/data/.runtime /app/data/.runtime/apk-packages \
     && chmod 0750 /app/data/.runtime \
@@ -157,10 +157,10 @@ RUN mkdir -p /app/workspace /app/data/.runtime/pip /app/data/.runtime/npm-global
     && chmod 0755 /app/data/.runtime/bin
 
 # Default environment
-ENV GOCLAW_CONFIG=/app/config.json \
+ENV GOCLAW_CONFIG=/app/data/config.json \
     GOCLAW_WORKSPACE=/app/workspace \
     GOCLAW_DATA_DIR=/app/data \
-    GOCLAW_SKILLS_DIR=/app/skills \
+    GOCLAW_SKILLS_DIR=/app/data/skills \
     GOCLAW_MIGRATIONS_DIR=/app/migrations \
     GOCLAW_HOST=0.0.0.0 \
     GOCLAW_PORT=18790

--- a/docs/deploy-tose.md
+++ b/docs/deploy-tose.md
@@ -1,0 +1,75 @@
+# Deploying GoClaw on TOSE
+
+TOSE can deploy GoClaw from a GitHub repository. GoClaw is a Dockerized Go
+service with an embedded React dashboard and listens on port `18790`.
+
+## Requirements
+
+- GitHub repository connected to the TOSE GitHub App.
+- PostgreSQL database with `pgcrypto` and `pgvector` support.
+- Project port set to `18790`.
+- Recommended resources: `2` CPU, `4` GB RAM, `1` replica.
+
+GoClaw migrations require:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS "vector";
+```
+
+If TOSE managed PostgreSQL does not support `pgvector`, use an external
+PostgreSQL provider that does, then set `GOCLAW_POSTGRES_DSN` to that database.
+
+## Environment Variables
+
+Set these variables in TOSE before deploying:
+
+```env
+GOCLAW_HOST=0.0.0.0
+GOCLAW_PORT=18790
+GOCLAW_CONFIG=/app/data/config.json
+GOCLAW_SKILLS_DIR=/app/data/skills
+GOCLAW_POSTGRES_DSN=postgresql://USER:PASSWORD@HOST:5432/DB?sslmode=require
+GOCLAW_GATEWAY_TOKEN=replace-with-random-token
+GOCLAW_ENCRYPTION_KEY=replace-with-64-char-hex-key
+```
+
+Optional provider/channel keys can be configured later from the dashboard or as
+TOSE environment variables.
+
+## CLI Flow
+
+```bash
+npm install -g @tosesh/tose
+tose login
+tose init
+tose env set GOCLAW_HOST=0.0.0.0 GOCLAW_PORT=18790 GOCLAW_CONFIG=/app/data/config.json GOCLAW_SKILLS_DIR=/app/data/skills
+tose env set GOCLAW_POSTGRES_DSN='postgresql://USER:PASSWORD@HOST:5432/DB?sslmode=require'
+tose env set GOCLAW_GATEWAY_TOKEN='replace-with-random-token'
+tose env set GOCLAW_ENCRYPTION_KEY='replace-with-64-char-hex-key'
+tose deploy
+tose logs --build -f
+```
+
+Generate production secrets locally, then paste them into TOSE:
+
+```bash
+openssl rand -hex 32  # GOCLAW_ENCRYPTION_KEY: 64 hex chars
+openssl rand -hex 32  # GOCLAW_GATEWAY_TOKEN
+```
+
+After the first deployment, verify:
+
+```bash
+curl https://YOUR-TOSE-APP/health
+```
+
+The expected response contains `"status":"ok"`.
+
+## Notes
+
+- The Dockerfile defaults are set for TOSE: embedded web UI, Python runtime, and
+  Node.js runtime are enabled by default.
+- Do not commit local `.env`, `data/`, `backups/`, or `goclaw-volumes*.tar.gz`.
+- If the dashboard loads but login/API calls fail, confirm that the project port
+  is `18790` and that the TOSE deployment is forwarding to that port.


### PR DESCRIPTION
## Summary
- Enable embedded web UI, Python, and Node runtimes by default for direct Docker builds on TOSE
- Move default config and skills paths under /app/data for cloud/persistent deployments
- Ignore local backup/data volume artifacts and add TOSE deployment notes

## Verification
- docker build -t goclaw-tose-check .
- docker run --rm --entrypoint /app/goclaw goclaw-tose-check version
- docker run --rm --entrypoint sh goclaw-tose-check -lc 'python3 --version && node --version && npm --version && test -d /app/data/skills && test -d /app/migrations && echo runtime-ok'
