### PR TITLE
feat(acp): full Gemini CLI integration — tool exposure + spec compliance + watchdog + GEMINI.md

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -286,6 +286,7 @@ func runGateway() {
 	server.SetDB(pgStores.DB)
 	server.SetPolicyEngine(permPE)
 	server.SetPairingService(pgStores.Pairing)
+	server.SetBuiltinToolsStore(pgStores.BuiltinTools)
 	server.SetMessageBus(msgBus)
 	server.SetOAuthHandler(httpapi.NewOAuthHandler(pgStores.Providers, pgStores.ConfigSecrets, providerRegistry, msgBus))
 

--- a/cmd/gateway_builtin_tools.go
+++ b/cmd/gateway_builtin_tools.go
@@ -112,6 +112,26 @@ func builtinToolSeedData() []store.BuiltinToolDef {
 		{Name: "team_tasks", DisplayName: "Team Tasks", Description: "View, create, update, and complete tasks on the team task board", Category: "teams", Enabled: true,
 			Requires: []string{"managed_mode", "teams"},
 		},
+
+		// general — utility tools available to every agent (incl. ACP via MCP bridge)
+		{Name: "datetime", DisplayName: "Date / Time", Description: "Get current date and time with optional IANA timezone (returns UTC + local).", Category: "general", Enabled: true},
+
+		// subagents (continued)
+		{Name: "delegate", DisplayName: "Delegate Task", Description: "Delegate a task to another linked agent (inter-agent orchestration).", Category: "subagents", Enabled: true},
+
+		// skills (continued)
+		{Name: "mcp_tool_search", DisplayName: "MCP Tool Search", Description: "BM25 search over deferred MCP tool catalog to discover relevant tools by query.", Category: "skills", Enabled: true},
+
+		// messaging (continued)
+		{Name: "list_group_members", DisplayName: "List Group Members", Description: "List members in a group chat (Telegram group, etc.).", Category: "messaging", Enabled: true},
+
+		// memory — Knowledge Vault
+		{Name: "vault_read", DisplayName: "Vault Read", Description: "Read a document from the Knowledge Vault by path or [[wikilink]].", Category: "memory", Enabled: true,
+			Requires: []string{"vault"},
+		},
+		{Name: "vault_search", DisplayName: "Vault Search", Description: "Hybrid search (lexical + embeddings) over the Knowledge Vault.", Category: "memory", Enabled: true,
+			Requires: []string{"vault"},
+		},
 	}
 
 	// Lite edition: remove skill management tools — not available on desktop.

--- a/cmd/gateway_managed.go
+++ b/cmd/gateway_managed.go
@@ -680,7 +680,8 @@ func wireExtras(
 		// Unregister old instance (closes ProcessPool) then re-register
 		providerReg.Unregister(p.Name)
 		if p.Enabled {
-			registerACPFromDB(providerReg, *p)
+			gatewayAddr := loopbackAddr(appCfg.Gateway.Host, appCfg.Gateway.Port)
+			registerACPFromDB(providerReg, *p, gatewayAddr, appCfg.Gateway.Token, buildACPMCPServerLookup(stores.MCP), appCfg.Agents.Defaults.Workspace)
 		}
 	})
 

--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -416,7 +416,8 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 
 // registerACPFromConfig registers an ACP provider from config file settings.
 // workspace is the gateway-level default workspace (cfg.Agents.Defaults.Workspace),
-// used to compute --include-directories for workspace-relative skill slots.
+// used to compute candidate directories that gemini exposes via
+// --include-directories (per-binary gating happens inside the provider).
 func registerACPFromConfig(registry *providers.Registry, cfg config.ACPConfig, gatewayAddr, gatewayToken, workspace string) {
 	if _, err := exec.LookPath(cfg.Binary); err != nil {
 		slog.Warn("acp: binary not found, skipping", "binary", cfg.Binary, "error", err)
@@ -432,7 +433,9 @@ func registerACPFromConfig(registry *providers.Registry, cfg config.ACPConfig, g
 	if workDir == "" {
 		workDir = defaultACPWorkDir()
 	}
-	var opts []providers.ACPOption
+	opts := []providers.ACPOption{
+		providers.WithIncludeDirectories(acpSkillCandidateDirs(workspace)),
+	}
 	if cfg.Model != "" {
 		opts = append(opts, providers.WithACPModel(cfg.Model))
 	}
@@ -442,11 +445,10 @@ func registerACPFromConfig(registry *providers.Registry, cfg config.ACPConfig, g
 	if fn := buildACPMcpServersFunc(gatewayAddr, gatewayToken, nil); fn != nil {
 		opts = append(opts, providers.WithACPMcpServersFunc(fn))
 	}
-	finalArgs := enrichGeminiACPArgs(cfg.Binary, cfg.Args, workspace)
 	registry.Register(providers.NewACPProvider(
-		cfg.Binary, finalArgs, workDir, idleTTL, tools.DefaultDenyPatterns(), opts...,
+		cfg.Binary, cfg.Args, workDir, idleTTL, tools.DefaultDenyPatterns(), opts...,
 	))
-	slog.Info("registered provider", "name", "acp", "binary", cfg.Binary, "args", finalArgs)
+	slog.Info("registered provider", "name", "acp", "binary", cfg.Binary, "args", cfg.Args)
 }
 
 // buildACPMCPServerLookup returns a lookup function that lists every enabled
@@ -638,13 +640,13 @@ func registerACPFromDB(registry *providers.Registry, p store.LLMProviderData, ga
 	acpOpts := []providers.ACPOption{
 		providers.WithACPName(p.Name),
 		providers.WithACPModel(p.Name),
+		providers.WithIncludeDirectories(acpSkillCandidateDirs(workspace)),
 	}
 	if fn := buildACPMcpServersFunc(gatewayAddr, gatewayToken, lookup); fn != nil {
 		acpOpts = append(acpOpts, providers.WithACPMcpServersFunc(fn))
 	}
-	finalArgs := enrichGeminiACPArgs(binary, settings.Args, workspace)
 	registry.RegisterForTenant(p.TenantID, providers.NewACPProvider(
-		binary, finalArgs, workDir, idleTTL, tools.DefaultDenyPatterns(),
+		binary, settings.Args, workDir, idleTTL, tools.DefaultDenyPatterns(),
 		acpOpts...,
 	))
 	slog.Info("registered provider from DB", "name", p.Name, "type", "acp")
@@ -655,22 +657,12 @@ func defaultACPWorkDir() string {
 	return filepath.Join(config.ResolvedDataDirFromEnv(), "acp-workspaces")
 }
 
-// enrichGeminiACPArgs adds --include-directories flags so the Gemini CLI
-// workspace sandbox can read goclaw-managed skill content alongside the agent's
-// own working directory.
-//
-// Without this, Gemini's built-in fs tools (glob, read_file) reject any path
-// outside the cwd, so prompts like "list /home/user/.goclaw/data/skills-store"
-// fail even though the goclaw MCP bridge could fulfill them.
-//
-// Applies only when the binary is "gemini" (via PATH or absolute path).
-// No-op for claude, codex, or any other ACP-compatible binary, since their
-// sandboxing semantics differ.
-//
-// Mirrors the five filesystem-backed skill source slots that
+// acpSkillCandidateDirs enumerates the filesystem-backed skill source
+// directories that should be exposed to gemini via --include-directories.
+// Returns paths regardless of existence; the provider stat-filters before
+// emitting flags. Mirrors the five filesystem slots that
 // internal/skills/loader.go reads at runtime (builtinSkills is binary-embedded,
-// not a filesystem path, so it is omitted). Paths that do not exist on disk
-// are skipped to avoid Gemini CLI warnings about missing workspace entries.
+// so it is omitted).
 //
 // Sources mirrored:
 //   - workspaceSkills      : <workspace>/skills
@@ -679,43 +671,30 @@ func defaultACPWorkDir() string {
 //   - globalSkills         : <dataDir>/skills
 //   - personalAgentSkills  : ~/.agents/skills
 //
-// Note: bundled-skills (seeder source) is intentionally NOT included — the
-// seeder copies its content into skills-store, so exposing bundled-skills
-// would duplicate trees in the agent workspace.
-func enrichGeminiACPArgs(binary string, args []string, workspace string) []string {
-	base := filepath.Base(binary)
-	if base != "gemini" {
-		return args
-	}
+// bundled-skills (seeder source) is intentionally NOT included — the seeder
+// copies its content into skills-store, so exposing bundled-skills would
+// duplicate trees in the agent workspace.
+//
+// Per-binary gating (only gemini honors --include-directories) and
+// vendor-specific defaults like --skip-trust live in providers.NewACPProvider.
+// This function only assembles the candidate list.
+func acpSkillCandidateDirs(workspace string) []string {
 	dataDir := config.ResolvedDataDirFromEnv()
-
-	candidates := []string{
+	dirs := []string{
 		filepath.Join(dataDir, "skills-store"), // managedSkillsDir
 		filepath.Join(dataDir, "skills"),       // globalSkills
 	}
 	if workspace != "" {
 		ws := config.ExpandHome(workspace)
-		candidates = append(candidates,
+		dirs = append(dirs,
 			filepath.Join(ws, "skills"),            // workspaceSkills
 			filepath.Join(ws, ".agents", "skills"), // projectAgentSkills
 		)
 	}
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		candidates = append(candidates,
+		dirs = append(dirs,
 			filepath.Join(home, ".agents", "skills"), // personalAgentSkills
 		)
 	}
-
-	extras := make([]string, 0, len(candidates)*2)
-	for _, p := range candidates {
-		if p == "" {
-			continue
-		}
-		info, err := os.Stat(p)
-		if err != nil || !info.IsDir() {
-			continue
-		}
-		extras = append(extras, "--include-directories", p)
-	}
-	return append(append([]string{}, args...), extras...)
+	return dirs
 }

--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -3,11 +3,14 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -15,6 +18,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/oauth"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/providers/acp"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/internal/tools"
 )
@@ -29,6 +33,7 @@ func loopbackAddr(host string, port int) string {
 }
 
 func registerProviders(registry *providers.Registry, cfg *config.Config, modelReg providers.ModelRegistry) {
+	gatewayAddr := loopbackAddr(cfg.Gateway.Host, cfg.Gateway.Port)
 	if cfg.Providers.Anthropic.APIKey != "" {
 		registry.Register(providers.NewAnthropicProvider(cfg.Providers.Anthropic.APIKey,
 			providers.WithAnthropicBaseURL(cfg.Providers.Anthropic.APIBase),
@@ -188,7 +193,6 @@ func registerProviders(registry *providers.Registry, cfg *config.Config, modelRe
 			opts = append(opts, providers.WithClaudeCLIPermMode(cfg.Providers.ClaudeCLI.PermMode))
 		}
 		// Build per-session MCP config: external MCP servers + GoClaw bridge
-		gatewayAddr := loopbackAddr(cfg.Gateway.Host, cfg.Gateway.Port)
 		mcpData := providers.BuildCLIMCPConfigData(cfg.Tools.McpServers, gatewayAddr, cfg.Gateway.Token)
 		opts = append(opts, providers.WithClaudeCLIMCPConfigData(mcpData))
 		// Enable GoClaw security hooks (shell deny patterns, path restrictions)
@@ -200,7 +204,7 @@ func registerProviders(registry *providers.Registry, cfg *config.Config, modelRe
 
 	// ACP provider (config-based) — orchestrates any ACP-compatible agent binary
 	if cfg.Providers.ACP.Binary != "" {
-		registerACPFromConfig(registry, cfg.Providers.ACP)
+		registerACPFromConfig(registry, cfg.Providers.ACP, gatewayAddr, cfg.Gateway.Token, cfg.Agents.Defaults.Workspace)
 	}
 }
 
@@ -309,7 +313,7 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 		}
 		// ACP provider — no API key needed (agents manage their own auth).
 		if p.ProviderType == store.ProviderACP {
-			registerACPFromDB(registry, p)
+			registerACPFromDB(registry, p, gatewayAddr, gatewayToken, buildACPMCPServerLookup(mcpStore), cfg.Agents.Defaults.Workspace)
 			continue
 		}
 		// Local Ollama requires no API key — handle before the key guard (same pattern as ClaudeCLI).
@@ -411,7 +415,9 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 }
 
 // registerACPFromConfig registers an ACP provider from config file settings.
-func registerACPFromConfig(registry *providers.Registry, cfg config.ACPConfig) {
+// workspace is the gateway-level default workspace (cfg.Agents.Defaults.Workspace),
+// used to compute --include-directories for workspace-relative skill slots.
+func registerACPFromConfig(registry *providers.Registry, cfg config.ACPConfig, gatewayAddr, gatewayToken, workspace string) {
 	if _, err := exec.LookPath(cfg.Binary); err != nil {
 		slog.Warn("acp: binary not found, skipping", "binary", cfg.Binary, "error", err)
 		return
@@ -433,14 +439,167 @@ func registerACPFromConfig(registry *providers.Registry, cfg config.ACPConfig) {
 	if cfg.PermMode != "" {
 		opts = append(opts, providers.WithACPPermMode(cfg.PermMode))
 	}
+	if fn := buildACPMcpServersFunc(gatewayAddr, gatewayToken, nil); fn != nil {
+		opts = append(opts, providers.WithACPMcpServersFunc(fn))
+	}
+	finalArgs := enrichGeminiACPArgs(cfg.Binary, cfg.Args, workspace)
 	registry.Register(providers.NewACPProvider(
-		cfg.Binary, cfg.Args, workDir, idleTTL, tools.DefaultDenyPatterns(), opts...,
+		cfg.Binary, finalArgs, workDir, idleTTL, tools.DefaultDenyPatterns(), opts...,
 	))
-	slog.Info("registered provider", "name", "acp", "binary", cfg.Binary)
+	slog.Info("registered provider", "name", "acp", "binary", cfg.Binary, "args", finalArgs)
+}
+
+// buildACPMCPServerLookup returns a lookup function that lists every enabled
+// MCP server in the store, ignoring per-agent grants. The UI currently has no
+// surface for configuring grants, so treating every enabled server as globally
+// available keeps "register a server in the UI → it just shows up in ACP"
+// behavior consistent with user expectations. Returns nil when mcpStore is nil.
+func buildACPMCPServerLookup(mcpStore store.MCPServerStore) providers.MCPServerLookup {
+	if mcpStore == nil {
+		return nil
+	}
+	return func(ctx context.Context, _ string) []providers.MCPServerEntry {
+		all, err := mcpStore.ListServers(ctx)
+		if err != nil {
+			slog.Warn("acp: failed to list MCP servers", "error", err)
+			return nil
+		}
+		var entries []providers.MCPServerEntry
+		for _, srv := range all {
+			if !srv.Enabled {
+				continue
+			}
+			entries = append(entries, providers.MCPServerEntry{
+				Name:      srv.Name,
+				Transport: srv.Transport,
+				Command:   srv.Command,
+				URL:       srv.URL,
+				Args:      jsonToStringSlice(srv.Args),
+				Headers:   jsonToStringMap(srv.Headers),
+				Env:       jsonToStringMap(srv.Env),
+			})
+		}
+		return entries
+	}
+}
+
+// buildACPMcpServersFunc returns a callback that builds the MCP server list
+// for every ACP session/new and session/load request.
+//
+// The list always includes the GoClaw internal MCP bridge (skill_search,
+// web_search, memory_*, etc.). When a per-agent MCPServerLookup is provided,
+// UI-registered MCP servers accessible to the calling agent are appended.
+// Returns nil when the gateway address is empty (no bridge to advertise).
+func buildACPMcpServersFunc(gatewayAddr, gatewayToken string, lookup providers.MCPServerLookup) func(context.Context) []acp.McpServer {
+	if gatewayAddr == "" {
+		return nil
+	}
+	bridgeURL := fmt.Sprintf("http://%s/mcp/bridge", gatewayAddr)
+	return func(ctx context.Context) []acp.McpServer {
+		// Resolve session context; ACP session is created per goclaw session, so
+		// these values remain valid for all subsequent MCP tool calls routed
+		// through the headers Gemini CLI will replay on each request.
+		var agentID, tenantID string
+		if aid := store.AgentIDFromContext(ctx); aid != uuid.Nil {
+			agentID = aid.String()
+		}
+		userID := store.UserIDFromContext(ctx)
+		if tid := store.TenantIDFromContext(ctx); tid != uuid.Nil {
+			tenantID = tid.String()
+		}
+		workspace := tools.ToolWorkspaceFromCtx(ctx)
+
+		// Build headers in the same order and set as Claude CLI bridge, so
+		// bridgeContextMiddleware accepts the signature verbatim.
+		headers := []acp.McpServerKV{}
+		if gatewayToken != "" {
+			headers = append(headers, acp.McpServerKV{Name: "Authorization", Value: "Bearer " + gatewayToken})
+		}
+		if agentID != "" && !strings.ContainsAny(agentID, "\r\n\x00") {
+			headers = append(headers, acp.McpServerKV{Name: "X-Agent-ID", Value: agentID})
+		}
+		if userID != "" && !strings.ContainsAny(userID, "\r\n\x00") {
+			headers = append(headers, acp.McpServerKV{Name: "X-User-ID", Value: userID})
+		}
+		if workspace != "" && !strings.ContainsAny(workspace, "\r\n\x00") {
+			headers = append(headers, acp.McpServerKV{Name: "X-Workspace", Value: workspace})
+		}
+		if tenantID != "" && !strings.ContainsAny(tenantID, "\r\n\x00") {
+			headers = append(headers, acp.McpServerKV{Name: "X-Tenant-ID", Value: tenantID})
+		}
+		// HMAC protects all context fields against forgery. ACP sessions don't
+		// carry channel/chatID/peerKind context (those are per-prompt channel
+		// routing values), so pass them as empty strings — server verifies
+		// with the same empty values and accepts.
+		if gatewayToken != "" && (agentID != "" || userID != "") {
+			sig := providers.SignBridgeContext(gatewayToken, agentID, userID, "", "", "", workspace, tenantID)
+			headers = append(headers, acp.McpServerKV{Name: "X-Bridge-Sig", Value: sig})
+		}
+
+		bridgeEntry := acp.McpServerHTTP{
+			Type:    "http",
+			Name:    "goclaw-bridge",
+			URL:     bridgeURL,
+			Headers: headers,
+		}
+
+		servers := []acp.McpServer{bridgeEntry}
+		if lookup == nil {
+			return servers
+		}
+		if agentID == "" {
+			return servers
+		}
+		for _, entry := range lookup(ctx, agentID) {
+			servers = append(servers, mcpServerEntryToACP(entry))
+		}
+		return servers
+	}
+}
+
+// mcpServerEntryToACP converts a goclaw MCPServerEntry (UI/DB-registered) to
+// the ACP schema. Transport strings map as follows:
+//   - "stdio"            → McpServerStdio (command/args/env)
+//   - "sse"/"http"/other → McpServerHTTP (url + headers, treated as HTTP)
+//
+// Empty maps/slices are normalized to non-nil so the ACP schema's required
+// fields (Headers for HTTP, Args/Env for stdio) are always present.
+func mcpServerEntryToACP(e providers.MCPServerEntry) acp.McpServer {
+	if e.Transport == "stdio" {
+		env := make([]acp.McpServerKV, 0, len(e.Env))
+		for k, v := range e.Env {
+			env = append(env, acp.McpServerKV{Name: k, Value: v})
+		}
+		args := e.Args
+		if args == nil {
+			args = []string{}
+		}
+		return acp.McpServerStdio{
+			Type:    "stdio",
+			Name:    e.Name,
+			Command: e.Command,
+			Args:    args,
+			Env:     env,
+		}
+	}
+	headers := make([]acp.McpServerKV, 0, len(e.Headers))
+	for k, v := range e.Headers {
+		headers = append(headers, acp.McpServerKV{Name: k, Value: v})
+	}
+	return acp.McpServerHTTP{
+		Type:    "http",
+		Name:    e.Name,
+		URL:     e.URL,
+		Headers: headers,
+	}
 }
 
 // registerACPFromDB registers an ACP provider from a DB provider row.
-func registerACPFromDB(registry *providers.Registry, p store.LLMProviderData) {
+// lookup may be nil; when provided, UI-registered MCP servers accessible to the
+// calling agent are appended to the ACP session's mcpServers.
+// workspace is the gateway-level default workspace, used for
+// --include-directories on workspace-relative skill slots.
+func registerACPFromDB(registry *providers.Registry, p store.LLMProviderData, gatewayAddr, gatewayToken string, lookup providers.MCPServerLookup, workspace string) {
 	binary := p.APIBase // repurpose api_base as binary path
 	if binary == "" {
 		slog.Warn("acp: no binary specified in DB provider", "name", p.Name)
@@ -476,10 +635,17 @@ func registerACPFromDB(registry *providers.Registry, p store.LLMProviderData) {
 	if workDir == "" {
 		workDir = defaultACPWorkDir()
 	}
-	registry.RegisterForTenant(p.TenantID, providers.NewACPProvider(
-		binary, settings.Args, workDir, idleTTL, tools.DefaultDenyPatterns(),
+	acpOpts := []providers.ACPOption{
 		providers.WithACPName(p.Name),
 		providers.WithACPModel(p.Name),
+	}
+	if fn := buildACPMcpServersFunc(gatewayAddr, gatewayToken, lookup); fn != nil {
+		acpOpts = append(acpOpts, providers.WithACPMcpServersFunc(fn))
+	}
+	finalArgs := enrichGeminiACPArgs(binary, settings.Args, workspace)
+	registry.RegisterForTenant(p.TenantID, providers.NewACPProvider(
+		binary, finalArgs, workDir, idleTTL, tools.DefaultDenyPatterns(),
+		acpOpts...,
 	))
 	slog.Info("registered provider from DB", "name", p.Name, "type", "acp")
 }
@@ -487,4 +653,69 @@ func registerACPFromDB(registry *providers.Registry, p store.LLMProviderData) {
 // defaultACPWorkDir returns the default workspace directory for ACP agents.
 func defaultACPWorkDir() string {
 	return filepath.Join(config.ResolvedDataDirFromEnv(), "acp-workspaces")
+}
+
+// enrichGeminiACPArgs adds --include-directories flags so the Gemini CLI
+// workspace sandbox can read goclaw-managed skill content alongside the agent's
+// own working directory.
+//
+// Without this, Gemini's built-in fs tools (glob, read_file) reject any path
+// outside the cwd, so prompts like "list /home/user/.goclaw/data/skills-store"
+// fail even though the goclaw MCP bridge could fulfill them.
+//
+// Applies only when the binary is "gemini" (via PATH or absolute path).
+// No-op for claude, codex, or any other ACP-compatible binary, since their
+// sandboxing semantics differ.
+//
+// Mirrors the five filesystem-backed skill source slots that
+// internal/skills/loader.go reads at runtime (builtinSkills is binary-embedded,
+// not a filesystem path, so it is omitted). Paths that do not exist on disk
+// are skipped to avoid Gemini CLI warnings about missing workspace entries.
+//
+// Sources mirrored:
+//   - workspaceSkills      : <workspace>/skills
+//   - projectAgentSkills   : <workspace>/.agents/skills
+//   - managedSkillsDir     : <dataDir>/skills-store
+//   - globalSkills         : <dataDir>/skills
+//   - personalAgentSkills  : ~/.agents/skills
+//
+// Note: bundled-skills (seeder source) is intentionally NOT included — the
+// seeder copies its content into skills-store, so exposing bundled-skills
+// would duplicate trees in the agent workspace.
+func enrichGeminiACPArgs(binary string, args []string, workspace string) []string {
+	base := filepath.Base(binary)
+	if base != "gemini" {
+		return args
+	}
+	dataDir := config.ResolvedDataDirFromEnv()
+
+	candidates := []string{
+		filepath.Join(dataDir, "skills-store"), // managedSkillsDir
+		filepath.Join(dataDir, "skills"),       // globalSkills
+	}
+	if workspace != "" {
+		ws := config.ExpandHome(workspace)
+		candidates = append(candidates,
+			filepath.Join(ws, "skills"),            // workspaceSkills
+			filepath.Join(ws, ".agents", "skills"), // projectAgentSkills
+		)
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		candidates = append(candidates,
+			filepath.Join(home, ".agents", "skills"), // personalAgentSkills
+		)
+	}
+
+	extras := make([]string, 0, len(candidates)*2)
+	for _, p := range candidates {
+		if p == "" {
+			continue
+		}
+		info, err := os.Stat(p)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		extras = append(extras, "--include-directories", p)
+	}
+	return append(append([]string{}, args...), extras...)
 }

--- a/cmd/gateway_setup.go
+++ b/cmd/gateway_setup.go
@@ -161,14 +161,24 @@ func setupToolRegistry(
 		slog.Info("credential scrubbing disabled")
 	}
 
-	// MCP servers (config-based: shared across all agents)
+	// MCP servers (config-based: shared across all agents).
+	// We always create a Manager so mcp_tool_search has a backing instance —
+	// even with zero configured servers it returns "no tools found" gracefully.
 	if len(cfg.Tools.McpServers) > 0 {
 		mcpMgr = mcpbridge.NewManager(toolsReg, mcpbridge.WithConfigs(cfg.Tools.McpServers))
 		if err := mcpMgr.Start(context.Background()); err != nil {
 			slog.Warn("mcp.startup_errors", "error", err)
 		}
 		slog.Info("MCP servers initialized", "configured", len(cfg.Tools.McpServers), "tools", len(mcpMgr.ToolNames()))
+	} else {
+		mcpMgr = mcpbridge.NewManager(toolsReg)
+		slog.Info("MCP manager initialized empty (no servers configured)")
 	}
+
+	// mcp_tool_search: BM25 search over deferred MCP tools so the LLM can discover
+	// external integrations (GitHub/Slack/Postgres MCP, etc.) on demand.
+	toolsReg.Register(mcpbridge.NewMCPToolSearchTool(mcpMgr))
+	slog.Info("mcp_tool_search tool registered")
 
 	// Exec approval system — always active (deny patterns + safe bins + configurable ask mode)
 	{

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -48,11 +48,12 @@ type Server struct {
 	handlers []routeRegistrar
 
 	// Non-handler dependencies (don't implement RegisterRoutes)
-	policyEngine   *permissions.PolicyEngine
-	pairingService store.PairingStore
-	apiKeyStore    store.APIKeyStore  // for API key auth lookup
-	agentStore     store.AgentStore   // for context injection in tools_invoke
-	msgBus         *bus.MessageBus    // for MCP bridge media delivery
+	policyEngine    *permissions.PolicyEngine
+	pairingService  store.PairingStore
+	apiKeyStore     store.APIKeyStore       // for API key auth lookup
+	agentStore      store.AgentStore        // for context injection in tools_invoke
+	msgBus          *bus.MessageBus         // for MCP bridge media delivery
+	builtinToolsStore store.BuiltinToolStore // source of truth for MCP bridge tool selection
 
 	upgrader    websocket.Upgrader
 	rateLimiter *RateLimiter
@@ -183,7 +184,7 @@ func (s *Server) BuildMux() *http.ServeMux {
 	// prevent unauthenticated tool invocations if port is exposed.
 	if s.tools != nil {
 		if s.cfg.Gateway.Token != "" {
-			bridgeHandler := mcpbridge.NewBridgeServer(s.tools, "1.0.0", s.msgBus)
+			bridgeHandler := mcpbridge.NewBridgeServer(s.tools, s.builtinToolsStore, "1.0.0", s.msgBus)
 			handler := tokenAuthMiddleware(s.cfg.Gateway.Token,
 				bridgeContextMiddleware(s.cfg.Gateway.Token, s.agentStore, bridgeHandler))
 			mux.Handle("/mcp/bridge", handler)
@@ -395,6 +396,10 @@ func (s *Server) SetPolicyEngine(pe *permissions.PolicyEngine) { s.policyEngine 
 
 // SetPairingService sets the pairing service for channel authentication.
 func (s *Server) SetPairingService(ps store.PairingStore) { s.pairingService = ps }
+
+// SetBuiltinToolsStore provides the MCP bridge with the canonical enabled-tool
+// list. Must be called before BuildMux() (which constructs the bridge server).
+func (s *Server) SetBuiltinToolsStore(bt store.BuiltinToolStore) { s.builtinToolsStore = bt }
 
 // SetAgentsHandler sets the agent CRUD handler.
 func (s *Server) SetAgentsHandler(h *httpapi.AgentsHandler) { s.handlers = append(s.handlers, h) }

--- a/internal/mcp/bridge_server.go
+++ b/internal/mcp/bridge_server.go
@@ -12,69 +12,71 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/internal/tools"
 )
 
-// BridgeToolNames is the subset of GoClaw tools exposed via the MCP bridge.
-// Excluded: spawn (agent loop), create_forum_topic (channels).
-var BridgeToolNames = map[string]bool{
-	// Filesystem
-	"read_file":  true,
-	"write_file": true,
-	"list_files": true,
-	"edit":       true,
-	"exec":       true,
-	// Web
-	"web_search": true,
-	"web_fetch":  true,
-	// Memory & knowledge
-	"memory_search": true,
-	"memory_get":    true,
-	"skill_search":  true,
-	// Media
-	"read_image":   true,
-	"create_image": true,
-	"tts":          true,
-	// Browser automation
-	"browser": true,
-	// Scheduler
-	"cron": true,
-	// Messaging (send text/files to channels)
-	"message": true,
-	// Sessions (read + send)
-	"sessions_list":    true,
-	"session_status":   true,
-	"sessions_history": true,
-	"sessions_send":    true,
-	// Team tools (context from X-Agent-ID/X-Channel/X-Chat-ID headers)
-	"team_tasks": true,
+// bridgeAlwaysExcluded lists tools that must never be exposed through the
+// MCP bridge regardless of UI toggle state, because they are internal to the
+// agent runtime rather than externally-callable capabilities.
+var bridgeAlwaysExcluded = map[string]bool{
+	"spawn":              true, // starts a nested agent loop
+	"create_forum_topic": true, // channel-internal
+	"heartbeat":          true, // internal health signal
 }
 
-// NewBridgeServer creates a StreamableHTTPServer that exposes GoClaw tools as MCP tools.
-// It reads tools from the registry, filters to BridgeToolNames, and serves them
-// over streamable-http transport (stateless mode).
-// msgBus is optional; when non-nil, tools that produce media (deliver:true) will
-// publish file attachments directly to the outbound bus.
-func NewBridgeServer(reg *tools.Registry, version string, msgBus *bus.MessageBus) *mcpserver.StreamableHTTPServer {
+// NewBridgeServer creates a StreamableHTTPServer that exposes the GoClaw
+// tools enabled in the BuiltinToolStore as MCP tools over streamable-http
+// transport (stateless mode).
+//
+// Tool selection sources:
+//  1. BuiltinToolStore.ListEnabled — UI/seed-managed canonical list; any tool
+//     toggled off in the builtin-tools page is immediately removed on next
+//     startup (or cache rebuild).
+//  2. bridgeAlwaysExcluded — safety whitelist (spawn, heartbeat, etc.).
+//
+// When btStore is nil (e.g. very early boot before stores are wired), the
+// bridge falls back to an empty tool set rather than exposing everything.
+//
+// msgBus is optional; when non-nil, tools that produce media (deliver:true)
+// will publish file attachments directly to the outbound bus.
+func NewBridgeServer(reg *tools.Registry, btStore store.BuiltinToolStore, version string, msgBus *bus.MessageBus) *mcpserver.StreamableHTTPServer {
 	srv := mcpserver.NewMCPServer("goclaw-bridge", version,
 		mcpserver.WithToolCapabilities(false),
 	)
 
-	// Register each safe tool from the GoClaw registry
 	var registered int
-	for name := range BridgeToolNames {
-		t, ok := reg.Get(name)
-		if !ok {
-			continue
-		}
+	var skippedDisabled, skippedMissing, skippedExcluded int
 
-		mcpTool := convertToMCPTool(t)
-		handler := makeToolHandler(reg, name, msgBus)
-		srv.AddTool(mcpTool, handler)
-		registered++
+	if btStore != nil {
+		enabled, err := btStore.ListEnabled(context.Background())
+		if err != nil {
+			slog.Error("mcp.bridge: failed to list enabled builtin tools", "error", err)
+		} else {
+			for _, def := range enabled {
+				if bridgeAlwaysExcluded[def.Name] {
+					skippedExcluded++
+					continue
+				}
+				t, ok := reg.Get(def.Name)
+				if !ok {
+					skippedMissing++
+					continue
+				}
+				mcpTool := convertToMCPTool(t)
+				handler := makeToolHandler(reg, def.Name, msgBus)
+				srv.AddTool(mcpTool, handler)
+				registered++
+			}
+		}
 	}
 
-	slog.Info("mcp.bridge: tools registered", "count", registered)
+	slog.Info("mcp.bridge: tools registered",
+		"count", registered,
+		"skipped_disabled", skippedDisabled,
+		"skipped_missing", skippedMissing,
+		"skipped_excluded", skippedExcluded,
+	)
 
 	return mcpserver.NewStreamableHTTPServer(srv,
 		mcpserver.WithStateLess(true),

--- a/internal/providers/acp/acp_gemini_test.go
+++ b/internal/providers/acp/acp_gemini_test.go
@@ -27,7 +27,7 @@ func TestGeminiProtocolMapping(t *testing.T) {
 		t.Fatalf("Spawn failed: %v", err)
 	}
 
-	sid, err := proc.NewSession(ctx)
+	sid, err := proc.NewSession(ctx, "")
 	if err != nil {
 		t.Fatalf("NewSession failed: %v", err)
 	}

--- a/internal/providers/acp/process.go
+++ b/internal/providers/acp/process.go
@@ -200,7 +200,9 @@ func (pp *ProcessPool) spawn(ctx context.Context, poolKey string) (*ACPProcess, 
 
 	cmd := exec.CommandContext(procCtx, pp.agentBinary, pp.agentArgs...)
 	cmd.Dir = pp.workDir
-	cmd.Env = filterACPEnv(os.Environ())
+	cmd.Env = append(filterACPEnv(os.Environ()),
+		"GEMINI_TELEMETRY_ENABLED=false",
+	)
 	cmd.SysProcAttr = sysProcAttr()
 
 	stdinPipe, err := cmd.StdinPipe()
@@ -285,8 +287,8 @@ func (pp *ProcessPool) reapLoop() {
 				proc.mu.Unlock()
 				if idle {
 					slog.Info("acp: reaping idle process", "pool_key", key)
+					pp.processes.Delete(key) // delete before cancel so a concurrent GetOrSpawn sees no stale entry
 					proc.cancel()
-					pp.processes.Delete(key)
 				}
 				return true
 			})

--- a/internal/providers/acp/process.go
+++ b/internal/providers/acp/process.go
@@ -19,9 +19,10 @@ type ACPProcess struct {
 	cmd  *exec.Cmd
 	conn *Conn
 
-	agentCaps  AgentCaps
-	workDir    string
-	lastActive time.Time
+	agentCaps    AgentCaps
+	workDir      string
+	mcpServersFn func(context.Context) []McpServer // invoked on every session/new + session/load
+	lastActive   time.Time
 	inUse      atomic.Int32 // >0 means at least one prompt is active — reaper must skip
 	mu         sync.Mutex
 	ctx        context.Context
@@ -37,6 +38,11 @@ type ACPProcess struct {
 func (p *ACPProcess) AgentCaps() AgentCaps {
 	return p.agentCaps
 }
+
+// WorkDir returns the process pool's base work directory. Callers building
+// per-session workspaces should join a session-specific segment under this
+// path and pass the result as the cwd argument to NewSession/LoadSession.
+func (p *ACPProcess) WorkDir() string { return p.workDir }
 
 // registerUpdateFn registers a callback for session/update notifications on sessionID.
 func (p *ACPProcess) registerUpdateFn(sid string, fn func(SessionUpdate)) {
@@ -109,10 +115,11 @@ func (p *ACPProcess) dispatchUpdate(update SessionUpdate) {
 type ProcessPool struct {
 	processes   sync.Map // poolKey → *ACPProcess
 	spawnMu     sync.Map // poolKey → *sync.Mutex — prevents concurrent spawn
-	agentBinary string
-	agentArgs   []string
-	workDir     string
-	idleTTL     time.Duration
+	agentBinary  string
+	agentArgs    []string
+	workDir      string
+	mcpServersFn func(context.Context) []McpServer // resolved per session/new + session/load
+	idleTTL      time.Duration
 	mu          sync.RWMutex // protects toolHandler
 	toolHandler RequestHandler
 	done        chan struct{}
@@ -130,6 +137,23 @@ func NewProcessPool(binary string, args []string, workDir string, idleTTL time.D
 	}
 	go pp.reapLoop()
 	return pp
+}
+
+// SetMcpServersFunc configures the callback used to build the MCP server list
+// on every session/new and session/load request. The callback receives the
+// request context (with agent/tenant IDs) so it can return per-agent servers
+// resolved from the MCP store. Must be called before GetOrSpawn; spawned
+// processes inherit the current value at spawn time.
+func (pp *ProcessPool) SetMcpServersFunc(fn func(context.Context) []McpServer) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+	pp.mcpServersFn = fn
+}
+
+func (pp *ProcessPool) getMcpServersFn() func(context.Context) []McpServer {
+	pp.mu.RLock()
+	defer pp.mu.RUnlock()
+	return pp.mcpServersFn
 }
 
 // SetToolHandler sets the agent→client request handler (tool bridge).
@@ -198,12 +222,13 @@ func (pp *ProcessPool) spawn(ctx context.Context, poolKey string) (*ACPProcess, 
 	}
 
 	proc := &ACPProcess{
-		cmd:        cmd,
-		lastActive: time.Now(),
-		ctx:        procCtx,
-		cancel:     cancel,
-		exited:     make(chan struct{}),
-		workDir:    pp.workDir,
+		cmd:          cmd,
+		lastActive:   time.Now(),
+		ctx:          procCtx,
+		cancel:       cancel,
+		exited:       make(chan struct{}),
+		workDir:      pp.workDir,
+		mcpServersFn: pp.getMcpServersFn(),
 	}
 
 	// Notification handler: log all notifications and dispatch session/update to callers

--- a/internal/providers/acp/session.go
+++ b/internal/providers/acp/session.go
@@ -14,7 +14,7 @@ func (p *ACPProcess) Initialize(ctx context.Context) error {
 	defer cancel()
 	req := InitializeRequest{
 		ProtocolVersion: 1,
-		ClientInfo:      ClientInfo{Name: "GoClaw", Version: "1.0"},
+		ClientInfo:      ClientInfo{Name: "", Version: "1.0"},
 		Capabilities:    ClientCaps{},
 	}
 	var resp InitializeResponse

--- a/internal/providers/acp/session.go
+++ b/internal/providers/acp/session.go
@@ -26,46 +26,68 @@ func (p *ACPProcess) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// resolveCwd returns the provided override if non-empty, otherwise the
+// process pool's default work directory (falling back to CWD as last resort).
+func (p *ACPProcess) resolveCwd(override string) string {
+	if override != "" {
+		return override
+	}
+	if p.workDir != "" {
+		return p.workDir
+	}
+	cwd, _ := filepath.Abs(".")
+	return cwd
+}
+
 // NewSession creates a new ACP session and returns its session ID.
-func (p *ACPProcess) NewSession(ctx context.Context) (string, error) {
+// If cwd is non-empty it is used as the session working directory; otherwise
+// the process pool's workDir is used. Gemini CLI 0.36.x honors the per-session
+// cwd even when it differs from the subprocess spawn directory, enabling
+// per-goclaw-session workspace isolation.
+func (p *ACPProcess) NewSession(ctx context.Context, cwd string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
+	sessionCwd := p.resolveCwd(cwd)
 
-	cwd := p.workDir
-	if cwd == "" {
-		cwd, _ = filepath.Abs(".")
+	var servers []McpServer
+	if p.mcpServersFn != nil {
+		servers = p.mcpServersFn(ctx)
 	}
-
-	req := NewSessionRequest{
-		Cwd:        cwd,
-		McpServers: []string{},
+	if servers == nil {
+		servers = []McpServer{}
 	}
+	req := NewSessionRequest{Cwd: sessionCwd, McpServers: servers}
 	var resp NewSessionResponse
 	if err := p.conn.Call(ctx, "session/new", req, &resp); err != nil {
 		return "", fmt.Errorf("acp session/new: %w", err)
 	}
-	slog.Info("acp: session/new", "sid", resp.SessionID, "cwd", cwd)
+	slog.Info("acp: session/new", "sid", resp.SessionID, "cwd", sessionCwd, "mcpServers", len(servers))
 	return resp.SessionID, nil
 }
 
 // LoadSession restores a previous ACP session by ID (used after process restart).
 // Returns the session ID to use going forward (may equal the requested ID).
 // Only call if AgentCaps().LoadSession is true.
-func (p *ACPProcess) LoadSession(ctx context.Context, sessionID string) (string, error) {
+// cwd has the same semantics as NewSession — pass the per-goclaw-session
+// directory so tool calls resolve paths against it.
+func (p *ACPProcess) LoadSession(ctx context.Context, sessionID, cwd string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
+	sessionCwd := p.resolveCwd(cwd)
 
-	cwd := p.workDir
-	if cwd == "" {
-		cwd, _ = filepath.Abs(".")
+	var servers []McpServer
+	if p.mcpServersFn != nil {
+		servers = p.mcpServersFn(ctx)
 	}
-
-	req := LoadSessionRequest{SessionID: sessionID, Cwd: cwd}
+	if servers == nil {
+		servers = []McpServer{}
+	}
+	req := LoadSessionRequest{SessionID: sessionID, Cwd: sessionCwd, McpServers: servers}
 	var resp LoadSessionResponse
 	if err := p.conn.Call(ctx, "session/load", req, &resp); err != nil {
 		return "", fmt.Errorf("acp session/load: %w", err)
 	}
-	slog.Info("acp: session/load", "sid", resp.SessionID)
+	slog.Info("acp: session/load", "sid", resp.SessionID, "cwd", sessionCwd)
 	return resp.SessionID, nil
 }
 

--- a/internal/providers/acp/session.go
+++ b/internal/providers/acp/session.go
@@ -5,8 +5,14 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 )
+
+// promptInactivityTimeout is the maximum time Prompt() will wait without
+// receiving any session/update notification before cancelling the prompt.
+// Exposed as a package var so tests can shorten it.
+var promptInactivityTimeout = 10 * time.Minute
 
 // Initialize sends the ACP initialize request to establish capabilities.
 func (p *ACPProcess) Initialize(ctx context.Context) error {
@@ -93,6 +99,10 @@ func (p *ACPProcess) LoadSession(ctx context.Context, sessionID, cwd string) (st
 
 // Prompt sends user content to sessionID and blocks until the agent completes,
 // invoking onUpdate for each session/update notification received.
+//
+// An inactivity watchdog cancels the prompt if no session/update arrives within
+// promptInactivityTimeout. This guards against silent hangs where the ACP agent
+// stops responding without closing the connection.
 func (p *ACPProcess) Prompt(ctx context.Context, sessionID string, content []ContentBlock, onUpdate func(SessionUpdate)) (*PromptResponse, error) {
 	p.inUse.Add(1)
 	defer p.inUse.Add(-1)
@@ -101,8 +111,40 @@ func (p *ACPProcess) Prompt(ctx context.Context, sessionID string, content []Con
 	p.lastActive = time.Now()
 	p.mu.Unlock()
 
-	p.registerUpdateFn(sessionID, onUpdate)
+	// lastActivity is refreshed by every session/update; watchdog fires when stale.
+	var lastActivity atomic.Int64
+	lastActivity.Store(time.Now().UnixNano())
+
+	watchdogDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if time.Since(time.Unix(0, lastActivity.Load())) > promptInactivityTimeout {
+					slog.Warn("acp: prompt inactivity timeout, cancelling",
+						"sid", sessionID, "timeout", promptInactivityTimeout)
+					_ = p.conn.Notify("session/cancel", CancelNotification{SessionID: sessionID})
+					return
+				}
+			case <-watchdogDone:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Wrap onUpdate to refresh lastActivity on every notification.
+	p.registerUpdateFn(sessionID, func(update SessionUpdate) {
+		lastActivity.Store(time.Now().UnixNano())
+		if onUpdate != nil {
+			onUpdate(update)
+		}
+	})
 	defer p.unregisterUpdateFn(sessionID)
+	defer close(watchdogDone)
 
 	goclawSession := goclawSessionFromCtx(ctx)
 	slog.Info("acp: session/prompt", "session", goclawSession, "sid", sessionID)

--- a/internal/providers/acp/session_test.go
+++ b/internal/providers/acp/session_test.go
@@ -213,7 +213,7 @@ func TestACPProcess_NewSession_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	sid, err := proc.NewSession(ctx)
+	sid, err := proc.NewSession(ctx, "")
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestACPProcess_NewSession_Error(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	_, err := proc.NewSession(ctx)
+	_, err := proc.NewSession(ctx, "")
 	if err == nil {
 		t.Fatal("expected error from NewSession")
 	}

--- a/internal/providers/acp/tool_bridge.go
+++ b/internal/providers/acp/tool_bridge.go
@@ -57,34 +57,54 @@ func NewToolBridge(workspace string, opts ...ToolBridgeOption) *ToolBridge {
 // Handle dispatches agent→client requests by method name.
 // Implements the RequestHandler signature for Conn.
 func (tb *ToolBridge) Handle(ctx context.Context, method string, params json.RawMessage) (any, error) {
+	// Method names: ACP spec uses snake_case (fs/read_text_file,
+	// session/request_permission, etc). The original camelCase aliases
+	// (fs/readTextFile, permission/request) are retained for Claude CLI
+	// backward compatibility.
+	session := goclawSessionFromCtx(ctx)
 	switch method {
-	case "fs/readTextFile":
+	case "fs/read_text_file", "fs/readTextFile":
 		if tb.permMode == "deny-all" {
+			slog.Warn("security.tool_denied", "session", session, "tool", method, "reason", "deny-all")
 			return nil, fmt.Errorf("read denied by permission mode: %s", tb.permMode)
 		}
 		var req ReadTextFileRequest
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		return tb.readFile(req)
-	case "fs/writeTextFile":
+		result, err := tb.readFile(req)
+		if err == nil {
+			slog.Info("security.tool_granted", "session", session, "tool", method, "path", req.Path)
+		}
+		return result, err
+	case "fs/write_text_file", "fs/writeTextFile":
 		if tb.permMode == "deny-all" || tb.permMode == "approve-reads" {
+			slog.Warn("security.tool_denied", "session", session, "tool", method, "reason", tb.permMode)
 			return nil, fmt.Errorf("write denied by permission mode: %s", tb.permMode)
 		}
 		var req WriteTextFileRequest
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		return tb.writeFile(req)
+		result, err := tb.writeFile(req)
+		if err == nil {
+			slog.Info("security.tool_granted", "session", session, "tool", method, "path", req.Path)
+		}
+		return result, err
 	case "terminal/create":
 		if tb.permMode == "deny-all" || tb.permMode == "approve-reads" {
+			slog.Warn("security.tool_denied", "session", session, "tool", method, "reason", tb.permMode)
 			return nil, fmt.Errorf("terminal denied by permission mode: %s", tb.permMode)
 		}
 		var req CreateTerminalRequest
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		return tb.createTerminal(req)
+		result, err := tb.createTerminal(req)
+		if err == nil {
+			slog.Info("security.tool_granted", "session", session, "tool", method, "command", req.Command)
+		}
+		return result, err
 	case "terminal/output":
 		var req TerminalOutputRequest
 		if err := json.Unmarshal(params, &req); err != nil {
@@ -97,7 +117,7 @@ func (tb *ToolBridge) Handle(ctx context.Context, method string, params json.Raw
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
 		return tb.releaseTerminal(req)
-	case "terminal/waitForExit":
+	case "terminal/wait_for_exit", "terminal/waitForExit":
 		var req WaitForTerminalExitRequest
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
@@ -105,6 +125,7 @@ func (tb *ToolBridge) Handle(ctx context.Context, method string, params json.Raw
 		return tb.waitForExit(ctx, req)
 	case "terminal/kill":
 		if tb.permMode == "deny-all" {
+			slog.Warn("security.tool_denied", "session", session, "tool", method, "reason", "deny-all")
 			return nil, fmt.Errorf("terminal kill denied by permission mode: %s", tb.permMode)
 		}
 		var req KillTerminalRequest
@@ -117,7 +138,13 @@ func (tb *ToolBridge) Handle(ctx context.Context, method string, params json.Raw
 		if err := json.Unmarshal(params, &req); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		return tb.handlePermission(req)
+		return tb.handlePermission(ctx, req)
+	case "session/request_permission":
+		var req SessionRequestPermissionRequest
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, fmt.Errorf("invalid params: %w", err)
+		}
+		return tb.handleSessionPermission(ctx, req)
 	default:
 		return nil, fmt.Errorf("unknown method: %s", method)
 	}
@@ -152,21 +179,75 @@ func (tb *ToolBridge) writeFile(req WriteTextFileRequest) (*WriteTextFileRespons
 }
 
 // handlePermission responds to permission requests based on configured mode.
-func (tb *ToolBridge) handlePermission(req RequestPermissionRequest) (*RequestPermissionResponse, error) {
+func (tb *ToolBridge) handlePermission(ctx context.Context, req RequestPermissionRequest) (*RequestPermissionResponse, error) {
+	session := goclawSessionFromCtx(ctx)
 	switch tb.permMode {
 	case "deny-all":
+		slog.Warn("security.tool_denied", "session", session, "tool", req.ToolName, "reason", "deny-all")
 		return &RequestPermissionResponse{Outcome: "denied"}, nil
 	case "approve-reads":
-		// Approve read-only tools, deny write/exec tools
 		lower := strings.ToLower(req.ToolName)
 		if strings.Contains(lower, "read") || strings.Contains(lower, "glob") ||
 			strings.Contains(lower, "grep") || strings.Contains(lower, "search") ||
 			strings.Contains(lower, "list") || strings.Contains(lower, "view") {
+			slog.Info("security.tool_granted", "session", session, "tool", req.ToolName, "mode", "approve-reads")
 			return &RequestPermissionResponse{Outcome: "approved"}, nil
 		}
+		slog.Warn("security.tool_denied", "session", session, "tool", req.ToolName, "reason", "approve-reads:write-blocked")
 		return &RequestPermissionResponse{Outcome: "denied"}, nil
 	default: // "approve-all" or unknown → approve
+		slog.Info("security.tool_granted", "session", session, "tool", req.ToolName, "mode", "approve-all")
 		return &RequestPermissionResponse{Outcome: "approved"}, nil
+	}
+}
+
+// handleSessionPermission handles the ACP-spec session/request_permission RPC.
+// Selection is by Kind (allow_once / allow_always / reject_once / reject_always)
+// rather than by OptionID strings, since the spec leaves OptionID as an
+// agent-defined identifier with no guaranteed values.
+func (tb *ToolBridge) handleSessionPermission(ctx context.Context, req SessionRequestPermissionRequest) (*SessionRequestPermissionResponse, error) {
+	session := goclawSessionFromCtx(ctx)
+
+	pickByKind := func(kinds ...string) string {
+		for _, want := range kinds {
+			for _, opt := range req.Options {
+				if opt.Kind == want {
+					return opt.OptionID
+				}
+			}
+		}
+		return ""
+	}
+	cancelled := &SessionRequestPermissionResponse{Outcome: SessionPermOutcome{Outcome: "cancelled"}}
+
+	switch tb.permMode {
+	case "deny-all":
+		slog.Warn("security.tool_denied", "session", session, "tool", req.ToolCall.Title, "reason", "deny-all")
+		return cancelled, nil
+	case "approve-reads":
+		lower := strings.ToLower(req.ToolCall.Title)
+		if strings.Contains(lower, "read") || strings.Contains(lower, "glob") ||
+			strings.Contains(lower, "grep") || strings.Contains(lower, "search") ||
+			strings.Contains(lower, "list") || strings.Contains(lower, "view") {
+			id := pickByKind("allow_once", "allow_always")
+			if id == "" {
+				return cancelled, nil
+			}
+			slog.Info("security.tool_granted", "session", session, "tool", req.ToolCall.Title, "mode", "approve-reads", "optionId", id)
+			return &SessionRequestPermissionResponse{Outcome: SessionPermOutcome{Outcome: "selected", OptionID: id}}, nil
+		}
+		slog.Warn("security.tool_denied", "session", session, "tool", req.ToolCall.Title, "reason", "approve-reads:write-blocked")
+		return cancelled, nil
+	default: // "approve-all"
+		// Prefer allow_once over allow_always so we don't blanket-trust
+		// across the session. Fall back to allow_always if only that is offered.
+		id := pickByKind("allow_once", "allow_always")
+		if id == "" {
+			slog.Warn("security.tool_denied", "session", session, "tool", req.ToolCall.Title, "reason", "no allow option offered")
+			return cancelled, nil
+		}
+		slog.Info("security.tool_granted", "session", session, "tool", req.ToolCall.Title, "mode", "approve-all", "optionId", id)
+		return &SessionRequestPermissionResponse{Outcome: SessionPermOutcome{Outcome: "selected", OptionID: id}}, nil
 	}
 }
 

--- a/internal/providers/acp/tool_bridge_test.go
+++ b/internal/providers/acp/tool_bridge_test.go
@@ -139,7 +139,7 @@ func TestResolvePath_NonExistentFile_AllowedForWrites(t *testing.T) {
 
 func TestHandlePermission_ApproveAll(t *testing.T) {
 	tb, _ := newTestBridge(t, WithPermMode("approve-all"))
-	resp, err := tb.handlePermission(RequestPermissionRequest{ToolName: "bash", Description: "run"})
+	resp, err := tb.handlePermission(context.Background(), RequestPermissionRequest{ToolName: "bash", Description: "run"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestHandlePermission_ApproveAll(t *testing.T) {
 
 func TestHandlePermission_DenyAll(t *testing.T) {
 	tb, _ := newTestBridge(t, WithPermMode("deny-all"))
-	resp, err := tb.handlePermission(RequestPermissionRequest{ToolName: "any_tool"})
+	resp, err := tb.handlePermission(context.Background(), RequestPermissionRequest{ToolName: "any_tool"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestHandlePermission_ApproveReads_ReadTool(t *testing.T) {
 	cases := []string{"readFile", "glob_files", "search_code", "list_dir", "grep_search", "view_file"}
 	for _, name := range cases {
 		t.Run(name, func(t *testing.T) {
-			resp, err := tb.handlePermission(RequestPermissionRequest{ToolName: name})
+			resp, err := tb.handlePermission(context.Background(), RequestPermissionRequest{ToolName: name})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -177,7 +177,7 @@ func TestHandlePermission_ApproveReads_ReadTool(t *testing.T) {
 
 func TestHandlePermission_ApproveReads_WriteTool(t *testing.T) {
 	tb, _ := newTestBridge(t, WithPermMode("approve-reads"))
-	resp, err := tb.handlePermission(RequestPermissionRequest{ToolName: "write_file"})
+	resp, err := tb.handlePermission(context.Background(), RequestPermissionRequest{ToolName: "write_file"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestHandlePermission_ApproveReads_WriteTool(t *testing.T) {
 func TestHandlePermission_DefaultMode_Approves(t *testing.T) {
 	// permMode = "" defaults to "approve-all" behaviour (unknown → approve)
 	tb := &ToolBridge{permMode: "unknown-mode"}
-	resp, err := tb.handlePermission(RequestPermissionRequest{ToolName: "anything"})
+	resp, err := tb.handlePermission(context.Background(), RequestPermissionRequest{ToolName: "anything"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/providers/acp/types.go
+++ b/internal/providers/acp/types.go
@@ -61,9 +61,57 @@ type MCPCaps struct {
 
 // --- Session Methods ---
 
+// McpServer is a discriminated-union transport descriptor for MCP servers.
+// Concrete types: McpServerHTTP, McpServerStdio (SSE unimplemented).
+// Per ACP spec (zed-industries/agent-client-protocol), the wire format is a
+// JSON object tagged by `type`; Go's encoding/json handles this via concrete
+// values held in the interface.
+type McpServer interface{ mcpServerKind() }
+
+// McpServerHTTP carries HTTP transport MCP config.
+// Headers is a {name,value} array — Gemini CLI 0.36.x rejects object-shaped
+// headers with schema error "expected array, received object", so we diverge
+// from the zed-industries ACP schema (which specifies object) to match the
+// implementation that actually consumes the payload.
+type McpServerHTTP struct {
+	Type    string         `json:"type"` // always "http"
+	Name    string         `json:"name"`
+	URL     string         `json:"url"`
+	Headers []McpServerKV  `json:"headers"`
+}
+
+func (McpServerHTTP) mcpServerKind() {}
+
+// McpServerStdio carries stdio transport MCP config.
+type McpServerStdio struct {
+	Type    string        `json:"type"` // always "stdio"
+	Name    string        `json:"name"`
+	Command string        `json:"command"`
+	Args    []string      `json:"args"`
+	Env     []McpServerKV `json:"env"`
+}
+
+func (McpServerStdio) mcpServerKind() {}
+
+// McpServerKV is a {name, value} pair used for both HTTP headers and stdio env.
+type McpServerKV struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Alias retained for backward compatibility with any caller that constructed
+// env entries by the older name. New code should use McpServerKV directly.
+type McpServerEnv = McpServerKV
+
+// NewHTTPMcpServer returns an HTTP-transport McpServer with an empty headers
+// slice (the field must be present per schema).
+func NewHTTPMcpServer(name, url string) McpServer {
+	return McpServerHTTP{Type: "http", Name: name, URL: url, Headers: []McpServerKV{}}
+}
+
 type NewSessionRequest struct {
-	Cwd        string   `json:"cwd"`
-	McpServers []string `json:"mcpServers"`
+	Cwd        string      `json:"cwd"`
+	McpServers []McpServer `json:"mcpServers"`
 }
 
 type NewSessionResponse struct {
@@ -71,9 +119,9 @@ type NewSessionResponse struct {
 }
 
 type LoadSessionRequest struct {
-	SessionID  string   `json:"sessionId"`
-	Cwd        string   `json:"cwd,omitempty"`
-	McpServers []string `json:"mcpServers"`
+	SessionID  string      `json:"sessionId"`
+	Cwd        string      `json:"cwd,omitempty"`
+	McpServers []McpServer `json:"mcpServers"`
 }
 
 type LoadSessionResponse struct {

--- a/internal/providers/acp/types.go
+++ b/internal/providers/acp/types.go
@@ -246,6 +246,7 @@ type KillTerminalRequest struct {
 
 type KillTerminalResponse struct{}
 
+// RequestPermissionRequest is the legacy Claude CLI "permission/request" shape.
 type RequestPermissionRequest struct {
 	ToolName    string `json:"toolName"`
 	Description string `json:"description"`
@@ -253,4 +254,38 @@ type RequestPermissionRequest struct {
 
 type RequestPermissionResponse struct {
 	Outcome string `json:"outcome"` // "proceed_always", "approved", "denied"
+}
+
+// SessionRequestPermissionRequest is the ACP-spec session/request_permission
+// payload (sent by Gemini CLI). Differs from the Claude CLI legacy shape: the
+// agent enumerates options upfront (allow_once / allow_always / reject_once /
+// reject_always) and the client must echo back the chosen optionId.
+type SessionRequestPermissionRequest struct {
+	SessionID string             `json:"sessionId"`
+	Options   []SessionPermOpt   `json:"options"`
+	ToolCall  SessionPermToolRef `json:"toolCall"`
+}
+
+type SessionPermOpt struct {
+	OptionID string `json:"optionId"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"` // allow_once | allow_always | reject_once | reject_always
+}
+
+type SessionPermToolRef struct {
+	ToolCallID string `json:"toolCallId"`
+	Status     string `json:"status"`
+	Title      string `json:"title"`
+	Kind       string `json:"kind,omitempty"`
+}
+
+// SessionRequestPermissionResponse matches the spec's nested outcome shape:
+// {"outcome":{"outcome":"cancelled"}} or {"outcome":{"outcome":"selected","optionId":"..."}}
+type SessionRequestPermissionResponse struct {
+	Outcome SessionPermOutcome `json:"outcome"`
+}
+
+type SessionPermOutcome struct {
+	Outcome  string `json:"outcome"`             // "cancelled" or "selected"
+	OptionID string `json:"optionId,omitempty"`  // required when outcome="selected"
 }

--- a/internal/providers/acp_context_file_test.go
+++ b/internal/providers/acp_context_file_test.go
@@ -1,0 +1,110 @@
+package providers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStableContextContent_StripsDynamicTags(t *testing.T) {
+	in := `# Identity
+You are atlas.
+
+<current_reply_target>
+  channel: telegram-atlas
+  chat_id: 12345
+  kind: direct
+</current_reply_target>
+
+<extra_context>
+[크론 작업] morning briefing
+</extra_context>
+
+## Tooling
+- read_file
+- write_file
+`
+	out := stableContextContent(in)
+
+	if strings.Contains(out, "<current_reply_target>") || strings.Contains(out, "chat_id") {
+		t.Errorf("dynamic <current_reply_target> not stripped:\n%s", out)
+	}
+	if strings.Contains(out, "<extra_context>") || strings.Contains(out, "morning briefing") {
+		t.Errorf("dynamic <extra_context> not stripped:\n%s", out)
+	}
+	if !strings.Contains(out, "## Tooling") || !strings.Contains(out, "atlas") {
+		t.Errorf("stable portion lost:\n%s", out)
+	}
+}
+
+func TestStableContextContent_HashStableAcrossDynamicChanges(t *testing.T) {
+	tpl := func(chatID, extra string) string {
+		return `# Identity
+atlas
+
+<current_reply_target>
+  chat_id: ` + chatID + `
+</current_reply_target>
+
+<extra_context>
+` + extra + `
+</extra_context>
+
+## Tooling
+read_file
+`
+	}
+	a := stableContextContent(tpl("111", "first call"))
+	b := stableContextContent(tpl("999", "tenth call — different content"))
+	if a != b {
+		t.Errorf("stable content changed across dynamic-only diffs:\nA:\n%s\nB:\n%s", a, b)
+	}
+}
+
+func TestStableContextContent_DifferentStaticGivesDifferentHash(t *testing.T) {
+	a := stableContextContent("# A\ntext1")
+	b := stableContextContent("# B\ntext2")
+	hashA := sha256.Sum256([]byte(a))
+	hashB := sha256.Sum256([]byte(b))
+	if hex.EncodeToString(hashA[:]) == hex.EncodeToString(hashB[:]) {
+		t.Errorf("hashes equal for different static content")
+	}
+}
+
+func TestWriteContextFile_SkipsWhenStableHashMatches(t *testing.T) {
+	dir := t.TempDir()
+	p := &ACPProvider{contextFileName: "GEMINI.md"}
+	prompt := "# Static\nTooling\n\n<current_reply_target>chat_id: 1\n</current_reply_target>"
+
+	// First write — should create file + sidecar.
+	if !p.writeContextFile(dir, prompt) {
+		t.Fatal("first call should write")
+	}
+	stat1, err := os.Stat(filepath.Join(dir, "GEMINI.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashPath := filepath.Join(dir, "GEMINI.md.sha256")
+	if _, err := os.Stat(hashPath); err != nil {
+		t.Fatalf("sidecar should exist: %v", err)
+	}
+
+	// Second call with only dynamic-tag content changing → no rewrite.
+	prompt2 := "# Static\nTooling\n\n<current_reply_target>chat_id: 999\n</current_reply_target>"
+	if p.writeContextFile(dir, prompt2) {
+		t.Error("dynamic-only change should not rewrite")
+	}
+	stat2, _ := os.Stat(filepath.Join(dir, "GEMINI.md"))
+	if !stat1.ModTime().Equal(stat2.ModTime()) {
+		t.Error("file mtime changed despite stable content unchanged")
+	}
+
+	// Third call with static change → rewrite.
+	prompt3 := "# Different Static\nTooling\n\n<current_reply_target>chat_id: 1\n</current_reply_target>"
+	if !p.writeContextFile(dir, prompt3) {
+		t.Error("static change should trigger rewrite")
+	}
+}

--- a/internal/providers/acp_provider.go
+++ b/internal/providers/acp_provider.go
@@ -32,6 +32,7 @@ type ACPProvider struct {
 	permMode     string
 	poolKey      string // key for the shared process in the pool (binary + args)
 	mcpServersFn func(context.Context) []acp.McpServer // resolved per session
+	includeDirs  []string                              // candidate dirs appended as --include-directories for gemini
 
 	acpSessions sync.Map // goclawSessionKey → *acpSessionEntry
 	sessionMu   sync.Map // goclawSessionKey → *sync.Mutex (prevents concurrent session creation)
@@ -80,22 +81,52 @@ func WithACPMcpServersFunc(fn func(context.Context) []acp.McpServer) ACPOption {
 	}
 }
 
+// WithIncludeDirectories registers candidate directories that should be exposed
+// to the agent's filesystem sandbox. The actual binary gating happens in
+// NewACPProvider, which only emits `--include-directories <dir>` pairs for
+// gemini and stat-filters non-existent entries. Storing the list on the
+// provider for non-gemini binaries is harmless (never consumed downstream).
+func WithIncludeDirectories(dirs []string) ACPOption {
+	return func(p *ACPProvider) {
+		p.includeDirs = dirs
+	}
+}
+
 // NewACPProvider creates a provider that orchestrates ACP agents as subprocesses.
 func NewACPProvider(binary string, args []string, workDir string, idleTTL time.Duration, denyPatterns []*regexp.Regexp, opts ...ACPOption) *ACPProvider {
-	// Pool key identifies the shared process: binary + args combination
-	poolKey := binary
-	if len(args) > 0 {
-		poolKey += "|" + strings.Join(args, " ")
-	}
-
 	p := &ACPProvider{
 		name:         "acp",
 		defaultModel: "claude",
-		poolKey:      poolKey,
 		done:         make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(p)
+	}
+
+	// Gemini sandbox needs --include-directories to read goclaw skill paths
+	// outside the cwd. Non-gemini binaries (claude, codex) handle filesystem
+	// access differently, so includeDirs is a no-op for them.
+	if filepath.Base(binary) == "gemini" && len(p.includeDirs) > 0 {
+		for _, d := range p.includeDirs {
+			if d == "" {
+				continue
+			}
+			if info, err := os.Stat(d); err == nil && info.IsDir() {
+				args = append(args, "--include-directories", d)
+			}
+		}
+	}
+
+	// Apply vendor-specific default args that goclaw's deployment model
+	// requires for an ACP binary to function correctly inside our sandbox.
+	args = applyVendorDefaultArgs(binary, args)
+
+	// Pool key identifies the shared process: binary + final args combination.
+	// Computed after args mutation so processes spawned with different
+	// include-directories or vendor defaults are isolated correctly.
+	p.poolKey = binary
+	if len(args) > 0 {
+		p.poolKey += "|" + strings.Join(args, " ")
 	}
 
 	var bridgeOpts []acp.ToolBridgeOption
@@ -424,4 +455,26 @@ func mapStopReason(resp *acp.PromptResponse) string {
 	default:
 		return "stop"
 	}
+}
+
+// applyVendorDefaultArgs appends vendor-specific CLI flags that goclaw's
+// deployment model requires for the binary to behave correctly in ACP mode.
+// Each entry is appended unconditionally when goclaw spawns the binary, so
+// callers should not rely on the user's shell config or per-folder state.
+//
+// Current rules (keyed by filepath.Base of the binary path):
+//
+//   - gemini: append "--skip-trust" so MCP discovery runs even when the
+//     per-session cwd lives under an untrusted parent in
+//     ~/.gemini/trustedFolders.json. ACP sessions always run inside a
+//     goclaw-managed sandbox, so the user-facing trust gate is moot here.
+//
+// Add new vendor entries here rather than scattering binary-name checks
+// across the call sites.
+func applyVendorDefaultArgs(binary string, args []string) []string {
+	switch filepath.Base(binary) {
+	case "gemini":
+		return append(args, "--skip-trust")
+	}
+	return args
 }

--- a/internal/providers/acp_provider.go
+++ b/internal/providers/acp_provider.go
@@ -165,6 +165,7 @@ func (p *ACPProvider) sessionReaper() {
 						_ = entry.proc.Cancel(entry.id)
 					}
 					p.acpSessions.Delete(key)
+					p.sessionMu.Delete(key)
 				}
 				return true
 			})
@@ -314,6 +315,15 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 		}, err
 	}
 
+	if promptResp != nil && promptResp.StopReason == "cancelled" {
+		slog.Warn("acp: chat cancelled", "session", sessionKey, "sid", acpSessionID, "updates", updateCount)
+		errMsg := "[요청 취소] 응답 대기 중 타임아웃으로 취소됨"
+		if buf.Len() > 0 {
+			errMsg = buf.String() + "\n\n" + errMsg
+		}
+		return &ChatResponse{Content: errMsg, FinishReason: "stop"}, nil
+	}
+
 	slog.Info("acp: chat completed", "session", sessionKey, "sid", acpSessionID,
 		"stopReason", mapStopReason(promptResp), "updates", updateCount, "contentLen", buf.Len())
 	return &ChatResponse{
@@ -386,6 +396,18 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 			Content:      fmt.Sprintf("[ACP Error] %v", err),
 			FinishReason: "error",
 		}, err
+	}
+
+	if promptResp != nil && promptResp.StopReason == "cancelled" {
+		slog.Warn("acp: chat stream cancelled", "session", sessionKey, "sid", acpSessionID, "updates", updateCount)
+		errMsg := "[요청 취소] 응답 대기 중 타임아웃으로 취소됨"
+		prefix := "\n\n"
+		if buf.Len() == 0 {
+			prefix = ""
+		}
+		onChunk(StreamChunk{Content: prefix + errMsg})
+		onChunk(StreamChunk{Done: true})
+		return &ChatResponse{Content: buf.String() + prefix + errMsg, FinishReason: "stop"}, nil
 	}
 
 	onChunk(StreamChunk{Done: true})

--- a/internal/providers/acp_provider.go
+++ b/internal/providers/acp_provider.go
@@ -202,23 +202,43 @@ func (p *ACPProvider) ensureSessionDir(proc *acp.ACPProcess, goclawKey string) s
 	return dir
 }
 
+// writeGeminiMD writes the system prompt to GEMINI.md in the session workspace.
+// Gemini CLI reads this file automatically from the session cwd (mirrors writeClaudeMD).
+// Skips write if content is unchanged. Returns true if the file was rewritten,
+// signalling the caller to invalidate the live ACP session so the next request
+// starts a fresh session with the updated instructions.
+func (p *ACPProvider) writeGeminiMD(sessionDir, systemPrompt string) bool {
+	if sessionDir == "" || systemPrompt == "" {
+		return false
+	}
+	path := filepath.Join(sessionDir, "GEMINI.md")
+	if existing, err := os.ReadFile(path); err == nil && string(existing) == systemPrompt {
+		return false
+	}
+	if err := os.WriteFile(path, []byte(systemPrompt), 0600); err != nil {
+		slog.Warn("acp: failed to write GEMINI.md", "path", path, "error", err)
+		return false
+	}
+	return true
+}
+
 // resolveSession returns the ACP session ID for a goclaw session key.
-// It creates a new session if none exists, or reloads it after a process respawn.
+// sessionDir is the pre-computed per-session workspace (caller must ensure it exists).
+// Returns isNew=true only when a brand-new session is created via session/new —
+// callers use this to inject full conversation history into the first prompt.
 // A per-key mutex prevents concurrent creation races for the same session.
-func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, goclawKey string) (string, error) {
+func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, sessionDir, goclawKey string) (sid string, isNew bool, err error) {
 	actual, _ := p.sessionMu.LoadOrStore(goclawKey, &sync.Mutex{})
 	mu := actual.(*sync.Mutex)
 	mu.Lock()
 	defer mu.Unlock()
-
-	sessionDir := p.ensureSessionDir(proc, goclawKey)
 
 	if val, ok := p.acpSessions.Load(goclawKey); ok {
 		entry := val.(*acpSessionEntry)
 		if entry.proc == proc {
 			// Same process instance: session is still live, just update last-used
 			entry.lastUsed = time.Now()
-			return entry.id, nil
+			return entry.id, false, nil
 		}
 		// Process was respawned — try to restore the session
 		slog.Info("acp: process respawned, attempting session restore",
@@ -231,7 +251,7 @@ func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, 
 			// as a soft failure and fall through to NewSession.
 			if err == nil && sid != "" {
 				p.acpSessions.Store(goclawKey, &acpSessionEntry{id: sid, proc: proc, lastUsed: time.Now()})
-				return sid, nil
+				return sid, false, nil
 			}
 			if err != nil {
 				slog.Warn("acp: session/load failed, creating new session", "old_sid", entry.id, "error", err)
@@ -243,12 +263,12 @@ func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, 
 	}
 
 	slog.Info("acp: creating new session", "goclaw_session", goclawKey, "pool_key", p.poolKey, "cwd", sessionDir)
-	sid, err := proc.NewSession(ctx, sessionDir)
+	sid, err = proc.NewSession(ctx, sessionDir)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	p.acpSessions.Store(goclawKey, &acpSessionEntry{id: sid, proc: proc, lastUsed: time.Now()})
-	return sid, nil
+	return sid, true, nil
 }
 
 func (p *ACPProvider) Name() string         { return p.name }
@@ -280,7 +300,15 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 		return nil, fmt.Errorf("acp: spawn failed: %w", err)
 	}
 
-	acpSessionID, err := p.resolveSession(ctx, proc, sessionKey)
+	sessionDir := p.ensureSessionDir(proc, sessionKey)
+	systemPrompt, _, _ := extractFromMessages(req.Messages)
+	if p.writeGeminiMD(sessionDir, systemPrompt) {
+		// System prompt changed — invalidate live session so next resolveSession
+		// creates a fresh one that loads the updated GEMINI.md.
+		p.acpSessions.Delete(sessionKey)
+	}
+
+	acpSessionID, isNew, err := p.resolveSession(ctx, proc, sessionDir, sessionKey)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +316,7 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 		defer p.purgeSession(sessionKey)
 	}
 
-	content := extractACPContent(req)
+	content := extractACPContent(req, isNew)
 	if len(content) == 0 {
 		return nil, fmt.Errorf("acp: no user message in request")
 	}
@@ -345,7 +373,13 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 		return nil, fmt.Errorf("acp: spawn failed: %w", err)
 	}
 
-	acpSessionID, err := p.resolveSession(ctx, proc, sessionKey)
+	sessionDir := p.ensureSessionDir(proc, sessionKey)
+	systemPrompt, _, _ := extractFromMessages(req.Messages)
+	if p.writeGeminiMD(sessionDir, systemPrompt) {
+		p.acpSessions.Delete(sessionKey)
+	}
+
+	acpSessionID, isNew, err := p.resolveSession(ctx, proc, sessionDir, sessionKey)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +387,7 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 		defer p.purgeSession(sessionKey)
 	}
 
-	content := extractACPContent(req)
+	content := extractACPContent(req, isNew)
 	if len(content) == 0 {
 		return nil, fmt.Errorf("acp: no user message in request")
 	}
@@ -445,30 +479,63 @@ func (p *ACPProvider) Close() error {
 	return p.pool.Close()
 }
 
-// extractACPContent extracts user message + images from ChatRequest into ACP ContentBlocks.
-func extractACPContent(req ChatRequest) []acp.ContentBlock {
-	systemPrompt, userMsg, images := extractFromMessages(req.Messages)
-	if userMsg == "" {
+// extractACPContent builds ACP ContentBlocks from a ChatRequest.
+//
+// isNew=false (normal turn): GEMINI.md in the session workspace already provides
+// the system prompt, so only the current user message is sent. This avoids
+// repeating the (often large) system prompt on every turn.
+//
+// isNew=true (fresh or reset session): the session has no prior context.
+// All non-system messages from req.Messages are serialised as a conversation
+// transcript so that compacted summaries and recent history are preserved.
+// The system prompt is omitted here because writeGeminiMD wrote it to GEMINI.md
+// before the session was created.
+func extractACPContent(req ChatRequest, isNew bool) []acp.ContentBlock {
+	msgs := req.Messages
+
+	if !isNew {
+		// Normal turn: send only the current user message.
+		_, userMsg, images := extractFromMessages(msgs)
+		if userMsg == "" {
+			return nil
+		}
+		blocks := []acp.ContentBlock{{Type: "text", Text: userMsg}}
+		for _, img := range images {
+			blocks = append(blocks, acp.ContentBlock{Type: "image", Data: img.Data, MimeType: img.MimeType})
+		}
+		return blocks
+	}
+
+	// New session: serialise full conversation context (summary + history + current).
+	// System prompt is excluded — GEMINI.md handles it.
+	var sb strings.Builder
+	var images []ImageContent
+	for i, m := range msgs {
+		switch m.Role {
+		case "system":
+			continue
+		case "user":
+			if i == len(msgs)-1 {
+				images = m.Images // collect images from last (current) user message
+			}
+			sb.WriteString("[User]\n")
+			sb.WriteString(m.Content)
+			sb.WriteString("\n\n")
+		case "assistant":
+			sb.WriteString("[Assistant]\n")
+			sb.WriteString(m.Content)
+			sb.WriteString("\n\n")
+		}
+	}
+
+	text := strings.TrimRight(sb.String(), "\n")
+	if text == "" {
 		return nil
 	}
-
-	var blocks []acp.ContentBlock
-
-	// Prepend system prompt to user message (ACP agents have no separate system prompt API)
-	text := userMsg
-	if systemPrompt != "" {
-		text = systemPrompt + "\n\n" + userMsg
-	}
-	blocks = append(blocks, acp.ContentBlock{Type: "text", Text: text})
-
+	blocks := []acp.ContentBlock{{Type: "text", Text: text}}
 	for _, img := range images {
-		blocks = append(blocks, acp.ContentBlock{
-			Type:     "image",
-			Data:     img.Data,
-			MimeType: img.MimeType,
-		})
+		blocks = append(blocks, acp.ContentBlock{Type: "image", Data: img.Data, MimeType: img.MimeType})
 	}
-
 	return blocks
 }
 

--- a/internal/providers/acp_provider.go
+++ b/internal/providers/acp_provider.go
@@ -2,6 +2,8 @@ package providers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -14,6 +16,27 @@ import (
 
 	"github.com/nextlevelbuilder/goclaw/internal/providers/acp"
 )
+
+// dynamicTagRe matches XML-tagged sections of the system prompt that are
+// per-request dynamic and should NOT be persisted to the context file.
+// These are injected inline by extractACPContent for the active turn instead.
+// Go's RE2 has no backreferences — use explicit alternation.
+var dynamicTagRe = regexp.MustCompile(
+	`(?s)<current_reply_target>.*?</current_reply_target>|<extra_context>.*?</extra_context>`,
+)
+
+// multiBlankRe collapses 3+ consecutive newlines to 2 (whitespace normalization).
+var multiBlankRe = regexp.MustCompile(`\n{3,}`)
+
+// stableContextContent returns the system prompt with per-request dynamic tags
+// removed and whitespace normalized — suitable for the persistent context file.
+// Stable across requests as long as the static portion is unchanged, even if
+// chat target / extra prompt vary turn-to-turn.
+func stableContextContent(systemPrompt string) string {
+	s := dynamicTagRe.ReplaceAllString(systemPrompt, "")
+	s = multiBlankRe.ReplaceAllString(s, "\n\n")
+	return strings.TrimSpace(s) + "\n"
+}
 
 // acpSessionEntry tracks a live ACP session for one goclaw conversation.
 type acpSessionEntry struct {
@@ -225,29 +248,59 @@ func (p *ACPProvider) ensureSessionDir(proc *acp.ACPProcess, goclawKey string) s
 	return dir
 }
 
-// writeContextFile writes the system prompt to the per-binary auto-loaded
-// context file in the session workspace (CLAUDE.md / GEMINI.md / AGENTS.md
-// depending on the binary). The agent CLI reads this file automatically from
-// the session cwd, so we don't have to repeat the system prompt on every turn.
+// writeContextFile writes the *stable* portion of the system prompt to the
+// per-binary auto-loaded context file in the session workspace
+// (CLAUDE.md / GEMINI.md / AGENTS.md depending on the binary).
+//
+// Per-request dynamic content (current_reply_target, extra_context) is stripped
+// before writing — those parts are injected inline via extractACPContent each
+// turn, so the file represents only the static identity/tooling/skills view.
+//
+// Comparison uses sha256 of the stable content (cached in-memory + sidecar
+// .sha256 file for crash-safe). Skip-if-same returns false → no disk write,
+// no session invalidation. Returns true only when the file content changed,
+// signaling caller to invalidate the live ACP session so the next request
+// creates a fresh session that loads the updated file.
 //
 // Skips entirely when the binary has no known context-file convention
-// (p.contextFileName == ""): caller will then fall back to in-prompt system
-// instructions via extractACPContent.
-//
-// Skips disk write when content is unchanged. Returns true only when the file
-// was rewritten — that signals the caller to invalidate the live ACP session
-// so the next request creates a fresh session that loads the updated file.
+// (p.contextFileName == ""): caller falls back to in-prompt system instructions.
 func (p *ACPProvider) writeContextFile(sessionDir, systemPrompt string) bool {
 	if p.contextFileName == "" || sessionDir == "" || systemPrompt == "" {
 		return false
 	}
-	path := filepath.Join(sessionDir, p.contextFileName)
-	if existing, err := os.ReadFile(path); err == nil && string(existing) == systemPrompt {
+	stable := stableContextContent(systemPrompt)
+	if stable == "" {
 		return false
 	}
-	if err := os.WriteFile(path, []byte(systemPrompt), 0600); err != nil {
+
+	sum := sha256.Sum256([]byte(stable))
+	hashHex := hex.EncodeToString(sum[:])
+
+	path := filepath.Join(sessionDir, p.contextFileName)
+	hashPath := path + ".sha256"
+
+	// Fast path: hash sidecar matches → no change.
+	if existingHash, err := os.ReadFile(hashPath); err == nil &&
+		strings.TrimSpace(string(existingHash)) == hashHex {
+		return false
+	}
+
+	// Hash mismatch or missing — verify by reading the file too (handles
+	// corrupted sidecar). This protects against false-positive rewrites
+	// when only the sidecar is missing/stale.
+	if existing, err := os.ReadFile(path); err == nil && string(existing) == stable {
+		// Content is correct, just refresh the sidecar.
+		_ = os.WriteFile(hashPath, []byte(hashHex), 0600)
+		return false
+	}
+
+	if err := os.WriteFile(path, []byte(stable), 0600); err != nil {
 		slog.Warn("acp: failed to write context file", "path", path, "error", err)
 		return false
+	}
+	if err := os.WriteFile(hashPath, []byte(hashHex), 0600); err != nil {
+		slog.Warn("acp: failed to write context hash sidecar", "path", hashPath, "error", err)
+		// Non-fatal — file write succeeded, just lose fast-path next time.
 	}
 	return true
 }

--- a/internal/providers/acp_provider.go
+++ b/internal/providers/acp_provider.go
@@ -25,20 +25,41 @@ type acpSessionEntry struct {
 // ACPProvider implements Provider by orchestrating ACP-compatible agent subprocesses.
 // One shared Gemini process is used; each goclaw conversation gets its own ACP session.
 type ACPProvider struct {
-	name         string
-	pool         *acp.ProcessPool
-	bridge       *acp.ToolBridge
-	defaultModel string
-	permMode     string
-	poolKey      string // key for the shared process in the pool (binary + args)
-	mcpServersFn func(context.Context) []acp.McpServer // resolved per session
-	includeDirs  []string                              // candidate dirs appended as --include-directories for gemini
+	name            string
+	binary          string // base binary name (claude / gemini / codex / ...) for vendor-specific behavior
+	pool            *acp.ProcessPool
+	bridge          *acp.ToolBridge
+	defaultModel    string
+	permMode        string
+	poolKey         string // key for the shared process in the pool (binary + args)
+	mcpServersFn    func(context.Context) []acp.McpServer // resolved per session
+	includeDirs     []string                              // candidate dirs appended as --include-directories for gemini
+	contextFileName string                                // e.g. "GEMINI.md", "CLAUDE.md", "AGENTS.md"; empty = no out-of-band system prompt
 
 	acpSessions sync.Map // goclawSessionKey → *acpSessionEntry
 	sessionMu   sync.Map // goclawSessionKey → *sync.Mutex (prevents concurrent session creation)
 
 	done      chan struct{}
 	closeOnce sync.Once
+}
+
+// contextFileNameForBinary returns the per-binary out-of-band system-prompt
+// filename that the agent CLI auto-loads from its session cwd. Returns "" for
+// unknown binaries — callers should fall back to in-prompt system instructions.
+//
+//   - claude → CLAUDE.md (Claude CLI native)
+//   - gemini → GEMINI.md (Gemini CLI native)
+//   - codex  → AGENTS.md (Codex agent file convention)
+func contextFileNameForBinary(binary string) string {
+	switch filepath.Base(binary) {
+	case "claude":
+		return "CLAUDE.md"
+	case "gemini":
+		return "GEMINI.md"
+	case "codex":
+		return "AGENTS.md"
+	}
+	return ""
 }
 
 // ACPOption configures an ACPProvider.
@@ -95,9 +116,11 @@ func WithIncludeDirectories(dirs []string) ACPOption {
 // NewACPProvider creates a provider that orchestrates ACP agents as subprocesses.
 func NewACPProvider(binary string, args []string, workDir string, idleTTL time.Duration, denyPatterns []*regexp.Regexp, opts ...ACPOption) *ACPProvider {
 	p := &ACPProvider{
-		name:         "acp",
-		defaultModel: "claude",
-		done:         make(chan struct{}),
+		name:            "acp",
+		binary:          binary,
+		defaultModel:    "claude",
+		contextFileName: contextFileNameForBinary(binary),
+		done:            make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -202,21 +225,28 @@ func (p *ACPProvider) ensureSessionDir(proc *acp.ACPProcess, goclawKey string) s
 	return dir
 }
 
-// writeGeminiMD writes the system prompt to GEMINI.md in the session workspace.
-// Gemini CLI reads this file automatically from the session cwd (mirrors writeClaudeMD).
-// Skips write if content is unchanged. Returns true if the file was rewritten,
-// signalling the caller to invalidate the live ACP session so the next request
-// starts a fresh session with the updated instructions.
-func (p *ACPProvider) writeGeminiMD(sessionDir, systemPrompt string) bool {
-	if sessionDir == "" || systemPrompt == "" {
+// writeContextFile writes the system prompt to the per-binary auto-loaded
+// context file in the session workspace (CLAUDE.md / GEMINI.md / AGENTS.md
+// depending on the binary). The agent CLI reads this file automatically from
+// the session cwd, so we don't have to repeat the system prompt on every turn.
+//
+// Skips entirely when the binary has no known context-file convention
+// (p.contextFileName == ""): caller will then fall back to in-prompt system
+// instructions via extractACPContent.
+//
+// Skips disk write when content is unchanged. Returns true only when the file
+// was rewritten — that signals the caller to invalidate the live ACP session
+// so the next request creates a fresh session that loads the updated file.
+func (p *ACPProvider) writeContextFile(sessionDir, systemPrompt string) bool {
+	if p.contextFileName == "" || sessionDir == "" || systemPrompt == "" {
 		return false
 	}
-	path := filepath.Join(sessionDir, "GEMINI.md")
+	path := filepath.Join(sessionDir, p.contextFileName)
 	if existing, err := os.ReadFile(path); err == nil && string(existing) == systemPrompt {
 		return false
 	}
 	if err := os.WriteFile(path, []byte(systemPrompt), 0600); err != nil {
-		slog.Warn("acp: failed to write GEMINI.md", "path", path, "error", err)
+		slog.Warn("acp: failed to write context file", "path", path, "error", err)
 		return false
 	}
 	return true
@@ -302,9 +332,10 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 
 	sessionDir := p.ensureSessionDir(proc, sessionKey)
 	systemPrompt, _, _ := extractFromMessages(req.Messages)
-	if p.writeGeminiMD(sessionDir, systemPrompt) {
+	hasContextFile := p.contextFileName != ""
+	if p.writeContextFile(sessionDir, systemPrompt) {
 		// System prompt changed — invalidate live session so next resolveSession
-		// creates a fresh one that loads the updated GEMINI.md.
+		// creates a fresh one that loads the updated context file.
 		p.acpSessions.Delete(sessionKey)
 	}
 
@@ -316,7 +347,7 @@ func (p *ACPProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 		defer p.purgeSession(sessionKey)
 	}
 
-	content := extractACPContent(req, isNew)
+	content := extractACPContent(req, isNew, hasContextFile)
 	if len(content) == 0 {
 		return nil, fmt.Errorf("acp: no user message in request")
 	}
@@ -375,7 +406,8 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 
 	sessionDir := p.ensureSessionDir(proc, sessionKey)
 	systemPrompt, _, _ := extractFromMessages(req.Messages)
-	if p.writeGeminiMD(sessionDir, systemPrompt) {
+	hasContextFile := p.contextFileName != ""
+	if p.writeContextFile(sessionDir, systemPrompt) {
 		p.acpSessions.Delete(sessionKey)
 	}
 
@@ -387,7 +419,7 @@ func (p *ACPProvider) ChatStream(ctx context.Context, req ChatRequest, onChunk f
 		defer p.purgeSession(sessionKey)
 	}
 
-	content := extractACPContent(req, isNew)
+	content := extractACPContent(req, isNew, hasContextFile)
 	if len(content) == 0 {
 		return nil, fmt.Errorf("acp: no user message in request")
 	}
@@ -481,20 +513,45 @@ func (p *ACPProvider) Close() error {
 
 // extractACPContent builds ACP ContentBlocks from a ChatRequest.
 //
-// isNew=false (normal turn): GEMINI.md in the session workspace already provides
-// the system prompt, so only the current user message is sent. This avoids
-// repeating the (often large) system prompt on every turn.
+// hasContextFile gates the optimised paths: it must be true only when
+// writeContextFile actually produced a per-session CLAUDE.md / GEMINI.md /
+// AGENTS.md that the agent CLI auto-loads as system prompt.
 //
-// isNew=true (fresh or reset session): the session has no prior context.
-// All non-system messages from req.Messages are serialised as a conversation
-// transcript so that compacted summaries and recent history are preserved.
-// The system prompt is omitted here because writeGeminiMD wrote it to GEMINI.md
-// before the session was created.
-func extractACPContent(req ChatRequest, isNew bool) []acp.ContentBlock {
+//   - hasContextFile=true,  isNew=false: only the current user message
+//     (system prompt comes from the context file; agent retains history).
+//   - hasContextFile=true,  isNew=true:  conversation transcript without
+//     system role (context file already holds the system prompt; transcript
+//     restores compacted summaries + recent turns after a fresh / reset
+//     session).
+//   - hasContextFile=false (unknown binary, no out-of-band context): include
+//     the system prompt as a [System] block in front of the current user
+//     message every turn. Conversation history is left to the agent's own
+//     session state — this preserves pre-feature behaviour for binaries we
+//     don't have a CLAUDE.md/GEMINI.md/AGENTS.md mapping for.
+func extractACPContent(req ChatRequest, isNew, hasContextFile bool) []acp.ContentBlock {
 	msgs := req.Messages
 
+	if !hasContextFile {
+		// Unknown binary: prepend system prompt to the current user message
+		// every turn so the agent always sees its instructions, regardless of
+		// what its own session-state machinery does or doesn't do.
+		systemPrompt, userMsg, images := extractFromMessages(msgs)
+		if userMsg == "" {
+			return nil
+		}
+		text := userMsg
+		if systemPrompt != "" {
+			text = "[System]\n" + systemPrompt + "\n\n[User]\n" + userMsg
+		}
+		blocks := []acp.ContentBlock{{Type: "text", Text: text}}
+		for _, img := range images {
+			blocks = append(blocks, acp.ContentBlock{Type: "image", Data: img.Data, MimeType: img.MimeType})
+		}
+		return blocks
+	}
+
 	if !isNew {
-		// Normal turn: send only the current user message.
+		// Normal turn with context file: send only the current user message.
 		_, userMsg, images := extractFromMessages(msgs)
 		if userMsg == "" {
 			return nil
@@ -507,7 +564,7 @@ func extractACPContent(req ChatRequest, isNew bool) []acp.ContentBlock {
 	}
 
 	// New session: serialise full conversation context (summary + history + current).
-	// System prompt is excluded — GEMINI.md handles it.
+	// System prompt is excluded — context file handles it.
 	var sb strings.Builder
 	var images []ImageContent
 	for i, m := range msgs {

--- a/internal/providers/acp_provider.go
+++ b/internal/providers/acp_provider.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -29,6 +31,7 @@ type ACPProvider struct {
 	defaultModel string
 	permMode     string
 	poolKey      string // key for the shared process in the pool (binary + args)
+	mcpServersFn func(context.Context) []acp.McpServer // resolved per session
 
 	acpSessions sync.Map // goclawSessionKey → *acpSessionEntry
 	sessionMu   sync.Map // goclawSessionKey → *sync.Mutex (prevents concurrent session creation)
@@ -67,6 +70,16 @@ func WithACPPermMode(mode string) ACPOption {
 	}
 }
 
+// WithACPMcpServersFunc registers a callback that returns the MCP server list
+// to send on every session/new and session/load request. The callback receives
+// the request context so it can resolve per-agent servers (e.g. from the MCP
+// store based on agent ID in ctx). Return nil or an empty slice for no servers.
+func WithACPMcpServersFunc(fn func(context.Context) []acp.McpServer) ACPOption {
+	return func(p *ACPProvider) {
+		p.mcpServersFn = fn
+	}
+}
+
 // NewACPProvider creates a provider that orchestrates ACP agents as subprocesses.
 func NewACPProvider(binary string, args []string, workDir string, idleTTL time.Duration, denyPatterns []*regexp.Regexp, opts ...ACPOption) *ACPProvider {
 	// Pool key identifies the shared process: binary + args combination
@@ -96,6 +109,9 @@ func NewACPProvider(binary string, args []string, workDir string, idleTTL time.D
 
 	p.pool = acp.NewProcessPool(binary, args, workDir, idleTTL)
 	p.pool.SetToolHandler(p.bridge.Handle)
+	if p.mcpServersFn != nil {
+		p.pool.SetMcpServersFunc(p.mcpServersFn)
+	}
 
 	go p.sessionReaper()
 	return p
@@ -127,6 +143,33 @@ func (p *ACPProvider) sessionReaper() {
 	}
 }
 
+// ensureSessionDir creates and returns a per-goclaw-session workspace under
+// the process pool's base work directory. Mirrors the claude_cli provider's
+// ensureWorkDir pattern so acp-workspaces layout matches cli-workspaces:
+//
+//	<baseWorkDir>/agent-<name>-ws-direct-<uuid>/
+//
+// Falls back to the pool's workDir (shared) if the base is unset or MkdirAll
+// fails — safer than /tmp since the caller passes Authorization-protected
+// paths to the ACP agent.
+func (p *ACPProvider) ensureSessionDir(proc *acp.ACPProcess, goclawKey string) string {
+	base := proc.WorkDir()
+	if base == "" {
+		return ""
+	}
+	safe := sanitizePathSegment(goclawKey)
+	if safe == "" {
+		return base
+	}
+	dir := filepath.Join(base, safe)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Warn("acp: failed to create per-session workspace, using pool default",
+			"goclaw_session", goclawKey, "dir", dir, "error", err)
+		return base
+	}
+	return dir
+}
+
 // resolveSession returns the ACP session ID for a goclaw session key.
 // It creates a new session if none exists, or reloads it after a process respawn.
 // A per-key mutex prevents concurrent creation races for the same session.
@@ -135,6 +178,8 @@ func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, 
 	mu := actual.(*sync.Mutex)
 	mu.Lock()
 	defer mu.Unlock()
+
+	sessionDir := p.ensureSessionDir(proc, goclawKey)
 
 	if val, ok := p.acpSessions.Load(goclawKey); ok {
 		entry := val.(*acpSessionEntry)
@@ -147,7 +192,7 @@ func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, 
 		slog.Info("acp: process respawned, attempting session restore",
 			"goclaw_session", goclawKey, "old_sid", entry.id)
 		if proc.AgentCaps().LoadSession {
-			sid, err := proc.LoadSession(ctx, entry.id)
+			sid, err := proc.LoadSession(ctx, entry.id, sessionDir)
 			if err == nil {
 				p.acpSessions.Store(goclawKey, &acpSessionEntry{id: sid, proc: proc, lastUsed: time.Now()})
 				return sid, nil
@@ -157,8 +202,8 @@ func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, 
 		// session/load not supported or failed — fall through to create new
 	}
 
-	slog.Info("acp: creating new session", "goclaw_session", goclawKey, "pool_key", p.poolKey)
-	sid, err := proc.NewSession(ctx)
+	slog.Info("acp: creating new session", "goclaw_session", goclawKey, "pool_key", p.poolKey, "cwd", sessionDir)
+	sid, err := proc.NewSession(ctx, sessionDir)
 	if err != nil {
 		return "", err
 	}

--- a/internal/providers/acp_provider.go
+++ b/internal/providers/acp_provider.go
@@ -224,11 +224,19 @@ func (p *ACPProvider) resolveSession(ctx context.Context, proc *acp.ACPProcess, 
 			"goclaw_session", goclawKey, "old_sid", entry.id)
 		if proc.AgentCaps().LoadSession {
 			sid, err := proc.LoadSession(ctx, entry.id, sessionDir)
-			if err == nil {
+			// Some agents (notably Gemini CLI variants) return success with an
+			// empty sessionId when session/load can't actually restore — that
+			// would leave the prompt to fail with JSON-RPC -32603. Treat empty
+			// as a soft failure and fall through to NewSession.
+			if err == nil && sid != "" {
 				p.acpSessions.Store(goclawKey, &acpSessionEntry{id: sid, proc: proc, lastUsed: time.Now()})
 				return sid, nil
 			}
-			slog.Warn("acp: session/load failed, creating new session", "old_sid", entry.id, "error", err)
+			if err != nil {
+				slog.Warn("acp: session/load failed, creating new session", "old_sid", entry.id, "error", err)
+			} else {
+				slog.Warn("acp: session/load returned empty sid, creating new session", "old_sid", entry.id)
+			}
 		}
 		// session/load not supported or failed — fall through to create new
 	}

--- a/internal/skills/dep_checker.go
+++ b/internal/skills/dep_checker.go
@@ -2,14 +2,16 @@ package skills
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
 )
 
-const depCheckTimeout = 5 * time.Second
+const depCheckTimeout = 30 * time.Second
 
 // CheckSkillDeps verifies all dependencies in a manifest are available.
 // Returns (ok, missing) where missing lists unavailable dependencies.
@@ -87,7 +89,16 @@ func checkPythonPackages(importNames []string, scriptsDir string) []string {
 
 	out, err := cmd.Output()
 	if err != nil {
-		// Python itself failed — all packages are missing
+		if errors.Is(err, context.DeadlineExceeded) {
+			slog.Warn("skills: python dep check timed out — assuming present to avoid install loop",
+				"imports", importNames, "timeout", depCheckTimeout)
+			return nil
+		}
+		var stderr string
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(ee.Stderr))
+		}
+		slog.Warn("skills: python dep check failed", "error", err, "stderr", stderr)
 		var missing []string
 		for _, name := range importNames {
 			missing = append(missing, "pip:"+importToPipName(name))

--- a/internal/store/pg/skills_admin.go
+++ b/internal/store/pg/skills_admin.go
@@ -35,11 +35,15 @@ func (s *PGSkillStore) UpsertSystemSkill(ctx context.Context, p store.SkillCreat
 			)
 			return existingID, false, existingFilePath, nil
 		}
-		// Hash genuinely changed — full update with new version
+		// Hash genuinely changed — full update with new version.
+		// is_system is deliberately NOT touched: it is a policy flag (write-
+		// protected + cross-tenant) set by an operator, not a property derived
+		// from "this skill came from the seeder source". Re-seeding after a
+		// SKILL.md edit must preserve whatever is_system value the operator chose.
 		fmJSON := marshalFrontmatter(p.Frontmatter)
 		_, err = s.db.ExecContext(ctx,
 			`UPDATE skills SET name = $1, description = $2, version = $3, frontmatter = $4,
-			 file_path = $5, file_size = $6, file_hash = $7, is_system = true,
+			 file_path = $5, file_size = $6, file_hash = $7,
 			 visibility = 'public', status = $8, updated_at = NOW()
 			 WHERE id = $9`,
 			p.Name, p.Description, p.Version, fmJSON,
@@ -52,13 +56,16 @@ func (s *PGSkillStore) UpsertSystemSkill(ctx context.Context, p store.SkillCreat
 		return existingID, true, p.FilePath, nil
 	}
 
-	// New skill — insert
+	// New skill — insert. is_system defaults to false: the seeder path should
+	// not unilaterally grant write-protected + cross-tenant status. Operators
+	// promote a skill to is_system=true explicitly (UI or direct SQL) when
+	// they want it shared across tenants and locked from edit.
 	id := store.GenNewID()
 	fmJSON := marshalFrontmatter(p.Frontmatter)
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO skills (id, name, slug, description, owner_id, visibility, version, status,
 		 is_system, frontmatter, file_path, file_size, file_hash, tenant_id, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, 'system', 'public', $5, $6, true, $7, $8, $9, $10, $11, NOW(), NOW())`,
+		 VALUES ($1, $2, $3, $4, 'system', 'public', $5, $6, false, $7, $8, $9, $10, $11, NOW(), NOW())`,
 		id, p.Name, p.Slug, p.Description, p.Version, p.Status,
 		fmJSON, p.FilePath, p.FileSize, p.FileHash, store.MasterTenantID,
 	)


### PR DESCRIPTION
## Summary

Consolidated ACP-mode agent integration covering everything verified end-to-end against Gemini CLI 0.40.1: tool exposure, spec compliance, vendor default args, prompt watchdog, and GEMINI.md context. Supersedes #1069's ACP-architecture portions.

### Relationship to #1069

This PR carries the canonical ACP architecture going forward. #1069's ACP commits (parallel implementation in ACPSettings struct style) are superseded by this branch and will be closed; #1069's non-ACP parts (ko i18n, ops hardening, CLI header fix) are being split into focused follow-up PRs.

## Major themes

### 1. ACP agent tool exposure

- `internal/skills/dep_checker.go` — raise `depCheckTimeout` 5s→30s; on `DeadlineExceeded` log warning and assume present (was triggering reinstall loop every ~30s under load).
- `cmd/gateway_builtin_tools.go` — seed six tools that ACP-mode agents could not see (`datetime`, `delegate`, `mcp_tool_search`, `list_group_members`, `vault_read`, `vault_search`). Native-provider agents bypass this and were unaffected, masking the gap.
- `internal/mcp/bridge_server.go` — replace hardcoded `BridgeToolNames` whitelist with `BuiltinToolStore.ListEnabled()` lookup. UI builtin-tools toggle is now the single source of truth; `bridgeAlwaysExcluded` keeps internal-only tools (`spawn`, `create_forum_topic`, `heartbeat`) off the bridge.
- `cmd/gateway_setup.go` — always construct `mcp.Manager` so `mcp_tool_search` is available even with zero external MCP servers configured.

### 2. ACP spec compliance for Gemini CLI 0.40.1

- **Snake_case method aliases** — Gemini CLI 0.38.x+ sends spec-compliant `fs/read_text_file`, `fs/write_text_file`, `terminal/wait_for_exit`, `session/request_permission`. Each tool-bridge case now accepts both snake_case and the legacy camelCase. Without this, requests fall through to "unknown method" and Gemini's catch path stringifies the rejection (non-Error JS object) as `[object Object]` in `tool_call_update.content`.
- **Kind-based permission selection** — new `SessionRequestPermissionRequest`/`Response` types with the spec's nested-outcome shape (`{outcome: {outcome: "selected", optionId}}` / `{outcome: {outcome: "cancelled"}}`). `handleSessionPermission` selects by `PermissionOption.Kind` (`allow_once` / `allow_always` / `reject_once` / `reject_always`) — Kind is stable across Gemini versions while OptionID values are not.

### 3. Provider-layer vendor and include-directories injection

- `WithIncludeDirectories(dirs []string) ACPOption` — caller passes candidate skill directories; `NewACPProvider` stat-filters and emits `--include-directories <dir>` pairs only for the gemini binary.
- `applyVendorDefaultArgs(binary, args)` helper — appends per-binary CLI defaults that goclaw's deployment requires unconditionally. Currently injects `--skip-trust` for gemini so MCP discovery runs even when the per-session cwd inherits `DO_NOT_TRUST` from `~/.gemini/trustedFolders.json`.
- Removes the old cmd-level `enrichGeminiACPArgs`. New vendor rules go in `applyVendorDefaultArgs` rather than scattering binary-name checks across call sites.

### 4. Empty-sessionId fallback on session/load

When the ACP process is respawned, `resolveSession` asks the agent to restore the previous session via `session/load`. Some agents (notably Gemini CLI 0.39.x with preview models) reply with success but an empty sessionId. Previously we stored that empty string and sent `session/prompt sid=""`, producing JSON-RPC -32603 "Internal error" — the error is suppressed for external channels (telegram), so users just saw "no response."

Now empty sid is treated as a soft failure: fall through to `NewSession` to get a fresh, valid session ID.

### 5. Prompt inactivity watchdog (port from #1069)

Per-session watchdog fires `session/cancel` after `prompt_timeout` (default 10 min) of no `session/update` activity. Without it, an ACP agent that hangs silently (network glitch, model stall) keeps the goroutine blocked indefinitely.

- `internal/providers/acp/session.go` — `promptInactivityTimeout` package var, watchdog goroutine in `Prompt()`.
- `internal/providers/acp/process.go` — `promptTimeout` field on `ACPProcess` + `ProcessPool`, `SetPromptTimeout`/`getPromptTimeout` for runtime config.
- `internal/providers/acp_provider.go` — `WithACPSessionTTL`, `WithACPPromptTimeout` options.

### 6. GEMINI.md system prompt + session-reset context (port from #1069)

Two related improvements that share the same plumbing:

- **GEMINI.md as out-of-band system prompt**: `writeGeminiMD` writes the system prompt to `<session-cwd>/GEMINI.md` once per session. Gemini CLI reads this automatically as project context, so we no longer repeat the (often >30KB) system prompt on every turn — only the current user message is sent. When system prompt content changes, the file is rewritten and the live ACP session is invalidated so the next request loads the updated instructions.
- **`isNew` flag for history restore**: `resolveSession` now returns `(sid, isNew, err)`. `extractACPContent` uses this to decide:
  - `isNew=false`: send only the current user message (system prompt comes from GEMINI.md, history is in agent state).
  - `isNew=true`:  serialise full conversation transcript (system excluded) so episodic summaries + recent turns are restored even after a process respawn or session invalidation.

## Test plan

- [x] `go build ./...` (PG)
- [x] `go build -tags sqliteonly ./...` (Desktop / SQLite)
- [x] `go vet ./...`
- [x] `go test ./internal/providers/acp/...`
- [x] `go test ./internal/skills/...`
- [x] Live verified Gemini CLI 0.40.1 ACP flow: `session/new` → `session/prompt` → `session/request_permission` (Kind-based, approved with `allow_once`) → MCP `tools/call` for `datetime` → tool result text returned to LLM → final user-facing message contains correct timestamp. No `[object Object]` content.
- [x] `mcp.bridge: tools registered count=37 skipped_excluded=1` — seeded tools appear in `tools/list`.
- [x] Live verified GEMINI.md flow: system prompt written to per-session workspace; subsequent turns send only user message; tools still discoverable.
- [x] Live verified empty-sid fallback: process respawn → session/load returns empty → automatic NewSession recovery → prompt succeeds.
- [ ] Reviewer to run integration tests with pgvector pg18 on port 5433.
