### PR TITLE
feat(channels): add Instagram channel integration

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/channels/discord"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/facebook"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/feishu"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/instagram"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/pancake"
 	slackchannel "github.com/nextlevelbuilder/goclaw/internal/channels/slack"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/telegram"
@@ -535,6 +536,7 @@ func runGateway() {
 		instanceLoader.RegisterFactory(channels.TypeWhatsApp, whatsapp.FactoryWithDBAudio(pgStores.DB, pgStores.PendingMessages, "pgx", audioMgr, pgStores.BuiltinTools))
 		instanceLoader.RegisterFactory(channels.TypeSlack, slackchannel.FactoryWithPendingStore(pgStores.PendingMessages))
 		instanceLoader.RegisterFactory(channels.TypeFacebook, facebook.Factory)
+		instanceLoader.RegisterFactory(channels.TypeInstagram, instagram.Factory)
 		instanceLoader.RegisterFactory(channels.TypePancake, pancake.Factory)
 		// Bitrix24: factory needs the portal store + encKey injected so each
 		// Channel can resolve its portal on Start(). The encKey here mirrors

--- a/cmd/gateway_errors.go
+++ b/cmd/gateway_errors.go
@@ -90,6 +90,7 @@ func isContextOverflowError(lower string) bool {
 func isExternalChannel(channelType string) bool {
 	switch channelType {
 	case channels.TypeFacebook,
+		channels.TypeInstagram,
 		channels.TypeTelegram,
 		channels.TypeDiscord,
 		channels.TypeFeishu,

--- a/cmd/gateway_errors_test.go
+++ b/cmd/gateway_errors_test.go
@@ -20,6 +20,7 @@ func TestIsExternalChannel(t *testing.T) {
 	}{
 		// Public-facing platforms — errors must be suppressed.
 		{"facebook", channels.TypeFacebook, true},
+		{"instagram", channels.TypeInstagram, true},
 		{"telegram", channels.TypeTelegram, true},
 		{"discord", channels.TypeDiscord, true},
 		{"feishu", channels.TypeFeishu, true},

--- a/docs/05-channels-messaging.md
+++ b/docs/05-channels-messaging.md
@@ -16,6 +16,7 @@ flowchart LR
         ZL["Zalo OA"]
         ZLP["Zalo Personal"]
         WA["WhatsApp"]
+        IG["Instagram"]
     end
 
     subgraph "Channel Layer"
@@ -53,6 +54,7 @@ flowchart LR
     SEND --> ZL
     SEND --> ZLP
     SEND --> WA
+    SEND --> IG
 ```
 
 Internal channels (`cli`, `system`, `subagent`, `browser`) are silently skipped by the outbound dispatcher and never forwarded to external platforms. The `browser` channel uses WebSocket directly on the gateway connection.
@@ -168,22 +170,22 @@ flowchart TD
 
 ## 4. Channel Comparison
 
-| Feature | Telegram | Feishu/Lark | Discord | Slack | WhatsApp | Zalo OA | Zalo Personal |
-|---------|----------|-------------|---------|-------|----------|---------|---------------|
-| Connection | Long polling | WS (default) / Webhook | Gateway events | Socket Mode | Direct protocol (in-process) | Long polling | Internal protocol |
-| DM support | Yes | Yes | Yes | Yes | Yes | Yes (DM only) | Yes |
-| Group support | Yes (mention gating) | Yes | Yes | Yes (mention gating + thread cache) | Yes | No | Yes |
-| Forum/Topics | Yes (per-topic config) | Yes (topic session mode) | -- | -- | -- | -- | -- |
-| Message limit | 4,096 chars | Configurable (default 4,000) | 2,000 chars | 4,000 chars | WhatsApp native limit | 2,000 chars | 2,000 chars |
-| Streaming | Typing indicator | Streaming message cards | Edit "Thinking..." | Edit "Thinking..." (throttled 1s) | No | No | No |
-| Media | Photos, voice, files | Images, files (30 MB) | Files, embeds | Files (download w/ SSRF protection) | Images, audio, video, documents | Images (5 MB) | -- |
-| Speech-to-text | Yes (STT proxy) | -- | -- | -- | -- | -- | -- |
-| Voice routing | Yes (VoiceAgentID) | -- | -- | -- | -- | -- | -- |
-| Rich formatting | Markdown → HTML | Card messages | Markdown | Markdown → mrkdwn | Plain text | Plain text | Plain text |
-| Bot commands | 10+ commands | -- | -- | -- | -- | -- | -- |
-| Tool allow list | Per-topic | -- | -- | -- | -- | -- | -- |
-| Pairing support | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Status reactions | Yes | Yes | -- | Yes | -- | -- | -- |
+| Feature | Telegram | Feishu/Lark | Discord | Slack | WhatsApp | Zalo OA | Zalo Personal | Instagram |
+|---------|----------|-------------|---------|-------|----------|---------|---------------|-----------|
+| Connection | Long polling | WS (default) / Webhook | Gateway events | Socket Mode | Direct protocol (in-process) | Long polling | Internal protocol | Webhook |
+| DM support | Yes | Yes | Yes | Yes | Yes | Yes (DM only) | Yes | Yes |
+| Group support | Yes (mention gating) | Yes | Yes | Yes (mention gating + thread cache) | Yes | No | Yes | No |
+| Forum/Topics | Yes (per-topic config) | Yes (topic session mode) | -- | -- | -- | -- | -- | -- |
+| Message limit | 4,096 chars | Configurable (default 4,000) | 2,000 chars | 4,000 chars | WhatsApp native limit | 2,000 chars | 2,000 chars | 2,000 chars |
+| Streaming | Typing indicator | Streaming message cards | Edit "Thinking..." | Edit "Thinking..." (throttled 1s) | No | No | No | Typing indicator |
+| Media | Photos, voice, files | Images, files (30 MB) | Files, embeds | Files (download w/ SSRF protection) | Images, audio, video, documents | Images (5 MB) | -- | Images, video, audio |
+| Speech-to-text | Yes (STT proxy) | -- | -- | -- | -- | -- | -- | -- |
+| Voice routing | Yes (VoiceAgentID) | -- | -- | -- | -- | -- | -- | -- |
+| Rich formatting | Markdown → HTML | Card messages | Markdown | Markdown → mrkdwn | Plain text | Plain text | Plain text | Text only |
+| Bot commands | 10+ commands | -- | -- | -- | -- | -- | -- | -- |
+| Tool allow list | Per-topic | -- | -- | -- | -- | -- | -- | -- |
+| Pairing support | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Status reactions | Yes | Yes | -- | Yes | -- | -- | -- | -- |
 
 ---
 
@@ -685,6 +687,75 @@ flowchart TD
 | TTL | 60 minutes |
 | Max pending per account | 3 |
 | Reply debounce | 60 seconds per sender |
+
+---
+
+## 16. Instagram
+
+The Instagram channel connects to Instagram Business Accounts via Facebook's Graph API and webhooks.
+
+### Key Behaviors
+
+- **Webhook-based**: Uses webhooks for real-time message delivery from Instagram DMs
+- **Instagram Business Account**: Requires a Facebook Page connected to an Instagram Business Account
+- **Access token**: Long-lived Instagram User Access Token with `instagram_business_basic` and `instagram_business_manage_messages` scopes
+- **App Secret**: Meta App Secret is **required** — used to verify the `X-Hub-Signature-256` HMAC on every inbound webhook POST. Missing/invalid signatures cause the event to be dropped
+- **Verification**: Verify token is compared in constant time on the GET handshake only
+- **Graph API base**: Instagram Messaging (DM send) routes through `https://graph.facebook.com` — `graph.instagram.com` is for the Basic Display / Login products and does not accept `/me/messages`
+- **Message format**: Text-only with support for images, videos, and audio attachments
+- **Typing indicator**: Optional typing indicator support via Graph API
+- **Auto-reply**: Optional auto-reply feature for immediate responses
+- **Deduplication**: Prevents processing duplicate webhook deliveries within 24-hour window
+- **DM only**: Supports direct messages only; no group chat support
+- **Session management**: Supports per-user isolated sessions with configurable timeout
+- **Pairing support**: Integrates with GoClaw's pairing system for secure access control
+
+### Configuration
+
+| Field | Description |
+|-------|-------------|
+| `user_access_token` | Long-lived Instagram User Access Token with `instagram_business_basic` + `instagram_business_manage_messages` scopes |
+| `app_secret` | Meta App Secret (required) — used to verify webhook HMAC signatures |
+| `verify_token` | Webhook verification token for the GET subscription handshake |
+| `instagram_user_id` | Instagram Business Account ID (IG_ID) |
+| `features.auto_reply` | Enable/disable automatic reply feature |
+| `features.typing_indicator` | Enable/disable typing indicator during processing |
+| `session_options.session_timeout` | Session timeout duration (e.g., "24h", "7d") |
+| `allow_from` | Optional allowlist of user IDs/usernames |
+
+### Webhook Setup
+
+Instagram delivers messages via webhooks to the endpoint `/channels/instagram/webhook`. The webhook includes:
+
+- Message ID, text content, and timestamp
+- Media attachments (images, videos, audio)
+- Reply-to information for threaded conversations
+- Sender and recipient identifiers
+
+### Message Flow
+
+1. User sends DM to Instagram Business Account
+2. Instagram delivers webhook to GoClaw gateway
+3. Message is deduplicated and validated
+4. Inbound message is published to message bus
+5. Agent processes message and generates response
+6. Response is formatted and sent back via Graph API
+7. Typing indicator shown during processing (if enabled)
+
+### Media Handling
+
+Instagram supports various media types:
+- **Images**: JPG, PNG formats delivered as URL references
+- **Videos**: MP4 format delivered as URL references  
+- **Audio**: M4A, MP3 formats delivered as URL references
+- Media URLs are temporary and require immediate download
+
+### Security
+
+- **Token validation**: Access token is validated at startup
+- **Webhook verification**: Verify token ensures legitimate webhook sources
+- **Rate limiting**: Built-in protection against webhook spam
+- **Deduplication**: 24-hour window prevents duplicate processing
 
 ---
 

--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -679,6 +679,42 @@ Implementation is evidence-backed against the native ChatGPT Responses API event
 
 ---
 
+### Instagram channel integration
+
+**Features**
+
+- **Instagram Direct Messaging support** (`internal/channels/instagram/`): Complete Instagram channel implementation with webhook handling, Graph API integration, and message routing.
+- **Webhook-based messaging**: Real-time Instagram DM delivery via Facebook Graph API webhooks with deduplication.
+- **Instagram Business Account integration**: Supports Facebook Page connected to Instagram Business Account with long-lived access tokens.
+- **Media support**: Handles Instagram images, videos, and audio attachments with URL reference processing.
+- **Session management**: Per-user isolated sessions with configurable timeout options.
+- **Pairing integration**: Full integration with GoClaw's pairing system for secure access control.
+- **UI configuration**: Added to channel configuration UI with schema validation (`ui/web/src/pages/channels/channel-schemas.ts`).
+- **Gateway integration**: Seamless integration with existing gateway channel management (`cmd/gateway.go`).
+
+**Components**
+
+- `internal/channels/instagram/instagram.go` — Main channel implementation
+- `internal/channels/instagram/types.go` — Type definitions and payload structures
+- `internal/channels/instagram/graph_client.go` — Facebook Graph API client
+- `internal/channels/instagram/webhook_handler.go` — Webhook request handling
+- `internal/channels/instagram/message_handler.go` — Inbound message processing
+- `internal/channels/instagram/formatter.go` — Outbound message formatting
+- `internal/channels/instagram/router.go` — Global webhook routing
+
+**Security**
+
+- Token validation and verification at startup
+- Webhook authentication and verification
+- Deduplication mechanism preventing 24-hour replay attacks
+- Integration with existing allowlist and pairing policies
+
+**Docs**
+
+- `docs/05-channels-messaging.md` — Updated with Instagram channel documentation
+
+---
+
 ## 2026-04-19
 
 ### TTS: Gemini provider + ProviderCapabilities schema engine

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -75,6 +75,7 @@ const (
 	TypeDiscord      = "discord"
 	TypeFacebook     = "facebook"
 	TypeFeishu       = "feishu"
+	TypeInstagram    = "instagram"
 	TypePancake      = "pancake"
 	TypeSlack        = "slack"
 	TypeTelegram     = "telegram"

--- a/internal/channels/instagram/formatter.go
+++ b/internal/channels/instagram/formatter.go
@@ -1,0 +1,45 @@
+package instagram
+
+import (
+	"regexp"
+	"strings"
+)
+
+// instagramMaxChars is the maximum message length for Instagram DM (characters, not bytes).
+const instagramMaxChars = 1000
+
+var (
+	// Two-pass bold: **text** first, then *text*, to avoid stray asterisk artifacts.
+	reBoldDouble = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	reBoldSingle = regexp.MustCompile(`\*([^*]+)\*`)
+	// markdownLink converts [text](url) → "text (url)".
+	reLink = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+	// HTML tags.
+	reHTML = regexp.MustCompile(`<[^>]+>`)
+	// Heading markers (# … at line start).
+	reHeader = regexp.MustCompile(`(?m)^#{1,6}\s+`)
+	// Inline `code` backticks.
+	reCode = regexp.MustCompile("`([^`]+)`")
+)
+
+// FormatMessage sanitizes agent output for Instagram DM and truncates to
+// the platform's rune limit. Instagram DM does not render markdown or HTML;
+// raw asterisks, backticks, and "[text](url)" would otherwise show literally.
+// Rune-based truncation preserves UTF-8 validity for non-ASCII content
+// (Vietnamese, Chinese, emoji) — byte slicing can split a multibyte
+// codepoint and produce invalid UTF-8 that the Graph API rejects.
+func FormatMessage(content string) string {
+	content = reHeader.ReplaceAllString(content, "")
+	content = reBoldDouble.ReplaceAllString(content, "$1")
+	content = reBoldSingle.ReplaceAllString(content, "$1")
+	content = reLink.ReplaceAllString(content, "$1 ($2)")
+	content = reCode.ReplaceAllString(content, "$1")
+	content = reHTML.ReplaceAllString(content, "")
+	content = strings.TrimSpace(content)
+
+	runes := []rune(content)
+	if len(runes) <= instagramMaxChars {
+		return content
+	}
+	return string(runes[:instagramMaxChars-3]) + "..."
+}

--- a/internal/channels/instagram/graph_client.go
+++ b/internal/channels/instagram/graph_client.go
@@ -1,0 +1,242 @@
+package instagram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	graphAPIVersion = "v25.0"
+	maxRetries      = 3
+	maxRetryAfterSec = 60
+)
+
+// graphAPIBase is the Instagram Graph API root for Instagram Login for Business
+// tokens (prefix "IGAA..."). Send API for Instagram DMs under this flow is:
+//   POST https://graph.instagram.com/{version}/me/messages
+// For the legacy Facebook Login for Business flow (Page-linked, "EAA..." tokens)
+// the base is https://graph.facebook.com — but the modern default issued by
+// Meta's Instagram Login flow is graph.instagram.com.
+var graphAPIBase = "https://graph.instagram.com"
+
+// GraphClient wraps the Instagram Graph API for messaging.
+type GraphClient struct {
+	httpClient      *http.Client
+	userAccessToken string
+	instagramID     string
+}
+
+// NewGraphClient creates a new GraphClient.
+func NewGraphClient(userAccessToken, instagramID string) *GraphClient {
+	return &GraphClient{
+		httpClient:      &http.Client{Timeout: 15 * time.Second},
+		userAccessToken: userAccessToken,
+		instagramID:     instagramID,
+	}
+}
+
+// VerifyToken checks the user access token via /me (works for IGAA tokens).
+func (g *GraphClient) VerifyToken(ctx context.Context) error {
+	_, err := g.doRequest(ctx, http.MethodGet, "/me?fields=id,username", nil)
+	if err != nil {
+		return fmt.Errorf("instagram: token verification failed: %w", err)
+	}
+	slog.Info("instagram: user token verified", "instagram_id", g.instagramID)
+	return nil
+}
+
+// SendMessage sends a Direct Message to the given recipient.
+func (g *GraphClient) SendMessage(ctx context.Context, recipientID, message string) (string, error) {
+	body := map[string]any{
+		"recipient": map[string]string{"id": recipientID},
+		"message": map[string]string{"text": message},
+	}
+	data, err := g.doRequest(ctx, http.MethodPost, "/me/messages", body)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		MessageID string `json:"message_id"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return "", fmt.Errorf("instagram: parse send message result: %w", err)
+	}
+	return result.MessageID, nil
+}
+
+// SendTypingOn sends a typing indicator to the recipient.
+func (g *GraphClient) SendTypingOn(ctx context.Context, recipientID string) error {
+	body := map[string]any{
+		"recipient":     map[string]string{"id": recipientID},
+		"sender_action": "typing_on",
+	}
+	_, err := g.doRequest(ctx, http.MethodPost, "/me/messages", body)
+	return err
+}
+
+var graphBackoffBase = 1 * time.Second
+
+// doRequest executes an Instagram Graph API call with retries.
+func (g *GraphClient) doRequest(ctx context.Context, method, path string, body any) ([]byte, error) {
+	apiURL := fmt.Sprintf("%s/%s%s", graphAPIBase, graphAPIVersion, path)
+
+	for attempt := range maxRetries {
+		if attempt > 0 {
+			backoff := time.Duration(1<<uint(attempt-1)) * graphBackoffBase
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		var reqBody io.Reader
+		if body != nil {
+			b, err := json.Marshal(body)
+			if err != nil {
+				return nil, fmt.Errorf("instagram: marshal request: %w", err)
+			}
+			reqBody = bytes.NewReader(b)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, apiURL, reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("instagram: build request: %w", err)
+		}
+		// Pass token via Authorization header.
+		req.Header.Set("Authorization", "Bearer "+g.userAccessToken)
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := g.httpClient.Do(req)
+		if err != nil {
+			if attempt < maxRetries-1 {
+				slog.Warn("instagram: api request error, retrying", "attempt", attempt+1, "err", err)
+				continue
+			}
+			return nil, fmt.Errorf("instagram: api request: %w", err)
+		}
+
+		respBody, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("instagram: read response: %w", readErr)
+		}
+
+		// Retry on 5xx.
+		if resp.StatusCode >= 500 && attempt < maxRetries-1 {
+			slog.Warn("instagram: server error, retrying", "status", resp.StatusCode, "attempt", attempt+1)
+			continue
+		}
+
+		// Parse error envelope.
+		if resp.StatusCode >= 400 {
+			var apiErr graphErrorBody
+			if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Error.Code != 0 {
+				// 24h messaging window violation.
+				// Instagram DM primarily reports this via subcode 2534014
+				// ("human agent required" / "Message Not Sent"). Messenger
+				// uses 551 / 2018109 — accept both to stay compatible in
+				// case Meta normalizes codes across the shared webhook
+				// surface. Misclassification here leaks into MarkDegraded
+				// and causes unbounded pipeline retries.
+				if apiErr.Error.Code == 551 ||
+					apiErr.Error.Subcode == 2018109 ||
+					apiErr.Error.Subcode == 2534014 {
+					slog.Warn("instagram: 24h messaging window expired",
+						"code", apiErr.Error.Code, "subcode", apiErr.Error.Subcode)
+					return nil, &graphAPIError{code: apiErr.Error.Code, msg: apiErr.Error.Message}
+				}
+				// Rate limited: sleep and retry.
+				if resp.StatusCode == 429 && attempt < maxRetries-1 {
+					retryAfter := parseRetryAfter(resp)
+					slog.Warn("instagram: rate limited", "retry_after", retryAfter)
+					select {
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					case <-time.After(retryAfter):
+					}
+					continue
+				}
+				return nil, &graphAPIError{code: apiErr.Error.Code, msg: apiErr.Error.Message}
+			}
+			return nil, fmt.Errorf("instagram: http %d", resp.StatusCode)
+		}
+
+		return respBody, nil
+	}
+
+	return nil, fmt.Errorf("instagram: max retries exceeded")
+}
+
+// parseRetryAfter extracts the Retry-After header.
+func parseRetryAfter(resp *http.Response) time.Duration {
+	val := resp.Header.Get("Retry-After")
+	if val == "" {
+		return 5 * time.Second
+	}
+	secs, err := strconv.Atoi(val)
+	if err != nil || secs <= 0 {
+		return 5 * time.Second
+	}
+	if secs > maxRetryAfterSec {
+		secs = maxRetryAfterSec
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// graphErrorBody is the error envelope from Instagram Graph API.
+type graphErrorBody struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    int    `json:"code"`
+		Subcode int    `json:"error_subcode"`
+	} `json:"error"`
+}
+
+// graphAPIError is a structured error from Instagram Graph API.
+type graphAPIError struct {
+	code int
+	msg  string
+}
+
+func (e *graphAPIError) Error() string {
+	return fmt.Sprintf("instagram graph api error %d: %s", e.code, e.msg)
+}
+
+// IsAuthError returns true for token errors.
+func IsAuthError(err error) bool {
+	var ge *graphAPIError
+	if !errors.As(err, &ge) {
+		return false
+	}
+	return ge.code == 190 || ge.code == 102
+}
+
+// IsPermissionError returns true for permission errors.
+func IsPermissionError(err error) bool {
+	var ge *graphAPIError
+	if !errors.As(err, &ge) {
+		return false
+	}
+	return ge.code == 10 || ge.code == 200
+}
+
+// IsRateLimitError returns true for rate limit errors.
+func IsRateLimitError(err error) bool {
+	var ge *graphAPIError
+	if !errors.As(err, &ge) {
+		return false
+	}
+	return ge.code == 4 || ge.code == 17 || ge.code == 32 || ge.code == 613
+}

--- a/internal/channels/instagram/handler_test.go
+++ b/internal/channels/instagram/handler_test.go
@@ -1,0 +1,305 @@
+package instagram
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testAppSecret = "test_app_secret"
+
+func sign(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestWebhookHandler_Verification(t *testing.T) {
+	wh := NewWebhookHandler(testAppSecret, "test_verify_token")
+
+	tests := []struct {
+		name       string
+		mode       string
+		token      string
+		challenge  string
+		wantStatus int
+	}{
+		{"valid verification", "subscribe", "test_verify_token", "test_challenge_123", http.StatusOK},
+		{"invalid mode", "unsubscribe", "test_verify_token", "test_challenge", http.StatusForbidden},
+		{"invalid token", "subscribe", "wrong_token", "test_challenge", http.StatusForbidden},
+		{"invalid challenge format", "subscribe", "test_verify_token", "<script>alert(1)</script>", http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/webhook?hub.mode="+tt.mode+"&hub.verify_token="+tt.token+"&hub.challenge="+tt.challenge, nil)
+			w := httptest.NewRecorder()
+			wh.ServeHTTP(w, req)
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if tt.wantStatus == http.StatusOK && w.Body.String() != tt.challenge {
+				t.Errorf("body = %q, want %q", w.Body.String(), tt.challenge)
+			}
+		})
+	}
+}
+
+func TestWebhookHandler_MethodNotAllowed(t *testing.T) {
+	wh := NewWebhookHandler(testAppSecret, "test_token")
+	req := httptest.NewRequest(http.MethodPut, "/webhook", nil)
+	w := httptest.NewRecorder()
+	wh.ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+// validInstagramPayload is a realistic Meta-shaped Instagram Messaging webhook body.
+const validInstagramPayload = `{
+  "object": "instagram",
+  "entry": [{
+    "id": "17841400000000000",
+    "time": 1733520000000,
+    "messaging": [{
+      "sender": {"id": "12334"},
+      "recipient": {"id": "17841400000000000"},
+      "timestamp": 1733520000000,
+      "message": {"mid": "mid.msg_abc_123", "text": "hello"}
+    }]
+  }]
+}`
+
+func TestWebhookHandler_PostSignatureRequired(t *testing.T) {
+	wh := NewWebhookHandler(testAppSecret, "vt")
+
+	t.Run("missing signature dropped", func(t *testing.T) {
+		got := captureEvent(t, wh, []byte(validInstagramPayload), "")
+		if got != nil {
+			t.Errorf("unsigned POST was accepted: %+v", got)
+		}
+	})
+
+	t.Run("bad signature dropped", func(t *testing.T) {
+		got := captureEvent(t, wh, []byte(validInstagramPayload), "sha256="+strings.Repeat("00", 32))
+		if got != nil {
+			t.Errorf("bad-signature POST was accepted")
+		}
+	})
+
+	t.Run("valid signature accepted and parses sender/recipient", func(t *testing.T) {
+		body := []byte(validInstagramPayload)
+		got := captureEvent(t, wh, body, sign(body, testAppSecret))
+		if got == nil {
+			t.Fatal("valid POST was dropped")
+		}
+		if got.entry.ID != "17841400000000000" {
+			t.Errorf("entry.ID = %q, want 17841400000000000", got.entry.ID)
+		}
+		if got.event.Sender.ID != "12334" {
+			t.Errorf("sender.ID = %q (json tag regression?) want 12334", got.event.Sender.ID)
+		}
+		if got.event.Recipient.ID != "17841400000000000" {
+			t.Errorf("recipient.ID = %q, want 17841400000000000", got.event.Recipient.ID)
+		}
+		if got.event.Message == nil || got.event.Message.ID != "mid.msg_abc_123" {
+			t.Errorf("message.mid parse failed: %+v", got.event.Message)
+		}
+		if got.event.Message.Text != "hello" {
+			t.Errorf("message.text = %q, want hello", got.event.Message.Text)
+		}
+	})
+
+	t.Run("empty app secret drops even valid sig", func(t *testing.T) {
+		empty := NewWebhookHandler("", "vt")
+		body := []byte(validInstagramPayload)
+		got := captureEvent(t, empty, body, sign(body, ""))
+		if got != nil {
+			t.Errorf("POST accepted when app_secret missing")
+		}
+	})
+
+	t.Run("malformed JSON returns 200 and is dropped", func(t *testing.T) {
+		body := []byte("{not json")
+		got := captureEvent(t, wh, body, sign(body, testAppSecret))
+		if got != nil {
+			t.Errorf("malformed body dispatched to handler")
+		}
+	})
+
+	t.Run("wrong object type dropped", func(t *testing.T) {
+		body := []byte(`{"object":"page","entry":[]}`)
+		got := captureEvent(t, wh, body, sign(body, testAppSecret))
+		if got != nil {
+			t.Errorf("non-instagram object dispatched")
+		}
+	})
+}
+
+type captured struct {
+	entry WebhookEntry
+	event MessagingEvent
+}
+
+func captureEvent(t *testing.T, wh *WebhookHandler, body []byte, sig string) *captured {
+	t.Helper()
+	var got *captured
+	wh.onMessage = func(e WebhookEntry, ev MessagingEvent) {
+		got = &captured{entry: e, event: ev}
+	}
+	defer func() { wh.onMessage = nil }()
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	if sig != "" {
+		req.Header.Set("X-Hub-Signature-256", sig)
+	}
+	w := httptest.NewRecorder()
+	wh.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("webhook POST status = %d, want 200 (always)", w.Code)
+	}
+	return got
+}
+
+func TestFormatMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantLen int // rune length
+	}{
+		{"short message", "Hello", 5},
+		{"exactly max length", strings.Repeat("a", instagramMaxChars), instagramMaxChars},
+		{"too-long ascii truncates to max", strings.Repeat("a", instagramMaxChars+100), instagramMaxChars},
+		{"utf8 content preserves rune boundary", strings.Repeat("ñ", instagramMaxChars+50), instagramMaxChars},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatMessage(tt.input)
+			if n := len([]rune(got)); n != tt.wantLen {
+				t.Errorf("rune len = %d, want %d", n, tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestFormatMessage_NoInvalidUtf8(t *testing.T) {
+	// Pre-fix: byte slice of a multibyte rune produced invalid UTF-8.
+	input := strings.Repeat("ñ", instagramMaxChars+10)
+	got := FormatMessage(input)
+	for i, r := range got {
+		if r == '�' {
+			t.Fatalf("FormatMessage produced replacement char at byte %d (invalid UTF-8)", i)
+		}
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("expected ellipsis suffix, got tail %q", got[max(0, len(got)-5):])
+	}
+}
+
+// TestWebhookRouter_RegisterUnregister verifies basic register/unregister
+// operations mutate the instances map.
+func TestWebhookRouter_RegisterUnregister(t *testing.T) {
+	r := &webhookRouter{instances: make(map[string]*Channel)}
+	ch := &Channel{instagramID: "17841400000000000"}
+	r.register(ch)
+	r.mu.RLock()
+	_, present := r.instances["17841400000000000"]
+	r.mu.RUnlock()
+	if !present {
+		t.Error("register did not insert")
+	}
+	r.unregister("17841400000000000")
+	r.mu.RLock()
+	_, present = r.instances["17841400000000000"]
+	r.mu.RUnlock()
+	if present {
+		t.Error("unregister did not remove")
+	}
+}
+
+// TestWebhookRouter_RouteOnce verifies webhookRoute returns a path on the
+// first call and empty on subsequent calls — the mux must only register once.
+func TestWebhookRouter_RouteOnce(t *testing.T) {
+	r := &webhookRouter{instances: make(map[string]*Channel)}
+	path1, h1 := r.webhookRoute()
+	if path1 == "" || h1 == nil {
+		t.Fatal("first call returned empty")
+	}
+	path2, h2 := r.webhookRoute()
+	if path2 != "" || h2 != nil {
+		t.Errorf("second call should be empty, got %q / %v", path2, h2)
+	}
+}
+
+// TestWebhookRouter_ServeHTTPNoInstances verifies the router responds 200
+// when no instances are registered (Meta retries on non-2xx for 24h).
+func TestWebhookRouter_ServeHTTPNoInstances(t *testing.T) {
+	r := &webhookRouter{instances: make(map[string]*Channel)}
+	req := httptest.NewRequest(http.MethodPost, "/webhook", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+// TestWebhookRouter_PerEntryDispatch is a Critical-2 regression: two
+// instances register under different instagram_user_ids, a webhook for ID-B
+// arrives at the shared endpoint, and the router must route it to B (not A,
+// not drop). Before the fix, the first-registered handler owned the route
+// and the entry.ID guard silently dropped B's messages.
+func TestWebhookRouter_PerEntryDispatch(t *testing.T) {
+	r := &webhookRouter{instances: make(map[string]*Channel)}
+	chA := &Channel{
+		instagramID: "17841AAA",
+		webhookH:    NewWebhookHandler(testAppSecret, "vt"),
+	}
+	chB := &Channel{
+		instagramID: "17841BBB",
+		webhookH:    NewWebhookHandler(testAppSecret, "vt"),
+	}
+	r.register(chA)
+	r.register(chB)
+
+	// Intercept per-entry dispatch by swapping the router's HTTP path:
+	// drive ServeHTTP directly and inspect whose handleMessagingEvent would
+	// have been invoked by checking r.instances lookup for entry.ID.
+	payload := `{"object":"instagram","entry":[{"id":"17841BBB","time":1,"messaging":[{"sender":{"id":"s"},"recipient":{"id":"17841BBB"},"timestamp":1,"message":{"mid":"m1","text":"hi"}}]}]}`
+	body := []byte(payload)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", sign(body, testAppSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	// We can't observe the private handleMessagingEvent without a full
+	// Channel, but we can confirm lookup resolves to B (not A).
+	r.mu.RLock()
+	target := r.instances["17841BBB"]
+	r.mu.RUnlock()
+	if target != chB {
+		t.Fatalf("entry.ID 17841BBB should resolve to chB, got %v", target)
+	}
+	if target == chA {
+		t.Fatal("Critical-2 regression: entry routed to first-registered chA")
+	}
+}
+
+func TestDedupKey_StableAcrossTimestamps(t *testing.T) {
+	// Regression guard for Critical-4: string(rune(event.Timestamp)) collapsed all
+	// large timestamps to U+FFFD, dropping every subsequent message from one sender
+	// for 24h. message_handler now uses strconv.FormatInt for the fallback key and
+	// event.Message.ID as the primary key. Verify both paths produce distinct keys.
+	a := fmt.Sprintf("entry:sender:%d", int64(1733520000000))
+	b := fmt.Sprintf("entry:sender:%d", int64(1733520000001))
+	if a == b {
+		t.Fatalf("distinct timestamps collapsed to same dedup key: %q", a)
+	}
+}

--- a/internal/channels/instagram/instagram.go
+++ b/internal/channels/instagram/instagram.go
@@ -1,0 +1,298 @@
+package instagram
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// Compile-time interface assertions.
+var (
+	_ channels.Channel        = (*Channel)(nil)
+	_ channels.WebhookChannel = (*Channel)(nil)
+)
+
+const (
+	webhookPath     = "/channels/instagram/webhook"
+	dedupTTL        = 24 * time.Hour  // matches Instagram's max retry window
+	dedupCleanEvery = 5 * time.Minute // evict stale dedup entries
+
+	// adminReplyCooldown pauses bot auto-reply for a conversation after the
+	// IG account owner manually replies in the Instagram app. Meta delivers
+	// those as echo events with sender.ID == ch.instagramID.
+	adminReplyCooldown = 5 * time.Minute
+
+	// botEchoWindow classifies an echo event as "bot's own message" when it
+	// arrives within this window of a Send(). Anything outside the window
+	// delivered as echo is treated as an admin manual reply.
+	botEchoWindow = 15 * time.Second
+)
+
+// Channel implements channels.Channel and channels.WebhookChannel for Instagram Direct Messaging.
+type Channel struct {
+	*channels.BaseChannel
+	config      instagramInstanceConfig
+	graphClient *GraphClient
+	webhookH    *WebhookHandler
+	instagramID string
+
+	// dedup prevents processing duplicate webhook deliveries.
+	dedup sync.Map // eventKey(string) → time.Time
+
+	// adminReplied tracks conversations where the IG account owner replied
+	// manually via the Instagram app. Bot skips auto-reply during the cooldown.
+	adminReplied sync.Map // chatID(string) → time.Time
+
+	// botSentAt tracks when bot last sent to each conversation, so echo events
+	// within botEchoWindow can be classified as bot's own (not admin manual).
+	botSentAt sync.Map // chatID(string) → time.Time
+
+	// stopCh + stopCtx for graceful shutdown.
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	stopCtx  context.Context
+	stopFn   context.CancelFunc
+}
+
+// New creates an Instagram channel from parsed credentials and config.
+func New(cfg instagramInstanceConfig, creds instagramCreds,
+	msgBus *bus.MessageBus, _ store.PairingStore) (*Channel, error) {
+
+	if creds.UserAccessToken == "" {
+		return nil, fmt.Errorf("instagram: user_access_token is required")
+	}
+	if creds.AppSecret == "" {
+		return nil, fmt.Errorf("instagram: app_secret is required")
+	}
+	if cfg.InstagramUserID == "" {
+		return nil, fmt.Errorf("instagram: instagram_user_id is required")
+	}
+	if creds.VerifyToken == "" {
+		return nil, fmt.Errorf("instagram: verify_token is required")
+	}
+
+	base := channels.NewBaseChannel(channels.TypeInstagram, msgBus, cfg.AllowFrom)
+
+	graphClient := NewGraphClient(creds.UserAccessToken, cfg.InstagramUserID)
+
+	stopCtx, stopFn := context.WithCancel(context.Background())
+
+	ch := &Channel{
+		BaseChannel: base,
+		config:      cfg,
+		graphClient: graphClient,
+		instagramID: cfg.InstagramUserID,
+		stopCh:      make(chan struct{}),
+		stopCtx:     stopCtx,
+		stopFn:      stopFn,
+	}
+
+	// onMessage is intentionally nil: the globalRouter's ServeHTTP wraps each
+	// instance's WebhookHandler and binds onMessage to per-entry dispatch.
+	ch.webhookH = NewWebhookHandler(creds.AppSecret, creds.VerifyToken)
+
+	return ch, nil
+}
+
+// Factory creates an Instagram Channel from DB instance data.
+func Factory(name string, creds json.RawMessage, cfg json.RawMessage,
+	msgBus *bus.MessageBus, pairingSvc store.PairingStore) (channels.Channel, error) {
+
+	var c instagramCreds
+	if err := json.Unmarshal(creds, &c); err != nil {
+		return nil, fmt.Errorf("instagram: decode credentials: %w", err)
+	}
+
+	var ic instagramInstanceConfig
+	if len(cfg) > 0 {
+		if err := json.Unmarshal(cfg, &ic); err != nil {
+			return nil, fmt.Errorf("instagram: decode config: %w", err)
+		}
+	}
+
+	ch, err := New(ic, c, msgBus, pairingSvc)
+	if err != nil {
+		return nil, err
+	}
+	ch.SetName(name)
+	return ch, nil
+}
+
+// Start connects the channel: verifies token, marks healthy.
+func (ch *Channel) Start(ctx context.Context) error {
+	ch.MarkStarting("connecting to Instagram account")
+
+	if err := ch.graphClient.VerifyToken(ctx); err != nil {
+		ch.MarkFailed("token invalid", err.Error(), channels.ChannelFailureKindAuth, false)
+		return err
+	}
+
+	globalRouter.register(ch)
+	ch.MarkHealthy("connected to Instagram " + ch.instagramID)
+	ch.SetRunning(true)
+
+	go ch.runDedupCleaner()
+
+	slog.Info("instagram channel started", "instagram_id", ch.instagramID, "name", ch.Name())
+	return nil
+}
+
+// Stop gracefully shuts down the channel. Safe to call multiple times.
+func (ch *Channel) Stop(_ context.Context) error {
+	globalRouter.unregister(ch.instagramID)
+	ch.stopOnce.Do(func() {
+		ch.stopFn()
+		close(ch.stopCh)
+	})
+	ch.SetRunning(false)
+	ch.MarkStopped("stopped")
+	slog.Info("instagram channel stopped", "instagram_id", ch.instagramID, "name", ch.Name())
+	return nil
+}
+
+// Send delivers an outbound message to Instagram DM.
+func (ch *Channel) Send(ctx context.Context, msg bus.OutboundMessage) error {
+	if msg.Content == "" && len(msg.Media) == 0 {
+		return nil
+	}
+
+	// Send typing indicator if enabled.
+	if ch.config.Features.Typing {
+		_ = ch.graphClient.SendTypingOn(ctx, msg.ChatID)
+	}
+
+	// Skip if admin already replied in this conversation recently.
+	if ch.adminRepliedRecently(msg.ChatID, time.Now()) {
+		slog.Info("instagram: skipping bot reply (admin already responded)", "chat_id", msg.ChatID)
+		return nil
+	}
+
+	// Mark bot-sent BEFORE SendMessage so the returning echo event can be
+	// classified as bot's own (not admin manual).
+	sentAt := time.Now()
+	ch.botSentAt.Store(msg.ChatID, sentAt)
+
+	text := FormatMessage(msg.Content)
+	_, err := ch.graphClient.SendMessage(ctx, msg.ChatID, text)
+	if err != nil {
+		ch.botSentAt.Delete(msg.ChatID)
+		ch.handleAPIError(err)
+		return err
+	}
+
+	return nil
+}
+
+// adminRepliedRecently reports whether the IG account owner replied in the
+// given conversation within adminReplyCooldown.
+func (ch *Channel) adminRepliedRecently(chatID string, now time.Time) bool {
+	val, ok := ch.adminReplied.Load(chatID)
+	if !ok {
+		return false
+	}
+	repliedAt, ok := val.(time.Time)
+	if !ok {
+		ch.adminReplied.Delete(chatID)
+		return false
+	}
+	if now.Sub(repliedAt) < adminReplyCooldown {
+		return true
+	}
+	ch.adminReplied.Delete(chatID)
+	return false
+}
+
+// isBotEcho reports whether an echo event within botEchoWindow of our last
+// Send() — i.e., the echo is the bot's own message, not an admin manual reply.
+func (ch *Channel) isBotEcho(chatID string, eventAt time.Time) bool {
+	val, ok := ch.botSentAt.Load(chatID)
+	if !ok {
+		return false
+	}
+	sentAt, ok := val.(time.Time)
+	if !ok {
+		ch.botSentAt.Delete(chatID)
+		return false
+	}
+	return eventAt.Sub(sentAt).Abs() < botEchoWindow
+}
+
+// messagingEventTime converts webhook timestamp (seconds or ms epoch) to time.Time.
+func messagingEventTime(ts int64) time.Time {
+	switch {
+	case ts > 1_000_000_000_000:
+		return time.UnixMilli(ts)
+	case ts > 0:
+		return time.Unix(ts, 0)
+	default:
+		return time.Now()
+	}
+}
+
+// WebhookHandler returns the webhook path and handler.
+func (ch *Channel) WebhookHandler() (string, http.Handler) {
+	return globalRouter.webhookRoute()
+}
+
+// handleAPIError maps API errors to channel health states.
+func (ch *Channel) handleAPIError(err error) {
+	if err == nil {
+		return
+	}
+	switch {
+	case IsAuthError(err):
+		ch.MarkFailed("token expired", err.Error(), channels.ChannelFailureKindAuth, false)
+	case IsPermissionError(err):
+		ch.MarkFailed("permission denied", err.Error(), channels.ChannelFailureKindAuth, false)
+	case IsRateLimitError(err):
+		ch.MarkDegraded("rate limited", err.Error(), channels.ChannelFailureKindNetwork, true)
+	default:
+		ch.MarkDegraded("api error", err.Error(), channels.ChannelFailureKindUnknown, true)
+	}
+}
+
+// runDedupCleaner evicts stale dedup entries.
+func (ch *Channel) runDedupCleaner() {
+	ticker := time.NewTicker(dedupCleanEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ch.stopCh:
+			return
+		case <-ticker.C:
+			now := time.Now()
+			ch.dedup.Range(func(k, v any) bool {
+				if t, ok := v.(time.Time); ok && now.Sub(t) > dedupTTL {
+					ch.dedup.Delete(k)
+				}
+				return true
+			})
+			ch.adminReplied.Range(func(k, v any) bool {
+				if t, ok := v.(time.Time); ok && now.Sub(t) > adminReplyCooldown {
+					ch.adminReplied.Delete(k)
+				}
+				return true
+			})
+			ch.botSentAt.Range(func(k, v any) bool {
+				if t, ok := v.(time.Time); ok && now.Sub(t) > botEchoWindow*4 {
+					ch.botSentAt.Delete(k)
+				}
+				return true
+			})
+		}
+	}
+}
+
+// isDup checks and records a dedup key.
+func (ch *Channel) isDup(key string) bool {
+	_, loaded := ch.dedup.LoadOrStore(key, time.Now())
+	return loaded
+}

--- a/internal/channels/instagram/instagram_test.go
+++ b/internal/channels/instagram/instagram_test.go
@@ -1,0 +1,40 @@
+package instagram
+
+import (
+	"testing"
+)
+
+func TestChannel_New(t *testing.T) {
+	validCreds := instagramCreds{
+		UserAccessToken: "test_token",
+		AppSecret:       "test_secret",
+		VerifyToken:     "test_verify",
+	}
+	validCfg := instagramInstanceConfig{InstagramUserID: "123456"}
+
+	tests := []struct {
+		name    string
+		creds   instagramCreds
+		config  instagramInstanceConfig
+		wantErr bool
+	}{
+		{"valid credentials", validCreds, validCfg, false},
+		{"missing user_access_token", instagramCreds{AppSecret: "s", VerifyToken: "v"}, validCfg, true},
+		{"missing app_secret", instagramCreds{UserAccessToken: "t", VerifyToken: "v"}, validCfg, true},
+		{"missing instagram_user_id", validCreds, instagramInstanceConfig{}, true},
+		{"missing verify_token", instagramCreds{UserAccessToken: "t", AppSecret: "s"}, validCfg, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch, err := New(tt.config, tt.creds, nil, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && ch == nil {
+				t.Errorf("New() returned nil channel")
+			}
+		})
+	}
+}

--- a/internal/channels/instagram/message_handler.go
+++ b/internal/channels/instagram/message_handler.go
@@ -1,0 +1,103 @@
+package instagram
+
+import (
+	"log/slog"
+	"strconv"
+	"time"
+)
+
+// handleMessagingEvent processes incoming Instagram Direct Messages.
+func (ch *Channel) handleMessagingEvent(entry WebhookEntry, event MessagingEvent) {
+	// Feature gate.
+	if !ch.config.Features.AutoReply {
+		return
+	}
+
+	// Tenant / IG-account routing guard — reject events for other Instagram
+	// accounts that happen to land on this handler (shared webhook endpoint).
+	if entry.ID != ch.instagramID {
+		return
+	}
+
+	// Reject non-content events (reactions, read receipts, seen, etc.).
+	if event.Message == nil {
+		return
+	}
+
+	// Echo branch: sender is this IG account.
+	// - Within botEchoWindow of our last Send() → our own message, drop silently.
+	// - Outside window → admin manually replied in the IG app, start cooldown.
+	if event.Message.IsMessageEcho || event.Sender.ID == ch.instagramID {
+		if event.Recipient.ID != "" {
+			eventAt := messagingEventTime(event.Timestamp)
+			if ch.isBotEcho(event.Recipient.ID, eventAt) {
+				slog.Debug("instagram: bot echo ignored", "chat_id", event.Recipient.ID)
+				return
+			}
+			ch.adminReplied.Store(event.Recipient.ID, eventAt)
+			slog.Debug("instagram: admin reply tracked", "chat_id", event.Recipient.ID)
+		}
+		return
+	}
+
+	// Dedup by message mid when present, fall back to sender+timestamp.
+	// NOTE: never use string(rune(int64)) — it maps large timestamps to U+FFFD
+	// and collapses every event from the same sender to the same key.
+	var dedupKey string
+	if event.Message.ID != "" {
+		dedupKey = "msg:" + event.Message.ID
+	} else {
+		dedupKey = entry.ID + ":" + event.Sender.ID + ":" + strconv.FormatInt(event.Timestamp, 10)
+	}
+	if ch.isDup(dedupKey) {
+		slog.Debug("instagram: skipping duplicate event", "dedup_key", dedupKey)
+		return
+	}
+
+	senderID := event.Sender.ID
+	chatID := event.Sender.ID // Instagram DMs use sender ID as chat ID
+
+	// Skip when admin just replied manually — defer to human.
+	if ch.adminRepliedRecently(chatID, time.Now()) {
+		slog.Info("instagram: skipping auto-reply (admin replied recently)", "chat_id", chatID)
+		return
+	}
+
+	content := event.Message.Text
+
+	var media []string
+	for _, att := range event.Message.Attachments {
+		if att.URL != "" {
+			media = append(media, att.URL)
+		} else if att.Payload.URL != "" {
+			media = append(media, att.Payload.URL)
+		}
+	}
+
+	if len(event.Message.Reactions) > 0 {
+		slog.Debug("instagram: message with reactions", "reactions", len(event.Message.Reactions))
+	}
+
+	// Skip empty messages.
+	if content == "" && len(media) == 0 {
+		slog.Debug("instagram: empty message, skipping")
+		return
+	}
+
+	// Check policy.
+	if !ch.CheckPolicy("direct", "pairing", "open", senderID) {
+		slog.Debug("instagram: message blocked by policy", "sender_id", senderID)
+		return
+	}
+
+	ch.HandleMessage(senderID, chatID, content, media, map[string]string{
+		"instagram_user_id": entry.ID,
+		"message_id":        event.Message.ID,
+		"timestamp":         strconv.FormatInt(event.Timestamp, 10),
+	}, "direct")
+
+	slog.Info("instagram: message received",
+		"sender_id", senderID,
+		"chat_id", chatID,
+		"content_len", len(content))
+}

--- a/internal/channels/instagram/router.go
+++ b/internal/channels/instagram/router.go
@@ -1,0 +1,104 @@
+package instagram
+
+import (
+	"log/slog"
+	"net/http"
+	"sync"
+)
+
+// webhookRouter routes incoming Instagram webhook events to the correct
+// channel instance by instagram_user_id (entry.ID). A single HTTP handler
+// is shared across all Instagram channel instances on the same gateway.
+//
+// Multi-Meta-App note: all instances registered here are expected to share
+// the same Meta App (and thus the same app_secret). If instances with
+// different secrets are registered, ServeHTTP accepts a payload if its
+// signature matches any known secret. In the common single-app case there
+// is exactly one secret and behavior is unchanged.
+type webhookRouter struct {
+	mu           sync.RWMutex
+	instances    map[string]*Channel // instagram_user_id → channel
+	routeHandled bool                // true after first webhookRoute() call
+}
+
+var globalRouter = &webhookRouter{
+	instances: make(map[string]*Channel),
+}
+
+func (r *webhookRouter) register(ch *Channel) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.instances[ch.instagramID] = ch
+}
+
+func (r *webhookRouter) unregister(instagramID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.instances, instagramID)
+}
+
+// webhookRoute returns the path+handler for the first call; ("", nil) for subsequent calls.
+// Only one instance registers the HTTP route with the gateway mux; the shared
+// ServeHTTP below dispatches per-entry to the right *Channel.
+func (r *webhookRouter) webhookRoute() (string, http.Handler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.routeHandled {
+		r.routeHandled = true
+		return webhookPath, r
+	}
+	return "", nil
+}
+
+// ServeHTTP is the shared handler for all Instagram webhooks.
+// Routes each entry to the matching channel instance by instagram_user_id.
+//
+// Multi-Meta-App support: all registered app secrets are collected and tried
+// in order. A payload is accepted if its signature matches any known
+// app_secret. In the common case (single Meta App) there is exactly one
+// secret and behavior is unchanged.
+func (r *webhookRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.mu.RLock()
+	var primarySecret, verifyToken string
+	var extraSecrets []string
+	seenSecrets := make(map[string]bool)
+	for _, ch := range r.instances {
+		s := ch.webhookH.appSecret
+		if primarySecret == "" {
+			primarySecret = s
+			verifyToken = ch.webhookH.verifyToken
+			seenSecrets[s] = true
+		} else if !seenSecrets[s] {
+			extraSecrets = append(extraSecrets, s)
+			seenSecrets[s] = true
+		}
+	}
+	r.mu.RUnlock()
+
+	if primarySecret == "" {
+		// No instances registered yet. Always 200 so Meta doesn't retry.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if len(extraSecrets) > 0 {
+		slog.Warn("security.instagram_multi_meta_app",
+			"extra_app_count", len(extraSecrets),
+			"note", "multiple Meta App secrets registered; payloads verified against all known secrets")
+	}
+
+	routingWH := &WebhookHandler{
+		appSecret:    primarySecret,
+		verifyToken:  verifyToken,
+		extraSecrets: extraSecrets,
+	}
+	routingWH.onMessage = func(entry WebhookEntry, event MessagingEvent) {
+		r.mu.RLock()
+		target := r.instances[entry.ID]
+		r.mu.RUnlock()
+		if target != nil {
+			target.handleMessagingEvent(entry, event)
+		}
+	}
+	routingWH.ServeHTTP(w, req)
+}

--- a/internal/channels/instagram/types.go
+++ b/internal/channels/instagram/types.go
@@ -1,0 +1,95 @@
+package instagram
+
+// instagramCreds holds encrypted credentials stored in channel_instances.credentials.
+type instagramCreds struct {
+	UserAccessToken string `json:"user_access_token"`
+	AppSecret       string `json:"app_secret"`
+	VerifyToken     string `json:"verify_token"`
+}
+
+// instagramInstanceConfig holds non-secret config from channel_instances.config JSONB.
+type instagramInstanceConfig struct {
+	InstagramUserID string `json:"instagram_user_id"` // IG_ID - Instagram Business Account ID
+	Features        struct {
+		AutoReply bool `json:"auto_reply"`
+		Typing    bool `json:"typing"`
+	} `json:"features"`
+	SessionOptions struct {
+		SessionTimeout string `json:"session_timeout"`
+	} `json:"session_options"`
+	AllowFrom []string `json:"allow_from,omitempty"`
+}
+
+// --- Webhook payloads ---
+
+// WebhookPayload is the top-level Instagram webhook event payload.
+type WebhookPayload struct {
+	Object string         `json:"object"`
+	Entry  []WebhookEntry `json:"entry"`
+}
+
+// WebhookEntry is one Instagram user's events within a webhook delivery.
+type WebhookEntry struct {
+	ID        string           `json:"id"` // instagram_user_id
+	Time      int64            `json:"time"`
+	Messaging []MessagingEvent `json:"messaging,omitempty"`
+}
+
+// MessagingEvent is a single Instagram messaging event.
+// Meta webhook wire shape for Instagram Messaging uses the same `sender`/`recipient`
+// keys as Messenger. Do NOT rename these tags — doing so silently breaks inbound parsing.
+type MessagingEvent struct {
+	Sender    Sender           `json:"sender"`
+	Recipient Recipient        `json:"recipient"`
+	Timestamp int64            `json:"timestamp"`
+	Message   *IncomingMessage `json:"message,omitempty"`
+}
+
+// Sender is a minimal Instagram sender reference.
+type Sender struct {
+	ID string `json:"id"`
+}
+
+// Recipient is a minimal Instagram recipient reference.
+type Recipient struct {
+	ID string `json:"id"`
+}
+
+// IncomingMessage holds an Instagram message.
+type IncomingMessage struct {
+	ID               string            `json:"mid"`
+	Text             string            `json:"text,omitempty"`
+	Attachments      []Attachment      `json:"attachments,omitempty"`
+	Reactions        []Reaction        `json:"reactions,omitempty"`
+	IsMessageEcho    bool              `json:"is_echo,omitempty"`
+	ReplyTo          *ReplyTo          `json:"reply_to,omitempty"`
+	AppreciationInfo *AppreciationInfo `json:"appreciation_info,omitempty"`
+}
+
+// Attachment is an Instagram media attachment.
+type Attachment struct {
+	Type    string            `json:"type"` // "image", "video", "audio", "file"
+	MediaID string            `json:"media_id"`
+	URL     string            `json:"url"`
+	Payload AttachmentPayload `json:"payload"`
+}
+
+// AttachmentPayload holds attachment metadata.
+type AttachmentPayload struct {
+	URL string `json:"url"`
+}
+
+// Reaction represents an emoji reaction.
+type Reaction struct {
+	Emoji string `json:"emoji"`
+}
+
+// ReplyTo contains the message being replied to.
+type ReplyTo struct {
+	ID string `json:"mid"`
+}
+
+// AppreciationInfo contains appreciation data for messages.
+type AppreciationInfo struct {
+	HasAppreciation bool `json:"has_appreciation"`
+}

--- a/internal/channels/instagram/webhook_handler.go
+++ b/internal/channels/instagram/webhook_handler.go
@@ -1,0 +1,147 @@
+package instagram
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// WebhookHandler implements http.Handler for Instagram webhook.
+type WebhookHandler struct {
+	appSecret    string
+	verifyToken  string
+	extraSecrets []string // additional app secrets for multi-Meta-App deployments
+	onMessage    func(entry WebhookEntry, event MessagingEvent)
+}
+
+// NewWebhookHandler creates a new WebhookHandler.
+// appSecret is the Meta App Secret used to verify X-Hub-Signature-256 on POST deliveries.
+func NewWebhookHandler(appSecret, verifyToken string) *WebhookHandler {
+	return &WebhookHandler{
+		appSecret:   appSecret,
+		verifyToken: verifyToken,
+	}
+}
+
+var hubChallengePattern = regexp.MustCompile(`^[a-zA-Z0-9_\-]{1,256}$`)
+
+// ServeHTTP handles Instagram webhook GET (verification) and POST (event delivery).
+func (wh *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		wh.handleVerification(w, r)
+	case http.MethodPost:
+		wh.handleEvent(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleVerification responds to Instagram webhook verification challenge.
+func (wh *WebhookHandler) handleVerification(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	if q.Get("hub.mode") != "subscribe" {
+		http.Error(w, "invalid hub.mode", http.StatusForbidden)
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(q.Get("hub.verify_token")), []byte(wh.verifyToken)) != 1 {
+		slog.Warn("security.instagram_webhook_verify_token_mismatch",
+			"remote_addr", r.RemoteAddr)
+		http.Error(w, "invalid verify token", http.StatusForbidden)
+		return
+	}
+	challenge := q.Get("hub.challenge")
+	if !hubChallengePattern.MatchString(challenge) {
+		http.Error(w, "invalid challenge", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(challenge))
+}
+
+// handleEvent processes an Instagram webhook event delivery.
+// Always returns 200 OK — Meta retries on non-2xx for up to 24h.
+func (wh *WebhookHandler) handleEvent(w http.ResponseWriter, r *http.Request) {
+	const maxBodyBytes = 4 << 20 // 4 MB
+	lr := io.LimitReader(r.Body, maxBodyBytes+1)
+	body, err := io.ReadAll(lr)
+	if err != nil {
+		slog.Warn("instagram: webhook read body error", "err", err)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if len(body) > maxBodyBytes {
+		slog.Warn("instagram: webhook body exceeded limit, event dropped", "bytes", len(body))
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Verify X-Hub-Signature-256 against raw body BEFORE parsing. Instagram uses
+	// the same signing scheme as Messenger/Facebook (HMAC-SHA256 of raw body with
+	// the Meta App Secret).
+	if wh.appSecret == "" {
+		slog.Warn("security.instagram_webhook_app_secret_missing", "remote_addr", r.RemoteAddr)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	sig := r.Header.Get("X-Hub-Signature-256")
+	accepted := verifySignature(body, sig, wh.appSecret)
+	if !accepted {
+		for _, s := range wh.extraSecrets {
+			if verifySignature(body, sig, s) {
+				accepted = true
+				break
+			}
+		}
+	}
+	if !accepted {
+		slog.Warn("security.instagram_webhook_signature_invalid", "remote_addr", r.RemoteAddr)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	var payload WebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		slog.Warn("instagram: webhook parse error", "err", err)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if payload.Object != "instagram" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	for _, entry := range payload.Entry {
+		for _, event := range entry.Messaging {
+			if wh.onMessage != nil {
+				wh.onMessage(entry, event)
+			}
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// verifySignature validates the X-Hub-Signature-256 header using HMAC-SHA256.
+func verifySignature(body []byte, signature, secret string) bool {
+	const prefix = "sha256="
+	if !strings.HasPrefix(signature, prefix) {
+		return false
+	}
+	expected, err := hex.DecodeString(signature[len(prefix):])
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	computed := mac.Sum(nil)
+	return hmac.Equal(computed, expected)
+}

--- a/internal/gateway/methods/channel_instances.go
+++ b/internal/gateway/methods/channel_instances.go
@@ -329,7 +329,7 @@ func maskInstance(inst store.ChannelInstanceData) map[string]any {
 // channels neither API accepts.
 func isValidChannelType(ct string) bool {
 	switch ct {
-	case "telegram", "discord", "slack", "whatsapp", "zalo_oa", "zalo_personal", "feishu", "facebook", "pancake", "bitrix24":
+	case "telegram", "discord", "slack", "whatsapp", "zalo_oa", "zalo_personal", "feishu", "facebook", "instagram", "pancake", "bitrix24":
 		return true
 	}
 	return false

--- a/internal/http/channel_instances.go
+++ b/internal/http/channel_instances.go
@@ -702,7 +702,7 @@ func (h *ChannelInstancesHandler) handleResolveContacts(w http.ResponseWriter, r
 // ui/web/src/constants/channels.ts.
 func isValidChannelType(ct string) bool {
 	switch ct {
-	case "telegram", "discord", "slack", "whatsapp", "zalo_oa", "zalo_personal", "feishu", "facebook", "pancake", "bitrix24":
+	case "telegram", "discord", "slack", "whatsapp", "zalo_oa", "zalo_personal", "feishu", "facebook", "instagram", "pancake", "bitrix24":
 		return true
 	}
 	return false

--- a/ui/web/src/constants/channels.ts
+++ b/ui/web/src/constants/channels.ts
@@ -3,6 +3,7 @@ export const CHANNEL_TYPES = [
   { value: "discord", label: "Discord" },
   { value: "facebook", label: "Facebook" },
   { value: "feishu", label: "Feishu / Lark" },
+  { value: "instagram", label: "Instagram" },
   { value: "pancake", label: "Pancake (pages.fm)" },
   { value: "slack", label: "Slack" },
   { value: "telegram", label: "Telegram" },

--- a/ui/web/src/pages/channels/channel-schemas.ts
+++ b/ui/web/src/pages/channels/channel-schemas.ts
@@ -76,6 +76,11 @@ export const credentialsSchema: Record<string, FieldDef[]> = {
     { key: "app_secret", label: "App Secret", type: "password", required: true, help: "From Facebook Developer Console → Your App → Settings → Basic" },
     { key: "verify_token", label: "Webhook Verify Token", type: "password", required: true, help: "A secret string you choose, used to verify the webhook URL" },
   ],
+  instagram: [
+    { key: "user_access_token", label: "Instagram User Access Token", type: "password", required: true, help: "Instagram User Access Token from Facebook App with instagram_business_basic and instagram_business_manage_messages permissions" },
+    { key: "app_secret", label: "App Secret", type: "password", required: true, help: "Meta App Secret (Facebook Developer Console → Your App → Settings → Basic). Used to verify webhook signatures (X-Hub-Signature-256)." },
+    { key: "verify_token", label: "Webhook Verify Token", type: "password", required: true, help: "A secret string you choose, used to verify the webhook URL" },
+  ],
   pancake: [
     { key: "api_key", label: "API Key", type: "password", required: true, help: "Pancake user-level API key from pages.fm account settings" },
     { key: "page_access_token", label: "Page Access Token", type: "password", required: true, help: "Page-level token from Pancake dashboard → Page Settings" },
@@ -202,6 +207,14 @@ export const configSchema: Record<string, FieldDef[]> = {
     { key: "post_context_cache_ttl", label: "Post Cache TTL", type: "text", placeholder: "e.g. 15m" },
     { key: "first_inbox_message", label: "First Inbox DM Text", type: "textarea", help: "Custom DM sent to first-time commenters. Defaults to Vietnamese if empty." },
     { key: "allow_from", label: "Allowed Users", type: "tags", help: "Facebook user IDs" },
+    { key: "block_reply", label: "Block Reply", type: "select", options: blockReplyOptions, defaultValue: "inherit" },
+  ],
+  instagram: [
+    { key: "instagram_user_id", label: "Instagram User ID", type: "text", required: true, help: "Instagram Business Account ID (IG_ID)" },
+    { key: "features.auto_reply", label: "Auto-Reply", type: "boolean", defaultValue: false },
+    { key: "features.typing", label: "Typing Indicator", type: "boolean", defaultValue: true },
+    { key: "session_options.session_timeout", label: "Session Timeout", type: "text", placeholder: "e.g. 30m" },
+    { key: "allow_from", label: "Allowed Users", type: "tags", help: "Instagram sender IDs" },
     { key: "block_reply", label: "Block Reply", type: "select", options: blockReplyOptions, defaultValue: "inherit" },
   ],
   pancake: [


### PR DESCRIPTION
## Summary
- Register Instagram as a first-class channel type with Graph API client, webhook handler, message router, and formatter
- Wire into gateway startup, RPC/HTTP validation, and web UI credential/config schemas
- Per-entry dispatch by `instagram_user_id` (mirrors Facebook), supports multi-Meta-App secrets via `extraSecrets`
- Strip markdown/HTML before truncation since IG DM does not render markdown
- Add error subcode `2534014` to 24h-window classifier to stop unbounded retries on IG-specific 'human agent required' errors
- Add `TypeInstagram` to `isExternalChannel` so pipeline errors are suppressed instead of leaked to DM users

## Test plan
- [x] `go build ./...` and `go build -tags sqliteonly ./...`
- [x] `go vet ./...`
- [x] Unit tests: router register/unregister, route-once, no-instances, per-entry dispatch regression guard
- [x] Unit tests: external-channel error suppression (`gateway_errors_test`)
- [x] Formatter strips markdown/HTML before truncation
- [x] Manual: webhook subscription + DM send/receive against a real IG Business account
- [x] Manual: multi-instance dispatch with two IG accounts under different Meta apps