### PR TITLE
fix(skills): instruct agent to use exact absolute path for skill files

### DIFF
--- a/internal/agent/systemprompt.go
+++ b/internal/agent/systemprompt.go
@@ -640,7 +640,7 @@ func buildSkillsSection(skillsSummary string, hasSkillSearch, hasSkillManage boo
 			"## Skills (mandatory)",
 			"",
 			"Before replying, scan `<available_skills>` below.",
-			"If a skill clearly applies, read its SKILL.md at the `<location>` path with `read_file`, then follow it.",
+			"If a skill clearly applies, read its SKILL.md at the `<location>` path with `read_file` (use the EXACT absolute path provided), then follow it.",
 			"If multiple could apply, choose the most specific one. Never read more than one skill up front.",
 			"If none apply, proceed normally.",
 			"",
@@ -655,7 +655,7 @@ func buildSkillsSection(skillsSummary string, hasSkillSearch, hasSkillManage boo
 			"Before replying, check if a skill applies:",
 			"1. Run `skill_search` with **English keywords** describing the domain (e.g. \"weather\", \"translate\", \"github\").",
 			"   Even if the user writes in another language, always search in English.",
-			"2. If a match is found, read its SKILL.md at the returned `location` with `read_file`, then follow it.",
+			"2. If a match is found, read its SKILL.md at the returned `location` with `read_file` (use the EXACT absolute path provided), then follow it.",
 			"3. If multiple skills match, choose the most specific one. Never read more than one skill up front.",
 			"4. If no match, proceed normally.",
 			"",
@@ -688,7 +688,7 @@ func buildSkillsSection(skillsSummary string, hasSkillSearch, hasSkillManage boo
 func buildWorkspaceSection(workspace string, sandboxEnabled bool, containerDir string) []string {
 	// Matching TS: when sandboxed, display container workdir; add guidance about host paths for file tools.
 	displayDir := workspace
-	guidance := "All file tool paths resolve relative to this directory. Use relative paths (e.g. \"docs/notes.md\", \".\") — do not guess absolute paths."
+	guidance := "All file tool paths resolve relative to this directory. Use relative paths (e.g. \"docs/notes.md\", \".\") for your own files. For skills, use the EXACT absolute path provided."
 	if sandboxEnabled && containerDir != "" {
 		displayDir = containerDir
 		guidance = fmt.Sprintf(

--- a/internal/tools/skill_search.go
+++ b/internal/tools/skill_search.go
@@ -134,7 +134,7 @@ func (t *SkillSearchTool) Execute(ctx context.Context, args map[string]any) *Res
 
 	// Include explicit next-step instruction in the result so the model follows through.
 	instruction := fmt.Sprintf(
-		"\n\nACTION REQUIRED: Call use_skill with name \"%s\", then read_file with path \"%s\" to read the skill instructions, then follow them.",
+		"\n\nACTION REQUIRED: Call use_skill with name \"%s\", then read_file with path \"%s\" (use the EXACT absolute path provided) to read the skill instructions, then follow them.",
 		results[0].Name, results[0].Location,
 	)
 


### PR DESCRIPTION
## Problem

The system prompt contains conflicting guidance that causes weaker models to mangle skill file paths:

1. **Skills section** says: *read its SKILL.md at the location path with read_file*
2. **Workspace section** says: *Use relative paths — do not guess absolute paths*

Models like MiniMax-M2.7 try to reconcile both instructions by stripping the absolute prefix from the skill path (e.g. `/app/data/skills-store/gpt-image-2-pro-max/1/SKILL.md` → `skills/gpt-image-2-pro-max-main/SKILL.md`), causing `file not found` errors.

## Fix

Resolves the contradiction by clarifying the boundary:

- **Workspace section**: relative paths for *user files*, exact absolute paths for *skills*
- **Skills section** (inline + search modes): adds `(use the EXACT absolute path provided)`
- **skill_search result**: adds the same emphasis in the ACTION REQUIRED instruction

## Files Changed

- `internal/agent/systemprompt.go` — 3 string changes in prompt guidance
- `internal/tools/skill_search.go` — 1 string change in search result instruction

## Impact

Minimal prompt size increase (~30 tokens). Helps weaker models follow skill paths correctly without affecting stronger models.