### PR TITLE
fix(providers): resolve HTTP 400 DeepSeek reasoning passback error during tool calls

### DIFF
--- a/internal/agent/loop_run.go
+++ b/internal/agent/loop_run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/internal/tools"
 	"github.com/nextlevelbuilder/goclaw/internal/tracing"
@@ -216,6 +217,25 @@ func (l *Loop) Run(ctx context.Context, req RunRequest) (*RunResult, error) {
 		if isChildTrace && l.traceCollector != nil && traceID != uuid.Nil {
 			l.traceCollector.SetTraceStatus(ctx, traceID, store.TraceStatusCompleted)
 		}
+
+		provider := l.provider
+		if req.ProviderOverride != nil {
+			provider = req.ProviderOverride
+		}
+		model := l.model
+		if req.ModelOverride != "" {
+			model = req.ModelOverride
+		}
+		reasoningDecision := providers.ResolveReasoningDecision(
+			provider, model,
+			l.reasoningConfig.Effort,
+			l.reasoningConfig.Fallback,
+			l.reasoningConfig.Source,
+		)
+		if reasoningDecision.StripThinking {
+			result.Thinking = ""
+		}
+
 		completedPayload := map[string]any{"content": result.Content}
 		if result.Thinking != "" {
 			completedPayload["thinking"] = result.Thinking

--- a/internal/providers/openai_chat.go
+++ b/internal/providers/openai_chat.go
@@ -28,14 +28,11 @@ func (p *OpenAIProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 		}
 	}
 
-	// Drop user-visible reasoning for models flagged as leakers (e.g. Kimi,
-	// DeepSeek-Reasoner). Usage.ThinkingTokens is preserved so billing stays
-	// correct (Phase 1 depends on this).
-	if resp != nil {
-		if strip, _ := req.Options[OptStripThinking].(bool); strip {
-			resp.Thinking = ""
-		}
-	}
+	// Note: We used to drop user-visible reasoning here for leaky models.
+	// However, DeepSeek strictly requires `reasoning_content` to be passed back
+	// on tool call iterations. Clearing `resp.Thinking` here causes HTTP 400s
+	// on subsequent passbacks. The responsibility of hiding leaked reasoning
+	// from the UI is now handled in the Agent loop (e.g. final payload stripping).
 
 	return resp, err
 }
@@ -126,9 +123,9 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, req ChatRequest, onChun
 		if reasoning == "" {
 			reasoning = delta.Reasoning
 		}
-		if reasoning != "" && !stripThinking {
+		if reasoning != "" {
 			result.Thinking += reasoning
-			if onChunk != nil {
+			if !stripThinking && onChunk != nil {
 				onChunk(StreamChunk{Thinking: reasoning})
 			}
 		}

--- a/internal/providers/openai_request.go
+++ b/internal/providers/openai_request.go
@@ -56,8 +56,20 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 
 		// Echo reasoning_content only for APIs/models that accept it on assistant history.
 		// Together Qwen and many OpenAI-compat gateways reject unknown message fields → HTTP 400.
-		if m.Thinking != "" && m.Role == "assistant" && openAIWireAssistantReasoningContent(model) {
-			msg["reasoning_content"] = m.Thinking
+		if m.Role == "assistant" && openAIWireAssistantReasoningContent(model) {
+			if m.Thinking != "" {
+				msg["reasoning_content"] = m.Thinking
+			} else {
+				// DeepSeek API strictly requires the reasoning_content field to be present
+				// on assistant messages (especially those with tool_calls) when thinking mode
+				// is active, even if the model didn't actually output any reasoning tokens.
+				// Omitting the field entirely triggers an HTTP 400 error.
+				fam := strings.ToLower(modelFamily(model))
+				full := strings.ToLower(model)
+				if strings.Contains(fam, "deepseek") || strings.Contains(full, "deepseek") {
+					msg["reasoning_content"] = ""
+				}
+			}
 		}
 
 		// Include content; omit empty content for assistant messages with tool_calls

--- a/internal/providers/openai_request_test.go
+++ b/internal/providers/openai_request_test.go
@@ -187,3 +187,57 @@ func TestBuildRequestBody_NativeToolInBody(t *testing.T) {
 		t.Error("native tool must not have 'function' field in request body")
 	}
 }
+
+// TestBuildRequestBody_DeepSeekReasoningContent verifies that deepseek models
+// unconditionally get reasoning_content: "" when m.Thinking is empty and tool_calls exist,
+// while other models (like gpt-4) do not get the field injected.
+func TestBuildRequestBody_DeepSeekReasoningContent(t *testing.T) {
+	p := NewOpenAIProvider("openai", "sk-test", "https://api.openai.com/v1", "deepseek-v4-pro")
+	
+	req := ChatRequest{
+		Model: "deepseek-v4-pro",
+		Messages: []Message{
+			{Role: "user", Content: "hello"},
+			{
+				Role:      "assistant",
+				Content:   "",
+				Thinking:  "", // Empty thinking
+				ToolCalls: []ToolCall{{ID: "call_123", Name: "test_tool"}},
+			},
+			{Role: "user", Content: "continue"}, // Prevent being stripped as trailing assistant prefill
+		},
+	}
+	
+	body := p.buildRequestBody("deepseek-v4-pro", req, false)
+	msgs, ok := body["messages"].([]map[string]any)
+	if !ok || len(msgs) == 0 {
+		t.Fatalf("failed to build messages")
+	}
+	
+	// DeepSeek should have reasoning_content injected
+	if val, exists := msgs[1]["reasoning_content"]; !exists || val != "" {
+		t.Errorf("expected reasoning_content to be present and empty for deepseek, got exists=%v val=%v", exists, val)
+	}
+	
+	// Test with GPT-4o (should not have reasoning_content injected)
+	p2 := NewOpenAIProvider("openai", "sk-test", "https://api.openai.com/v1", "gpt-4o")
+	req2 := ChatRequest{
+		Model: "gpt-4o",
+		Messages: []Message{
+			{Role: "user", Content: "hello"},
+			{
+				Role:      "assistant",
+				Content:   "",
+				Thinking:  "",
+				ToolCalls: []ToolCall{{ID: "call_123", Name: "test_tool"}},
+			},
+			{Role: "user", Content: "continue"},
+		},
+	}
+	
+	body2 := p2.buildRequestBody("gpt-4o", req2, false)
+	msgs2 := body2["messages"].([]map[string]any)
+	if _, exists := msgs2[1]["reasoning_content"]; exists {
+		t.Errorf("expected reasoning_content to NOT be present for gpt-4o")
+	}
+}


### PR DESCRIPTION
## Description
This PR fixes an HTTP 400 `invalid_request_error` encountered when using DeepSeek models (e.g., `deepseek-v4-pro`, `deepseek-reasoner`) with Thinking Mode enabled during multi-turn tool calling.
The DeepSeek API enforces a strict schema requirement: any `assistant` message in the context history that includes `tool_calls` **must** also include the `reasoning_content` field, even if the model did not emit any reasoning tokens in that specific turn. Previously, WorkBuddy would either omit this field when it was empty, or improperly drop the reasoning content entirely inside the provider layer when `stripThinking` was active.
### Changes Made
1. **Preserve Reasoning History (`internal/providers/openai_chat.go`)**: 
   - Ensure `result.Thinking` is always accumulated regardless of the `stripThinking` flag. This guarantees that the chain of thought is correctly added to the message history for subsequent API passback.
2. **Strict Schema Compliance (`internal/providers/openai_request.go`)**: 
   - When building the request payload for DeepSeek models, if an assistant message's `Thinking` is empty, explicitly inject `reasoning_content: ""` into the JSON. This satisfies DeepSeek's strict JSON schema validation.
3. **Safe UI Output Stripping (`internal/agent/loop_run.go`)**: 
   - Moved the responsibility of hiding leaked reasoning from the UI out of the provider layer. `result.Thinking` is now explicitly cleared from the final `completedPayload` at the end of the agent loop if `reasoningDecision.StripThinking` is true.
4. **Unit Testing (`internal/providers/openai_request_test.go`)**: 
   - Added specific tests (`TestBuildRequestBody_DeepSeekReasoningContent`) to ensure `reasoning_content` is accurately injected for DeepSeek models and safely omitted for standard OpenAI models (like GPT-4o).
## Related Issues
Fixes #1047

## Summary
<!-- 1-2 sentences: What does this PR do and why? -->

## Type
<!-- Check one -->
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [ ] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
