### PR TITLE
fix(http,ws): RBAC for providers read + master predefined context files (#1075, #1054)

### DIFF
--- a/internal/gateway/methods/agents.go
+++ b/internal/gateway/methods/agents.go
@@ -37,6 +37,33 @@ func (m *AgentsMethods) isOwnerUser(userID string) bool {
 	return canSeeAll(permissions.RoleViewer, m.cfg.Gateway.OwnerIDs, userID)
 }
 
+// authorizePredefinedAgentEdit returns "" if the caller may edit ag, or a
+// localized error message. Open agents bypass the guard.
+func (m *AgentsMethods) authorizePredefinedAgentEdit(ctx context.Context, ag *store.AgentData, method, file string) string {
+	if ag.AgentType != store.AgentTypePredefined {
+		return ""
+	}
+	userID := store.UserIDFromContext(ctx)
+	isAgentOwner := ag.OwnerID == userID
+	isMaster := store.IsMasterScope(ctx) || m.isOwnerUser(userID)
+	if !isAgentOwner && !isMaster {
+		locale := store.LocaleFromContext(ctx)
+		return i18n.T(locale, i18n.MsgOwnerOnly, "edit predefined agent")
+	}
+	if !isAgentOwner && isMaster {
+		attrs := []any{
+			"method", method,
+			"agent_id", ag.ID.String(),
+			"user_id", userID,
+		}
+		if file != "" {
+			attrs = append(attrs, "file", file)
+		}
+		slog.Info("security.master_override", attrs...)
+	}
+	return ""
+}
+
 func (m *AgentsMethods) Register(router *gateway.MethodRouter) {
 	router.Register(protocol.MethodAgent, m.handleAgent)
 	router.Register(protocol.MethodAgentWait, m.handleAgentWait)

--- a/internal/gateway/methods/agents.go
+++ b/internal/gateway/methods/agents.go
@@ -39,12 +39,18 @@ func (m *AgentsMethods) isOwnerUser(userID string) bool {
 
 // authorizePredefinedAgentEdit returns "" if the caller may edit ag, or a
 // localized error message. Open agents bypass the guard.
-func (m *AgentsMethods) authorizePredefinedAgentEdit(ctx context.Context, ag *store.AgentData, method, file string) string {
+//
+// userID must come from the WS client (client.UserID()), not ctx — the WS
+// dispatcher injects locale/tenant/role into ctx but not userID, so reading
+// it from ctx here would always return "" and reject the agent's own owner.
+func (m *AgentsMethods) authorizePredefinedAgentEdit(ctx context.Context, ag *store.AgentData, userID, method, file string) string {
 	if ag.AgentType != store.AgentTypePredefined {
 		return ""
 	}
-	userID := store.UserIDFromContext(ctx)
-	isAgentOwner := ag.OwnerID == userID
+	isAgentOwner := userID != "" && ag.OwnerID == userID
+	// Defense-in-depth: IsMasterScope already covers role==owner + master tenant,
+	// but isOwnerUser also catches userIDs in cfg.Gateway.OwnerIDs whose context
+	// role hasn't been promoted (e.g. legacy paths that skip role enrichment).
 	isMaster := store.IsMasterScope(ctx) || m.isOwnerUser(userID)
 	if !isAgentOwner && !isMaster {
 		locale := store.LocaleFromContext(ctx)
@@ -54,7 +60,9 @@ func (m *AgentsMethods) authorizePredefinedAgentEdit(ctx context.Context, ag *st
 		attrs := []any{
 			"method", method,
 			"agent_id", ag.ID.String(),
-			"user_id", userID,
+		}
+		if userID != "" {
+			attrs = append(attrs, "user_id", userID)
 		}
 		if file != "" {
 			attrs = append(attrs, "file", file)

--- a/internal/gateway/methods/agents_files.go
+++ b/internal/gateway/methods/agents_files.go
@@ -181,6 +181,11 @@ func (m *AgentsMethods) handleFilesSet(ctx context.Context, client *gateway.Clie
 			return
 		}
 
+		if msg := m.authorizePredefinedAgentEdit(ctx, ag, protocol.MethodAgentsFileSet, params.Name); msg != "" {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrUnauthorized, msg))
+			return
+		}
+
 		if err := m.agentStore.SetAgentContextFile(ctx, ag.ID, params.Name, params.Content); err != nil {
 			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, i18n.T(locale, i18n.MsgFailedToSave, "file", err.Error())))
 			return

--- a/internal/gateway/methods/agents_files.go
+++ b/internal/gateway/methods/agents_files.go
@@ -181,7 +181,7 @@ func (m *AgentsMethods) handleFilesSet(ctx context.Context, client *gateway.Clie
 			return
 		}
 
-		if msg := m.authorizePredefinedAgentEdit(ctx, ag, protocol.MethodAgentsFileSet, params.Name); msg != "" {
+		if msg := m.authorizePredefinedAgentEdit(ctx, ag, client.UserID(), protocol.MethodAgentsFileSet, params.Name); msg != "" {
 			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrUnauthorized, msg))
 			return
 		}

--- a/internal/gateway/methods/agents_files_master_test.go
+++ b/internal/gateway/methods/agents_files_master_test.go
@@ -1,0 +1,117 @@
+package methods
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/permissions"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+func TestFilesSet_MasterCanEditPredefined_OtherUserAgent(t *testing.T) {
+	tenantA := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	stub := &guardStubStore{
+		agent:       newPredefinedAgent(tenantA, "alice"),
+		agentTenant: tenantA,
+	}
+	m := newGuardMethods(t, stub, "system")
+
+	getLog := captureSlog(t)
+	client := guardClient(permissions.RoleOwner, tenantA, "system")
+	req := buildRequest(t, "files-set-master", protocol.MethodAgentsFileSet, map[string]any{
+		"agentId": stub.agent.AgentKey,
+		"name":    "SOUL.md",
+		"content": "# soul (master edit)",
+	})
+
+	m.handleFilesSet(guardCtx(client, "system"), client, req)
+
+	if stub.setFileRecorded() != 1 {
+		t.Fatalf("SetAgentContextFile called %d times, want 1", stub.setFileRecorded())
+	}
+	logged := getLog()
+	if !strings.Contains(logged, "security.master_override") {
+		t.Fatalf("missing security.master_override slog line. got: %q", logged)
+	}
+	if !strings.Contains(logged, "SOUL.md") {
+		t.Fatalf("expected file name SOUL.md in slog. got: %q", logged)
+	}
+	if !strings.Contains(logged, stub.agent.ID.String()) {
+		t.Fatalf("expected agent_id in slog. got: %q", logged)
+	}
+}
+
+func TestFilesSet_OwnerCanEditOwnPredefined(t *testing.T) {
+	tenantA := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	stub := &guardStubStore{
+		agent:       newPredefinedAgent(tenantA, "alice"),
+		agentTenant: tenantA,
+	}
+	m := newGuardMethods(t, stub)
+
+	getLog := captureSlog(t)
+	client := guardClient(permissions.RoleAdmin, tenantA, "alice")
+	req := buildRequest(t, "files-set-owner", protocol.MethodAgentsFileSet, map[string]any{
+		"agentId": stub.agent.AgentKey,
+		"name":    "SOUL.md",
+		"content": "# soul (owner edit)",
+	})
+
+	m.handleFilesSet(guardCtx(client, "alice"), client, req)
+
+	if stub.setFileRecorded() != 1 {
+		t.Fatalf("SetAgentContextFile called %d times, want 1", stub.setFileRecorded())
+	}
+	if logged := getLog(); strings.Contains(logged, "security.master_override") {
+		t.Fatalf("owner branch must not emit master_override slog. got: %q", logged)
+	}
+}
+
+func TestFilesSet_NonOwnerNonMaster_Rejected(t *testing.T) {
+	tenantA := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	stub := &guardStubStore{
+		agent:       newPredefinedAgent(tenantA, "alice"),
+		agentTenant: tenantA,
+	}
+	m := newGuardMethods(t, stub)
+
+	client := guardClient(permissions.RoleAdmin, tenantA, "bob")
+	req := buildRequest(t, "files-set-bob", protocol.MethodAgentsFileSet, map[string]any{
+		"agentId": stub.agent.AgentKey,
+		"name":    "SOUL.md",
+		"content": "# soul (unauthorized)",
+	})
+
+	m.handleFilesSet(guardCtx(client, "bob"), client, req)
+
+	if stub.setFileRecorded() != 0 {
+		t.Fatalf("SetAgentContextFile called %d times, want 0 (rejected write must not mutate)", stub.setFileRecorded())
+	}
+}
+
+// Two-tenant fixture: master in tenant A must not reach an agent in tenant B.
+// GetByKey returns not-found before the master guard runs.
+func TestFilesSet_CrossTenantMaster_NotFound(t *testing.T) {
+	tenantA := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	tenantB := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	stub := &guardStubStore{
+		agent:       newPredefinedAgent(tenantB, "alice"),
+		agentTenant: tenantB,
+	}
+	m := newGuardMethods(t, stub)
+
+	client := guardClient(permissions.RoleOwner, tenantA, "system")
+	req := buildRequest(t, "files-set-cross-tenant", protocol.MethodAgentsFileSet, map[string]any{
+		"agentId": stub.agent.AgentKey,
+		"name":    "SOUL.md",
+		"content": "# soul (cross-tenant attempt)",
+	})
+
+	m.handleFilesSet(guardCtx(client, "system"), client, req)
+
+	if stub.setFileRecorded() != 0 {
+		t.Fatalf("SetAgentContextFile called %d times, want 0 (cross-tenant lookup must not mutate)", stub.setFileRecorded())
+	}
+}

--- a/internal/gateway/methods/agents_files_master_test.go
+++ b/internal/gateway/methods/agents_files_master_test.go
@@ -26,7 +26,7 @@ func TestFilesSet_MasterCanEditPredefined_OtherUserAgent(t *testing.T) {
 		"content": "# soul (master edit)",
 	})
 
-	m.handleFilesSet(guardCtx(client, "system"), client, req)
+	m.handleFilesSet(guardCtx(client), client, req)
 
 	if stub.setFileRecorded() != 1 {
 		t.Fatalf("SetAgentContextFile called %d times, want 1", stub.setFileRecorded())
@@ -59,7 +59,7 @@ func TestFilesSet_OwnerCanEditOwnPredefined(t *testing.T) {
 		"content": "# soul (owner edit)",
 	})
 
-	m.handleFilesSet(guardCtx(client, "alice"), client, req)
+	m.handleFilesSet(guardCtx(client), client, req)
 
 	if stub.setFileRecorded() != 1 {
 		t.Fatalf("SetAgentContextFile called %d times, want 1", stub.setFileRecorded())
@@ -84,7 +84,7 @@ func TestFilesSet_NonOwnerNonMaster_Rejected(t *testing.T) {
 		"content": "# soul (unauthorized)",
 	})
 
-	m.handleFilesSet(guardCtx(client, "bob"), client, req)
+	m.handleFilesSet(guardCtx(client), client, req)
 
 	if stub.setFileRecorded() != 0 {
 		t.Fatalf("SetAgentContextFile called %d times, want 0 (rejected write must not mutate)", stub.setFileRecorded())
@@ -109,7 +109,7 @@ func TestFilesSet_CrossTenantMaster_NotFound(t *testing.T) {
 		"content": "# soul (cross-tenant attempt)",
 	})
 
-	m.handleFilesSet(guardCtx(client, "system"), client, req)
+	m.handleFilesSet(guardCtx(client), client, req)
 
 	if stub.setFileRecorded() != 0 {
 		t.Fatalf("SetAgentContextFile called %d times, want 0 (cross-tenant lookup must not mutate)", stub.setFileRecorded())

--- a/internal/gateway/methods/agents_master_guard_helpers_test.go
+++ b/internal/gateway/methods/agents_master_guard_helpers_test.go
@@ -1,0 +1,144 @@
+package methods
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/agent"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/gateway"
+	"github.com/nextlevelbuilder/goclaw/internal/permissions"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+// guardStubStore embeds the interface so unexpected calls panic.
+// GetByKey enforces tenant scope to model the production query.
+type guardStubStore struct {
+	store.AgentStore
+
+	mu             sync.Mutex
+	agent          *store.AgentData
+	agentTenant    uuid.UUID
+	updateCalls    []map[string]any
+	setFileCalls   []setFileCall
+	getFilesReturn []store.AgentContextFileData
+}
+
+type setFileCall struct {
+	AgentID  uuid.UUID
+	FileName string
+	Content  string
+}
+
+var errAgentNotFound = errors.New("agent not found")
+
+func (s *guardStubStore) GetByKey(ctx context.Context, _ string) (*store.AgentData, error) {
+	if s.agentTenant != uuid.Nil {
+		if got := store.TenantIDFromContext(ctx); got != s.agentTenant {
+			return nil, errAgentNotFound
+		}
+	}
+	return s.agent, nil
+}
+
+func (s *guardStubStore) Update(_ context.Context, _ uuid.UUID, updates map[string]any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.updateCalls = append(s.updateCalls, updates)
+	return nil
+}
+
+func (s *guardStubStore) SetAgentContextFile(_ context.Context, agentID uuid.UUID, name, content string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.setFileCalls = append(s.setFileCalls, setFileCall{AgentID: agentID, FileName: name, Content: content})
+	return nil
+}
+
+func (s *guardStubStore) GetAgentContextFiles(_ context.Context, _ uuid.UUID) ([]store.AgentContextFileData, error) {
+	return s.getFilesReturn, nil
+}
+
+func (s *guardStubStore) PropagateContextFile(_ context.Context, _ uuid.UUID, _ string) (int, error) {
+	return 0, nil
+}
+
+func (s *guardStubStore) updateRecorded() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.updateCalls)
+}
+
+func (s *guardStubStore) setFileRecorded() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.setFileCalls)
+}
+
+func newGuardMethods(t *testing.T, stub store.AgentStore, ownerIDs ...string) *AgentsMethods {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Gateway.OwnerIDs = ownerIDs
+	return &AgentsMethods{
+		agents:     agent.NewRouter(),
+		cfg:        cfg,
+		workspace:  t.TempDir(),
+		agentStore: stub,
+	}
+}
+
+// guardCtx reproduces the minimum router.handleRequest injects so handlers see
+// the same tenantID / role / userID values they would in production.
+func guardCtx(client *gateway.Client, userID string) context.Context {
+	ctx := context.Background()
+	if tid := client.TenantID(); tid != uuid.Nil {
+		ctx = store.WithTenantID(ctx, tid)
+	}
+	if role := client.Role(); role != "" {
+		ctx = store.WithRole(ctx, string(role))
+	}
+	if userID != "" {
+		ctx = store.WithUserID(ctx, userID)
+	}
+	return ctx
+}
+
+func captureSlog(t *testing.T) func() string {
+	t.Helper()
+	prev := slog.Default()
+	buf := &bytes.Buffer{}
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return func() string { return buf.String() }
+}
+
+func buildRequest(t *testing.T, id, method string, params map[string]any) *protocol.RequestFrame {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	return &protocol.RequestFrame{ID: id, Method: method, Params: raw}
+}
+
+func newPredefinedAgent(tenantID uuid.UUID, ownerID string) *store.AgentData {
+	return &store.AgentData{
+		BaseModel: store.BaseModel{ID: uuid.New()},
+		TenantID:  tenantID,
+		AgentKey:  "test-agent",
+		AgentType: store.AgentTypePredefined,
+		OwnerID:   ownerID,
+	}
+}
+
+func guardClient(role permissions.Role, tenantID uuid.UUID, userID string) *gateway.Client {
+	return gateway.NewTestClient(role, tenantID, userID)
+}

--- a/internal/gateway/methods/agents_master_guard_helpers_test.go
+++ b/internal/gateway/methods/agents_master_guard_helpers_test.go
@@ -95,18 +95,16 @@ func newGuardMethods(t *testing.T, stub store.AgentStore, ownerIDs ...string) *A
 	}
 }
 
-// guardCtx reproduces the minimum router.handleRequest injects so handlers see
-// the same tenantID / role / userID values they would in production.
-func guardCtx(client *gateway.Client, userID string) context.Context {
+// guardCtx mirrors what router.handleRequest injects in production: locale,
+// tenantID, tenantSlug, role — but NOT userID. Handlers that need userID
+// must read it from client.UserID(); see authorizePredefinedAgentEdit.
+func guardCtx(client *gateway.Client) context.Context {
 	ctx := context.Background()
 	if tid := client.TenantID(); tid != uuid.Nil {
 		ctx = store.WithTenantID(ctx, tid)
 	}
 	if role := client.Role(); role != "" {
 		ctx = store.WithRole(ctx, string(role))
-	}
-	if userID != "" {
-		ctx = store.WithUserID(ctx, userID)
 	}
 	return ctx
 }

--- a/internal/gateway/methods/agents_update.go
+++ b/internal/gateway/methods/agents_update.go
@@ -74,6 +74,11 @@ func (m *AgentsMethods) handleUpdate(ctx context.Context, client *gateway.Client
 			return
 		}
 
+		if msg := m.authorizePredefinedAgentEdit(ctx, ag, protocol.MethodAgentsUpdate, ""); msg != "" {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrUnauthorized, msg))
+			return
+		}
+
 		updates := map[string]any{}
 		if params.Name != "" {
 			updates["display_name"] = params.Name

--- a/internal/gateway/methods/agents_update.go
+++ b/internal/gateway/methods/agents_update.go
@@ -74,7 +74,7 @@ func (m *AgentsMethods) handleUpdate(ctx context.Context, client *gateway.Client
 			return
 		}
 
-		if msg := m.authorizePredefinedAgentEdit(ctx, ag, protocol.MethodAgentsUpdate, ""); msg != "" {
+		if msg := m.authorizePredefinedAgentEdit(ctx, ag, client.UserID(), protocol.MethodAgentsUpdate, ""); msg != "" {
 			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrUnauthorized, msg))
 			return
 		}

--- a/internal/gateway/methods/agents_update_master_test.go
+++ b/internal/gateway/methods/agents_update_master_test.go
@@ -1,0 +1,111 @@
+package methods
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/permissions"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+func TestAgentsUpdate_MasterCanUpdatePredefined_OtherUserAgent(t *testing.T) {
+	tenantA := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	stub := &guardStubStore{
+		agent:       newPredefinedAgent(tenantA, "alice"),
+		agentTenant: tenantA,
+	}
+	m := newGuardMethods(t, stub, "system")
+
+	getLog := captureSlog(t)
+	client := guardClient(permissions.RoleOwner, tenantA, "system")
+	req := buildRequest(t, "update-master", protocol.MethodAgentsUpdate, map[string]any{
+		"agentId": stub.agent.AgentKey,
+		"name":    "Renamed Agent",
+	})
+
+	m.handleUpdate(guardCtx(client, "system"), client, req)
+
+	if stub.updateRecorded() != 1 {
+		t.Fatalf("Update called %d times, want 1", stub.updateRecorded())
+	}
+	if got := stub.updateCalls[0]["display_name"]; got != "Renamed Agent" {
+		t.Fatalf("display_name = %v, want Renamed Agent", got)
+	}
+	logged := getLog()
+	if !strings.Contains(logged, "security.master_override") {
+		t.Fatalf("missing security.master_override slog line. got: %q", logged)
+	}
+	if !strings.Contains(logged, protocol.MethodAgentsUpdate) {
+		t.Fatalf("expected method=%q in slog. got: %q", protocol.MethodAgentsUpdate, logged)
+	}
+}
+
+func TestAgentsUpdate_OwnerCanUpdateOwnPredefined(t *testing.T) {
+	tenantA := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	stub := &guardStubStore{
+		agent:       newPredefinedAgent(tenantA, "alice"),
+		agentTenant: tenantA,
+	}
+	m := newGuardMethods(t, stub)
+
+	getLog := captureSlog(t)
+	client := guardClient(permissions.RoleAdmin, tenantA, "alice")
+	req := buildRequest(t, "update-owner", protocol.MethodAgentsUpdate, map[string]any{
+		"agentId": stub.agent.AgentKey,
+		"model":   "claude-opus-4-1",
+	})
+
+	m.handleUpdate(guardCtx(client, "alice"), client, req)
+
+	if stub.updateRecorded() != 1 {
+		t.Fatalf("Update called %d times, want 1", stub.updateRecorded())
+	}
+	if logged := getLog(); strings.Contains(logged, "security.master_override") {
+		t.Fatalf("owner branch must not emit master_override slog. got: %q", logged)
+	}
+}
+
+func TestAgentsUpdate_NonOwnerNonMaster_Rejected(t *testing.T) {
+	tenantA := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	stub := &guardStubStore{
+		agent:       newPredefinedAgent(tenantA, "alice"),
+		agentTenant: tenantA,
+	}
+	m := newGuardMethods(t, stub)
+
+	client := guardClient(permissions.RoleAdmin, tenantA, "bob")
+	req := buildRequest(t, "update-bob", protocol.MethodAgentsUpdate, map[string]any{
+		"agentId": stub.agent.AgentKey,
+		"name":    "Hijacked",
+	})
+
+	m.handleUpdate(guardCtx(client, "bob"), client, req)
+
+	if stub.updateRecorded() != 0 {
+		t.Fatalf("Update called %d times, want 0 (rejected request must not mutate)", stub.updateRecorded())
+	}
+}
+
+func TestAgentsUpdate_CrossTenantMaster_NotFound(t *testing.T) {
+	tenantA := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	tenantB := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	stub := &guardStubStore{
+		agent:       newPredefinedAgent(tenantB, "alice"),
+		agentTenant: tenantB,
+	}
+	m := newGuardMethods(t, stub)
+
+	client := guardClient(permissions.RoleOwner, tenantA, "system")
+	req := buildRequest(t, "update-cross-tenant", protocol.MethodAgentsUpdate, map[string]any{
+		"agentId": stub.agent.AgentKey,
+		"name":    "Cross Tenant Attempt",
+	})
+
+	m.handleUpdate(guardCtx(client, "system"), client, req)
+
+	if stub.updateRecorded() != 0 {
+		t.Fatalf("Update called %d times, want 0 (cross-tenant lookup must not mutate)", stub.updateRecorded())
+	}
+}

--- a/internal/gateway/methods/agents_update_master_test.go
+++ b/internal/gateway/methods/agents_update_master_test.go
@@ -25,7 +25,7 @@ func TestAgentsUpdate_MasterCanUpdatePredefined_OtherUserAgent(t *testing.T) {
 		"name":    "Renamed Agent",
 	})
 
-	m.handleUpdate(guardCtx(client, "system"), client, req)
+	m.handleUpdate(guardCtx(client), client, req)
 
 	if stub.updateRecorded() != 1 {
 		t.Fatalf("Update called %d times, want 1", stub.updateRecorded())
@@ -57,7 +57,7 @@ func TestAgentsUpdate_OwnerCanUpdateOwnPredefined(t *testing.T) {
 		"model":   "claude-opus-4-1",
 	})
 
-	m.handleUpdate(guardCtx(client, "alice"), client, req)
+	m.handleUpdate(guardCtx(client), client, req)
 
 	if stub.updateRecorded() != 1 {
 		t.Fatalf("Update called %d times, want 1", stub.updateRecorded())
@@ -81,7 +81,7 @@ func TestAgentsUpdate_NonOwnerNonMaster_Rejected(t *testing.T) {
 		"name":    "Hijacked",
 	})
 
-	m.handleUpdate(guardCtx(client, "bob"), client, req)
+	m.handleUpdate(guardCtx(client), client, req)
 
 	if stub.updateRecorded() != 0 {
 		t.Fatalf("Update called %d times, want 0 (rejected request must not mutate)", stub.updateRecorded())
@@ -103,7 +103,7 @@ func TestAgentsUpdate_CrossTenantMaster_NotFound(t *testing.T) {
 		"name":    "Cross Tenant Attempt",
 	})
 
-	m.handleUpdate(guardCtx(client, "system"), client, req)
+	m.handleUpdate(guardCtx(client), client, req)
 
 	if stub.updateRecorded() != 0 {
 		t.Fatalf("Update called %d times, want 0 (cross-tenant lookup must not mutate)", stub.updateRecorded())

--- a/internal/http/agents.go
+++ b/internal/http/agents.go
@@ -391,6 +391,13 @@ func (h *AgentsHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// owner_id is silently dropped by the allowlist filter below; reject up front
+	// so callers don't see a misleading 200 when ownership transfer is attempted.
+	if _, present := updates["owner_id"]; present {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest, i18n.T(locale, i18n.MsgOwnerIDImmutable))
+		return
+	}
+
 	// Allowlist: only permit known agent columns to be updated.
 	// Defense-in-depth against column injection via arbitrary JSON keys.
 	allowed := filterAllowedKeys(updates, agentAllowedFields)

--- a/internal/http/agents_owner_immutable_test.go
+++ b/internal/http/agents_owner_immutable_test.go
@@ -1,0 +1,104 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/crypto"
+	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// Embeds the interface so unexpected method calls panic — surfaces test drift.
+type stubAgentStoreForUpdate struct {
+	store.AgentStore
+	agent       *store.AgentData
+	updatedWith map[string]any
+	updateCount int
+}
+
+func (s *stubAgentStoreForUpdate) GetByID(_ context.Context, _ uuid.UUID) (*store.AgentData, error) {
+	return s.agent, nil
+}
+
+func (s *stubAgentStoreForUpdate) Update(_ context.Context, _ uuid.UUID, updates map[string]any) error {
+	s.updatedWith = updates
+	s.updateCount++
+	return nil
+}
+
+func setupOwnerImmutableTest(t *testing.T) (*http.ServeMux, *stubAgentStoreForUpdate, string) {
+	t.Helper()
+	const token = "admin-token"
+	setupTestCache(t, map[string]*store.APIKeyData{
+		crypto.HashAPIKey(token): {
+			ID:       uuid.New(),
+			Scopes:   []string{"operator.admin"},
+			TenantID: store.MasterTenantID,
+		},
+	})
+
+	stub := &stubAgentStoreForUpdate{
+		agent: &store.AgentData{
+			BaseModel: store.BaseModel{ID: uuid.New()},
+			TenantID:  store.MasterTenantID,
+			AgentKey:  "test-agent",
+			AgentType: store.AgentTypePredefined,
+			OwnerID:   "alice",
+			Provider:  "anthropic",
+			Model:     "claude-sonnet-4-5",
+		},
+	}
+
+	h := NewAgentsHandler(stub, nil, nil, nil, nil, "", nil, nil, nil)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return mux, stub, token
+}
+
+func TestPutAgentRejectsOwnerID(t *testing.T) {
+	mux, stub, token := setupOwnerImmutableTest(t)
+
+	body := `{"owner_id":"bob"}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/agents/"+stub.agent.ID.String(), bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", w.Code, w.Body.String())
+	}
+	wantMsg := i18n.T("en", i18n.MsgOwnerIDImmutable)
+	if !strings.Contains(w.Body.String(), wantMsg) {
+		t.Fatalf("body = %q, want substring %q", w.Body.String(), wantMsg)
+	}
+	if stub.updateCount != 0 {
+		t.Fatalf("Update called %d times, want 0 (reject must not mutate)", stub.updateCount)
+	}
+}
+
+func TestPutAgentAllowsBodyWithoutOwnerID(t *testing.T) {
+	mux, stub, token := setupOwnerImmutableTest(t)
+
+	body := `{"model":"claude-opus-4-1"}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/agents/"+stub.agent.ID.String(), bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+	if stub.updateCount != 1 {
+		t.Fatalf("Update called %d times, want 1", stub.updateCount)
+	}
+	if got := stub.updatedWith["model"]; got != "claude-opus-4-1" {
+		t.Fatalf("Update model = %v, want claude-opus-4-1", got)
+	}
+}

--- a/internal/http/oauth_test.go
+++ b/internal/http/oauth_test.go
@@ -414,7 +414,7 @@ func TestOAuthHandlerProviderLogoutRoute(t *testing.T) {
 	}
 }
 
-func TestProvidersHandlerRequiresAdmin(t *testing.T) {
+func TestProvidersHandlerWritesRequireAdmin(t *testing.T) {
 	token := "operator-key"
 	setupTestCache(t, map[string]*store.APIKeyData{
 		crypto.HashAPIKey(token): {
@@ -428,7 +428,7 @@ func TestProvidersHandlerRequiresAdmin(t *testing.T) {
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 
-	req := httptest.NewRequest("GET", "/v1/providers", nil)
+	req := httptest.NewRequest("POST", "/v1/providers", strings.NewReader(`{"name":"x"}`))
 	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -119,32 +119,30 @@ func (h *ProvidersHandler) emitProviderCacheInvalidate(name string) {
 
 // RegisterRoutes registers all provider management routes on the given mux.
 func (h *ProvidersHandler) RegisterRoutes(mux *http.ServeMux) {
-	// Provider CRUD
-	mux.HandleFunc("GET /v1/providers", h.auth(h.handleListProviders))
-	mux.HandleFunc("POST /v1/providers", h.auth(h.handleCreateProvider))
-	mux.HandleFunc("GET /v1/providers/{id}", h.auth(h.handleGetProvider))
-	mux.HandleFunc("PUT /v1/providers/{id}", h.auth(h.handleUpdateProvider))
-	mux.HandleFunc("DELETE /v1/providers/{id}", h.auth(h.handleDeleteProvider))
+	mux.HandleFunc("GET /v1/providers", h.authRead(h.handleListProviders))
+	mux.HandleFunc("POST /v1/providers", h.authAdmin(h.handleCreateProvider))
+	mux.HandleFunc("GET /v1/providers/{id}", h.authRead(h.handleGetProvider))
+	mux.HandleFunc("PUT /v1/providers/{id}", h.authAdmin(h.handleUpdateProvider))
+	mux.HandleFunc("DELETE /v1/providers/{id}", h.authAdmin(h.handleDeleteProvider))
 
-	// Model listing (proxied to upstream provider API)
-	mux.HandleFunc("GET /v1/providers/{id}/models", h.auth(h.handleListProviderModels))
+	mux.HandleFunc("GET /v1/providers/{id}/models", h.authRead(h.handleListProviderModels))
 
-	// Provider + model verification (pre-flight check)
-	mux.HandleFunc("POST /v1/providers/{id}/verify", h.auth(h.handleVerifyProvider))
-	mux.HandleFunc("POST /v1/providers/{id}/verify-embedding", h.auth(h.handleVerifyEmbedding))
+	mux.HandleFunc("POST /v1/providers/{id}/verify", h.authAdmin(h.handleVerifyProvider))
+	mux.HandleFunc("POST /v1/providers/{id}/verify-embedding", h.authAdmin(h.handleVerifyEmbedding))
 
-	// Provider-scoped Codex pool activity monitor
-	mux.HandleFunc("GET /v1/providers/{id}/codex-pool-activity", h.auth(h.handleProviderCodexPoolActivity))
+	mux.HandleFunc("GET /v1/providers/{id}/codex-pool-activity", h.authRead(h.handleProviderCodexPoolActivity))
 
-	// Embedding system status
-	mux.HandleFunc("GET /v1/embedding/status", h.auth(h.handleEmbeddingStatus))
+	mux.HandleFunc("GET /v1/embedding/status", h.authRead(h.handleEmbeddingStatus))
 
-	// Claude CLI auth status (global — not per-provider)
-	mux.HandleFunc("GET /v1/providers/claude-cli/auth-status", h.auth(h.handleClaudeCLIAuthStatus))
+	mux.HandleFunc("GET /v1/providers/claude-cli/auth-status", h.authRead(h.handleClaudeCLIAuthStatus))
 }
 
-func (h *ProvidersHandler) auth(next http.HandlerFunc) http.HandlerFunc {
+func (h *ProvidersHandler) authAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return requireAuth(permissions.RoleAdmin, next)
+}
+
+func (h *ProvidersHandler) authRead(next http.HandlerFunc) http.HandlerFunc {
+	return requireAuth("", next)
 }
 
 // maskAPIKey replaces non-empty API keys with "***".

--- a/internal/http/providers_test.go
+++ b/internal/http/providers_test.go
@@ -344,3 +344,67 @@ func TestProvidersHandlerUpdateRejectsIncompatibleEmbeddingDimensions(t *testing
 		t.Fatalf("embedding dimensions = %+v, want 1536 preserved", es)
 	}
 }
+
+func TestProvidersHandlerRoleMatrix(t *testing.T) {
+	const (
+		viewerToken   = "viewer-key"
+		operatorToken = "operator-key"
+		adminToken    = "admin-key"
+	)
+	setupTestCache(t, map[string]*store.APIKeyData{
+		crypto.HashAPIKey(viewerToken):   {ID: uuid.New(), Scopes: []string{"operator.read"}},
+		crypto.HashAPIKey(operatorToken): {ID: uuid.New(), Scopes: []string{"operator.write"}},
+		crypto.HashAPIKey(adminToken):    {ID: uuid.New(), Scopes: []string{"operator.admin"}},
+	})
+
+	providerStore := newMockProviderStore()
+	provider := &store.LLMProviderData{
+		BaseModel:    store.BaseModel{ID: uuid.New()},
+		Name:         "openai",
+		ProviderType: store.ProviderOpenAICompat,
+		APIBase:      "https://api.openai.com/v1",
+		APIKey:       "sk-test",
+		Enabled:      true,
+	}
+	if err := providerStore.CreateProvider(context.Background(), provider); err != nil {
+		t.Fatalf("seed provider: %v", err)
+	}
+
+	handler := NewProvidersHandler(providerStore, newMockSecretsStore(), nil, "")
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		body       string
+		token      string
+		wantStatus int
+	}{
+		{"viewer-get-list", http.MethodGet, "/v1/providers", "", viewerToken, http.StatusOK},
+		{"operator-get-list", http.MethodGet, "/v1/providers", "", operatorToken, http.StatusOK},
+		{"viewer-get-one", http.MethodGet, "/v1/providers/" + provider.ID.String(), "", viewerToken, http.StatusOK},
+		{"operator-post-forbidden", http.MethodPost, "/v1/providers", `{"name":"x","provider_type":"openai_compat","api_base":"https://x/v1","api_key":"k","enabled":true}`, operatorToken, http.StatusForbidden},
+		{"viewer-put-forbidden", http.MethodPut, "/v1/providers/" + provider.ID.String(), `{"enabled":false}`, viewerToken, http.StatusForbidden},
+		{"viewer-delete-forbidden", http.MethodDelete, "/v1/providers/" + provider.ID.String(), "", viewerToken, http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body *bytes.Buffer
+			if tc.body != "" {
+				body = bytes.NewBufferString(tc.body)
+			} else {
+				body = bytes.NewBuffer(nil)
+			}
+			req := httptest.NewRequest(tc.method, tc.path, body)
+			req.Header.Set("Authorization", "Bearer "+tc.token)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d, body=%s", w.Code, tc.wantStatus, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/http/validate.go
+++ b/internal/http/validate.go
@@ -37,8 +37,7 @@ func validateAgentTTSParams(ttsParams map[string]any) error {
 }
 
 // --- Field allowlists for update endpoints ---
-// Each map lists the columns that HTTP clients may update.
-// Immutable fields (id, owner_id, created_at, deleted_at) are excluded.
+// owner_id is rejected up front by handleUpdate, not silently dropped here.
 
 var agentAllowedFields = map[string]bool{
 	"agent_key": true, "agent_type": true, "display_name": true,

--- a/internal/i18n/catalog_en.go
+++ b/internal/i18n/catalog_en.go
@@ -24,6 +24,7 @@ func init() {
 		MsgAgentNotFound:       "agent not found: %s",
 		MsgCannotDeleteDefault: "cannot delete the default agent",
 		MsgUserCtxRequired:     "user context required",
+		MsgOwnerIDImmutable:    "owner_id cannot be changed via this endpoint",
 
 		// Chat
 		MsgRateLimitExceeded: "rate limit exceeded — please wait",

--- a/internal/i18n/catalog_vi.go
+++ b/internal/i18n/catalog_vi.go
@@ -24,6 +24,7 @@ func init() {
 		MsgAgentNotFound:       "không tìm thấy agent: %s",
 		MsgCannotDeleteDefault: "không thể xóa agent mặc định",
 		MsgUserCtxRequired:     "yêu cầu ngữ cảnh người dùng",
+		MsgOwnerIDImmutable:    "không thể thay đổi owner_id qua endpoint này",
 
 		// Chat
 		MsgRateLimitExceeded: "vượt quá giới hạn tốc độ — vui lòng đợi",

--- a/internal/i18n/catalog_zh.go
+++ b/internal/i18n/catalog_zh.go
@@ -24,6 +24,7 @@ func init() {
 		MsgAgentNotFound:       "未找到Agent：%s",
 		MsgCannotDeleteDefault: "无法删除默认Agent",
 		MsgUserCtxRequired:     "需要用户上下文",
+		MsgOwnerIDImmutable:    "无法通过此端点更改 owner_id",
 
 		// Chat
 		MsgRateLimitExceeded: "请求频率超限 — 请稍候",

--- a/internal/i18n/keys.go
+++ b/internal/i18n/keys.go
@@ -25,6 +25,7 @@ const (
 	MsgAgentNotFound       = "error.agent_not_found"       // "agent not found: %s"
 	MsgCannotDeleteDefault = "error.cannot_delete_default" // "cannot delete the default agent"
 	MsgUserCtxRequired     = "error.user_ctx_required"     // "user context required"
+	MsgOwnerIDImmutable    = "error.owner_id_immutable"    // "owner_id cannot be changed via this endpoint"
 
 	// --- Chat ---
 	MsgRateLimitExceeded = "error.rate_limit"       // "rate limit exceeded — please wait"

--- a/ui/web/src/pages/agents/agent-detail/agent-files-tab.tsx
+++ b/ui/web/src/pages/agents/agent-detail/agent-files-tab.tsx
@@ -39,6 +39,7 @@ export function AgentFilesTab({
 }: AgentFilesTabProps) {
   const { t } = useTranslation("agents");
   const userId = useAuthStore((s) => s.userId);
+  const isMasterScope = useAuthStore((s) => s.isMasterScope);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [content, setContent] = useState("");
   const [loading, setLoading] = useState(false);
@@ -51,7 +52,8 @@ export function AgentFilesTab({
   const isOpen = agent.agent_type === "open";
   const isPredefined = agent.agent_type === "predefined";
   const isOwner = agent.owner_id === userId;
-  const canEdit = !isPredefined || isOwner;
+  const canEditPredefined = isOwner || isMasterScope;
+  const canEdit = !isPredefined || canEditPredefined;
 
   const displayFiles = files.filter(
     (f) =>
@@ -108,7 +110,7 @@ export function AgentFilesTab({
     return <OpenAgentEmptyState files={displayFiles} />;
   }
 
-  const aiActions = isPredefined && isOwner && (
+  const aiActions = isPredefined && canEditPredefined && (
     <>
       {onResummon && (
         <Button
@@ -137,7 +139,7 @@ export function AgentFilesTab({
 
   return (
     <div className="space-y-3">
-      {isPredefined && !isOwner && (
+      {isPredefined && !canEditPredefined && (
         <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
           <Lock className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
           <div className="text-sm">


### PR DESCRIPTION
## Summary
- #1075 — Operator (incl. browser-paired) can now `GET /v1/providers*`; writes still Admin-gated. Unblocks `/setup`.
- #1054 — Three coupled defects:
  - `PUT /v1/agents/{id}` no longer silently drops `owner_id`; returns 400 with localized `MsgOwnerIDImmutable`.
  - WS `agents.files.set` and `agents.update` now require agent owner OR master scope on predefined agents (closes pre-existing security gap). Master-override branch emits `slog.Info("security.master_override", …)`.
  - UI banner / AI actions on `agent-files-tab.tsx` use `isOwner || isMasterScope` so master sees the editor; non-owner non-master still sees the read-only banner.

## Test plan
- [x] `go build ./... && go build -tags sqliteonly ./... && go vet ./...` clean
- [x] `go test ./internal/http/... ./internal/gateway/methods/...` — new tests pass:
  - `TestProvidersHandlerRoleMatrix` (T1–T3), `TestProvidersHandlerWritesRequireAdmin`
  - `TestPutAgentRejectsOwnerID`, `TestPutAgentAllowsBodyWithoutOwnerID` (T8/T9)
  - `TestFilesSet_*` and `TestAgentsUpdate_*` (T4–T7, T-update-1..4, T-slog) incl. two-tenant cross-tenant fixture
- [x] `pnpm build` (web) clean
- [ ] Manual smoke (T10): master sees editor (no banner) on predefined agent owned by other user; non-owner non-master Operator still sees banner.

## Out of scope (follow-up)
- Open-agent file writes via WS (`SetUserContextFile` callers) remain unguarded — same defense-in-depth class as predefined, tracked separately.
- Dedicated ownership-transfer endpoint (with audit + cascade) — needed if/when UI surfaces ownership transfer.

## i18n
- Backend: `MsgOwnerIDImmutable` added to en/vi/zh catalogs.
- UI: no new keys (existing `files.readOnly{,Desc}` accurate for non-master non-owner).

## RBAC matrix (providers, post-fix)
| Verb | Admin | Operator | Viewer |
|------|-------|----------|--------|
| GET | ✓ | ✓ | ✓ |
| POST/PUT/DELETE/verify | ✓ | 403 | 403 |