### PR TITLE
feat(config): add GOCLAW_CRON_JOB_TIMEOUT env var for cron timeout

### DIFF
--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -275,6 +275,9 @@ func (c *Config) applyEnvOverrides() {
 	if c.Tools.Browser.RemoteURL != "" {
 		c.Tools.Browser.Enabled = true
 	}
+
+	// Cron job execution
+	envStr("GOCLAW_CRON_JOB_TIMEOUT", &c.Cron.JobTimeout)
 }
 
 

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // --- Default ---
@@ -261,5 +262,57 @@ func TestLoad_OwnerIDsEmpty(t *testing.T) {
 		if id == "" {
 			t.Fatal("empty owner ID should not be included")
 		}
+	}
+}
+
+// --- Cron job timeout env override ---
+
+func TestLoad_CronJobTimeout_EnvVar(t *testing.T) {
+	t.Setenv("GOCLAW_CRON_JOB_TIMEOUT", "1h")
+
+	cfg, err := Load("/nonexistent/path")
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if got := cfg.Cron.JobTimeoutDuration(); got != time.Hour {
+		t.Fatalf("cron timeout: got %v, want 1h", got)
+	}
+}
+
+func TestLoad_CronJobTimeout_Invalid_FallsBackToDefault(t *testing.T) {
+	t.Setenv("GOCLAW_CRON_JOB_TIMEOUT", "not-a-duration")
+
+	cfg, err := Load("/nonexistent/path")
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if got := cfg.Cron.JobTimeoutDuration(); got != DefaultJobTimeout {
+		t.Fatalf("invalid duration should fall back to default %v, got %v", DefaultJobTimeout, got)
+	}
+}
+
+func TestLoad_CronJobTimeout_Unset_UsesDefault(t *testing.T) {
+	cfg, err := Load("/nonexistent/path")
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if got := cfg.Cron.JobTimeoutDuration(); got != DefaultJobTimeout {
+		t.Fatalf("unset env should use default %v, got %v", DefaultJobTimeout, got)
+	}
+}
+
+func TestLoad_CronJobTimeout_EnvOverridesFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json5")
+	os.WriteFile(cfgPath, []byte(`{"cron":{"job_timeout":"5m"}}`), 0644)
+
+	t.Setenv("GOCLAW_CRON_JOB_TIMEOUT", "30m")
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if got := cfg.Cron.JobTimeoutDuration(); got != 30*time.Minute {
+		t.Fatalf("env should override file: got %v, want 30m", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `GOCLAW_CRON_JOB_TIMEOUT` env var mapping in `applyEnvOverrides()`, completing the `GOCLAW_*` env var pattern for `CronConfig.JobTimeout`.
- Lets operators override cron job timeout without editing the JSON config file — useful for deployments running multi-turn LLM agents with large contexts where 10m default is too short.
- Zero breaking change: unset/invalid values fall through to the existing `DefaultJobTimeout` (10m) behavior via the existing `JobTimeoutDuration()` helper, which already handles parse errors with `slog.Warn`.

Closes #1098

## Changes

`internal/config/config_load.go` — one new section in the operational-config block (next to Browser):

```go
// Cron job execution
envStr("GOCLAW_CRON_JOB_TIMEOUT", &c.Cron.JobTimeout)
```

`internal/config/config_load_test.go` — 4 new test cases:

- `TestLoad_CronJobTimeout_EnvVar` — `GOCLAW_CRON_JOB_TIMEOUT=1h` → `1h`
- `TestLoad_CronJobTimeout_Invalid_FallsBackToDefault` — invalid value → 10m (logs warn)
- `TestLoad_CronJobTimeout_Unset_UsesDefault` — unset → 10m
- `TestLoad_CronJobTimeout_EnvOverridesFile` — file `5m` + env `30m` → `30m` (env wins)

## Test plan

- [x] `go build ./...` (PG build)
- [x] `go build -tags sqliteonly ./...` (Desktop/SQLite build)
- [x] `go vet ./...`
- [x] `go test ./internal/config/` — 4 new + all existing tests pass
- [ ] Manual: run gateway with `GOCLAW_CRON_JOB_TIMEOUT=1h` and confirm a long cron job is no longer killed at 10m

## Notes for reviewers

- Placement chosen near the operational-config block (Sandbox/Browser) rather than the secrets block at the top, since cron timeout is a runtime parameter, not a credential.
- No new error handling needed — `CronConfig.JobTimeoutDuration()` already validates and falls back. This was confirmed by the existing `TestCronConfig_JobTimeoutDuration_Invalid` test.
- No changes to default behavior; existing deployments without the env var see no difference.