### PR TITLE
fix: forward extra params from chain config in callStandardImageGenAPI

### DIFF
--- a/internal/tools/create_image.go
+++ b/internal/tools/create_image.go
@@ -216,11 +216,21 @@ func (t *CreateImageTool) callImageGenAPI(ctx context.Context, apiKey, apiBase, 
 
 // callStandardImageGenAPI uses the /images/generations endpoint (OpenAI and compatible providers).
 func (t *CreateImageTool) callStandardImageGenAPI(ctx context.Context, apiKey, apiBase, model, prompt string, params map[string]any) ([]byte, *providers.Usage, error) {
+	// Internal/routing keys not forwarded to the API.
+	skipKeys := map[string]bool{
+		"prompt": true, "aspect_ratio": true, "_provider_type": true,
+	}
 	body := map[string]any{
 		"model":           model,
 		"prompt":          prompt,
 		"n":               1,
 		"response_format": "b64_json",
+	}
+	// Forward extra provider-specific params from chain config (e.g. size, quality, output_format).
+	for k, v := range params {
+		if !skipKeys[k] {
+			body[k] = v
+		}
 	}
 
 	jsonBody, err := json.Marshal(body)


### PR DESCRIPTION
## Summary
Allow chain config params (size, quality, output_format, etc.) to be passed through to the image generation API request body, enabling provider-specific parameters to be configured per-chain without code changes.

**Root cause:** `callStandardImageGenAPI` built a fixed request body ignoring any extra params stored in the chain config `params` field. The params from chain config were already passed into the function via the `params map[string]any` argument but were not forwarded to the API request.

**Fix:** Merge extra params from chain config into the request body, skipping internal routing keys (`prompt`, `aspect_ratio`, `_provider_type`).

## Changed
- `internal/tools/create_image.go`: `callStandardImageGenAPI` now forwards extra chain config params to the API request body