### PR TITLE
fix(skills): resolve {baseDir} placeholder in DB-backed skill content

### DIFF
--- a/internal/store/pg/skills_content.go
+++ b/internal/store/pg/skills_content.go
@@ -40,6 +40,11 @@ func (s *PGSkillStore) LoadSkill(ctx context.Context, name string) (string, bool
 	if err != nil {
 		return "", false
 	}
+	// Resolve {baseDir} placeholder so SKILL.md script-invocation lines hold
+	// absolute paths regardless of agent CWD. Mirrors skills.Loader.LoadSkill
+	// substitution; without it, agents reading SKILL.md via this RPC see the
+	// literal placeholder.
+	content = strings.ReplaceAll(content, "{baseDir}", info.BaseDir)
 	return content, true
 }
 

--- a/internal/store/sqlitestore/skills_content.go
+++ b/internal/store/sqlitestore/skills_content.go
@@ -35,6 +35,11 @@ func (s *SQLiteSkillStore) LoadSkill(ctx context.Context, name string) (string, 
 	if err != nil {
 		return "", false
 	}
+	// Resolve {baseDir} placeholder so SKILL.md script-invocation lines hold
+	// absolute paths regardless of agent CWD. Mirrors skills.Loader.LoadSkill
+	// substitution; without it, agents reading SKILL.md via this RPC see the
+	// literal placeholder.
+	content = strings.ReplaceAll(content, "{baseDir}", info.BaseDir)
 	return content, true
 }
 


### PR DESCRIPTION
## Summary

Both PG and SQLite skill stores returned SKILL.md content without the `{baseDir}` substitution that `skills.Loader.LoadSkill` performs for file-based access. Agents reading SKILL.md via this RPC saw the literal placeholder, breaking script-invocation lines that expect absolute paths.

Mirror the loader's substitution in both store implementations so behavior is consistent regardless of access path.

## Test plan

- [ ] Read a SKILL.md with `{baseDir}` placeholder via the DB store (skills.GetContent or RPC) and verify the placeholder is resolved to the absolute path
- [ ] Verify the same content read via file-based loader (existing path) is unchanged
- [ ] Sanity: agent uses a skill with script-invocation lines and the script runs from the correct directory