### PR TITLE
fix(sandbox): avoid shell in FsBridge writes

### DIFF
--- a/internal/sandbox/fsbridge.go
+++ b/internal/sandbox/fsbridge.go
@@ -50,23 +50,27 @@ func (b *FsBridge) ReadFile(ctx context.Context, path string) (string, error) {
 }
 
 // WriteFile writes content to a file inside the container, creating directories as needed.
-// When append is true, content is appended (shell >>); otherwise the file is overwritten (shell >).
+// When append is true, content is appended; otherwise the file is overwritten.
 // Matching TS FsBridge.writeFile().
 func (b *FsBridge) WriteFile(ctx context.Context, path, content string, appendMode bool) error {
 	resolved := b.resolvePath(path)
 
-	// Create parent directory
+	// Create parent directory.
 	dir := resolved[:strings.LastIndex(resolved, "/")]
 	if dir != "" && dir != "/" {
 		_, _, _, _ = b.dockerExec(ctx, nil, "mkdir", "-p", dir)
 	}
 
-	redir := ">"
+	// Write content via stdin without invoking a shell. Passing the resolved path
+	// as a discrete argv entry prevents shell metacharacters in filenames from
+	// being interpreted as commands inside the sandbox container.
+	args := []string{"tee"}
 	if appendMode {
-		redir = ">>"
+		args = append(args, "-a")
 	}
-	// Write content via stdin pipe
-	_, stderr, exitCode, err := b.dockerExec(ctx, []byte(content), "sh", "-c", fmt.Sprintf("cat %s %q", redir, resolved))
+	args = append(args, "--", resolved)
+
+	_, stderr, exitCode, err := b.dockerExec(ctx, []byte(content), args...)
 	if err != nil {
 		return fmt.Errorf("fsbridge write: %w", err)
 	}

--- a/internal/sandbox/fsbridge_test.go
+++ b/internal/sandbox/fsbridge_test.go
@@ -1,0 +1,112 @@
+package sandbox
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFsBridgeWriteFileDoesNotInvokeShell(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "docker.log")
+	stdinPath := filepath.Join(tmp, "stdin.txt")
+	dockerPath := filepath.Join(tmp, "docker")
+
+	script := `#!/bin/sh
+{
+  echo CALL
+  i=0
+  for arg in "$@"; do
+    echo "ARG[$i]=$arg"
+    i=$((i + 1))
+  done
+} >> "$DOCKER_LOG"
+
+for arg in "$@"; do
+  if [ "$arg" = "tee" ]; then
+    cat > "$DOCKER_STDIN"
+    break
+  fi
+done
+`
+	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+	t.Setenv("PATH", tmp+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DOCKER_LOG", logPath)
+	t.Setenv("DOCKER_STDIN", stdinPath)
+
+	bridge := NewFsBridge("container-id", "/workspace")
+	maliciousPath := `nested/evil$(touch /tmp/goclaw-fsbridge-pwned);name.txt`
+	content := "safe content"
+
+	if err := bridge.WriteFile(context.Background(), maliciousPath, content, false); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read docker log: %v", err)
+	}
+	log := string(logBytes)
+
+	if strings.Contains(log, "ARG[3]=sh") || strings.Contains(log, "ARG[4]=-c") || strings.Contains(log, "cat >") {
+		t.Fatalf("WriteFile invoked shell command path; log:\n%s", log)
+	}
+	if !strings.Contains(log, "ARG[3]=tee") {
+		t.Fatalf("expected write command to use tee without shell; log:\n%s", log)
+	}
+	if !strings.Contains(log, "ARG[4]=--") {
+		t.Fatalf("expected tee delimiter before filename; log:\n%s", log)
+	}
+	if !strings.Contains(log, `ARG[5]=/workspace/`+maliciousPath) {
+		t.Fatalf("expected malicious filename to remain one argv entry; log:\n%s", log)
+	}
+
+	stdinBytes, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatalf("read captured stdin: %v", err)
+	}
+	if string(stdinBytes) != content {
+		t.Fatalf("stdin content = %q, want %q", string(stdinBytes), content)
+	}
+}
+
+func TestFsBridgeWriteFileAppendUsesTeeAppendArg(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "docker.log")
+	dockerPath := filepath.Join(tmp, "docker")
+
+	script := `#!/bin/sh
+{
+  echo CALL
+  i=0
+  for arg in "$@"; do
+    echo "ARG[$i]=$arg"
+    i=$((i + 1))
+  done
+} >> "$DOCKER_LOG"
+cat >/dev/null
+`
+	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+	t.Setenv("PATH", tmp+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DOCKER_LOG", logPath)
+
+	bridge := NewFsBridge("container-id", "/workspace")
+	if err := bridge.WriteFile(context.Background(), "append.txt", "more", true); err != nil {
+		t.Fatalf("WriteFile append returned error: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read docker log: %v", err)
+	}
+	log := string(logBytes)
+	if !strings.Contains(log, "ARG[3]=tee") || !strings.Contains(log, "ARG[4]=-a") || !strings.Contains(log, "ARG[5]=--") {
+		t.Fatalf("expected append write to use `tee -a -- <path>`; log:\n%s", log)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes `FsBridge.WriteFile` command injection by removing the `sh -c` write path.
- Passes the sandbox target filename as a discrete argv entry to `tee` instead of interpolating it into a shell command string.
- Adds regression tests for command-substitution-style filenames and append mode.

## Security impact
A path such as `notes/$(touch /tmp/pwned).txt` is now treated as a literal filename argument instead of being evaluated by the shell.

## Test plan
- `gofmt -w internal/sandbox/fsbridge.go internal/sandbox/fsbridge_test.go`
- `go test ./internal/sandbox -count=1`
- `git diff --cached --check`

Closes #1121
