### PR TITLE
fix(providers): increase HTTP connection pool for embedding provider

### DIFF
--- a/internal/providers/embedding_openai.go
+++ b/internal/providers/embedding_openai.go
@@ -40,8 +40,15 @@ func NewOpenAIEmbeddingProvider(apiKey, apiBase, model string) *OpenAIEmbeddingP
 		apiKey:       apiKey,
 		apiBase:      strings.TrimRight(apiBase, "/"),
 		model:        model,
-		client:       &http.Client{Timeout: 60 * time.Second},
-		retry:        DefaultRetryConfig(),
+		client: &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 30,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+		retry: DefaultRetryConfig(),
 	}
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                     
  Fix HTTP connection pool starvation in embedding provider that caused
  `team_tasks(action="search")` to block when >5 concurrent requests hit                                                                                                                                                                                                                                                                                                                                                         
  the embedding API simultaneously.                                   
                                                                           
  ## Type
  - [x] Bug fix
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ## Target Branch
  `dev`                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                      
  ## Checklist                                                             
  - [x] `go build ./...` passes
  - [x] `go build -tags sqliteonly ./...` passes
  - [x] `go vet ./...` passes
  - [x] No hardcoded secrets or credentials                                                                                                                                                                                                                                                                                                                                                                                      
  - [x] SQL queries use parameterized `$1, $2` (no string concat)
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ## Test Plan                                                        
  1. Deploy to staging                                                     
  2. Trigger 10+ concurrent chat sessions that call `team_tasks(action="search")`
  3. Verify all requests complete without blocking                                                                                                                                                                                                                                                                                                                                                                               
  4. Previously: >5 concurrent requests would hang indefinitely
  5. After fix: 30 concurrent connections supported per host 