### PR TITLE
Pass locale through cron run path so meta lines render in user's language

### DIFF
--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -12,10 +13,62 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/scheduler"
 	"github.com/nextlevelbuilder/goclaw/internal/sessions"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
+
+// resolveCronLocale walks the user → tenant cascade defined for cron-triggered
+// agent runs:
+//
+//	1) tenant_users.metadata->>'locale'  (job.UserID × job.TenantID)
+//	2) tenants.settings->>'locale'       (tenant default)
+//	3) "" (caller is responsible for falling back to i18n.DefaultLocale)
+//
+// The cascade reuses jsonb metadata fields that already exist on tenant_users
+// and tenants — no schema changes, no env vars.
+func resolveCronLocale(ctx context.Context, tenantStore store.TenantStore, tenantID uuid.UUID, userID string) string {
+	if tenantStore == nil || tenantID == uuid.Nil {
+		return ""
+	}
+	// 1) tenant_users.metadata
+	if userID != "" {
+		if tus, err := tenantStore.ListUserTenants(ctx, userID); err == nil {
+			for _, tu := range tus {
+				if tu.TenantID != tenantID {
+					continue
+				}
+				if loc := jsonbLocale(tu.Metadata); loc != "" {
+					return loc
+				}
+				break
+			}
+		}
+	}
+	// 2) tenants.settings
+	if t, err := tenantStore.GetTenant(ctx, tenantID); err == nil && t != nil {
+		if loc := jsonbLocale(t.Settings); loc != "" {
+			return loc
+		}
+	}
+	return ""
+}
+
+// jsonbLocale extracts a "locale" string from a jsonb blob. Returns "" on
+// missing key, parse error, or non-string value.
+func jsonbLocale(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var bag struct {
+		Locale string `json:"locale"`
+	}
+	if json.Unmarshal(raw, &bag) != nil {
+		return ""
+	}
+	return bag.Locale
+}
 
 // makeCronJobHandler creates a cron job handler that routes through the scheduler's cron lane.
 // This ensures per-session concurrency control (same job can't run concurrently)
@@ -24,7 +77,7 @@ import (
 // Safe because cron jobs only fire after Start(), well after this is set.
 var cronHeartbeatWakeFn func(agentID string)
 
-func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg *config.Config, channelMgr *channels.Manager, sessionMgr store.SessionStore, agentStore store.AgentStore) func(job *store.CronJob) (*store.CronJobResult, error) {
+func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg *config.Config, channelMgr *channels.Manager, sessionMgr store.SessionStore, agentStore store.AgentStore, tenantStore store.TenantStore) func(job *store.CronJob) (*store.CronJobResult, error) {
 	return func(job *store.CronJob) (*store.CronJobResult, error) {
 		agentID := job.AgentID
 		if agentID == "" && agentStore != nil {
@@ -61,29 +114,33 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 		// Resolve channel type for system prompt context.
 		channelType := resolveChannelType(channelMgr, channel)
 
-		// Build cron context so the agent knows delivery target and requester.
-		var extraPrompt string
-		if job.Deliver && job.DeliverChannel != "" && job.DeliverTo != "" {
-			extraPrompt = fmt.Sprintf(
-				"[Cron Job]\nThis is scheduled job \"%s\" (ID: %s).\n"+
-					"Requester: user %s on channel \"%s\" (chat %s).\n"+
-					"Your response will be automatically delivered to that chat — just produce the content directly.",
-				job.Name, job.ID, job.UserID, job.DeliverChannel, job.DeliverTo,
-			)
-		} else {
-			extraPrompt = fmt.Sprintf(
-				"[Cron Job]\nThis is scheduled job \"%s\" (ID: %s), created by user %s.\n"+
-					"Delivery is not configured — respond normally.",
-				job.Name, job.ID, job.UserID,
-			)
-		}
-
 		// Build context with tenant scope and timeout so agent loop events are
 		// scoped correctly and a hung agent can't block the cron scheduler forever.
 		jobTimeout := cfg.Cron.JobTimeoutDuration()
 		cronCtx, cancelCron := context.WithTimeout(context.Background(), jobTimeout)
 		defer cancelCron()
 		cronCtx = store.WithTenantID(cronCtx, job.TenantID)
+
+		// Cron has no inbound channel locale (unlike WS connect or HTTP
+		// Accept-Language). Resolve via tenant_users → tenants cascade so the
+		// system prompt and meta lines render in the right language. Empty
+		// locale falls through to i18n.DefaultLocale (English) inside i18n.T.
+		cronLocale := resolveCronLocale(cronCtx, tenantStore, job.TenantID, job.UserID)
+		if cronLocale != "" {
+			cronCtx = store.WithLocale(cronCtx, cronLocale)
+		}
+
+		// Build cron context so the agent knows delivery target and requester.
+		var extraPrompt string
+		if job.Deliver && job.DeliverChannel != "" && job.DeliverTo != "" {
+			extraPrompt = i18n.T(cronLocale, i18n.MsgSysCronJobMetaDeliver,
+				job.Name, job.ID, job.UserID, job.DeliverChannel, job.DeliverTo,
+			)
+		} else {
+			extraPrompt = i18n.T(cronLocale, i18n.MsgSysCronJobMetaNoDeliver,
+				job.Name, job.ID, job.UserID,
+			)
+		}
 
 		// Reset session before each cron run to prevent tool errors from previous
 		// runs from polluting the context and blocking future executions (#294).

--- a/cmd/gateway_heartbeat.go
+++ b/cmd/gateway_heartbeat.go
@@ -42,7 +42,7 @@ func startCronAndHeartbeat(
 	heartbeatMethods *methods.HeartbeatMethods,
 ) *heartbeat.Ticker {
 	// Start cron service with job handler (routes through scheduler's cron lane)
-	pgStores.Cron.SetOnJob(makeCronJobHandler(sched, msgBus, cfg, channelMgr, pgStores.Sessions, pgStores.Agents))
+	pgStores.Cron.SetOnJob(makeCronJobHandler(sched, msgBus, cfg, channelMgr, pgStores.Sessions, pgStores.Agents, pgStores.Tenants))
 	pgStores.Cron.SetOnEvent(func(event store.CronEvent) {
 		server.BroadcastEvent(*protocol.NewEvent(protocol.EventCron, event))
 	})

--- a/internal/agent/loop_history.go
+++ b/internal/agent/loop_history.go
@@ -227,6 +227,7 @@ func (l *Loop) buildMessages(ctx context.Context, history []providers.Message, s
 		ContextFiles:           contextFiles,
 		AgentType:              l.agentType,
 		ExtraPrompt:            extraSystemPrompt,
+		Locale:                 store.LocaleFromContext(ctx),
 		SandboxEnabled:         l.sandboxEnabled,
 		SandboxContainerDir:    l.sandboxContainerDir,
 		SandboxWorkspaceAccess: l.sandboxWorkspaceAccess,

--- a/internal/agent/systemprompt.go
+++ b/internal/agent/systemprompt.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bootstrap"
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/internal/tools"
@@ -115,6 +116,7 @@ type SystemPromptConfig struct {
 	ContextFiles  []bootstrap.ContextFile // bootstrap files for # Project Context
 	ExtraPrompt   string                  // extra system prompt (subagent context, etc.)
 	AgentType     string                  // "open" or "predefined" — affects context file framing
+	Locale        string                  // i18n locale (en/ko/zh/vi) — drives meta line translation; empty = DefaultLocale
 
 	HasSkillSearch      bool              // skill_search tool registered? (for search-mode prompt)
 	HasSkillManage      bool              // skill_manage tool registered + skill_evolve enabled for this agent
@@ -238,20 +240,24 @@ func BuildSystemPrompt(cfg SystemPromptConfig) string {
 		channelLabel = cfg.Channel
 	}
 	if channelLabel != "" {
-		chatType := "a direct chat"
-		if cfg.PeerKind == "group" {
-			chatType = "a group chat"
-			if cfg.ChatTitle != "" {
-				// Sanitize: strip quotes/newlines, truncate to prevent prompt injection
-				// (group admins control the title).
-				title := strings.NewReplacer("\"", "", "\n", " ", "\r", "").Replace(cfg.ChatTitle)
-				if len([]rune(title)) > 100 {
-					title = string([]rune(title)[:100])
-				}
-				chatType = fmt.Sprintf("group chat \"%s\"", title)
+		// Locale-aware greeting. Empty Locale falls back to i18n.DefaultLocale (English).
+		locale := cfg.Locale
+		var greeting string
+		switch {
+		case cfg.PeerKind == "group" && cfg.ChatTitle != "":
+			// Sanitize: strip quotes/newlines, truncate to prevent prompt injection
+			// (group admins control the title).
+			title := strings.NewReplacer("\"", "", "\n", " ", "\r", "").Replace(cfg.ChatTitle)
+			if len([]rune(title)) > 100 {
+				title = string([]rune(title)[:100])
 			}
+			greeting = i18n.T(locale, i18n.MsgSysChannelGreetingGroupTitled, channelLabel, title)
+		case cfg.PeerKind == "group":
+			greeting = i18n.T(locale, i18n.MsgSysChannelGreetingGroup, channelLabel)
+		default:
+			greeting = i18n.T(locale, i18n.MsgSysChannelGreetingDirect, channelLabel)
 		}
-		lines = append(lines, fmt.Sprintf("You are a personal assistant running in %s (%s).", channelLabel, chatType))
+		lines = append(lines, greeting)
 		lines = append(lines, "")
 
 		// Inject explicit reply-target block so the LLM has a copy-paste-ready

--- a/internal/i18n/catalog_en.go
+++ b/internal/i18n/catalog_en.go
@@ -226,5 +226,12 @@ func init() {
 
 		// Message tool cross-target forward notice
 		MessageCrossTargetForwarded: "📤 Forwarded to %s as requested: %q",
+
+		// System prompt meta (locale-aware framing for ACP/MCP-bridged agents)
+		MsgSysChannelGreetingDirect:      "You are a personal assistant running in %s (a direct chat).",
+		MsgSysChannelGreetingGroup:       "You are a personal assistant running in %s (a group chat).",
+		MsgSysChannelGreetingGroupTitled: "You are a personal assistant running in %s (group chat \"%s\").",
+		MsgSysCronJobMetaDeliver:         "[Cron Job]\nThis is scheduled job \"%s\" (ID: %s).\nRequester: user %s on channel \"%s\" (chat %s).\nYour response will be automatically delivered to that chat — just produce the content directly.",
+		MsgSysCronJobMetaNoDeliver:       "[Cron Job]\nThis is scheduled job \"%s\" (ID: %s), created by user %s.\nDelivery is not configured — respond normally.",
 	})
 }

--- a/internal/i18n/catalog_ko.go
+++ b/internal/i18n/catalog_ko.go
@@ -1,0 +1,18 @@
+package i18n
+
+// Korean catalog. Only entries that need a Korean override are listed;
+// everything else falls back to English via lookup() in i18n.go.
+// Add more translations here as needed — keys not present here resolve
+// to the English template automatically.
+func init() {
+	register(LocaleKO, map[string]string{
+		// System prompt meta — drives the leading line and the cron meta block.
+		// Locale-correct framing here is what nudges the model toward Korean
+		// responses for ACP/MCP-bridged agents in cron/heartbeat contexts.
+		MsgSysChannelGreetingDirect:      "당신은 %s에서 동작하는 개인 비서입니다 (1:1 채팅).",
+		MsgSysChannelGreetingGroup:       "당신은 %s에서 동작하는 개인 비서입니다 (그룹 채팅).",
+		MsgSysChannelGreetingGroupTitled: "당신은 %s에서 동작하는 개인 비서입니다 (그룹 채팅 \"%s\").",
+		MsgSysCronJobMetaDeliver:         "[크론 작업]\n예약된 작업 \"%s\" (ID: %s)을 수행합니다.\n요청자: 사용자 %s, 채널 \"%s\" (채팅 %s).\n응답은 해당 채팅으로 자동 전달됩니다 — 내용만 작성하면 됩니다.",
+		MsgSysCronJobMetaNoDeliver:       "[크론 작업]\n예약된 작업 \"%s\" (ID: %s), 사용자 %s가 등록함.\n전달 설정이 없으므로 평소대로 응답하세요.",
+	})
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -11,6 +11,7 @@ const (
 	LocaleEN = "en"
 	LocaleVI = "vi"
 	LocaleZH = "zh"
+	LocaleKO = "ko"
 
 	DefaultLocale = LocaleEN
 )
@@ -58,7 +59,7 @@ func lookup(locale, key string) string {
 // IsSupported returns true if the locale is a known language.
 func IsSupported(locale string) bool {
 	switch locale {
-	case LocaleEN, LocaleVI, LocaleZH:
+	case LocaleEN, LocaleVI, LocaleZH, LocaleKO:
 		return true
 	}
 	return false
@@ -69,7 +70,7 @@ func Normalize(locale string) string {
 	if IsSupported(locale) {
 		return locale
 	}
-	// Handle common prefixes: "en-US" → "en", "vi-VN" → "vi", "zh-CN" → "zh"
+	// Handle common prefixes: "en-US" → "en", "vi-VN" → "vi", "zh-CN" → "zh", "ko-KR" → "ko"
 	if len(locale) >= 2 {
 		prefix := locale[:2]
 		if IsSupported(prefix) {

--- a/internal/i18n/keys.go
+++ b/internal/i18n/keys.go
@@ -228,4 +228,11 @@ const (
 	MsgHookBudgetExceeded          = "hook.budget_exceeded"           // "tenant hook token budget exceeded"
 	MsgHookPerTurnCapReached       = "hook.per_turn_cap_reached"      // "hook invocation per-turn cap reached"
 	MsgHookBuiltinReadOnly         = "hook.builtin_readonly"          // "builtin hooks are read-only except for the enabled toggle"
+
+	// --- System prompt meta (locale-aware framing for ACP/MCP-bridged agents) ---
+	MsgSysChannelGreetingDirect      = "sysprompt.channel_greeting_direct"       // "You are a personal assistant running in %s (a direct chat)."
+	MsgSysChannelGreetingGroup       = "sysprompt.channel_greeting_group"        // "You are a personal assistant running in %s (a group chat)."
+	MsgSysChannelGreetingGroupTitled = "sysprompt.channel_greeting_group_titled" // "You are a personal assistant running in %s (group chat \"%s\")."
+	MsgSysCronJobMetaDeliver         = "sysprompt.cron_meta_deliver"             // "[Cron Job]\nThis is scheduled job \"%s\" (ID: %s).\nRequester: user %s on channel \"%s\" (chat %s).\nYour response will be automatically delivered to that chat — just produce the content directly."
+	MsgSysCronJobMetaNoDeliver       = "sysprompt.cron_meta_no_deliver"          // "[Cron Job]\nThis is scheduled job \"%s\" (ID: %s), created by user %s.\nDelivery is not configured — respond normally."
 )


### PR DESCRIPTION
## Summary

Cron-triggered agent runs had no inbound channel locale (no WS connect
param, no `Accept-Language` header), so the system prompt and the cron
extra-context block were always built in English regardless of the
user's preferred language. The English meta lines — sitting at the
beginning and end of the prompt, where models weight instructions most
— pushed responses into English even when context files explicitly
asked for another language.

This change wires locale through the cron path using **only existing
data structures**: `tenants.settings` and `tenant_users.metadata` jsonb
columns. No new environment variable, no new `agents.other_config`
key, no schema change.

## Resolution chain

```
cron run
  ├─ tenant_users.metadata->>'locale'   (per-user override; jsonb field already exists)
  ├─ tenants.settings->>'locale'        (tenant default; jsonb field already exists)
  └─ i18n.DefaultLocale                 (= LocaleEN, unchanged fallback)
```

Empty resolution skips `store.WithLocale` entirely, so existing
deployments with no `locale` set anywhere keep getting English — no
behavioural regression.

## Changes

- `internal/i18n`: add `LocaleKO` plus `catalog_ko.go`. Only the new
  prompt-meta keys are translated; everything else falls through to the
  English catalog.
- `internal/i18n/keys.go`: five new keys —
  `MsgSysChannelGreeting{Direct,Group,GroupTitled}` and
  `MsgSysCronJobMeta{Deliver,NoDeliver}`.
- `internal/agent/systemprompt.go`: add `SystemPromptConfig.Locale` and
  replace the hardcoded *"You are a personal assistant running in
  X (a direct chat)."* line with `i18n.T()`.
- `internal/agent/loop_history.go`: feed
  `store.LocaleFromContext(ctx)` into `SystemPromptConfig.Locale`.
- `cmd/gateway_cron.go`: `resolveCronLocale()` cascade and an
  `i18n.T`-driven `extraPrompt`. Cron context picks up `WithLocale`
  before scheduling the agent loop.
- `cmd/gateway_heartbeat.go`: pass `pgStores.Tenants` to the cron
  handler factory.

## Operator usage

Set the tenant default once:
```sql
UPDATE tenants SET settings = settings || '{"locale":"ko"}' WHERE slug='master';
```

Per-user override (e.g. one Vietnamese member in an otherwise Korean
tenant):
```sql
UPDATE tenant_users SET metadata = metadata || '{"locale":"vi"}' WHERE …;
```

## Test plan

- [ ] `go vet ./...`
- [ ] `go build -tags embedui ./...`
- [ ] `go test ./internal/i18n/...`
- [ ] With `tenants.settings.locale = "ko"`, force-run a cron via
      `cron.run` WS RPC and verify `cron_run_logs.summary` is in
      Korean.
- [ ] Force-run with `tenants.settings.locale` unset and confirm the
      summary stays in English (regression guard).
- [ ] Force-run with `tenant_users.metadata.locale = "vi"` for the
      cron's `user_id` and confirm the summary is in Vietnamese
      (override path).