### PR TITLE
fix(discord): suppress pairing reply in groups without @mention (#1091)

### DIFF
--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -45,7 +45,7 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 	}
 
 	// Pre-compute mention flag for groups so policy gating can suppress
-	// pairing replies when the bot was not addressed (issue #1091).
+	// pairing replies when the bot was not addressed.
 	mentioned := false
 	if !isDM {
 		for _, u := range m.Mentions {

--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -44,12 +44,29 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 		peerKind = "direct"
 	}
 
+	// Pre-compute mention flag for groups so policy gating can suppress
+	// pairing replies when the bot was not addressed (issue #1091).
+	mentioned := false
+	if !isDM {
+		for _, u := range m.Mentions {
+			if u.ID == c.botUserID {
+				mentioned = true
+				break
+			}
+		}
+		if !mentioned && m.ReferencedMessage != nil &&
+			m.ReferencedMessage.Author != nil &&
+			m.ReferencedMessage.Author.ID == c.botUserID {
+			mentioned = true
+		}
+	}
+
 	if isDM {
 		if !c.checkDMPolicy(ctx, senderID, channelID) {
 			return
 		}
 	} else {
-		if !c.checkGroupPolicy(ctx, senderID, channelID) {
+		if !c.checkGroupPolicy(ctx, senderID, channelID, mentioned) {
 			slog.Debug("discord group message rejected by policy",
 				"user_id", senderID,
 				"username", senderName,
@@ -167,20 +184,8 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 
 	// Mention gating: in groups, only respond when bot is @mentioned (default true).
 	// When not mentioned, record message to pending history for later context.
+	// `mentioned` was pre-computed above for policy gating.
 	if peerKind == "group" && c.RequireMention() {
-		mentioned := false
-		for _, u := range m.Mentions {
-			if u.ID == c.botUserID {
-				mentioned = true
-				break
-			}
-		}
-		// Reply to bot's message counts as implicit mention.
-		if !mentioned && m.ReferencedMessage != nil &&
-			m.ReferencedMessage.Author != nil &&
-			m.ReferencedMessage.Author.ID == c.botUserID {
-			mentioned = true
-		}
 		if !mentioned {
 			// Collect media file paths for group history context.
 			var mediaPaths []string
@@ -318,12 +323,17 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 }
 
 // checkGroupPolicy evaluates the group policy for a sender, with pairing support.
-func (c *Channel) checkGroupPolicy(ctx context.Context, senderID, channelID string) bool {
+// When RequireMention is enabled, pairing replies only fire if the bot was
+// explicitly addressed — otherwise the bot stays silent in the channel.
+func (c *Channel) checkGroupPolicy(ctx context.Context, senderID, channelID string, mentioned bool) bool {
 	result := c.CheckGroupPolicy(ctx, senderID, channelID, c.config.GroupPolicy)
 	switch result {
 	case channels.PolicyAllow:
 		return true
 	case channels.PolicyNeedsPairing:
+		if c.RequireMention() && !mentioned {
+			return false
+		}
 		groupSenderID := fmt.Sprintf("group:%s", channelID)
 		c.sendPairingReply(ctx, groupSenderID, channelID)
 		return false


### PR DESCRIPTION
## Summary

Hotfix for #1091. Discord channels with `pairing` group policy + `Require @mention in groups` enabled were spamming pairing codes on every group message.

**Root cause:** `handleMessage` called `checkGroupPolicy` (which fires `sendPairingReply` on `PolicyNeedsPairing`) before the mention gate ran, so the pairing reply bypassed the mention requirement.

**Fix:** Pre-compute the `mentioned` flag once at the top of `handleMessage`, pass it into `checkGroupPolicy`, and skip `sendPairingReply` when `RequireMention()` is enabled and the bot was not addressed. The existing mention gate later in the function reuses the same flag (deduped).

DMs are intentionally unchanged — every DM is implicitly directed at the bot, so `checkDMPolicy` keeps its current pairing-reply behavior.

## Behavior after fix

| Scenario | Before | After |
|---|---|---|
| Group, paired user, mentioned | reply | reply (unchanged) |
| Group, paired user, not mentioned | record history | record history (unchanged) |
| Group, unpaired user, mentioned | pairing code | pairing code (unchanged) |
| Group, unpaired user, **not mentioned**, `require_mention=true` | **pairing code (bug)** | **silent (fixed)** |
| Group, unpaired user, not mentioned, `require_mention=false` | pairing code | pairing code (unchanged) |
| DM, unpaired user | pairing code | pairing code (unchanged) |

## Test plan

- [x] `go build ./...` (PG)
- [x] `go build -tags sqliteonly ./...` (Desktop)
- [x] `go vet ./internal/channels/discord/...`
- [x] `go test ./internal/channels/discord/...`
- [ ] Manual: Discord group with `pairing` + `require_mention=true`, send message without mention → bot stays silent
- [ ] Manual: same group, @-mention bot from unpaired account → bot replies with pairing code
- [ ] Manual: DM unpaired bot → bot replies with pairing code (no regression)

Fixes #1091