### PR TITLE
fix(ops): bot token masking + episodic timeout 120s + path_escape log levels

### DIFF
--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"sync"
 
 	"github.com/google/uuid"
@@ -11,6 +12,19 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
+
+// reBotToken matches Telegram bot tokens in URLs (bot<id>:<secret>/).
+var reBotToken = regexp.MustCompile(`bot\d+:[A-Za-z0-9_-]+/`)
+
+// MaskBotToken replaces bot tokens in error messages with "bot***/" so
+// secrets do not leak into journalctl when channel start / sync / watchdog
+// errors are logged. Safe to call with nil.
+func MaskBotToken(err error) string {
+	if err == nil {
+		return ""
+	}
+	return reBotToken.ReplaceAllString(err.Error(), "bot***/")
+}
 
 // ChannelStream is the per-run streaming handle stored on RunContext.
 // Each channel implementation returns a ChannelStream from CreateStream().
@@ -99,7 +113,7 @@ func (m *Manager) StartAll(ctx context.Context) error {
 		m.syncChannelHealthLocked(name, channel)
 		if err := channel.Start(ctx); err != nil {
 			m.recordChannelStartFailureLocked(name, channel, "", err)
-			slog.Error("failed to start channel", "channel", name, "error", err)
+			slog.Error("failed to start channel", "channel", name, "error", MaskBotToken(err))
 			continue
 		}
 		m.syncChannelHealthLocked(name, channel)

--- a/internal/channels/telegram/channel.go
+++ b/internal/channels/telegram/channel.go
@@ -231,7 +231,7 @@ func (c *Channel) Start(ctx context.Context) error {
 		for attempt := 1; attempt <= 3; attempt++ {
 			if err := c.SyncMenuCommands(syncCtx, commands); err != nil {
 				lastErr = err
-				slog.Warn("failed to sync telegram menu commands", "error", err, "attempt", attempt)
+				slog.Warn("failed to sync telegram menu commands", "error", channels.MaskBotToken(err), "attempt", attempt)
 				if attempt < 3 {
 					select {
 					case <-syncCtx.Done():

--- a/internal/consolidation/episodic_worker.go
+++ b/internal/consolidation/episodic_worker.go
@@ -165,7 +165,10 @@ func (w *episodicWorker) summarizeFromMessages(ctx context.Context, provider pro
 		}
 	}
 
-	sctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	// 120s — ACP-mode providers (Gemini CLI etc.) need 5~10s for spawn +
+	// initialize + session/new before the LLM call begins; 30s often timed out
+	// during the model response itself.
+	sctx, cancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cancel()
 
 	resp, err := provider.Chat(sctx, providers.ChatRequest{

--- a/internal/tools/filesystem.go
+++ b/internal/tools/filesystem.go
@@ -394,6 +394,7 @@ func resolvePathWithAllowed(path, workspace string, restrict bool, allowedPrefix
 			return real, nil
 		}
 	}
+	slog.Warn("security.path_escape", "path", cleaned, "resolved", cleaned, "workspace", workspace)
 	slog.Warn("read_file: access denied", "path", cleaned, "workspace", workspace, "allowedPrefixes", allowedPrefixes)
 	return "", err
 }
@@ -515,7 +516,9 @@ func resolvePath(path, workspace string, restrict bool) (string, error) {
 
 	// Validate canonical path stays within canonical workspace.
 	if !isPathInside(real, wsReal) {
-		slog.Warn("security.path_escape", "path", path, "resolved", real, "workspace", wsReal)
+		// debug: routine deny path. resolvePathWithAllowed re-emits warn at
+		// the higher-level 'access denied' boundary, so don't double-warn here.
+		slog.Debug("security.path_escape", "path", path, "resolved", real, "workspace", wsReal)
 		return "", fmt.Errorf("access denied: path outside workspace")
 	}
 


### PR DESCRIPTION
## Summary

Three small operational improvements split out from #1069. Each is independent of the others; reviewer can drop any one without affecting the rest.

### 1. Telegram bot token log masking (security)

\`internal/channels/manager.go\`, \`internal/channels/telegram/channel.go\`

\`\`\`go
var reBotToken = regexp.MustCompile(\`bot\d+:[A-Za-z0-9_-]+/\`)
func MaskBotToken(err error) string { ... }  // → "bot***/"
\`\`\`

Channel start failure and \`SyncMenuCommands\` retry failure logs were emitting the upstream Telegram URL verbatim, which contains the bot token. journalctl/log aggregators would capture this. Now masked to \`bot***/\`.

### 2. Episodic summarize timeout 30s → 120s

\`internal/consolidation/episodic_worker.go\`

ACP-mode providers (Gemini CLI etc.) need 5~10s for spawn + initialize + session/new before the LLM call begins. 30s often timed out during the model response itself, leaving sessions without summaries.

### 3. \`security.path_escape\` log levels rebalanced

\`internal/tools/filesystem.go\`

- \`resolvePathWithAllowed\` (allow-list variant): now emits **warn** when the allow-list fallback rejects a path. Was previously silent — only the higher-level 'access denied' line showed up, hiding the path-escape root cause.
- Inner \`resolvePath\`: warn → **debug**. \`resolvePathWithAllowed\` re-emits warn at its boundary, so the inner call dropping to debug avoids double-warns for routine deny cases (every \`read_file\` fallback path goes through here twice).

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/channels/...\`
- [ ] Reviewer to confirm bot token doesn't appear in journalctl after triggering a channel start failure
- [ ] Reviewer to confirm episodic summary completes for ACP-mode agents under load

## Notes

Original commit on the merge branch (00a817f5) also included masking inside a \`runWatchdog\` retry path. That watchdog infrastructure is a separate feature in #1069 not yet on dev, so this PR drops the watchdog-dependent line. If the watchdog feature lands later, a follow-up one-line patch can add the mask there.