### PR TITLE
fix(providers): list gpt-5.5 for ChatGPT OAuth

### DIFF
--- a/internal/http/provider_models_catalog.go
+++ b/internal/http/provider_models_catalog.go
@@ -84,6 +84,7 @@ func acpModels() []ModelInfo {
 // chatGPTOAuthModels returns models available via ChatGPT OAuth integration.
 func chatGPTOAuthModels() []ModelInfo {
 	return withReasoningCapabilities([]ModelInfo{
+		{ID: "gpt-5.5", Name: "GPT-5.5"},
 		{ID: "gpt-5.4", Name: "GPT-5.4"},
 		{ID: "gpt-5.4-mini", Name: "GPT-5.4 Mini"},
 		{ID: "gpt-5.3-codex", Name: "GPT-5.3 Codex"},

--- a/internal/http/provider_models_test.go
+++ b/internal/http/provider_models_test.go
@@ -95,24 +95,39 @@ func TestProvidersHandlerListProviderModelsChatGPTOAuthIncludesReasoningMetadata
 		t.Fatalf("reasoning_defaults.effort = %q, want high", result.ReasoningDefaults.Effort)
 	}
 
-	var found bool
+	var found54 bool
+	var found55 bool
 	for _, model := range result.Models {
-		if model.ID != "gpt-5.4" {
-			continue
-		}
-		found = true
-		if model.Reasoning == nil {
-			t.Fatal("gpt-5.4 reasoning = nil, want capability metadata")
-		}
-		if model.Reasoning.DefaultEffort != "none" {
-			t.Fatalf("gpt-5.4 default_effort = %q, want none", model.Reasoning.DefaultEffort)
-		}
-		if got := model.Reasoning.Levels; len(got) != 5 || got[4] != "xhigh" {
-			t.Fatalf("gpt-5.4 levels = %#v, want none..xhigh", got)
+		switch model.ID {
+		case "gpt-5.4":
+			found54 = true
+			if model.Reasoning == nil {
+				t.Fatal("gpt-5.4 reasoning = nil, want capability metadata")
+			}
+			if model.Reasoning.DefaultEffort != "none" {
+				t.Fatalf("gpt-5.4 default_effort = %q, want none", model.Reasoning.DefaultEffort)
+			}
+			if got := model.Reasoning.Levels; len(got) != 5 || got[4] != "xhigh" {
+				t.Fatalf("gpt-5.4 levels = %#v, want none..xhigh", got)
+			}
+		case "gpt-5.5":
+			found55 = true
+			if model.Reasoning == nil {
+				t.Fatal("gpt-5.5 reasoning = nil, want capability metadata")
+			}
+			if model.Reasoning.DefaultEffort != "none" {
+				t.Fatalf("gpt-5.5 default_effort = %q, want none", model.Reasoning.DefaultEffort)
+			}
+			if got := model.Reasoning.Levels; len(got) != 5 || got[4] != "xhigh" {
+				t.Fatalf("gpt-5.5 levels = %#v, want none..xhigh", got)
+			}
 		}
 	}
-	if !found {
+	if !found54 {
 		t.Fatal("gpt-5.4 not found in ChatGPT OAuth model list")
+	}
+	if !found55 {
+		t.Fatal("gpt-5.5 not found in ChatGPT OAuth model list")
 	}
 }
 

--- a/internal/providers/reasoning_capability.go
+++ b/internal/providers/reasoning_capability.go
@@ -25,6 +25,7 @@ type reasoningCapabilityEntry struct {
 }
 
 var reasoningCapabilityEntries = []reasoningCapabilityEntry{
+	{id: "gpt-5.5", capability: ReasoningCapability{Levels: []string{"none", "low", "medium", "high", "xhigh"}, DefaultEffort: "none"}},
 	{id: "gpt-5.4-mini", capability: ReasoningCapability{Levels: []string{"none", "low", "medium", "high", "xhigh"}, DefaultEffort: "none"}},
 	{id: "gpt-5-mini", capability: ReasoningCapability{Levels: []string{"none", "low", "medium", "high", "xhigh"}, DefaultEffort: "none"}},
 	{id: "gpt-5.4", capability: ReasoningCapability{Levels: []string{"none", "low", "medium", "high", "xhigh"}, DefaultEffort: "none"}},


### PR DESCRIPTION
## Summary
- add GPT-5.5 to the ChatGPT OAuth model catalog
- add reasoning metadata so the model picker exposes reasoning controls
- extend provider model API coverage to assert GPT-5.5 is listed

## Testing
- docker run --rm -v "/root/.config/superpowers/worktrees/Goclaw/chatgpt-oauth-gpt-5-5:/src" -w /src golang:1.26-bookworm go test ./internal/http -run TestProvidersHandlerListProviderModelsChatGPTOAuthIncludesReasoningMetadata