### PR TITLE
fix(gateway): re-apply tool rate limiter after system_configs overlay

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -192,6 +192,18 @@ func runGateway() {
 			slog.Info("system_configs applied to in-memory config", "keys", len(sysConfigs))
 		}
 	}
+
+	// Re-apply tool rate limiter using DB-overlaid config. setupToolRegistry
+	// initialised the limiter from the JSON5 default before ApplySystemConfigs
+	// ran, so DB-driven changes to tools.rate_limit_per_hour were lost. Replace
+	// the limiter object now that cfg reflects the DB value. Safe: server has
+	// not started, no in-flight tool calls.
+	if cfg.Tools.RateLimitPerHour > 0 {
+		toolsReg.SetRateLimiter(tools.NewToolRateLimiter(cfg.Tools.RateLimitPerHour))
+		slog.Info("tool rate limiting reapplied from system_configs", "per_hour", cfg.Tools.RateLimitPerHour)
+	} else {
+		toolsReg.SetRateLimiter(nil)
+	}
 	setupMemoryEmbeddings(pgStores, providerRegistry)
 
 	// Resolve background provider for consolidation + vault enrichment.

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -168,6 +168,42 @@ func TestRegistry_ExecuteWithContext_RateLimiting(t *testing.T) {
 	}
 }
 
+// SetRateLimiter must be re-callable so that startup code can swap the limiter
+// after DB-overlaid config is applied (cmd/gateway.go re-applies once
+// system_configs has overlaid the JSON5 default).
+func TestRegistry_SetRateLimiter_ReplacesPriorLimiter(t *testing.T) {
+	reg := NewRegistry()
+	reg.SetRateLimiter(NewToolRateLimiter(1)) // simulate JSON5 default
+	reg.Register(&mockTool{name: "tool"})
+
+	// Replace with higher limit (simulates DB overlay = 5)
+	reg.SetRateLimiter(NewToolRateLimiter(5))
+
+	for i := range 5 {
+		result := reg.ExecuteWithContext(context.Background(), "tool", nil,
+			"", "", "", "session-replace", nil)
+		if result.IsError {
+			t.Errorf("call %d should succeed under new 5/h limit: %s", i, result.ForLLM)
+		}
+	}
+	result := reg.ExecuteWithContext(context.Background(), "tool", nil,
+		"", "", "", "session-replace", nil)
+	if !result.IsError {
+		t.Error("6th call should hit the 5/h limit")
+	}
+
+	// Disable rate limiting via nil — verifies the gateway path that disables
+	// the limiter when cfg.Tools.RateLimitPerHour <= 0.
+	reg.SetRateLimiter(nil)
+	for i := range 10 {
+		result := reg.ExecuteWithContext(context.Background(), "tool", nil,
+			"", "", "", "session-replace", nil)
+		if result.IsError {
+			t.Errorf("call %d after nil limiter should be unbounded", i)
+		}
+	}
+}
+
 func TestRegistry_ExecuteWithContext_NoRateLimitWithoutSessionKey(t *testing.T) {
 	reg := NewRegistry()
 	reg.SetRateLimiter(NewToolRateLimiter(1))


### PR DESCRIPTION
## Summary
- `setupToolRegistry` initialises the tool rate limiter from `cfg.Tools.RateLimitPerHour` early in startup (gateway.go line 137), but `system_configs` DB overlay (`cfg.ApplySystemConfigs`) runs ~50 lines later. DB overrides of `tools.rate_limit_per_hour` were silently lost - the limiter object was already built from the JSON5 default.
- Re-apply the limiter after `ApplySystemConfigs` so the DB value wins. Server has not started yet, no in-flight tool calls. `nil` case handled too so DB writes can disable rate limiting without restart.

## Why this matters
Production observation: a Zalo sales-bot session burst past the 150/h default and operators tried to bump it via `system_configs` UPDATE + container restart. No effect. Workaround was to inject `/app/data/config.json` with `{"tools":{"rate_limit_per_hour":800}}`, which contradicts the DB-as-source-of-truth pattern other tunables rely on.

## Tests
- New: `TestRegistry_SetRateLimiter_ReplacesPriorLimiter` covers the replace-with-higher-limit path and the `nil`-disables path.
- All existing rate limiter tests still pass.
- `go build ./...`, `go build -tags sqliteonly ./...`, `go vet ./...` clean.

## Out of scope
The same ordering pattern likely affects other config consumed inside `setupToolRegistry` (`tools.scrub_credentials`, MCP server wiring from DB). Those need a broader restructure - kept out of this hotfix.

## Test plan
- [ ] Merge to `dev`, deploy, set `UPDATE system_configs SET value='800' WHERE key='tools.rate_limit_per_hour'`, restart container, verify log line `tool rate limiting reapplied from system_configs per_hour=800`.
- [ ] Confirm the existing `tool rate limiting enabled per_hour=<json5_default>` log still fires earlier - the reapply log is additive.
- [ ] Set DB value to `0`, restart, verify limiter is disabled (no `tool rate limit exceeded` errors regardless of call volume).