### PR TITLE
fix(exec): allow skills-store and user allow_paths as working_dir

### DIFF
--- a/cmd/gateway_tools_wiring.go
+++ b/cmd/gateway_tools_wiring.go
@@ -125,6 +125,16 @@ func wireExtraTools(
 			pa.AllowPaths(userAllowPaths...)
 		}
 	}
+	// exec working_dir validation shares the same allow-list as file tools so
+	// the agent can cd into a skill dir to run its scripts. Note: subagent
+	// ExecTool is constructed separately in buildSubagentToolsRegistry and
+	// does NOT inherit this — that's an intentional scope limit for now.
+	if execTool, ok := toolsReg.Get("exec"); ok {
+		if pa, ok := execTool.(tools.PathAllowable); ok {
+			pa.AllowPaths(skillsAllowPaths...)
+			pa.AllowPaths(userAllowPaths...)
+		}
+	}
 
 	// Memory tools are PG-backed; always available.
 	hasMemory = true

--- a/internal/tools/filesystem.go
+++ b/internal/tools/filesystem.go
@@ -394,7 +394,10 @@ func resolvePathWithAllowed(path, workspace string, restrict bool, allowedPrefix
 			return real, nil
 		}
 	}
-	slog.Warn("read_file: access denied", "path", cleaned, "workspace", workspace, "allowedPrefixes", allowedPrefixes)
+	// Caller-neutral message: this function is shared by read_file, list_files,
+	// read_image, send_file, and exec (working_dir validation). The tool name
+	// is surfaced via the surrounding tool_call_update event.
+	slog.Warn("path access denied", "path", cleaned, "workspace", workspace, "allowedPrefixes", allowedPrefixes)
 	return "", err
 }
 

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -39,6 +39,7 @@ type ExecTool struct {
 	pathDenyPatterns []*regexp.Regexp // always-on path-based denials (DenyPaths)
 	pathDenyRoots    []string         // raw deny roots for nested workspace exemptions
 	denyExemptions   []string         // substrings that exempt a command from deny
+	allowedPrefixes  []string         // extra path prefixes allowed as working_dir (AllowPaths)
 	restrict         bool
 	sandboxMgr       sandbox.Manager      // nil = no sandbox, execute on host
 	approvalMgr      *ExecApprovalManager // nil = no approval needed
@@ -125,6 +126,15 @@ func (t *ExecTool) DenyPaths(paths ...string) {
 // are exempt because the argument ".goclaw/skills-store/tool.py" starts with the prefix.
 func (t *ExecTool) AllowPathExemptions(prefixes ...string) {
 	t.denyExemptions = append(t.denyExemptions, prefixes...)
+}
+
+// AllowPaths adds path prefixes that exec is allowed to use as working_dir,
+// even when restrict_to_workspace is true (e.g. skills directories).
+// Implements the PathAllowable interface for uniform wiring with file tools.
+// Distinct from AllowPathExemptions, which exempts command arguments from
+// deny pattern matching.
+func (t *ExecTool) AllowPaths(prefixes ...string) {
+	t.allowedPrefixes = append(t.allowedPrefixes, prefixes...)
 }
 
 // normalizeCommand applies NFKC Unicode normalization and strips zero-width
@@ -372,7 +382,9 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *Result {
 			// stricter write-allowed prefixes (team root excluded) to block
 			// cross-chat cwd even for "read-only" commands like cat, since we
 			// cannot prove the shell command will not write.
-			allowed := allowedWriteWithTeamWorkspace(ctx, nil)
+			// Base prefixes come from AllowPaths (skills-store, user-configured
+			// allow_paths) so the agent can cd into skill dirs to run scripts.
+			allowed := allowedWriteWithTeamWorkspace(ctx, t.allowedPrefixes)
 			resolved, err := resolvePathWithAllowed(wd, wsBase, true, allowed)
 			if err != nil {
 				return ErrorResult(err.Error())

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -72,7 +72,9 @@ type ApprovalAware interface {
 	SetApprovalManager(*ExecApprovalManager, string)
 }
 
-// PathAllowable tools can allow extra path prefixes for read access.
+// PathAllowable tools can allow extra path prefixes beyond the workspace.
+// Each implementor interprets the prefixes against its own operation
+// (read/write/edit/list target, or exec working_dir).
 type PathAllowable interface {
 	AllowPaths(...string)
 }


### PR DESCRIPTION
## Summary

`ExecTool`'s `working_dir` validation passed `nil` as the base allow-prefix list to `resolvePathWithAllowed`, while file tools (`read_file`, `list_files`, `write_file`, `edit`, `send_file`) all use `t.allowedPrefixes` seeded in `wireExtraTools` with the skills directories and user-configured `allow_paths`.

The asymmetry meant agents could read files inside a skill's directory but could not `cd` there to run its scripts — they had to fall back to absolute paths with `cat`, losing the natural `cd skill && ./script` idiom. Concretely, cron-triggered seed runs hit a deny for `working_dir=/.../skills-store/<skill>/<ver>` while harvesting keyword data, and the agent learned to route around it with absolute paths.

## Changes

- Add `allowedPrefixes` to `ExecTool` and implement the existing `PathAllowable` interface so `wireExtraTools` wires it identically to the file tools.
- `shell.go` working_dir validation now uses `t.allowedPrefixes` as the base (still write-class, so team-root remains excluded for cross-chat safety).
- Generalize `PathAllowable`'s doc comment — the interface is already used by write/edit tools and now exec, so the original "for read access" phrasing was misleading.
- Neutralize the `"read_file: access denied"` log in `resolvePathWithAllowed`. That function is shared by read_file, list_files, read_image, send_file, and exec working_dir validation; the message now reads `"path access denied"` and the actual caller is identifiable via the surrounding `tool_call_update` event.

## Out of scope

Subagent ExecTool, constructed separately in `buildSubagentToolsRegistry`, deliberately does NOT inherit this wiring — that's a parallel inconsistency that does not affect top-level (cron-triggered) sessions and is left as a separate concern.

## Test plan

- [ ] Direct MCP bridge `tools/call name=exec working_dir=<skills-store/<skill>/<ver>>` succeeds (previously denied)
- [ ] Cron-triggered agent runs a skill script with `cd skill_dir && ./script` pattern successfully
- [ ] `read_file` / `list_files` for paths outside skills-store still deny as before (no widening of read scope)
- [ ] Log entry on deny now reads `path access denied` (not `read_file: access denied`)