### PR TITLE
fix(cron): stamp + replay creator sender/role across cron fires

### DIFF
--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -94,6 +94,15 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 			sessionMgr.Save(cronCtx, sessionKey)
 		}
 
+		// Replay the human creator's sender + role each time the job fires.
+		// Stamped at create time by cron tool handleAdd; without it,
+		// group-scope cron actions (write_file, cron mutations from inside
+		// the scheduled turn) fail group-context permission checks because
+		// UserID is the group scope, not a real human. Empty values
+		// (DM crons, system-installed crons) preserve prior behaviour.
+		creatorSenderID := job.Payload.CreatorSenderID
+		creatorRole := job.Payload.CreatorRole
+
 		// Schedule through cron lane — scheduler handles agent resolution and concurrency
 		outCh := sched.Schedule(cronCtx, scheduler.LaneCron, agent.RunRequest{
 			SessionKey:        sessionKey,
@@ -103,6 +112,8 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 			ChatID:            job.DeliverTo,
 			PeerKind:          peerKind,
 			UserID:            job.UserID,
+			SenderID:          creatorSenderID,
+			Role:              creatorRole,
 			RunID:             fmt.Sprintf("cron:%s", job.ID),
 			Stream:            false,
 			ExtraSystemPrompt: extraPrompt,

--- a/internal/gateway/methods/cron.go
+++ b/internal/gateway/methods/cron.go
@@ -89,7 +89,14 @@ func (m *CronMethods) handleCreate(ctx context.Context, client *gateway.Client, 
 		return
 	}
 
-	job, err := m.service.AddJob(ctx, params.Name, params.Schedule, params.Message, params.Deliver, params.DeliverChannel, params.DeliverTo, params.AgentID, client.UserID())
+	// Capture the creator's sender + role so the job's later runs can
+	// attribute group-scope actions back to a real human (file_writer +
+	// cron permission gates). For WS clients, we only have a UserID — there
+	// is no separate "Telegram numeric sender" upstream of this RPC, so
+	// these are typically empty here. WS-installed crons that need to
+	// fire in group chats should be created via a Telegram-rooted flow
+	// instead, where the cron tool's handleAdd captures sender from ctx.
+	job, err := m.service.AddJob(ctx, params.Name, params.Schedule, params.Message, params.Deliver, params.DeliverChannel, params.DeliverTo, params.AgentID, client.UserID(), "", "")
 	if err != nil {
 		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, err.Error()))
 		return

--- a/internal/gateway/methods/cron_test.go
+++ b/internal/gateway/methods/cron_test.go
@@ -31,16 +31,22 @@ func (s *stubCronStore) addJob(id, name, userID string) {
 }
 
 func (s *stubCronStore) AddJob(_ context.Context, name string, schedule store.CronSchedule, message string,
-	deliver bool, channel, to, agentID, userID string) (*store.CronJob, error) {
+	deliver bool, channel, to, agentID, userID, creatorSenderID, creatorRole string) (*store.CronJob, error) {
 	if s.addErr != nil {
 		return nil, s.addErr
 	}
 	job := &store.CronJob{
-		ID:      "new-job-id",
-		Name:    name,
-		UserID:  userID,
-		Enabled: true,
+		ID:       "new-job-id",
+		Name:     name,
+		UserID:   userID,
+		Enabled:  true,
 		Schedule: schedule,
+		Payload: store.CronPayload{
+			Kind:            "agent_turn",
+			Message:         message,
+			CreatorSenderID: creatorSenderID,
+			CreatorRole:     creatorRole,
+		},
 	}
 	s.addedJob = job
 	s.jobs[job.ID] = job

--- a/internal/store/cron_store.go
+++ b/internal/store/cron_store.go
@@ -51,6 +51,19 @@ type CronPayload struct {
 	Kind    string `json:"kind" db:"-"`
 	Message string `json:"message" db:"-"`
 	Command string `json:"command,omitempty" db:"-"`
+
+	// CreatorSenderID + CreatorRole carry the identity of the human who
+	// scheduled this job. Stamped at create time, replayed as RunRequest
+	// SenderID/Role when the job fires. Without these, group-scope crons
+	// fail CheckFileWriterPermission / CheckCronPermission inside the
+	// scheduled agent's turn ("system context cannot ... in group chats")
+	// because UserID alone is the GROUP scope, not a real human.
+	//
+	// Empty is valid (DM crons, system-installed crons): the firing
+	// preserves existing behaviour and group-scope permission checks
+	// still deny if the agent attempts a gated mutation.
+	CreatorSenderID string `json:"creatorSenderId,omitempty" db:"-"`
+	CreatorRole     string `json:"creatorRole,omitempty" db:"-"`
 }
 
 // CronJobState tracks runtime state for a job.
@@ -108,7 +121,14 @@ type CronEvent struct {
 
 // CronStore manages scheduled jobs.
 type CronStore interface {
-	AddJob(ctx context.Context, name string, schedule CronSchedule, message string, deliver bool, channel, to, agentID, userID string) (*CronJob, error)
+	// AddJob creates a new scheduled job. creatorSenderID + creatorRole are
+	// optional and may be empty — they're stamped onto the job's Payload so
+	// that when the job fires, the agent run can attribute actions back to
+	// the human who scheduled the cron (passed as RunRequest.SenderID/Role).
+	// Without this attribution, group-scope crons fail group-scoped permission
+	// checks at fire time because UserID alone is the group scope, not a
+	// human. Empty values preserve pre-existing behaviour.
+	AddJob(ctx context.Context, name string, schedule CronSchedule, message string, deliver bool, channel, to, agentID, userID, creatorSenderID, creatorRole string) (*CronJob, error)
 	GetJob(ctx context.Context, jobID string) (*CronJob, bool)
 	ListJobs(ctx context.Context, includeDisabled bool, agentID, userID string) []CronJob
 	RemoveJob(ctx context.Context, jobID string) error

--- a/internal/store/pg/cron_crud.go
+++ b/internal/store/pg/cron_crud.go
@@ -12,7 +12,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
-func (s *PGCronStore) AddJob(ctx context.Context, name string, schedule store.CronSchedule, message string, deliver bool, channel, to, agentID, userID string) (*store.CronJob, error) {
+func (s *PGCronStore) AddJob(ctx context.Context, name string, schedule store.CronSchedule, message string, deliver bool, channel, to, agentID, userID, creatorSenderID, creatorRole string) (*store.CronJob, error) {
 	// Apply default timezone for cron expressions when not set per-job.
 	if schedule.TZ == "" && schedule.Kind == "cron" && s.defaultTZ != "" {
 		schedule.TZ = s.defaultTZ
@@ -24,7 +24,10 @@ func (s *PGCronStore) AddJob(ctx context.Context, name string, schedule store.Cr
 	}
 
 	payload := store.CronPayload{
-		Kind: "agent_turn", Message: message,
+		Kind:            "agent_turn",
+		Message:         message,
+		CreatorSenderID: creatorSenderID,
+		CreatorRole:     creatorRole,
 	}
 	payloadJSON, _ := json.Marshal(payload)
 

--- a/internal/store/sqlitestore/cron_crud.go
+++ b/internal/store/sqlitestore/cron_crud.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
-func (s *SQLiteCronStore) AddJob(ctx context.Context, name string, schedule store.CronSchedule, message string, deliver bool, channel, to, agentID, userID string) (*store.CronJob, error) {
+func (s *SQLiteCronStore) AddJob(ctx context.Context, name string, schedule store.CronSchedule, message string, deliver bool, channel, to, agentID, userID, creatorSenderID, creatorRole string) (*store.CronJob, error) {
 	if schedule.TZ == "" && schedule.Kind == "cron" && s.defaultTZ != "" {
 		schedule.TZ = s.defaultTZ
 	}
@@ -28,7 +28,10 @@ func (s *SQLiteCronStore) AddJob(ctx context.Context, name string, schedule stor
 	}
 
 	payload := store.CronPayload{
-		Kind: "agent_turn", Message: message,
+		Kind:            "agent_turn",
+		Message:         message,
+		CreatorSenderID: creatorSenderID,
+		CreatorRole:     creatorRole,
 	}
 	payloadJSON, _ := json.Marshal(payload)
 

--- a/internal/tools/cron.go
+++ b/internal/tools/cron.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nextlevelbuilder/goclaw/internal/store"
@@ -292,7 +293,27 @@ func (t *CronTool) handleAdd(ctx context.Context, args map[string]any, agentID, 
 		agentID = explicit
 	}
 
-	job, err := t.cronStore.AddJob(ctx, name, schedule, message, deliver, channel, to, agentID, userID)
+	// Capture the human creator's sender + role at the moment of scheduling.
+	// These ride along on the job's payload and are replayed as the
+	// RunRequest's SenderID/Role each time the job fires (gateway_cron.go).
+	// Without them, group-scope cron mutations and write_file inside the
+	// scheduled agent's turn fail group-context permission checks because
+	// UserID alone is the group scope, not a real human.
+	//
+	// Synthetic senders (subagent:, teammate:, ticker:, ...) are deliberately
+	// dropped — we never want to attribute a future cron run to a system
+	// component. Empty creator → preserves prior behaviour.
+	creatorSenderID := store.SenderIDFromContext(ctx)
+	if isSyntheticSender := func(s string) bool {
+		return strings.HasPrefix(s, "system:") || strings.HasPrefix(s, "notification:") ||
+			strings.HasPrefix(s, "teammate:") || strings.HasPrefix(s, "ticker:") ||
+			strings.HasPrefix(s, "subagent:") || s == "session_send_tool"
+	}; isSyntheticSender(creatorSenderID) {
+		creatorSenderID = ""
+	}
+	creatorRole := store.RoleFromContext(ctx)
+
+	job, err := t.cronStore.AddJob(ctx, name, schedule, message, deliver, channel, to, agentID, userID, creatorSenderID, creatorRole)
 	if err != nil {
 		return ErrorResult(fmt.Sprintf("failed to create cron job: %v", err))
 	}

--- a/internal/tools/cron_creator_propagation_test.go
+++ b/internal/tools/cron_creator_propagation_test.go
@@ -1,0 +1,116 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// fakeCronStoreCapture captures the AddJob arguments so tests can assert that
+// handleAdd correctly forwards creator attribution from ctx into the store.
+type fakeCronStoreCapture struct {
+	store.CronStore // pin nil — embed for compile satisfaction; only AddJob is used here
+	gotCreatorSender string
+	gotCreatorRole   string
+	gotUserID        string
+}
+
+func (f *fakeCronStoreCapture) AddJob(_ context.Context, name string, schedule store.CronSchedule,
+	message string, deliver bool, channel, to, agentID, userID, creatorSenderID, creatorRole string,
+) (*store.CronJob, error) {
+	f.gotCreatorSender = creatorSenderID
+	f.gotCreatorRole = creatorRole
+	f.gotUserID = userID
+	return &store.CronJob{
+		ID:      "test-job",
+		Name:    name,
+		AgentID: agentID,
+		UserID:  userID,
+		Payload: store.CronPayload{
+			Kind:            "agent_turn",
+			Message:         message,
+			CreatorSenderID: creatorSenderID,
+			CreatorRole:     creatorRole,
+		},
+		Enabled: true,
+	}, nil
+}
+
+// TestCronTool_handleAdd_PropagatesRealSender verifies a Telegram-rooted
+// human dispatch (ctx with a numeric senderID + role) is stamped onto the
+// new cron job's Payload — without that, scheduled runs in group chats
+// hit "system context cannot ... in group chats" the moment they call
+// write_file or another cron mutation.
+func TestCronTool_handleAdd_PropagatesRealSender(t *testing.T) {
+	fake := &fakeCronStoreCapture{}
+	tool := &CronTool{cronStore: fake}
+
+	ctx := context.Background()
+	ctx = store.WithSenderID(ctx, "5218954741") // real Telegram numeric id
+	ctx = store.WithRole(ctx, "admin")
+	ctx = store.WithAgentID(ctx, uuid.New())
+
+	args := map[string]any{
+		"job": map[string]any{
+			"name":     "neo-daily",
+			"schedule": map[string]any{"kind": "cron", "expr": "0 8 * * *", "tz": "Asia/Ho_Chi_Minh"},
+			"message":  "Run the daily content cycle",
+		},
+	}
+	res := tool.handleAdd(ctx, args, "agent-x", "group:telegram:-1003812294018")
+
+	if res.IsError {
+		t.Fatalf("handleAdd returned error: %s", res.ForLLM)
+	}
+	if got, want := fake.gotCreatorSender, "5218954741"; got != want {
+		t.Errorf("creatorSenderID = %q, want %q (real Telegram sender lost during cron creation)", got, want)
+	}
+	if got, want := fake.gotCreatorRole, "admin"; got != want {
+		t.Errorf("creatorRole = %q, want %q", got, want)
+	}
+}
+
+// TestCronTool_handleAdd_DropsSyntheticSender ensures we don't accidentally
+// stamp a synthetic sender (subagent:..., teammate:..., ticker:...) onto a
+// scheduled job — that would attribute every future fire to a system
+// component, defeating the deny-on-empty guard at fire time.
+func TestCronTool_handleAdd_DropsSyntheticSender(t *testing.T) {
+	syntheticSenders := []string{
+		"subagent:abc123",
+		"teammate:dashboard",
+		"ticker:heartbeat",
+		"system:cron-installer",
+		"notification:progress",
+		"session_send_tool",
+	}
+
+	for _, syn := range syntheticSenders {
+		t.Run(syn, func(t *testing.T) {
+			fake := &fakeCronStoreCapture{}
+			tool := &CronTool{cronStore: fake}
+
+			ctx := context.Background()
+			ctx = store.WithSenderID(ctx, syn)
+			ctx = store.WithAgentID(ctx, uuid.New())
+
+			args := map[string]any{
+				"job": map[string]any{
+					"name":     "test",
+					"schedule": map[string]any{"kind": "every", "everyMs": float64(60_000)},
+					"message":  "tick",
+				},
+			}
+			res := tool.handleAdd(ctx, args, "agent-x", "user-x")
+			if res.IsError {
+				t.Fatalf("handleAdd error: %s", res.ForLLM)
+			}
+			if fake.gotCreatorSender != "" {
+				t.Errorf("synthetic sender %q leaked into stored creator: got %q, want empty",
+					syn, fake.gotCreatorSender)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Cron jobs created in a group context (UserID like \`group:telegram:-100…\`) consistently fail group-scope permission checks the moment they fire — the scheduled agent ends up with an empty SenderID, and any \`write_file\` or \`cron\` mutation inside that turn trips:

> permission denied: system context cannot ... in group chats. If this is a legitimate user action, ensure the acting sender is preserved through the tool chain.

Root cause: \`gateway_cron.go\` built the RunRequest with \`UserID = job.UserID\` but no \`SenderID\`. \`loop_context.injectContext\` skips \`WithSenderID\` when \`req.SenderID\` is empty, so the agent's resumed ctx had no human attribution. \`UserID\` alone is the group scope, not a real user.

## Fix

Capture the human's sender + role at cron-**create** time; replay them at every **fire**.

- \`store.CronPayload\`: new \`CreatorSenderID\` + \`CreatorRole\` fields (JSON-serialized into the existing \`payload\` column — **no DB migration**).
- \`CronStore.AddJob\`: signature gains \`creatorSenderID\` + \`creatorRole\`. PG + sqlite impls thread them into the new payload fields.
- \`internal/tools/cron.go\` \`handleAdd\`: reads \`SenderIDFromContext\` + \`RoleFromContext\`, drops synthetic prefixes (\`subagent:\`, \`teammate:\`, \`ticker:\`, \`system:\`, \`notification:\`, \`session_send_tool\`) so we never attribute future fires to a system component, then calls \`AddJob\` with the captured creator.
- \`cmd/gateway_cron.go\`: passes \`job.Payload.CreatorSenderID\` + \`CreatorRole\` into \`RunRequest.SenderID\` + \`Role\` each fire. Empty values preserve prior behaviour — DM crons, system-installed crons, and pre-fix crons all keep the deny-on-empty guard at fire time. **No security relaxation.**
- \`gateway/methods/cron.go\` (WS RPC): explicitly passes empty creator strings. There is no separate \"Telegram numeric sender\" upstream of the WS handler, so WS-installed crons that need to fire in group chats should be created via a Telegram-rooted flow (ctx-aware) instead.

## Failure repro

1. Human pings agent in a group → \`@bot create cron neo-daily for the content cycle…\`
2. Agent calls \`cron(action=\"add\", ...)\` → job stored with \`UserID=\"group:...\"\`, no creator sender
3. Cron fires → agent resumes, calls \`write_file\` to log cycle output
4. Returns: \`permission denied: system context cannot write files in group chats\`

After this fix the same flow:
1-3. As above; job now stores \`Payload.CreatorSenderID = \"<human>\"\`
4. Cron fires with \`req.SenderID = \"<human>\"\` → \`write_file\` succeeds with attributed audit trail.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/store/... ./internal/tools/ ./internal/gateway/methods/ ./cmd/\` passes (existing + new)
- [x] New tests:
  - \`TestCronTool_handleAdd_PropagatesRealSender\` — Telegram-rooted human dispatch survives roundtrip into \`Payload.CreatorSenderID\`.
  - \`TestCronTool_handleAdd_DropsSyntheticSender\` (table-driven, 6 synthetic prefixes) — synthetic ctx senders are deliberately dropped, never attributed.

## Related

Companion fix to #1128 (team-task announce sender propagation). Together they close the \"system context cannot write\" denial across both re-ingress paths a Lead-style agent uses inside a daily-cycle workflow.