### PR TITLE
feat(config): add GOCLAW_CRON_JOB_TIMEOUT env var override

### DIFF
--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -122,6 +122,9 @@ func (c *Config) applyEnvOverrides() {
 	envStr("GOCLAW_SLACK_APP_TOKEN", &c.Channels.Slack.AppToken)
 	envStr("GOCLAW_SLACK_USER_TOKEN", &c.Channels.Slack.UserToken)
 
+	// Cron
+	envStr("GOCLAW_CRON_JOB_TIMEOUT", &c.Cron.JobTimeout)
+
 	// TTS secrets
 	envStr("GOCLAW_TTS_OPENAI_API_KEY", &c.Tts.OpenAI.APIKey)
 	envStr("GOCLAW_TTS_ELEVENLABS_API_KEY", &c.Tts.ElevenLabs.APIKey)


### PR DESCRIPTION
## Summary
- Add `GOCLAW_CRON_JOB_TIMEOUT` env var to override `cron.job_timeout` from config file.
- Aligns with existing `GOCLAW_*` env var convention.

Closes #1098.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/config/...`
- [ ] Verify `GOCLAW_CRON_JOB_TIMEOUT=1h ./goclaw` overrides default 10m at runtime.