### PR TITLE
fix(mcp): use standalone flag matching to prevent false positives

### DIFF
--- a/internal/mcp/validation.go
+++ b/internal/mcp/validation.go
@@ -24,10 +24,15 @@ var allowedCommands = map[string]bool{
 var shellMetaChars = regexp.MustCompile(`[;|&$` + "`" + `(){}[\]<>]`)
 
 // Dangerous arg flags that enable code execution.
-var dangerousArgPatterns = []string{
+// These are matched as standalone flags only (exact match or flag=value form).
+var dangerousFlagPatterns = []string{
 	"--eval", "-e", "-c",      // Code execution flags
 	"--require", "-r",         // Module injection
 	"--import",                // ES module injection
+}
+
+// Dangerous code patterns that should be caught anywhere in an argument.
+var dangerousCodePatterns = []string{
 	"exec(", "eval(",          // Inline code
 	"__import__",              // Python import injection
 	"child_process",           // Node.js process spawning
@@ -96,7 +101,12 @@ func ValidateCommand(cmd string) error {
 func ValidateArgs(args []string) error {
 	for i, arg := range args {
 		argLower := strings.ToLower(arg)
-		for _, pattern := range dangerousArgPatterns {
+		for _, pattern := range dangerousFlagPatterns {
+			if isStandaloneFlag(argLower, pattern) {
+				return fmt.Errorf("arg[%d] contains dangerous pattern %q", i, pattern)
+			}
+		}
+		for _, pattern := range dangerousCodePatterns {
 			if strings.Contains(argLower, pattern) {
 				return fmt.Errorf("arg[%d] contains dangerous pattern %q", i, pattern)
 			}
@@ -107,6 +117,26 @@ func ValidateArgs(args []string) error {
 		}
 	}
 	return nil
+}
+
+// isStandaloneFlag checks if arg matches a flag pattern as a standalone flag,
+// avoiding false positives from package names containing the flag as a substring.
+// Examples: "-c" matches, "-c=value" matches, "clickup-cli" does NOT match.
+func isStandaloneFlag(arg, flag string) bool {
+	if arg == flag {
+		return true
+	}
+	if after, ok := strings.CutPrefix(arg, flag); ok {
+		// Must be followed by a non-alphabetic character or end-of-string
+		if len(after) == 0 || !isAlpha(rune(after[0])) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlpha(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
 }
 
 // ValidateURL checks URL for SSRF vulnerabilities using the existing security package.


### PR DESCRIPTION
This is an independent contribution from an open-source contributor.

## Summary

Fix false positive in MCP argument validation where package names containing `-c` (like `clickup-cli`) are incorrectly rejected as dangerous patterns.

## Root Cause

`ValidateArgs()` in `internal/mcp/validation.go` used `strings.Contains` for all dangerous patterns. This caused `-c` to match inside `-cli`, triggering false positives for npm packages like `clickup-cli`, `mcp-cli`, etc.

## Fix

Split `dangerousArgPatterns` into two categories:
- **dangerousFlagPatterns** (`-c`, `-e`, `-r`, `--eval`, `--require`, `--import`): matched using new `isStandaloneFlag()` helper that checks for exact match or flag=value form, avoiding substring false positives
- **dangerousCodePatterns** (`exec(`, `eval(`, `__import__`, `child_process`, `subprocess`): continue using `strings.Contains` for code injection patterns that should be caught anywhere

## Testing

- All existing tests pass — flag patterns like `-c`, `-e`, `--eval` still correctly rejected
- Package names like `clickup-cli`, `@clickup-cli`, `mcp-cli` no longer trigger false positives
- Merged flag+value forms like `-c"code"`, `-e=script`, `--eval=code` still correctly rejected

Closes #1027