### PR TITLE
feat(media): pluggable storage backend + S3 implementation

### DIFF
--- a/cmd/gateway_managed.go
+++ b/cmd/gateway_managed.go
@@ -68,10 +68,16 @@ func wireExtras(
 		contextFileInterceptor = tools.NewContextFileInterceptor(stores.Agents, workspace, agentCtxCache, userCtxCache)
 	}
 
-	// 1c. Persistent media storage for cross-turn image/document access
-	mediaStore, err := media.NewStore(filepath.Join(workspace, ".media"))
+	// 1c. Persistent media storage for cross-turn image/document access.
+	// Default is the historical filesystem-backed store under
+	// {workspace}/.media. Set GOCLAW_MEDIA_BACKEND=s3 (plus the matching
+	// _S3_* env vars) to switch to S3 without touching call sites — the
+	// Store façade hides the backend choice from the rest of the code.
+	mediaCfg := media.LoadConfigFromEnv(filepath.Join(workspace, ".media"))
+	mediaStore, err := media.NewStoreFromConfig(context.Background(), mediaCfg)
 	if err != nil {
-		slog.Warn("media store creation failed, images will not persist across turns", "error", err)
+		slog.Warn("media store creation failed, images will not persist across turns",
+			"backend", mediaCfg.Backend, "error", err)
 	}
 
 	// Wire media cleanup on session delete.

--- a/internal/media/backend.go
+++ b/internal/media/backend.go
@@ -1,0 +1,38 @@
+package media
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+// Backend persists session-scoped media files. Implementations decide
+// where the bytes live — local filesystem, S3, etc. — but must keep the
+// same key shape: {sessionHash}/{id}.{ext}.
+//
+// LocalPath is intentionally part of the contract because most current
+// callers want a filesystem path they can hand to ffmpeg, pypdf, or a
+// container bind mount. Remote-only backends are expected to cache the
+// object locally on first request and return the cache path.
+type Backend interface {
+	// Save persists the file at srcPath under sessionKey and returns the
+	// generated media ID plus the extension that was applied. The source
+	// file SHOULD be removed by the backend on success.
+	Save(ctx context.Context, sessionKey, srcPath, mime string) (id string, ext string, err error)
+
+	// Open returns a reader for the bytes of a previously-saved media ID.
+	// The caller must close the reader.
+	Open(ctx context.Context, id string) (io.ReadCloser, error)
+
+	// LocalPath returns a filesystem path the caller can read directly.
+	// Remote backends MAY block while fetching the object into a local
+	// cache. Returns ErrNotFound if the ID is unknown.
+	LocalPath(ctx context.Context, id string) (string, error)
+
+	// Delete removes every media file persisted under sessionKey.
+	Delete(ctx context.Context, sessionKey string) error
+}
+
+// ErrNotFound is returned by Backend implementations when a media ID has
+// no corresponding object. Callers can match it with errors.Is.
+var ErrNotFound = errors.New("media: not found")

--- a/internal/media/config.go
+++ b/internal/media/config.go
@@ -1,0 +1,68 @@
+package media
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Config selects and parameterises the media Backend. Populate it
+// programmatically or via LoadConfigFromEnv.
+type Config struct {
+	// Backend is "fs" (default) or "s3".
+	Backend string
+
+	// FS-only.
+	BaseDir string
+
+	// S3-only.
+	Bucket   string
+	Prefix   string
+	Region   string
+	Endpoint string // for S3-compatible services (MinIO, R2, DO Spaces)
+	CacheDir string
+}
+
+// LoadConfigFromEnv pulls the standard GOCLAW_MEDIA_* variables out of
+// the environment. Sensible defaults: fs backend, baseDir = defaultBase.
+func LoadConfigFromEnv(defaultBase string) Config {
+	cfg := Config{
+		Backend:  strings.ToLower(strings.TrimSpace(os.Getenv("GOCLAW_MEDIA_BACKEND"))),
+		BaseDir:  strings.TrimSpace(os.Getenv("GOCLAW_MEDIA_BASEDIR")),
+		Bucket:   strings.TrimSpace(os.Getenv("GOCLAW_MEDIA_S3_BUCKET")),
+		Prefix:   strings.TrimSpace(os.Getenv("GOCLAW_MEDIA_S3_PREFIX")),
+		Region:   strings.TrimSpace(os.Getenv("GOCLAW_MEDIA_S3_REGION")),
+		Endpoint: strings.TrimSpace(os.Getenv("GOCLAW_MEDIA_S3_ENDPOINT")),
+		CacheDir: strings.TrimSpace(os.Getenv("GOCLAW_MEDIA_S3_CACHE_DIR")),
+	}
+	if cfg.Backend == "" {
+		cfg.Backend = "fs"
+	}
+	if cfg.BaseDir == "" {
+		cfg.BaseDir = defaultBase
+	}
+	return cfg
+}
+
+// NewBackend builds the Backend selected by cfg.
+func NewBackend(ctx context.Context, cfg Config) (Backend, error) {
+	switch cfg.Backend {
+	case "", "fs":
+		return NewFSBackend(cfg.BaseDir)
+	case "s3":
+		return NewS3Backend(ctx, cfg)
+	default:
+		return nil, fmt.Errorf("media: unknown backend %q (want fs|s3)", cfg.Backend)
+	}
+}
+
+// NewStoreFromConfig is the convenience entry point for code that wants
+// a *Store (the historical façade) instead of a bare Backend.
+func NewStoreFromConfig(ctx context.Context, cfg Config) (*Store, error) {
+	b, err := NewBackend(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return NewStoreWithBackend(b), nil
+}

--- a/internal/media/fs_backend.go
+++ b/internal/media/fs_backend.go
@@ -1,0 +1,115 @@
+package media
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+)
+
+// FSBackend stores media files on the local filesystem under
+// {baseDir}/{sessionHash}/{id}.{ext}. It is the historical and default
+// implementation of Backend; behaviour is preserved exactly from the
+// pre-refactor media.Store so existing deployments see no change.
+type FSBackend struct {
+	baseDir string
+}
+
+// NewFSBackend creates an FSBackend rooted at baseDir. The directory is
+// created if it doesn't exist.
+func NewFSBackend(baseDir string) (*FSBackend, error) {
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return nil, fmt.Errorf("media fs: create base dir: %w", err)
+	}
+	return &FSBackend{baseDir: baseDir}, nil
+}
+
+func (b *FSBackend) Save(_ context.Context, sessionKey, srcPath, mime string) (string, string, error) {
+	dir := b.sessionDir(sessionKey)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", "", fmt.Errorf("media fs: create session dir: %w", err)
+	}
+
+	mediaID := uuid.New().String()
+	ext := ExtFromMime(mime)
+	if ext == "" {
+		ext = filepath.Ext(srcPath)
+	}
+	dstPath := filepath.Join(dir, mediaID+ext)
+
+	// Same-filesystem rename is cheap; fall back to copy+remove across
+	// devices (e.g. when the workspace volume differs from tmpfs).
+	if err := os.Rename(srcPath, dstPath); err == nil {
+		return mediaID, ext, nil
+	}
+	if err := copyFile(srcPath, dstPath); err != nil {
+		return "", "", fmt.Errorf("media fs: copy file: %w", err)
+	}
+	_ = os.Remove(srcPath)
+	return mediaID, ext, nil
+}
+
+func (b *FSBackend) Open(ctx context.Context, id string) (io.ReadCloser, error) {
+	p, err := b.LocalPath(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(p)
+}
+
+func (b *FSBackend) LocalPath(_ context.Context, id string) (string, error) {
+	// Media files are stored as {sessionHash}/{id}.{ext}. The session
+	// hash is not part of the public ID, so we glob across sessions —
+	// IDs are uuid.New so the chance of collision is negligible.
+	matches, err := filepath.Glob(filepath.Join(b.baseDir, "*", id+".*"))
+	if err != nil {
+		return "", fmt.Errorf("media fs: glob for %s: %w", id, err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("%w: %s", ErrNotFound, id)
+	}
+	return matches[0], nil
+}
+
+func (b *FSBackend) Delete(_ context.Context, sessionKey string) error {
+	dir := b.sessionDir(sessionKey)
+	if err := os.RemoveAll(dir); err != nil {
+		slog.Warn("media fs: failed to delete session dir", "dir", dir, "error", err)
+		return err
+	}
+	return nil
+}
+
+func (b *FSBackend) sessionDir(sessionKey string) string {
+	h := sha256.Sum256([]byte(sessionKey))
+	hash := fmt.Sprintf("%x", h[:6]) // 12 hex chars, filesystem-safe
+	return filepath.Join(b.baseDir, hash)
+}
+
+// copyFile copies src to dst using buffered I/O.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}
+
+// Ensure FSBackend satisfies Backend at compile time.
+var _ Backend = (*FSBackend)(nil)

--- a/internal/media/fs_backend_test.go
+++ b/internal/media/fs_backend_test.go
@@ -1,0 +1,95 @@
+package media
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFSBackend_SaveLoadDelete is the core round-trip: write a file,
+// look it up by ID, read it back, then drop the session.
+func TestFSBackend_SaveLoadDelete(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	base := t.TempDir()
+	b, err := NewFSBackend(base)
+	if err != nil {
+		t.Fatalf("NewFSBackend: %v", err)
+	}
+
+	src := filepath.Join(t.TempDir(), "src.png")
+	if err := os.WriteFile(src, []byte("PNG-bytes"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	id, ext, err := b.Save(ctx, "session-a", src, "image/png")
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if id == "" || ext != ".png" {
+		t.Fatalf("unexpected save result: id=%q ext=%q", id, ext)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("expected src to be consumed, got err=%v", err)
+	}
+
+	p, err := b.LocalPath(ctx, id)
+	if err != nil {
+		t.Fatalf("LocalPath: %v", err)
+	}
+	if !strings.HasPrefix(p, base) {
+		t.Fatalf("LocalPath %q outside base %q", p, base)
+	}
+
+	rc, err := b.Open(ctx, id)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	body, _ := io.ReadAll(rc)
+	rc.Close()
+	if string(body) != "PNG-bytes" {
+		t.Fatalf("Open returned %q, want PNG-bytes", body)
+	}
+
+	if err := b.Delete(ctx, "session-a"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := b.LocalPath(ctx, id); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("after Delete LocalPath err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestFSBackend_MimeOverridesExtension confirms ExtFromMime wins over
+// the source file's own extension — important because some upstream
+// callers hand us a tempfile with no extension at all.
+func TestFSBackend_MimeOverridesExtension(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b, _ := NewFSBackend(t.TempDir())
+
+	src := filepath.Join(t.TempDir(), "no-ext-here")
+	_ = os.WriteFile(src, []byte("x"), 0o644)
+
+	_, ext, err := b.Save(ctx, "s", src, "audio/mpeg")
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if ext != ".mp3" {
+		t.Fatalf("ext = %q, want .mp3", ext)
+	}
+}
+
+// TestFSBackend_LoadPathMissingReturnsErrNotFound is what callers
+// (media handlers, agent loop) match on when a stale ID slips through.
+func TestFSBackend_LoadPathMissingReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	b, _ := NewFSBackend(t.TempDir())
+	_, err := b.LocalPath(context.Background(), "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/media/s3_backend.go
+++ b/internal/media/s3_backend.go
@@ -1,0 +1,344 @@
+package media
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/google/uuid"
+)
+
+const (
+	s3UploadPartSize    = 10 << 20 // 10 MB
+	s3UploadConcurrency = 3
+	s3ManifestSubprefix = "_manifests"
+)
+
+// S3Backend stores media objects in an S3 bucket under a configurable
+// prefix. Object layout mirrors FSBackend:
+//
+//	{prefix}/{sessionHash}/{id}.{ext}     — payload
+//	{prefix}/_manifests/{id}              — sessionHash/{id}.{ext} pointer
+//
+// Manifests let LocalPath / Open resolve a bare media ID into its full
+// S3 key without scanning the whole bucket; they're tiny (a few dozen
+// bytes) and cleaned up alongside the session on Delete.
+type S3Backend struct {
+	client   *s3.Client
+	uploader *manager.Uploader
+	bucket   string
+	prefix   string
+	cacheDir string
+}
+
+// NewS3Backend builds an S3Backend from the supplied config. Credentials
+// come from the default SDK chain (env vars, ~/.aws/credentials, IAM
+// role on EC2/ECS/EKS) — there is intentionally no static-key field on
+// Config; production deployments should use an instance profile.
+func NewS3Backend(ctx context.Context, cfg Config) (*S3Backend, error) {
+	if cfg.Bucket == "" {
+		return nil, errors.New("media s3: bucket is required")
+	}
+
+	region := cfg.Region
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	loadOpts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(region),
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, loadOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("media s3: load aws config: %w", err)
+	}
+
+	var s3Opts []func(*s3.Options)
+	if cfg.Endpoint != "" {
+		endpoint := cfg.Endpoint
+		s3Opts = append(s3Opts, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+			o.UsePathStyle = true // MinIO / most S3-compatible services
+		})
+	}
+	client := s3.NewFromConfig(awsCfg, s3Opts...)
+
+	cacheDir := cfg.CacheDir
+	if cacheDir == "" {
+		cacheDir = filepath.Join(os.TempDir(), "goclaw-media-cache")
+	}
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("media s3: create cache dir: %w", err)
+	}
+
+	uploader := manager.NewUploader(client, func(u *manager.Uploader) {
+		u.PartSize = s3UploadPartSize
+		u.Concurrency = s3UploadConcurrency
+	})
+
+	return &S3Backend{
+		client:   client,
+		uploader: uploader,
+		bucket:   cfg.Bucket,
+		prefix:   strings.TrimSuffix(cfg.Prefix, "/"),
+		cacheDir: cacheDir,
+	}, nil
+}
+
+func (b *S3Backend) Save(ctx context.Context, sessionKey, srcPath, mime string) (string, string, error) {
+	mediaID := uuid.New().String()
+	ext := ExtFromMime(mime)
+	if ext == "" {
+		ext = filepath.Ext(srcPath)
+	}
+
+	sessionHash := s3SessionHash(sessionKey)
+	objectKey := b.objectKey(sessionHash, mediaID, ext)
+
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return "", "", fmt.Errorf("media s3: open src: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := b.uploader.Upload(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(b.bucket),
+		Key:         aws.String(objectKey),
+		Body:        f,
+		ContentType: aws.String(mime),
+	}); err != nil {
+		return "", "", fmt.Errorf("media s3: upload %q: %w", objectKey, err)
+	}
+
+	// Manifest write makes the {id → object key} lookup O(1); without it
+	// LocalPath would have to scan the whole bucket prefix.
+	manifestKey := b.manifestKey(mediaID)
+	manifestBody := sessionHash + "/" + mediaID + ext
+	if _, err := b.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(b.bucket),
+		Key:         aws.String(manifestKey),
+		Body:        strings.NewReader(manifestBody),
+		ContentType: aws.String("text/plain"),
+	}); err != nil {
+		// Best-effort cleanup: drop the just-uploaded object so we don't
+		// leak orphans on a partial save.
+		_, _ = b.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: aws.String(b.bucket),
+			Key:    aws.String(objectKey),
+		})
+		return "", "", fmt.Errorf("media s3: write manifest %q: %w", manifestKey, err)
+	}
+
+	// Match FSBackend's "consume src" contract so callers don't have to
+	// remember which backend they're talking to.
+	_ = os.Remove(srcPath)
+	return mediaID, ext, nil
+}
+
+func (b *S3Backend) Open(ctx context.Context, id string) (io.ReadCloser, error) {
+	relKey, err := b.resolveManifest(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := b.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(b.bucket),
+		Key:    aws.String(b.qualify(relKey)),
+	})
+	if err != nil {
+		if isS3NoSuchKey(err) {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, id)
+		}
+		return nil, fmt.Errorf("media s3: get object %q: %w", relKey, err)
+	}
+	return resp.Body, nil
+}
+
+func (b *S3Backend) LocalPath(ctx context.Context, id string) (string, error) {
+	relKey, err := b.resolveManifest(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	cachePath := filepath.Join(b.cacheDir, filepath.FromSlash(relKey))
+	if _, err := os.Stat(cachePath); err == nil {
+		return cachePath, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		return "", fmt.Errorf("media s3: create cache dir: %w", err)
+	}
+
+	resp, err := b.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(b.bucket),
+		Key:    aws.String(b.qualify(relKey)),
+	})
+	if err != nil {
+		if isS3NoSuchKey(err) {
+			return "", fmt.Errorf("%w: %s", ErrNotFound, id)
+		}
+		return "", fmt.Errorf("media s3: get object %q: %w", relKey, err)
+	}
+	defer resp.Body.Close()
+
+	// Write to a sibling temp file then rename, so a partial download
+	// never gets surfaced as a valid cache entry.
+	tmp, err := os.CreateTemp(filepath.Dir(cachePath), "media-*.part")
+	if err != nil {
+		return "", fmt.Errorf("media s3: create cache tmp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpName)
+		return "", fmt.Errorf("media s3: write cache: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return "", fmt.Errorf("media s3: close cache tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, cachePath); err != nil {
+		_ = os.Remove(tmpName)
+		return "", fmt.Errorf("media s3: finalize cache: %w", err)
+	}
+	return cachePath, nil
+}
+
+func (b *S3Backend) Delete(ctx context.Context, sessionKey string) error {
+	sessionHash := s3SessionHash(sessionKey)
+	sessionPrefix := b.qualify(sessionHash + "/")
+
+	// Collect every payload key in the session — we'll need the bare IDs
+	// to wipe their manifests too.
+	var payloadKeys []s3types.ObjectIdentifier
+	var ids []string
+	paginator := s3.NewListObjectsV2Paginator(b.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(b.bucket),
+		Prefix: aws.String(sessionPrefix),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("media s3: list %q: %w", sessionPrefix, err)
+		}
+		for _, obj := range page.Contents {
+			if obj.Key == nil {
+				continue
+			}
+			payloadKeys = append(payloadKeys, s3types.ObjectIdentifier{Key: obj.Key})
+			ids = append(ids, idFromKey(*obj.Key))
+		}
+	}
+
+	if err := b.deleteKeys(ctx, payloadKeys); err != nil {
+		return err
+	}
+
+	manifestKeys := make([]s3types.ObjectIdentifier, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		manifestKeys = append(manifestKeys, s3types.ObjectIdentifier{Key: aws.String(b.manifestKey(id))})
+	}
+	if err := b.deleteKeys(ctx, manifestKeys); err != nil {
+		slog.Warn("media s3: manifest cleanup had failures (non-fatal)", "session_hash", sessionHash, "error", err)
+	}
+
+	return nil
+}
+
+func (b *S3Backend) deleteKeys(ctx context.Context, keys []s3types.ObjectIdentifier) error {
+	for start := 0; start < len(keys); start += 1000 {
+		end := start + 1000
+		if end > len(keys) {
+			end = len(keys)
+		}
+		_, err := b.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(b.bucket),
+			Delete: &s3types.Delete{Objects: keys[start:end], Quiet: aws.Bool(true)},
+		})
+		if err != nil {
+			return fmt.Errorf("media s3: delete batch: %w", err)
+		}
+	}
+	return nil
+}
+
+func (b *S3Backend) resolveManifest(ctx context.Context, id string) (string, error) {
+	resp, err := b.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(b.bucket),
+		Key:    aws.String(b.manifestKey(id)),
+	})
+	if err != nil {
+		if isS3NoSuchKey(err) {
+			return "", fmt.Errorf("%w: %s", ErrNotFound, id)
+		}
+		return "", fmt.Errorf("media s3: read manifest %q: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if err != nil {
+		return "", fmt.Errorf("media s3: read manifest body %q: %w", id, err)
+	}
+	rel := strings.TrimSpace(string(body))
+	if rel == "" || strings.Contains(rel, "..") {
+		return "", fmt.Errorf("media s3: manifest %q has invalid body", id)
+	}
+	return rel, nil
+}
+
+func (b *S3Backend) objectKey(sessionHash, id, ext string) string {
+	return b.qualify(sessionHash + "/" + id + ext)
+}
+
+func (b *S3Backend) manifestKey(id string) string {
+	return b.qualify(s3ManifestSubprefix + "/" + id)
+}
+
+func (b *S3Backend) qualify(rel string) string {
+	rel = strings.TrimPrefix(rel, "/")
+	if b.prefix == "" {
+		return rel
+	}
+	return b.prefix + "/" + rel
+}
+
+// idFromKey reverses objectKey for a payload object — used during
+// session delete to know which manifests to clean up.
+func idFromKey(key string) string {
+	base := filepath.Base(key)
+	if i := strings.LastIndex(base, "."); i > 0 {
+		return base[:i]
+	}
+	return base
+}
+
+func s3SessionHash(sessionKey string) string {
+	h := sha256.Sum256([]byte(sessionKey))
+	return fmt.Sprintf("%x", h[:6])
+}
+
+// isS3NoSuchKey matches the SDK's typed NoSuchKey / NotFound errors that
+// callers translate into media.ErrNotFound.
+func isS3NoSuchKey(err error) bool {
+	var nsk *s3types.NoSuchKey
+	if errors.As(err, &nsk) {
+		return true
+	}
+	var nf *s3types.NotFound
+	return errors.As(err, &nf)
+}
+
+// Ensure S3Backend satisfies Backend at compile time.
+var _ Backend = (*S3Backend)(nil)

--- a/internal/media/store.go
+++ b/internal/media/store.go
@@ -1,94 +1,66 @@
 package media
 
 import (
-	"crypto/sha256"
-	"fmt"
-	"io"
-	"log/slog"
-	"os"
-	"path/filepath"
+	"context"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
-// Store provides persistent media file storage scoped by session.
-// Files are organized as: {baseDir}/{sessionHash}/{uuid}.{ext}
+// Store is a thin façade over a Backend that preserves the pre-refactor
+// public API. External code keeps using *Store with the same method
+// signatures; new code SHOULD depend on Backend directly so tests can
+// substitute fakes.
 type Store struct {
-	baseDir string
+	b Backend
 }
 
-// NewStore creates a media store rooted at baseDir.
-// The directory is created if it doesn't exist.
+// NewStore creates a Store backed by a local filesystem at baseDir.
+// Kept as the no-arg entry point so existing callers don't change.
 func NewStore(baseDir string) (*Store, error) {
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
-		return nil, fmt.Errorf("media: create base dir: %w", err)
-	}
-	return &Store{baseDir: baseDir}, nil
-}
-
-// SaveFile moves or copies a file to persistent storage.
-// Returns the unique media ID and the destination path.
-func (s *Store) SaveFile(sessionKey, srcPath, mime string) (id string, dstPath string, err error) {
-	dir := s.sessionDir(sessionKey)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", "", fmt.Errorf("media: create session dir: %w", err)
-	}
-
-	mediaID := uuid.New().String()
-	ext := ExtFromMime(mime)
-	if ext == "" {
-		ext = filepath.Ext(srcPath)
-	}
-	dstPath = filepath.Join(dir, mediaID+ext)
-
-	// Try rename first (fast, same filesystem).
-	if err := os.Rename(srcPath, dstPath); err == nil {
-		return mediaID, dstPath, nil
-	}
-
-	// Fallback: copy + remove source.
-	if err := copyFile(srcPath, dstPath); err != nil {
-		return "", "", fmt.Errorf("media: copy file: %w", err)
-	}
-	_ = os.Remove(srcPath) // best-effort cleanup of source
-	return mediaID, dstPath, nil
-}
-
-// LoadPath returns the filesystem path for a media ID.
-// Returns an error if the file doesn't exist.
-func (s *Store) LoadPath(id string) (string, error) {
-	// Media files are stored as {sessionHash}/{id}.{ext}.
-	// Since we don't know the session hash, glob for the ID across all session dirs.
-	matches, err := filepath.Glob(filepath.Join(s.baseDir, "*", id+".*"))
+	b, err := NewFSBackend(baseDir)
 	if err != nil {
-		return "", fmt.Errorf("media: glob for %s: %w", id, err)
+		return nil, err
 	}
-	if len(matches) == 0 {
-		return "", fmt.Errorf("media: file not found: %s", id)
-	}
-	return matches[0], nil
+	return &Store{b: b}, nil
 }
 
-// DeleteSession removes all media files for a session.
+// NewStoreWithBackend wraps an explicit Backend (S3, in-memory test fake, …).
+func NewStoreWithBackend(b Backend) *Store { return &Store{b: b} }
+
+// Backend exposes the underlying backend for callers that want to bypass
+// the legacy façade and use the modern API directly (Open, context-aware
+// methods). Keeps the door open for incremental migration without
+// breaking the pre-refactor API.
+func (s *Store) Backend() Backend { return s.b }
+
+// SaveFile mirrors the pre-refactor signature: returns the media ID and
+// the local filesystem path the caller can read immediately.
+func (s *Store) SaveFile(sessionKey, srcPath, mime string) (id string, dstPath string, err error) {
+	ctx := context.Background()
+	id, _, err = s.b.Save(ctx, sessionKey, srcPath, mime)
+	if err != nil {
+		return "", "", err
+	}
+	dstPath, err = s.b.LocalPath(ctx, id)
+	if err != nil {
+		return "", "", err
+	}
+	return id, dstPath, nil
+}
+
+// LoadPath returns a local filesystem path for a saved media ID.
+// Remote backends transparently cache the object before returning.
+func (s *Store) LoadPath(id string) (string, error) {
+	return s.b.LocalPath(context.Background(), id)
+}
+
+// DeleteSession removes every media file for a session key.
 func (s *Store) DeleteSession(sessionKey string) error {
-	dir := s.sessionDir(sessionKey)
-	if err := os.RemoveAll(dir); err != nil {
-		slog.Warn("media: failed to delete session dir", "dir", dir, "error", err)
-		return err
-	}
-	return nil
-}
-
-// sessionDir returns the directory path for a session's media files.
-// Uses first 12 chars of SHA-256 hash of sessionKey for filesystem safety.
-func (s *Store) sessionDir(sessionKey string) string {
-	h := sha256.Sum256([]byte(sessionKey))
-	hash := fmt.Sprintf("%x", h[:6]) // 12 hex chars
-	return filepath.Join(s.baseDir, hash)
+	return s.b.Delete(context.Background(), sessionKey)
 }
 
 // ExtFromMime returns a file extension (with dot) for a MIME type.
+// Lives on Store rather than per-backend so both backends agree on the
+// extension that ends up in the object key.
 func ExtFromMime(mime string) string {
 	switch {
 	case strings.HasPrefix(mime, "image/jpeg"):
@@ -116,24 +88,4 @@ func ExtFromMime(mime string) string {
 	default:
 		return ""
 	}
-}
-
-// copyFile copies src to dst using buffered I/O.
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	if _, err := io.Copy(out, in); err != nil {
-		return err
-	}
-	return out.Close()
 }


### PR DESCRIPTION
## Summary

Adds a `media.Backend` interface and an `S3Backend` implementation so goclaw can run on ephemeral hosts without losing session media on restart. The existing filesystem behaviour is preserved exactly — `GOCLAW_MEDIA_BACKEND` defaults to ``fs`` and every current call site keeps working unchanged.

Three commits, intentionally separable for review:

1. **refactor(media): introduce Backend interface, keep Store as façade** — splits `internal/media/store.go` into `backend.go` (interface), `fs_backend.go` (the historical implementation, unchanged), and a thin `store.go` façade. No behaviour change.
2. **feat(media): add S3Backend + env-driven factory** — `S3Backend` persists objects under `{prefix}/{sessionHash}/{id}.{ext}` with a manifest sidecar at `{prefix}/_manifests/{id}` so `LocalPath`/`Open` resolve a bare ID in two GETs. Credentials come from the default SDK chain only (IAM role / env), no static-key field. `LocalPath` lazily caches into `os.TempDir()/goclaw-media-cache` with atomic rename. `Delete` paginates the session prefix and `DeleteObjects` in batches of 1000.
3. **feat(media): wire env-driven backend selection + FSBackend tests** — `cmd/gateway_managed.go` now goes through `media.LoadConfigFromEnv` / `NewStoreFromConfig`. Adds round-trip / mime-ext / not-found tests for the FS backend.

## Why

Today `media.Store` is concrete and FS-only. Deployments on Fargate / K8s without persistent volumes / EC2 ASGs that rotate instances drop their session media on every restart. The workaround — pointing `baseDir` at EFS/EBS — is heavier than handing the same problem to S3 with a 7-day lifecycle rule.

Secondary win: the concrete `*media.Store` type made it impossible to substitute a fake in tests; new code can now depend on `media.Backend` directly.

## Env vars

| Var | Default | Purpose |
| --- | --- | --- |
| `GOCLAW_MEDIA_BACKEND` | `fs` | `fs` or `s3` |
| `GOCLAW_MEDIA_BASEDIR` | `{workspace}/.media` | FS only |
| `GOCLAW_MEDIA_S3_BUCKET` | — | required when backend=s3 |
| `GOCLAW_MEDIA_S3_PREFIX` | empty | key prefix inside the bucket |
| `GOCLAW_MEDIA_S3_REGION` | `us-east-1` | |
| `GOCLAW_MEDIA_S3_ENDPOINT` | — | for MinIO / R2 / DO Spaces |
| `GOCLAW_MEDIA_S3_CACHE_DIR` | `$TMPDIR/goclaw-media-cache` | local read cache |

IAM permissions needed for the bucket: `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket`, `s3:DeleteObjects`.

## Test plan

- [x] FSBackend unit tests (round-trip, mime ext precedence, ErrNotFound).
- [ ] S3Backend integration: not in the test suite — gated on `GOCLAW_TEST_S3_BUCKET` would be the natural follow-up; happy to add in this PR if you'd like.
- [ ] Build + existing tests on CI.
- [ ] Smoke on my fork's staging once merged downstream (`injectinglabs/goclaw`).

## Out of scope

- Workspace-as-S3 (covers user-generated files under `workspace/generated/...`). That requires a separate workspace abstraction and is orthogonal to session media.
- Signed download URLs for generated documents — already covered upstream via `POST /v1/files/sign`.

## Open questions

1. Naming: `Backend` vs `Storage` vs `Driver`? I went with `Backend` to match `internal/backup`. Happy to rename.
2. Should `Save` take an `io.Reader` instead of `srcPath`? Current callers all have a local file, so `srcPath` keeps the FS backend's rename-fast-path; reader-based API would force FS to write a tempfile.
3. Add a gated `s3_backend_test.go` in this PR, or as a follow-up?

🤖 Generated with [Claude Code](https://claude.com/claude-code)