### PR TITLE
feat(acp): surface session/update tool_call notifications at Info level

### DIFF
--- a/internal/providers/acp/process.go
+++ b/internal/providers/acp/process.go
@@ -216,6 +216,38 @@ func (pp *ProcessPool) spawn(ctx context.Context, poolKey string) (*ACPProcess, 
 				slog.Warn("acp: session/update parse failed", "error", err)
 				return
 			}
+			// Surface tool-call notifications at Info level so operators can
+			// distinguish "permission granted" (security.tool_granted) from
+			// "tool actually executed / produced output". Without this the
+			// status transitions are buried in Debug-level params dumps.
+			if update.ToolCall != nil {
+				preview := ""
+				for _, c := range update.ToolCall.Content {
+					if c.Type == "text" && c.Text != "" {
+						preview += c.Text
+						if len(preview) > 400 {
+							break
+						}
+					}
+				}
+				if len(preview) > 400 {
+					preview = preview[:400] + "...(truncated)"
+				}
+				slog.Info("acp: tool_call_update",
+					"sid", update.SessionID,
+					"id", update.ToolCall.ID,
+					"name", update.ToolCall.Name,
+					"status", update.ToolCall.Status,
+					"content_preview", preview)
+			}
+			if update.Update.SessionUpdate == "tool_call" || update.Update.SessionUpdate == "tool_call_update" {
+				slog.Info("acp: tool_call_update (inline)",
+					"sid", update.SessionID,
+					"id", update.Update.ToolCallID,
+					"title", update.Update.Title,
+					"kind", update.Update.Kind,
+					"status", update.Update.Status)
+			}
 			proc.dispatchUpdate(update)
 		}
 	}


### PR DESCRIPTION
## Summary

\`session/update\` notifications that carry tool-call state (the spec's \`ToolCall\` struct and the \`tool_call\` / \`tool_call_update\` inline variant) were only dumped at \`Debug\` level inside the raw params blob. From an operator's vantage point, \`security.tool_granted\` (\"permission granted\") and an actually-successful execution looked identical in \`journalctl\` — there was no signal for the failure path in between.

This made a recent regression hard to diagnose: an ACP agent was granted permission to run a script, the script silently failed inside the bridge, the agent then hallucinated a fake success message — and the only visible Info-level evidence was \`security.tool_granted\`, with no \`status=failed\` indicator anywhere.

## Change

Emit one structured Info log per \`session/update\` notification that carries tool-call state:

\`\`\`
acp: tool_call_update sid=... id=... name=... status=completed|failed|in_progress
content_preview=\"<first 400 chars of textual content>\"
\`\`\`

Two emit sites cover both spec shapes:

- Outer \`update.ToolCall\` (newer ACP layout)
- Inline \`update.Update.SessionUpdate == \"tool_call\" | \"tool_call_update\"\` (Gemini's current emission)

## Behaviour

- No logic change beyond logging.
- Preview is bounded to 400 chars + truncation marker.
- Debug-level params dump preserved.

## Test plan

- [x] \`go build ./...\`
- [x] \`go build -tags sqliteonly ./...\`
- [x] After deploy: triggering a cron showed \`status=failed\` immediately after \`security.tool_granted\` for the first attempt and \`status=completed\` for the second — the gap the granted-only log was hiding.