### PR TITLE
fix(agent): suppress empty final content instead of sending literal "..."

### DIFF
--- a/internal/agent/loop_finalize.go
+++ b/internal/agent/loop_finalize.go
@@ -54,8 +54,22 @@ func (l *Loop) finalizeRun(
 	// 5. Full sanitization pipeline (matching TS extractAssistantText + sanitizeUserFacingText)
 	rs.finalContent = SanitizeAssistantContent(rs.finalContent)
 
-	// 6. Handle NO_REPLY: save to session for context but mark as silent.
-	isSilent := IsSilentReply(rs.finalContent)
+	// 6. Silent-reply detection. Two cases collapse to the same delivery behavior
+	// (suppress) but stay distinct in logs so empty-output bugs don't hide behind
+	// the deliberate NO_REPLY signal.
+	isSilentByToken := IsSilentReply(rs.finalContent)
+	isEmptyOutput := rs.finalContent == "" && !isSilentByToken
+	if isEmptyOutput {
+		slog.Warn("agent produced empty final content; suppressing delivery",
+			"agent", l.id,
+			"session", req.SessionKey,
+			"iteration", rs.iteration,
+			"thinking_len", len(rs.finalThinking),
+			"tool_calls", rs.totalToolCalls,
+			"async_tool_calls", len(rs.asyncToolCalls),
+		)
+	}
+	isSilent := isSilentByToken || isEmptyOutput
 
 	// 5b. Skill evolution: postscript suggestion after complex tasks.
 	if l.skillEvolve && l.skillNudgeInterval > 0 &&
@@ -64,15 +78,6 @@ func (l *Loop) finalizeRun(
 		rs.skillPostscriptSent = true
 		locale := store.LocaleFromContext(ctx)
 		rs.finalContent += "\n\n---\n_" + i18n.T(locale, i18n.MsgSkillNudgePostscript) + "_"
-	}
-
-	// 7. Fallback for empty content
-	if rs.finalContent == "" {
-		if len(rs.asyncToolCalls) > 0 {
-			rs.finalContent = "..."
-		} else {
-			rs.finalContent = "..."
-		}
 	}
 
 	// Append content suffix (e.g. image markdown for WS) before saving to session.
@@ -197,8 +202,10 @@ func (l *Loop) finalizeRun(
 	// 8. Metadata Stripping: Clean internal [[...]] tags for user-facing content
 	rs.finalContent = StripMessageDirectives(rs.finalContent)
 	if isSilent {
-		slog.Info("agent loop: NO_REPLY detected, suppressing delivery",
-			"agent", l.id, "session", req.SessionKey)
+		if isSilentByToken {
+			slog.Info("agent loop: NO_REPLY detected, suppressing delivery",
+				"agent", l.id, "session", req.SessionKey)
+		}
 		rs.finalContent = ""
 	}
 

--- a/internal/pipeline/finalize_stage.go
+++ b/internal/pipeline/finalize_stage.go
@@ -40,12 +40,23 @@ func (s *FinalizeStage) Execute(ctx context.Context, state *RunState) error {
 
 	// 2. NO_REPLY detection: save to session for context but mark as silent.
 	// Must run BEFORE session flush so the agent message is persisted even if suppressed.
-	isSilent := s.deps.IsSilentReply != nil && s.deps.IsSilentReply(state.Observe.FinalContent)
+	isSilentByToken := s.deps.IsSilentReply != nil && s.deps.IsSilentReply(state.Observe.FinalContent)
 
-	// 2b. Fallback for empty content (matching v2: channels need non-empty content to deliver).
-	if state.Observe.FinalContent == "" && !isSilent {
-		state.Observe.FinalContent = "..."
+	// 2b. Empty final content: suppress delivery instead of sending placeholder "...".
+	// Distinguish from NO_REPLY (which is the model's deliberate silence) so debugging
+	// can spot when the model returned no usable content (provider parsing bug, context
+	// exhaustion, reasoning-only output, etc.). Treat both as silent for delivery purposes.
+	isEmptyOutput := state.Observe.FinalContent == "" && !isSilentByToken
+	if isEmptyOutput {
+		slog.Warn("agent produced empty final content; suppressing delivery",
+			"session", state.Input.SessionKey,
+			"iteration", state.Iteration,
+			"thinking_len", len(state.Observe.FinalThinking),
+			"tool_calls", state.Tool.TotalToolCalls,
+			"async_tool_calls", len(state.Tool.AsyncToolCalls),
+		)
 	}
+	isSilent := isSilentByToken || isEmptyOutput
 
 	// 2c. Append content suffix (e.g. image markdown for WS) with dedup.
 	if state.Input.ContentSuffix != "" && s.deps.DeduplicateMediaSuffix != nil {
@@ -148,10 +159,13 @@ func (s *FinalizeStage) Execute(ctx context.Context, state *RunState) error {
 		state.Observe.FinalContent = s.deps.StripMessageDirectives(state.Observe.FinalContent)
 	}
 
-	// 10. Suppress NO_REPLY (after session flush — content is persisted for context).
+	// 10. Suppress silent replies (after session flush — content is persisted for context).
+	// Covers both NO_REPLY token (deliberate) and empty output (likely upstream issue).
 	if isSilent {
-		slog.Info("v3 pipeline: NO_REPLY detected, suppressing delivery",
-			"session", state.Input.SessionKey)
+		if isSilentByToken {
+			slog.Info("v3 pipeline: NO_REPLY detected, suppressing delivery",
+				"session", state.Input.SessionKey)
+		}
 		state.Observe.FinalContent = ""
 	}
 

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -1538,6 +1538,76 @@ func TestFinalizeStage_SanitizesContent(t *testing.T) {
 	}
 }
 
+// TestFinalizeStage_EmptyContent_SuppressesInsteadOfEllipsis verifies that
+// empty FinalContent is treated as silent (suppressed delivery), NOT replaced
+// with literal "...". Regression guard for trace 019e01c2 where users saw
+// stray "..." messages in chat when the LLM produced no usable content.
+func TestFinalizeStage_EmptyContent_SuppressesInsteadOfEllipsis(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		// IsSilentReply must be wired so the stage knows to distinguish empty
+		// from NO_REPLY. Mirror production wiring (returns true for NO_REPLY token).
+		IsSilentReply: func(s string) bool {
+			return strings.HasPrefix(strings.TrimSpace(s), "NO_REPLY")
+		},
+		FlushMessages: func(_ context.Context, _ string, _ []providers.Message) error { return nil },
+	}
+	stage := NewFinalizeStage(deps)
+	state := defaultState()
+	state.Observe.FinalContent = ""
+
+	if err := stage.Execute(context.Background(), state); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if state.Observe.FinalContent != "" {
+		t.Errorf("FinalContent = %q, want empty (suppressed, not '...')", state.Observe.FinalContent)
+	}
+}
+
+// TestFinalizeStage_NoReplyToken_StillSuppresses verifies NO_REPLY semantics
+// remain unchanged after the empty-content fix.
+func TestFinalizeStage_NoReplyToken_StillSuppresses(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		SanitizeContent: func(s string) string { return s },
+		IsSilentReply: func(s string) bool {
+			return strings.HasPrefix(strings.TrimSpace(s), "NO_REPLY")
+		},
+		FlushMessages: func(_ context.Context, _ string, _ []providers.Message) error { return nil },
+	}
+	stage := NewFinalizeStage(deps)
+	state := defaultState()
+	state.Observe.FinalContent = "NO_REPLY: just observing"
+
+	if err := stage.Execute(context.Background(), state); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if state.Observe.FinalContent != "" {
+		t.Errorf("FinalContent = %q, want empty after NO_REPLY suppression", state.Observe.FinalContent)
+	}
+}
+
+// TestFinalizeStage_RealContent_PassesThrough verifies non-empty,
+// non-NO_REPLY content reaches downstream unchanged (modulo sanitize).
+func TestFinalizeStage_RealContent_PassesThrough(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		SanitizeContent: func(s string) string { return s },
+		IsSilentReply:   func(string) bool { return false },
+		FlushMessages:   func(_ context.Context, _ string, _ []providers.Message) error { return nil },
+	}
+	stage := NewFinalizeStage(deps)
+	state := defaultState()
+	state.Observe.FinalContent = "real reply"
+
+	if err := stage.Execute(context.Background(), state); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if state.Observe.FinalContent != "real reply" {
+		t.Errorf("FinalContent = %q, want 'real reply'", state.Observe.FinalContent)
+	}
+}
+
 func TestFinalizeStage_DeduplicatesMediaByPath(t *testing.T) {
 	t.Parallel()
 	deps := &PipelineDeps{}


### PR DESCRIPTION
## Summary

- Bỏ hardcoded `"..."` fallback ở v2 (`internal/agent/loop_finalize.go`) và v3 (`internal/pipeline/finalize_stage.go`) finalize.
- Coi empty `FinalContent` như silent reply (suppress delivery, không leak `"..."` xuống channel).
- Thêm `slog.Warn` riêng cho case empty (kèm session/iteration/thinking_len/tool_calls/async_tool_calls) để root cause LLM trả rỗng không bị che bởi NO_REPLY.
- NO_REPLY token semantics giữ nguyên.

## Why

Trace evidence (`019e01c2-b12d-7bf7-babc-29833b288f81`, agent `tra`, model qwen3.6-plus qua bailian):
- LLM trả 596 output tokens với câu trả lời tiếng Việt đầy đủ (~700 chars).
- Nhưng `traces.output_preview` và `sessions.messages[].content` đều lưu literal `"..."`.
- User thấy bot reply `"..."` 2 lần liên tiếp trong group Zalo.

Root cause proximate là fallback ở finalize: `if FinalContent == "" → "..."`. Bug ảnh hưởng tất cả channel (Telegram/Discord/Zalo/Feishu/WhatsApp/Slack), không Zalo-specific.

Downstream consumer (`cmd/gateway_consumer_normal.go:468`, `cmd/gateway_announce_queue.go:137`) đã có sẵn check `Content == "" || IsSilentReply(...)` để suppress + cleanup placeholder. Fallback `"..."` đang bypass logic này. Fix này feed đúng empty xuống path đó.

## What changed

| File | Δ | What |
|---|---|---|
| `internal/pipeline/finalize_stage.go` | +14/-6 | Tách `isSilentByToken` vs `isEmptyOutput`, gộp thành `isSilent`; bỏ branch fallback `"..."`; log warn cho empty |
| `internal/agent/loop_finalize.go` | +18/-15 | Same logic cho v2 path (predefined agents) |
| `internal/pipeline/stages_test.go` | +70 | 3 regression tests: empty→suppress, NO_REPLY→suppress, real→passthrough |

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags sqliteonly ./...` clean (desktop edition)
- [x] `go vet ./...` clean
- [x] `go test ./internal/pipeline/ ./internal/agent/` pass
- [x] 3 regression tests pass (`TestFinalizeStage_EmptyContent_SuppressesInsteadOfEllipsis`, `TestFinalizeStage_NoReplyToken_StillSuppresses`, `TestFinalizeStage_RealContent_PassesThrough`)
- [ ] Reproduce trên staging: trigger run với input gần context_window, kiểm tra log `agent produced empty final content; suppressing delivery` xuất hiện và channel KHÔNG gửi `"..."`

## Unresolved

- **Root cause gốc** (vì sao `FinalContent` rỗng dù LLM trả 596 output tokens) chưa giải - fix này chặn symptom rò ra user, không sửa nguyên nhân Content rỗng. Cần điều tra parser bailian/qwen3.6-plus (có thể đẩy text vào `reasoning_content` field) qua log warn mới khi reproduce. Tracking riêng nếu confirm.

## Behavior change cho consumer

Sau fix:
```
WARN agent produced empty final content; suppressing delivery
  session=agent:tra:tra-on-zalo:group:7937974080316500889
  iteration=1 thinking_len=1300 tool_calls=0 async_tool_calls=0
```
→ channel nhận `Content=""` → không send tin nhắn `"..."` nữa. Placeholder cleanup vẫn chạy bình thường nếu channel có streaming/placeholder.