### PR TITLE
chore(mcp): allow mcp-server-darwin-arm64 in validation allowlist

### DIFF
--- a/internal/mcp/validation.go
+++ b/internal/mcp/validation.go
@@ -18,6 +18,7 @@ var allowedCommands = map[string]bool{
 	"java": true, "dotnet": true, "php": true,
 	"uvx": true, "uv": true, "pipx": true,
 	"deno": true, "bun": true,
+	"mcp-server-darwin-arm64": true,
 }
 
 // Shell metacharacters that indicate injection attempt.


### PR DESCRIPTION
## Summary

Local pkg-helper installs an `mcp-server-darwin-arm64` binary on macOS hosts, but the existing allowlist in `internal/mcp/validation.go` (deno, bun, uvx, ...) didn't cover it, so MCP server config validation rejected legitimate entries. One-line addition.

## Changes

- **`internal/mcp/validation.go`** — add `"mcp-server-darwin-arm64": true` to `allowedCommands`.

## Test plan

- [x] `go build ./...` clean
- [x] Existing validation tests pass; rejected commands list unchanged for everything else.

If reviewers prefer a more general pattern (e.g. `mcp-server-*`) instead of the specific name, happy to switch.