### PR TITLE
fix(cli): use openai_compat instead of openai-compat in provider setup

### DIFF
--- a/cmd/providers_cmd.go
+++ b/cmd/providers_cmd.go
@@ -125,7 +125,7 @@ func runProvidersAdd() {
 		{"OpenAI", "openai"},
 		{"OpenRouter", "openrouter"},
 		{"DashScope (Alibaba)", "dashscope"},
-		{"OpenAI-compatible", "openai-compat"},
+		{"OpenAI-compatible", "openai_compat"},
 	}
 	providerType, err := promptSelect("Provider type", typeOptions, 0)
 	if err != nil {
@@ -150,7 +150,7 @@ func runProvidersAdd() {
 	// Step 4: Base URL (pre-fill per type, editable)
 	defaultURL := defaultBaseURL(providerType)
 	baseURL := ""
-	if providerType == "openai-compat" {
+	if providerType == "openai_compat" {
 		baseURL, err = promptString("Base URL", "e.g. https://api.example.com/v1", defaultURL)
 		if err != nil {
 			fmt.Println("Cancelled.")

--- a/cmd/setup_provider.go
+++ b/cmd/setup_provider.go
@@ -49,7 +49,7 @@ func addProvider() {
 		{"OpenAI", "openai"},
 		{"OpenRouter", "openrouter"},
 		{"DashScope (Alibaba)", "dashscope"},
-		{"OpenAI-compatible", "openai-compat"},
+		{"OpenAI-compatible", "openai_compat"},
 	}
 	providerType, err := promptSelect("Provider type", typeOptions, 0)
 	if err != nil {
@@ -68,7 +68,7 @@ func addProvider() {
 	}
 
 	baseURL := ""
-	if providerType == "openai-compat" {
+	if providerType == "openai_compat" {
 		baseURL, err = promptString("Base URL", "e.g. https://api.example.com/v1", "")
 		if err != nil {
 			return


### PR DESCRIPTION
Fixes #1046

## Problem

The CLI setup wizard (`goclaw setup`) and `providers add` command display `openai-compat` as the provider type, but the HTTP API (`/v1/providers`) and database validation expect `openai_compat` (underscore).

This mismatch causes provider creation to fail during the setup process.

## Solution

Change `openai-compat` to `openai_compat` in the CLI provider type definitions to match the internal constant `store.ProviderOpenAICompat`.

## Changes

- `cmd/setup_provider.go`: Updated provider type mapping and check
- `cmd/providers_cmd.go`: Updated provider type mapping and check
