### PR TITLE
feat(web_search): add `provider` arg to force a specific engine

### DIFF
--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -163,6 +163,10 @@ func (t *WebSearchTool) Parameters() map[string]any {
 				"type":        "string",
 				"description": "Filter results by discovery time. Supports 'pd' (past day), 'pw' (past week), 'pm' (past month), 'py' (past year), and date range 'YYYY-MM-DDtoYYYY-MM-DD'.",
 			},
+			"provider": map[string]any{
+				"type":        "string",
+				"description": "Optional: force a specific provider (e.g., 'tavily', 'exa', 'brave', 'duckduckgo'). When omitted, the tenant's configured provider chain is used (first-success-wins). Use this to force cross-engine corroboration — call once with each provider and compare results.",
+			},
 		},
 		"required": []string{"query"},
 	}
@@ -183,6 +187,7 @@ func (t *WebSearchTool) Execute(ctx context.Context, args map[string]any) *Resul
 	searchLang, _ := args["search_lang"].(string)
 	uiLang, _ := args["ui_lang"].(string)
 	freshness, _ := args["freshness"].(string)
+	requestedProvider, _ := args["provider"].(string)
 
 	params := searchParams{
 		Query:      query,
@@ -193,18 +198,40 @@ func (t *WebSearchTool) Execute(ctx context.Context, args map[string]any) *Resul
 		Freshness:  freshness,
 	}
 
-	// Check cache (scoped per channel to prevent cross-channel cache poisoning)
+	// Check cache (scoped per channel + provider to prevent cross-engine cache mixing)
 	channel := ToolChannelFromCtx(ctx)
-	cacheKey := fmt.Sprintf("%s:%s", channel, buildSearchCacheKey(params))
+	cacheKey := fmt.Sprintf("%s:%s:%s", channel, requestedProvider, buildSearchCacheKey(params))
 	if cached, ok := t.cache.get(cacheKey); ok {
-		slog.Debug("web_search cache hit", "query", query)
+		slog.Debug("web_search cache hit", "query", query, "provider", requestedProvider)
 		return NewResult(cached)
 	}
 
 	// Resolve per-request provider chain from tenant config_secrets + settings overlay.
 	chain := t.resolveChain(ctx)
 
-	// Try providers in order (first success wins)
+	// If caller explicitly named a provider, narrow the chain to just that one.
+	// This unlocks cross-engine corroboration (caller invokes once per engine
+	// and compares results) — without a provider param, the first-success-wins
+	// chain hides everything after the first hit.
+	if requestedProvider != "" {
+		filtered := make([]SearchProvider, 0, 1)
+		for _, p := range chain {
+			if strings.EqualFold(p.Name(), requestedProvider) {
+				filtered = append(filtered, p)
+				break
+			}
+		}
+		if len(filtered) == 0 {
+			available := make([]string, 0, len(chain))
+			for _, p := range chain {
+				available = append(available, p.Name())
+			}
+			return ErrorResult(fmt.Sprintf("provider %q not configured for this tenant; available: %v", requestedProvider, available))
+		}
+		chain = filtered
+	}
+
+	// Try providers in order (first success wins, unless narrowed above)
 	var lastErr error
 	for _, provider := range chain {
 		results, err := provider.Search(ctx, params)

--- a/internal/tools/web_search_provider_param_test.go
+++ b/internal/tools/web_search_provider_param_test.go
@@ -1,0 +1,149 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// searchStubProvider returns a fixed result so we can assert which provider ran.
+type searchStubProvider struct {
+	name    string
+	called  *bool
+	result  searchResult
+	failure error
+}
+
+func (s *searchStubProvider) Name() string { return s.name }
+func (s *searchStubProvider) Search(_ context.Context, _ searchParams) ([]searchResult, error) {
+	if s.called != nil {
+		*s.called = true
+	}
+	if s.failure != nil {
+		return nil, s.failure
+	}
+	return []searchResult{s.result}, nil
+}
+
+// makeStubbedTool installs a fixed chain of searchStubProviders for the master tenant
+// so Execute() bypasses the real provider chain resolution.
+func makeStubbedTool(t *testing.T, providers ...*searchStubProvider) (*WebSearchTool, context.Context) {
+	t.Helper()
+	tool := &WebSearchTool{
+		secrets:    newFakeSecretsStore(),
+		cache:      newWebCache(defaultCacheMaxEntries, defaultCacheTTL),
+		chainCache: newTenantChainCache(),
+	}
+	tid := uuid.New()
+	ctx := store.WithTenantID(context.Background(), tid)
+	chain := make([]SearchProvider, len(providers))
+	for i, p := range providers {
+		chain[i] = p
+	}
+	tool.chainCache.Set(tid, chain)
+	return tool, ctx
+}
+
+// TestExecute_ProviderParam_NarrowsChainToOne — when caller passes provider="exa",
+// the brave provider must NOT be called even though it sits earlier in the chain.
+func TestExecute_ProviderParam_NarrowsChainToOne(t *testing.T) {
+	braveCalled, exaCalled := false, false
+	tool, ctx := makeStubbedTool(t,
+		&searchStubProvider{name: "brave", called: &braveCalled, result: searchResult{Title: "brave-hit", URL: "https://b.example/x"}},
+		&searchStubProvider{name: "exa", called: &exaCalled, result: searchResult{Title: "exa-hit", URL: "https://e.example/x"}},
+	)
+
+	res := tool.Execute(ctx, map[string]any{
+		"query":    "solana dex volume",
+		"provider": "exa",
+	})
+
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.ForLLM)
+	}
+	if braveCalled {
+		t.Errorf("brave was called but provider=\"exa\" requested a narrowed chain")
+	}
+	if !exaCalled {
+		t.Errorf("exa not called despite provider=\"exa\"")
+	}
+	if !strings.Contains(res.ForLLM, "exa-hit") {
+		t.Errorf("expected exa result in output, got: %s", res.ForLLM)
+	}
+}
+
+// TestExecute_ProviderParam_CaseInsensitive — "EXA", "Exa", "exa" all work.
+func TestExecute_ProviderParam_CaseInsensitive(t *testing.T) {
+	for _, want := range []string{"EXA", "Exa", "exa"} {
+		t.Run(want, func(t *testing.T) {
+			exaCalled := false
+			tool, ctx := makeStubbedTool(t,
+				&searchStubProvider{name: "brave", called: nil, result: searchResult{Title: "brave-hit"}},
+				&searchStubProvider{name: "exa", called: &exaCalled, result: searchResult{Title: "exa-hit"}},
+			)
+			res := tool.Execute(ctx, map[string]any{"query": "q", "provider": want})
+			if res.IsError {
+				t.Fatalf("error: %s", res.ForLLM)
+			}
+			if !exaCalled {
+				t.Errorf("exa should be called for provider=%q", want)
+			}
+		})
+	}
+}
+
+// TestExecute_ProviderParam_Unknown — caller asking for a provider not in the
+// tenant chain gets a clear error listing what IS available.
+func TestExecute_ProviderParam_Unknown(t *testing.T) {
+	tool, ctx := makeStubbedTool(t,
+		&searchStubProvider{name: "brave", result: searchResult{}},
+		&searchStubProvider{name: "exa", result: searchResult{}},
+	)
+	res := tool.Execute(ctx, map[string]any{"query": "q", "provider": "google"})
+	if !res.IsError {
+		t.Fatalf("expected error for unknown provider, got success: %s", res.ForLLM)
+	}
+	if !strings.Contains(res.ForLLM, "google") || !strings.Contains(res.ForLLM, "brave") || !strings.Contains(res.ForLLM, "exa") {
+		t.Errorf("error should name unknown provider AND list available ones, got: %s", res.ForLLM)
+	}
+}
+
+// TestExecute_NoProviderParam_FallsBackToFirstSuccessWins — omitting provider
+// preserves the existing behaviour: chain order is honoured, first success wins.
+func TestExecute_NoProviderParam_FallsBackToFirstSuccessWins(t *testing.T) {
+	braveCalled, exaCalled := false, false
+	tool, ctx := makeStubbedTool(t,
+		&searchStubProvider{name: "brave", called: &braveCalled, result: searchResult{Title: "brave-hit"}},
+		&searchStubProvider{name: "exa", called: &exaCalled, result: searchResult{Title: "exa-hit"}},
+	)
+	res := tool.Execute(ctx, map[string]any{"query": "q"})
+	if res.IsError {
+		t.Fatalf("error: %s", res.ForLLM)
+	}
+	if !braveCalled {
+		t.Errorf("brave should be called first when no provider param")
+	}
+	if exaCalled {
+		t.Errorf("exa should NOT be called when brave succeeded (first-success-wins)")
+	}
+}
+
+// TestExecute_ProviderParam_CacheIsolated — same query but different `provider`
+// args must NOT collide in the cache, otherwise cross-engine corroboration
+// would just replay one engine's result twice.
+func TestExecute_ProviderParam_CacheIsolated(t *testing.T) {
+	braveCalled, exaCalled := false, false
+	tool, ctx := makeStubbedTool(t,
+		&searchStubProvider{name: "brave", called: &braveCalled, result: searchResult{Title: "brave-hit"}},
+		&searchStubProvider{name: "exa", called: &exaCalled, result: searchResult{Title: "exa-hit"}},
+	)
+	_ = tool.Execute(ctx, map[string]any{"query": "q", "provider": "brave"})
+	_ = tool.Execute(ctx, map[string]any{"query": "q", "provider": "exa"})
+	if !braveCalled || !exaCalled {
+		t.Fatalf("both providers should run for distinct provider args (brave=%v, exa=%v)", braveCalled, exaCalled)
+	}
+}


### PR DESCRIPTION
## Summary

Currently `web_search` resolves a tenant-configured provider chain (e.g. tavily → exa → brave) and stops at the first success. That's the right default for cost/latency, but it makes **cross-engine corroboration impossible at the agent level**: the caller has no way to ask \"search the same query on Exa specifically\" once Tavily already returned a hit.

This PR adds an optional `provider` argument. When set, the chain is narrowed to the named provider (case-insensitive); other providers are not queried. First-success-wins fallback is preserved when the arg is omitted.

## Concrete use case

A research agent verifying source freshness:

1. Call A: `web_search(query=\"Solana DEX volume\", freshness=\"pd\", provider=\"tavily\")`
2. Call B: `web_search(query=\"Solana DEX volume\", freshness=\"pd\", provider=\"exa\")`
3. URLs in **both** result sets → high-confidence original primary sources.
4. URLs in only one engine → republish suspect; verify with `web_fetch` page metadata.

Without `provider`, both calls return the same cached Tavily payload and the corroboration is meaningless.

## Changes

- **`internal/tools/web_search.go`**
  - New optional `provider` arg in `Parameters()`.
  - When passed, the resolved chain is narrowed to the matching provider (case-insensitive). Unknown name returns an error listing what IS configured for the tenant.
  - Cache key now includes `requestedProvider` so per-engine results don't collide.
- **`internal/tools/web_search_provider_param_test.go`** (new)
  - 5 cases: narrowing, case-insensitivity, unknown provider error, default first-success preservation, cache isolation.

## Backward compatibility

Fully backward-compatible — `provider` is optional. Existing callers (and existing cached entries during rollout) continue to work because the cache key change only affects new writes; old keys age out via TTL.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/tools/...` passes (new + existing)
- [x] Unit-tested all four code paths: narrowed-chain, case-insensitive match, unknown provider error, default fallback
- [x] Cache isolation verified (same query, two providers → both engines run)

## Related

Used by the c02-choros content-research agent (Max) to implement multi-layer source-freshness verification — agent calls each engine separately and cross-checks URLs to detect republished/syndicated content slipping past Tavily/Exa's date filters. Currently shipped in our fork (`mozaa-solana/goclaw`); upstreaming so the capability is broadly available.