### PR TITLE
feat(ui): 展示 MCP 工具进度

### DIFF
--- a/ui/web/src/components/chat/activity-indicator.tsx
+++ b/ui/web/src/components/chat/activity-indicator.tsx
@@ -58,6 +58,11 @@ function getPhaseConfig(activity: RunActivity) {
       };
     case "leader_processing":
       return { icon: Users, animation: "animate-pulse", color: "text-emerald-500", label: "Processing team results..." };
+    case "mcp_progress": {
+      const ratio = activity.total ? ` (${activity.progress ?? 0}/${activity.total})` : "";
+      const label = activity.message || (activity.tool ? `Running ${activity.tool}` : "MCP progress");
+      return { icon: Wrench, animation: "animate-pulse", color: "text-blue-500", label: `${label}${ratio}` };
+    }
     default:
       return { icon: Brain, animation: "animate-pulse", color: "text-muted-foreground", label: "Working..." };
   }

--- a/ui/web/src/components/chat/chat-top-bar.tsx
+++ b/ui/web/src/components/chat/chat-top-bar.tsx
@@ -26,6 +26,7 @@ const phaseLabels: Record<RunActivity["phase"], string> = {
   compacting: "Compacting…",
   retrying: "Retrying…",
   leader_processing: "Processing team results…",
+  mcp_progress: "MCP progress…",
 };
 
 export function ChatTopBar({ agentId, isRunning, isBusy, activity, teamTasks, onToggleTaskPanel, taskPanelOpen, session }: ChatTopBarProps) {

--- a/ui/web/src/components/chat/tool-call-card.tsx
+++ b/ui/web/src/components/chat/tool-call-card.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Wrench, AlertTriangle, ChevronRight, Zap } from "lucide-react";
+import { Wrench, AlertTriangle, ChevronRight, Zap, CircleDot } from "lucide-react";
 import type { ToolStreamEntry } from "@/types/chat";
 
 const isSkillTool = (name: string) => name === "use_skill";
+type ProgressHistoryItem = NonNullable<ToolStreamEntry["progressHistory"]>[number];
 
 /** Build a short summary string from tool arguments for inline display. */
 function buildToolSummary(entry: ToolStreamEntry): string | null {
@@ -23,12 +24,16 @@ interface ToolCallCardProps {
 export function ToolCallCard({ entry, compact }: ToolCallCardProps) {
   const { t } = useTranslation("common");
   const hasDetails = entry.arguments || entry.result;
+  const hasProgressEventData = !!entry.progressEvent || !!entry.progressRunId || !!entry.progressTimestamp || !!entry.progressEventData;
+  const history = entry.progressHistory ?? [];
   const hasError = entry.phase === "error" && !!entry.errorContent;
-  const canExpand = hasDetails || hasError;
+  const canExpand = hasDetails || hasError || hasProgressEventData || history.length > 0;
   const [expanded, setExpanded] = useState(false);
   const summary = buildToolSummary(entry);
   const skill = isSkillTool(entry.name);
   const displayName = skill ? `skill: ${(entry.arguments?.name as string) || "unknown"}` : entry.name;
+  const progressRatio = entry.progressTotal ? `${entry.progress ?? 0}/${entry.progressTotal}` : "";
+  const visibleHistory = history.map(toDisplayEvent).filter((item) => item.visible).slice(-8);
 
   return (
     <div className={compact ? "" : "rounded-md border bg-muted"}>
@@ -41,13 +46,37 @@ export function ToolCallCard({ entry, compact }: ToolCallCardProps) {
         <ToolIcon phase={entry.phase} isSkill={skill} />
         <span className="font-medium shrink-0">{displayName}</span>
         {summary && <span className="truncate text-muted-foreground ml-1">{summary}</span>}
+        {entry.phase === "calling" && entry.progressMessage && (
+          <span className="min-w-0 truncate text-blue-500 ml-1">
+            {entry.progressMessage}
+          </span>
+        )}
         <span className="ml-auto flex items-center gap-1 shrink-0">
+          {entry.phase === "calling" && progressRatio && (
+            <span className="text-xs-plus text-blue-500">{progressRatio}</span>
+          )}
           <PhaseLabel phase={entry.phase} isSkill={skill} />
           {canExpand && (
             <ChevronRight className={`h-3 w-3 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""}`} />
           )}
         </span>
       </button>
+      {visibleHistory.length > 0 && (
+        <div className="border-t border-muted bg-background/60 px-3 py-2">
+          <div className="space-y-1.5">
+            {visibleHistory.map((item, idx) => (
+              <div key={`${item.timestamp ?? "evt"}-${idx}`} className="grid grid-cols-[16px_1fr_auto] gap-2 text-xs">
+                <CircleDot className={`mt-0.5 h-3 w-3 ${item.accent}`} />
+                <div className="min-w-0">
+                  <div className="truncate font-medium text-foreground">{item.title}</div>
+                  {item.detail && <div className="truncate text-muted-foreground">{item.detail}</div>}
+                </div>
+                {item.ratio && <div className="text-xs-plus text-muted-foreground">{item.ratio}</div>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
       {expanded && canExpand && (
         <div className="border-t border-muted px-2 py-1.5 space-y-1.5">
           {hasError && (
@@ -58,6 +87,14 @@ export function ToolCallCard({ entry, compact }: ToolCallCardProps) {
               <div className="text-2xs font-semibold uppercase text-muted-foreground mb-0.5">{t("toolArguments")}</div>
               <pre className="whitespace-pre-wrap text-xs-plus font-mono bg-background rounded p-1.5 max-h-40 overflow-y-auto">
                 {JSON.stringify(entry.arguments, null, 2)}
+              </pre>
+            </div>
+          )}
+          {history.length > 0 && (
+            <div>
+              <div className="text-2xs font-semibold uppercase text-muted-foreground mb-0.5">Event Trace</div>
+              <pre className="whitespace-pre-wrap text-xs-plus font-mono bg-background rounded p-1.5 max-h-72 overflow-y-auto">
+                {JSON.stringify(history.map(toRawEvent), null, 2)}
               </pre>
             </div>
           )}
@@ -73,6 +110,151 @@ export function ToolCallCard({ entry, compact }: ToolCallCardProps) {
       )}
     </div>
   );
+}
+
+function toDisplayEvent(item: ProgressHistoryItem) {
+  const data = progressEventData(item);
+  const event = progressEventName(item);
+  const ratio = typeof item.progress === "number" && typeof item.total === "number" ? `${item.progress}/${item.total}` : "";
+  const action = stringValue(data.last_action);
+  const excerpt = stringValue(data.last_excerpt);
+  const step = numberOrString(data.step);
+  const phase = stringValue(data.phase);
+
+  if (event === "heartbeat") {
+    return { visible: false, title: "", accent: "text-muted-foreground" };
+  }
+
+  const payload = asRecord(data.payload);
+  const payloadTitle = stringValue(payload?.title);
+  const payloadText = stringValue(payload?.text);
+  if (payloadTitle || payloadText) {
+    return {
+      visible: true,
+      title: payloadTitle || event,
+      detail: payloadText,
+      ratio,
+      accent: event === "run_failed" ? "text-red-500" : event === "run_completed" ? "text-emerald-500" : "text-blue-500",
+      timestamp: item.timestamp,
+    };
+  }
+
+  if (event === "step_start") {
+    return { visible: false, title: "", accent: "text-muted-foreground" };
+  }
+  if (event === "step_end") {
+    if (action === "wait") {
+      return { visible: false, title: "", accent: "text-muted-foreground" };
+    }
+    const translated = translateBrowserAction(action, excerpt);
+    return {
+      visible: true,
+      title: translated.title,
+      detail: translated.detail || (step ? `浏览器步骤 ${step} 完成` : ""),
+      ratio,
+      accent: action === "click" ? "text-emerald-500" : "text-blue-500",
+      timestamp: item.timestamp,
+    };
+  }
+
+  const message = item.message || stringValue(data.message);
+  if (event === "run_started") {
+    return { visible: true, title: message || "任务已开始", detail: stringValue(data.form_url), ratio, accent: "text-blue-500", timestamp: item.timestamp };
+  }
+  if (event === "phase_started") {
+    return { visible: true, title: message || (phase ? `进入 ${phase} 阶段` : "进入处理阶段"), detail: phase, ratio, accent: "text-blue-500", timestamp: item.timestamp };
+  }
+  if (event === "phase_completed") {
+    return { visible: true, title: message || (phase ? `${phase} 阶段完成` : "阶段完成"), detail: phase, ratio, accent: "text-emerald-500", timestamp: item.timestamp };
+  }
+  if (event === "user_response_received") {
+    const intent = asRecord(data.intent);
+    return {
+      visible: true,
+      title: message || "已收到用户回复",
+      detail: stringValue(intent?.intent) || stringValue(intent?.reason),
+      ratio,
+      accent: "text-emerald-500",
+      timestamp: item.timestamp,
+    };
+  }
+  if (event === "run_failed") {
+    return { visible: true, title: message || "任务失败", detail: stringValue(data.error), ratio, accent: "text-red-500", timestamp: item.timestamp };
+  }
+  if (event === "run_completed") {
+    return { visible: true, title: message || "任务完成", detail: stringValue(data.final_text) || stringValue(data.submission_result), ratio, accent: "text-emerald-500", timestamp: item.timestamp };
+  }
+
+  return { visible: true, title: message || event, detail: event, ratio, accent: "text-muted-foreground", timestamp: item.timestamp };
+}
+
+function translateBrowserAction(action: string, excerpt: string) {
+  if (action === "input") {
+    const typed = excerpt.match(/Typed '([^']*)'/)?.[1];
+    return { title: typed ? `已输入：${typed}` : "已填写表单内容", detail: excerpt };
+  }
+  if (action === "click") {
+    if (/submit/i.test(excerpt)) return { title: "已点击提交", detail: excerpt };
+    return { title: "已点击页面按钮", detail: excerpt };
+  }
+  if (action === "wait") {
+    return { title: "等待页面响应", detail: excerpt };
+  }
+  if (action === "done") {
+    return { title: "浏览器任务完成", detail: trimText(excerpt, 120) };
+  }
+  if (action.includes("guard_status")) {
+    return { title: "校验提交状态", detail: trimText(excerpt, 120) };
+  }
+  return { title: action ? `浏览器动作：${action}` : "完成一个浏览器步骤", detail: trimText(excerpt, 120) };
+}
+
+function toRawEvent(item: ProgressHistoryItem) {
+  const envelope = asRecord(item.eventData);
+  if (envelope && (typeof envelope.event === "string" || envelope.data)) {
+    return envelope;
+  }
+  return {
+    event: item.event,
+    run_id: item.runId,
+    timestamp: item.timestamp,
+    progress: item.progress,
+    total: item.total,
+    message: item.message,
+    data: item.eventData,
+  };
+}
+
+function progressEventName(item: ProgressHistoryItem): string {
+  const envelope = asRecord(item.eventData);
+  return stringValue(envelope?.event) || item.event || "event";
+}
+
+function progressEventData(item: ProgressHistoryItem): Record<string, unknown> {
+  const envelope = asRecord(item.eventData);
+  const nested = asRecord(envelope?.data);
+  if (nested) return nested;
+  return envelope ?? {};
+}
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
+  return undefined;
+}
+
+function stringValue(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function numberOrString(v: unknown): string {
+  if (typeof v === "number") return String(v);
+  if (typeof v === "string") return v;
+  return "";
+}
+
+function trimText(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 3)}...`;
 }
 
 function ToolIcon({ phase, isSkill }: { phase: ToolStreamEntry["phase"]; isSkill?: boolean }) {

--- a/ui/web/src/pages/chat/hooks/use-chat-messages.ts
+++ b/ui/web/src/pages/chat/hooks/use-chat-messages.ts
@@ -224,7 +224,52 @@ export function useChatMessages(sessionKey: string, agentId: string) {
         case "activity": {
           const phase = event.payload?.phase as RunActivity["phase"];
           if (phase) {
-            const newActivity: RunActivity = { phase, tool: event.payload?.tool as string | undefined, tools: event.payload?.tools as string[] | undefined, iteration: event.payload?.iteration as number | undefined };
+            if (phase === "mcp_progress") {
+              const toolCallId = event.payload?.id as string | undefined;
+              const toolName = event.payload?.tool as string | undefined;
+              const now = Date.now();
+              toolStreamRef.current = toolStreamRef.current.map((t) => {
+                const matches = toolCallId ? t.toolCallId === toolCallId : toolName && t.name === toolName && t.phase === "calling";
+                if (!matches) return t;
+                return {
+                  ...t,
+                  progress: typeof event.payload?.progress === "number" ? event.payload.progress : undefined,
+                  progressTotal: typeof event.payload?.total === "number" ? event.payload.total : undefined,
+                  progressMessage: event.payload?.message as string | undefined,
+                  progressEvent: event.payload?.event as string | undefined,
+                  progressRunId: event.payload?.run_id as string | undefined,
+                  progressTimestamp: event.payload?.timestamp as string | undefined,
+                  progressEventData: event.payload?.event_data as Record<string, unknown> | undefined,
+                  progressHistory: [
+                    ...(t.progressHistory ?? []),
+                    {
+                      event: event.payload?.event as string | undefined,
+                      runId: event.payload?.run_id as string | undefined,
+                      timestamp: event.payload?.timestamp as string | undefined,
+                      message: event.payload?.message as string | undefined,
+                      progress: typeof event.payload?.progress === "number" ? event.payload.progress : undefined,
+                      total: typeof event.payload?.total === "number" ? event.payload.total : undefined,
+                      eventData: event.payload?.event_data as Record<string, unknown> | undefined,
+                    },
+                  ].slice(-12),
+                  updatedAt: now,
+                };
+              });
+              setToolStream(toolStreamRef.current);
+            }
+            const newActivity: RunActivity = {
+              phase,
+              tool: event.payload?.tool as string | undefined,
+              tools: event.payload?.tools as string[] | undefined,
+              iteration: event.payload?.iteration as number | undefined,
+              progress: typeof event.payload?.progress === "number" ? event.payload.progress : undefined,
+              total: typeof event.payload?.total === "number" ? event.payload.total : undefined,
+              message: event.payload?.message as string | undefined,
+              event: event.payload?.event as string | undefined,
+              runId: event.payload?.run_id as string | undefined,
+              timestamp: event.payload?.timestamp as string | undefined,
+              eventData: event.payload?.event_data as Record<string, unknown> | undefined,
+            };
             activityRef.current = newActivity; setActivity(newActivity);
           }
           break;

--- a/ui/web/src/types/chat.ts
+++ b/ui/web/src/types/chat.ts
@@ -4,12 +4,19 @@ import type { Message } from "./session";
 
 /** Activity phase tracking during agent run */
 export interface RunActivity {
-  phase: "thinking" | "tool_exec" | "streaming" | "compacting" | "retrying" | "leader_processing";
+  phase: "thinking" | "tool_exec" | "streaming" | "compacting" | "retrying" | "leader_processing" | "mcp_progress";
   tool?: string;
   tools?: string[];
   iteration?: number;
   retryAttempt?: number;
   retryMax?: number;
+  progress?: number;
+  total?: number;
+  message?: string;
+  event?: string;
+  runId?: string;
+  timestamp?: string;
+  eventData?: Record<string, unknown>;
 }
 
 /** Team task tracking from team.task.* events */
@@ -69,6 +76,13 @@ export interface AgentEventPayload {
     tool?: string;
     tools?: string[];
     iteration?: number;
+    progress?: number;
+    total?: number;
+    message?: string;
+    event?: string;
+    run_id?: string;
+    timestamp?: string;
+    event_data?: Record<string, unknown>;
     // run.retrying event fields
     attempt?: number;
     maxAttempts?: number;
@@ -86,6 +100,22 @@ export interface ToolStreamEntry {
   arguments?: Record<string, unknown>;
   result?: string;
   errorContent?: string;
+  progress?: number;
+  progressTotal?: number;
+  progressMessage?: string;
+  progressEvent?: string;
+  progressRunId?: string;
+  progressTimestamp?: string;
+  progressEventData?: Record<string, unknown>;
+  progressHistory?: {
+    event?: string;
+    runId?: string;
+    timestamp?: string;
+    message?: string;
+    progress?: number;
+    total?: number;
+    eventData?: Record<string, unknown>;
+  }[];
   startedAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
## 提交理由

后端已经能把外部 MCP 工具的中间事件转成 `mcp_progress`，但 GoClaw Web UI 原来主要只能看到工具正在运行或最终结果。用户在长任务期间缺少可读的进度反馈，容易误以为任务卡住。

这次前端改动把 MCP progress 展示到工具卡片和顶部活动状态中，让用户能看到当前步骤、进度比例、事件摘要，并能展开查看原始 Event Trace，补齐“后端流式进度 -> 前端可见进度”的体验闭环。

## 主要改动

- 在 activity indicator / chat top bar 中识别 `mcp_progress`。
- 在工具卡片中展示 progress message、progress/total 比例。
- 为工具卡片保留 progress history，并展示最近的可读事件。
- 支持展开查看 Event Trace，方便调试长任务工具调用。
- 将部分浏览器动作事件翻译成更可读的中文摘要。

## 影响范围

- 仅影响 GoClaw Web 聊天界面的工具调用展示。
- 不改动后端协议，不改动 MCP Agent 执行逻辑。
- 没有 MCP progress 的普通工具卡片仍按原逻辑展示。

## 验证

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm lint`（通过，保留一个既有文件 `app-layout.tsx` 的 unused eslint-disable warning）
