### PR TITLE
fix(cron): invert stateless gate to match UI label

### DIFF
--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -85,11 +85,14 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 		defer cancelCron()
 		cronCtx = store.WithTenantID(cronCtx, job.TenantID)
 
-		// Reset session before each cron run to prevent tool errors from previous
-		// runs from polluting the context and blocking future executions (#294).
-		// Save() persists the empty session to DB so stale data won't reload after restart.
-		// Stateless jobs skip this — they intentionally carry no session history.
-		if !job.Stateless {
+		// Stateless jobs explicitly reset their session before each run — they
+		// carry no history between executions, matching the "Stateless" UI label
+		// and statelessHelp ("each run starts fresh without loading previous
+		// messages"). Stateful (non-stateless) jobs keep prior turns to enable
+		// multi-run dialog.
+		// Save() persists the empty session to DB so stale data won't reload
+		// after restart (#294).
+		if job.Stateless {
 			sessionMgr.Reset(cronCtx, sessionKey)
 			sessionMgr.Save(cronCtx, sessionKey)
 		}


### PR DESCRIPTION
## Summary

- The cron handler reset the session when `stateless=false` and skipped reset when `stateless=true` — the opposite of every UI locale's label (en/ko/zh/vi all say *"each run starts fresh without loading previous messages"*).
- One-character logic fix in `cmd/gateway_cron.go` (`if !job.Stateless` → `if job.Stateless`) so runtime matches the UI contract. Comment block reworded for clarity.
- No DB migration: existing values were set by users based on the UI label, so they already encode the intended behavior.

## Impact

A daily ETL cron with `stateless=true` was observed accumulating 38 messages over 18 days, causing the LLM to short-circuit tool calls and replay prior assistant turns (silent ETL failure — cron reported \`status=ok\` while DB rows were never written).

After the fix:
- `stateless=true` → session reset every run (matches UI label, intended for ETL/one-shot jobs)
- `stateless=false` → session preserved across runs (multi-run dialog crons)

## Test plan

- [x] \`go build ./...\` (PG build)
- [x] \`go build -tags sqliteonly ./...\` (Desktop build)
- [x] \`go vet ./cmd/...\`
- [ ] After deploy: confirm a \`stateless=true\` cron's session row has \`messages = '[]'\` after the first post-fix run
- [ ] Confirm a \`stateless=false\` cron retains prior turns (regression check)