### PR TITLE
fix(exec): exempt venv python interpreter from .goclaw/ path deny

### DIFF
--- a/cmd/gateway_setup.go
+++ b/cmd/gateway_setup.go
@@ -221,6 +221,14 @@ func setupToolRegistry(
 				filepath.Join(dataDir, "skills-store")+"/",
 				filepath.Join(dataDir, "tenants")+"/",
 			)
+			// Allow the goclaw-managed Python venv interpreter to be invoked with its
+			// absolute path. venv/bin/python3 is a symlink to the real interpreter
+			// (e.g. linuxbrew cellar), and matchesAnyPathExemption resolves symlinks
+			// before comparing — so we must exempt the *resolved* target dir.
+			// Resolved at startup; falls back silently if venv not present.
+			if real, err := filepath.EvalSymlinks(filepath.Join(filepath.Dir(dataDir), "venv", "bin", "python3")); err == nil {
+				et.AllowPathExemptions(filepath.Dir(real) + "/")
+			}
 			// Harden: block access to internal workspace files via shell commands.
 			// Prevents `cat ../config.json`, `cat memory.db` etc. from user workspaces.
 			et.DenyPaths(


### PR DESCRIPTION
## Summary

The ExecTool's `.goclaw/` path-deny silently rejected legitimate invocations of the goclaw-managed Python interpreter via its absolute path:

\`\`\`
/home/user/.goclaw/venv/bin/python3 .../script.py
\`\`\`

The first token matched the deny pattern but no exemption, so the whole command was denied without a clear error path — agents either failed outright or worked only via fragile cwd-local symlink heuristics generated by the LLM.

A naive exemption (e.g. \`.goclaw/venv/bin/\`) does not help: \`matchesAnyPathExemption\` resolves both tokens and exemption candidates via \`filepath.EvalSymlinks\`, and \`venv/bin/python3\` is a symlink into the host's python cellar. The canonicalized token (\`/home/linuxbrew/.../python3.14\`) never matches a literal venv-relative prefix.

## Fix

Resolve \`venv/bin/python3\` once at startup and exempt the directory of its real target:

\`\`\`go
if real, err := filepath.EvalSymlinks(filepath.Join(filepath.Dir(dataDir), \"venv\", \"bin\", \"python3\")); err == nil {
    et.AllowPathExemptions(filepath.Dir(real) + \"/\")
}
\`\`\`

Falls through silently if no venv is present.

## Behaviour change

Operators who invoke the pinned venv interpreter via its absolute path (the recommended pattern for ETL/cron scripts, since shell-PATH fallback can silently pick the wrong python) no longer get denied.

## Test plan

- [x] \`go build ./...\` (PG build)
- [x] \`go build -tags sqliteonly ./...\` (Desktop build)
- [x] After deploy: cron with \`/home/user/.goclaw/venv/bin/python3 /home/user/.goclaw/data/skills-store/.../script.py\` completed in a single \`mcp_goclaw-bridge_exec\` call (\`status=completed\`), verified via the new \`acp: tool_call_update\` log + DB row check