### PR TITLE
fix(teams): propagate task result in team task completion event

### DIFF
--- a/cmd/gateway_events.go
+++ b/cmd/gateway_events.go
@@ -214,7 +214,15 @@ func (d *gatewayDeps) wireTeamProgressNotifySubscriber() {
 		case protocol.EventTeamTaskAssigned:
 			content = fmt.Sprintf("📋 Task #%d \"%s\" → assigned to %s", payload.TaskNumber, payload.Subject, agentName)
 		case protocol.EventTeamTaskCompleted:
-			content = fmt.Sprintf("✅ Task #%d \"%s\" completed", payload.TaskNumber, payload.Subject)
+			if payload.Result != "" {
+				result := payload.Result
+				if len(result) > 300 {
+					result = result[:300] + "…"
+				}
+				content = fmt.Sprintf("✅ Task #%d \"%s\" completed\n%s", payload.TaskNumber, payload.Subject, result)
+			} else {
+				content = fmt.Sprintf("✅ Task #%d \"%s\" completed", payload.TaskNumber, payload.Subject)
+			}
 		case protocol.EventTeamTaskProgress:
 			if payload.ProgressStep != "" {
 				content = fmt.Sprintf("⏳ Task #%d \"%s\": %d%% — %s", payload.TaskNumber, payload.Subject, payload.ProgressPercent, payload.ProgressStep)

--- a/internal/tools/team_event_helpers.go
+++ b/internal/tools/team_event_helpers.go
@@ -100,6 +100,11 @@ func WithLocalKey(lk string) TaskEventOption {
 	return func(p *protocol.TeamTaskEventPayload) { p.LocalKey = lk }
 }
 
+// WithResult sets Result on the payload (used for task completion reports).
+func WithResult(r string) TaskEventOption {
+	return func(p *protocol.TeamTaskEventPayload) { p.Result = r }
+}
+
 // WithCommentText sets CommentText on the payload.
 func WithCommentText(t string) TaskEventOption {
 	return func(p *protocol.TeamTaskEventPayload) { p.CommentText = t }

--- a/internal/tools/team_tasks_lifecycle.go
+++ b/internal/tools/team_tasks_lifecycle.go
@@ -104,6 +104,7 @@ func (t *TeamTasksTool) executeComplete(ctx context.Context, args map[string]any
 		WithOwner(ownerKey, t.manager.AgentDisplayName(ctx, ownerKey)),
 		WithContextInfo(ctx),
 		WithLocalKey(taskLocalKey),
+		WithResult(result),
 	))
 
 	// Dependent tasks are dispatched by the consumer after this agent's turn ends

--- a/pkg/protocol/team_events.go
+++ b/pkg/protocol/team_events.go
@@ -104,6 +104,9 @@ type TeamTaskEventPayload struct {
 	LocalKey         string `json:"local_key,omitempty"`
 	Timestamp        string `json:"timestamp"`
 
+	// Result summary (for team.task.completed events — the member's completion report).
+	Result string `json:"result,omitempty"`
+
 	// Comment text preview (for team.task.commented events, truncated).
 	CommentText string `json:"comment_text,omitempty"`
 


### PR DESCRIPTION
## Summary

- Add `Result string` field to `TeamTaskEventPayload` protocol struct (populated on `team.task.completed` events)
- Add `WithResult(r string)` option helper in `team_event_helpers.go`
- Pass `WithResult(result)` when broadcasting `EventTeamTaskCompleted` in `executeComplete()`
- Update completion notification format to include result summary (truncated at 300 chars)

## Problem

When a member agent completes a task, the `EventTeamTaskCompleted` bus event carried no result data. Downstream subscribers (notification, audit) had no way to surface the completion output without re-querying the task store.

## Solution

Populate `Result` directly in the broadcast payload at completion time. Two consumer paths benefit:

1. **External notify** — completion message now includes the result snippet instead of just `"✅ Task #N completed"`
2. **Bus subscribers** — can read `payload.Result` without an extra DB round-trip

## Test plan

- [ ] Member agent completes a task with a non-empty result string
- [ ] Verify `EventTeamTaskCompleted` payload carries the result
- [ ] Verify notification includes result snippet (≤300 chars) followed by `…` if truncated
- [ ] Verify empty result still produces the original `"✅ Task #N completed"` format (no trailing newline)