### PR TITLE
fix(skills): normalize backslash in ZIP entry names for Windows compatibility

### DIFF
--- a/internal/http/skills_upload.go
+++ b/internal/http/skills_upload.go
@@ -199,15 +199,16 @@ func (h *SkillsHandler) handleUpload(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 		}
-		// Skip macOS/system artifacts
-		if skills.IsSystemArtifact(entryName) {
-			continue
-		}
 		// Normalize Windows backslash separators in ZIP entries.
 		// ZIPs created on Windows may use `\` instead of `/` in paths,
 		// causing files like "scripts\search.py" to be extracted as a
 		// single flat file instead of scripts/search.py on Linux.
 		entryName = strings.ReplaceAll(entryName, "\\", "/")
+		// Skip macOS/system artifacts after separator normalization so
+		// entries like "__MACOSX\\._SKILL.md" are filtered too.
+		if skills.IsSystemArtifact(entryName) {
+			continue
+		}
 		// Security: prevent path traversal
 		name := filepath.Clean(entryName)
 		if strings.Contains(name, "..") {

--- a/internal/http/skills_upload.go
+++ b/internal/http/skills_upload.go
@@ -203,6 +203,11 @@ func (h *SkillsHandler) handleUpload(w http.ResponseWriter, r *http.Request) {
 		if skills.IsSystemArtifact(entryName) {
 			continue
 		}
+		// Normalize Windows backslash separators in ZIP entries.
+		// ZIPs created on Windows may use `\` instead of `/` in paths,
+		// causing files like "scripts\search.py" to be extracted as a
+		// single flat file instead of scripts/search.py on Linux.
+		entryName = strings.ReplaceAll(entryName, "\\", "/")
 		// Security: prevent path traversal
 		name := filepath.Clean(entryName)
 		if strings.Contains(name, "..") {

--- a/internal/http/skills_upload_test.go
+++ b/internal/http/skills_upload_test.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -703,6 +704,47 @@ func TestHandleUpload_ResponseIncludesIsNew(t *testing.T) {
 }
 
 // --- Security Guard Tests ---
+
+func TestHandleUpload_NormalizesBackslashZipEntryPaths(t *testing.T) {
+	handler, skillStore, ctx, _ := newTestUploadHandler(t)
+	stubUploadDepFns(t,
+		func(context.Context, *skills.SkillManifest, []string) (*skills.InstallResult, error) {
+			return nil, nil
+		},
+		func(*skills.SkillManifest) (bool, []string) { return true, nil },
+	)
+
+	req := newZipUploadRequest(t, ctx, map[string]string{
+		"SKILL.md":           skillMarkdown("Windows ZIP Skill", "windows-zip-skill"),
+		"scripts\\search.py": "print('ok')\n",
+	})
+	w := httptest.NewRecorder()
+	handler.handleUpload(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	info, ok := skillStore.GetSkillByID(ctx, uuid.MustParse(resp.ID))
+	if !ok {
+		t.Fatal("GetSkillByID returned !ok")
+	}
+
+	wantPath := filepath.Join(info.BaseDir, "scripts", "search.py")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected normalized path %s to exist: %v", wantPath, err)
+	}
+	flatPath := filepath.Join(info.BaseDir, `scripts\search.py`)
+	if _, err := os.Stat(flatPath); !os.IsNotExist(err) {
+		t.Fatalf("flat backslash path %s exists or stat failed unexpectedly: %v", flatPath, err)
+	}
+}
 
 func TestHandleUpload_MaliciousContent_CurlPipeBash_Rejected(t *testing.T) {
 	handler, _, ctx, _ := newTestUploadHandler(t)


### PR DESCRIPTION
## Problem

ZIP archives created on Windows may use backslash (`\`) as path separator instead of forward slash (`/`) in entry names. When these archives are extracted on Linux, the backslash is treated as a literal character in the filename, causing files like `scripts\search.py` to be created as a **single flat file** instead of the proper `scripts/search.py` directory structure.

This breaks skill execution when skills contain subdirectories (e.g. `scripts/`, `references/`).

## Root Cause

The [ZIP specification (PKZIP APPNOTE)](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) requires forward slashes, but many Windows tools (Python `zipfile`, .NET `ZipArchive`, older archivers) produce non-conforming archives with backslashes.

The current extraction logic in `skills_upload.go` uses `filepath.Clean()` which does **not** convert backslashes to forward slashes on Linux (since `\` is a valid filename character on Linux).

## Fix

Added `strings.ReplaceAll(entryName, \, /)` normalization before `filepath.Clean()` during skill ZIP extraction. This is a single-line defensive fix that handles the edge case without affecting correctly-formed archives.

## Testing

- Uploaded a Windows-created ZIP containing `scripts\search.py` entry
- Before fix: file created as `scripts\search.py` (flat) → skill execution fails
- After fix: file correctly extracted as `scripts/search.py` (subdirectory) → skill works