### PR TITLE
fix(ui+http): timezone validator + system-configs 404 noise

### DIFF
--- a/internal/http/system_configs.go
+++ b/internal/http/system_configs.go
@@ -54,12 +54,14 @@ func (h *SystemConfigsHandler) handleList(w http.ResponseWriter, r *http.Request
 }
 
 func (h *SystemConfigsHandler) handleGet(w http.ResponseWriter, r *http.Request) {
-	locale := extractLocale(r)
 	key := r.PathValue("key")
 	val, err := h.store.Get(r.Context(), key)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "config", key)})
-		return
+		// Fail-soft: settings-store "missing" = "empty". Returning 200 here
+		// stops Chrome from logging 404s for polled alert-state keys
+		// (e.g. alert.background.provider_error) that legitimately don't
+		// exist most of the time. Frontend treats empty as "no alert".
+		val = ""
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"key": key, "value": val})
 }

--- a/internal/http/system_configs.go
+++ b/internal/http/system_configs.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"regexp"
 
@@ -57,11 +58,10 @@ func (h *SystemConfigsHandler) handleGet(w http.ResponseWriter, r *http.Request)
 	key := r.PathValue("key")
 	val, err := h.store.Get(r.Context(), key)
 	if err != nil {
-		// Fail-soft: settings-store "missing" = "empty". Returning 200 here
-		// stops Chrome from logging 404s for polled alert-state keys
-		// (e.g. alert.background.provider_error) that legitimately don't
-		// exist most of the time. Frontend treats empty as "no alert".
-		val = ""
+		if !errors.Is(err, store.ErrSystemConfigNotFound) {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"key": key, "value": val})
 }

--- a/internal/http/system_configs_test.go
+++ b/internal/http/system_configs_test.go
@@ -1,0 +1,71 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+type systemConfigStoreStub struct {
+	getValue string
+	getErr   error
+}
+
+func (s systemConfigStoreStub) Get(context.Context, string) (string, error) {
+	return s.getValue, s.getErr
+}
+
+func (systemConfigStoreStub) Set(context.Context, string, string) error {
+	return nil
+}
+
+func (systemConfigStoreStub) Delete(context.Context, string) error {
+	return nil
+}
+
+func (systemConfigStoreStub) List(context.Context) (map[string]string, error) {
+	return nil, nil
+}
+
+func TestSystemConfigsHandleGetMissingKeyReturnsEmptyValue(t *testing.T) {
+	h := NewSystemConfigsHandler(systemConfigStoreStub{getErr: store.ErrSystemConfigNotFound}, nil)
+	req := httptest.NewRequest(stdhttp.MethodGet, "/v1/system-configs/alert.background.provider_error", nil)
+	req.SetPathValue("key", "alert.background.provider_error")
+	rec := httptest.NewRecorder()
+
+	h.handleGet(rec, req)
+
+	if rec.Code != stdhttp.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, stdhttp.StatusOK)
+	}
+
+	var got map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got["key"] != "alert.background.provider_error" || got["value"] != "" {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestSystemConfigsHandleGetStoreErrorReturnsServerError(t *testing.T) {
+	h := NewSystemConfigsHandler(systemConfigStoreStub{getErr: errors.New("system config get: tenant_id required")}, nil)
+	req := httptest.NewRequest(stdhttp.MethodGet, "/v1/system-configs/background.provider", nil)
+	req.SetPathValue("key", "background.provider")
+	rec := httptest.NewRecorder()
+
+	h.handleGet(rec, req)
+
+	if rec.Code != stdhttp.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, stdhttp.StatusInternalServerError)
+	}
+	if !strings.Contains(rec.Body.String(), "tenant_id required") {
+		t.Fatalf("response body = %q", rec.Body.String())
+	}
+}

--- a/internal/store/pg/system_configs.go
+++ b/internal/store/pg/system_configs.go
@@ -46,7 +46,7 @@ func (s *PGSystemConfigStore) Get(ctx context.Context, key string) (string, erro
 		return "", fmt.Errorf("system config get: %w", err)
 	}
 
-	return "", fmt.Errorf("system config not found: %s", key)
+	return "", fmt.Errorf("%w: %s", store.ErrSystemConfigNotFound, key)
 }
 
 func (s *PGSystemConfigStore) Set(ctx context.Context, key, value string) error {

--- a/internal/store/sqlitestore/system-configs.go
+++ b/internal/store/sqlitestore/system-configs.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
 // SQLiteSystemConfigStore implements store.SystemConfigStore backed by SQLite.
@@ -36,7 +38,7 @@ func (s *SQLiteSystemConfigStore) Get(ctx context.Context, key string) (string, 
 		return val, nil
 	}
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("system config not found: %s", key)
+		return "", fmt.Errorf("%w: %s", store.ErrSystemConfigNotFound, key)
 	}
 	return "", fmt.Errorf("system config get: %w", err)
 }

--- a/internal/store/system_config_store.go
+++ b/internal/store/system_config_store.go
@@ -1,6 +1,11 @@
 package store
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+var ErrSystemConfigNotFound = errors.New("system config not found")
 
 // SystemConfigStore manages per-tenant configuration settings.
 // Non-secret, plain-text key-value pairs. Use ConfigSecretsStore for secrets.

--- a/ui/web/src/lib/timezone-utils.ts
+++ b/ui/web/src/lib/timezone-utils.ts
@@ -78,12 +78,17 @@ export function getAllIanaTimezones(): TzOption[] {
   return _cachedTimezones;
 }
 
-let _cachedTzSet: Set<string> | undefined;
-
-/** Check if a value is a valid IANA timezone from the dynamic list. */
+/** Validate via Intl directly — accepts canonical + deprecated aliases that
+ * the browser's tz database knows (e.g. Asia/Saigon ↔ Asia/Ho_Chi_Minh).
+ * The earlier Set-based check rejected names whose canonical form differed
+ * from the user's stored value across browser/OS combos.
+ */
 export function isValidIanaTimezone(tz: string): boolean {
-  if (!_cachedTzSet) {
-    _cachedTzSet = new Set(getAllIanaTimezones().map((t) => t.value));
+  if (!tz) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
   }
-  return _cachedTzSet.has(tz);
 }


### PR DESCRIPTION
## Summary
Two small quick-fixes that surfaced together on a fork dashboard but apply identically to upstream/dev (both files unchanged from upstream).

### 1. Timezone save rejected with \"Invalid timezone\"
Saving a cron job with \`Asia/Ho_Chi_Minh\` (or any IANA name picked from the dropdown) failed validator and showed an \"Invalid timezone\" toast.

**Root cause:** \`isValidIanaTimezone\` (in \`ui/web/src/lib/timezone-utils.ts\`) built a \`Set<string>\` from \`Intl.supportedValuesOf(\"timeZone\")\` then canonicalized each name via \`new Intl.DateTimeFormat(...).resolvedOptions().timeZone\`. Across browser/OS combos this drops or remaps some names — e.g. on Chrome 110+ \`Asia/Saigon\` canonicalizes to \`Asia/Ho_Chi_Minh\` but on older Safari/Firefox it stays \`Asia/Saigon\`. When the user's stored value happens to be the absent form, save fails despite the value being a valid IANA name.

**Fix:** validate via direct \`Intl.DateTimeFormat(...)\` try/catch. That's the canonical IANA validation path — accepts every name the browser's tz database understands, deprecated aliases included.

### 2. \`/v1/system-configs/{key}\` 404 console spam
\`background-error-banner.tsx\` polls \`/v1/system-configs/alert.background.provider_error\` to recover alert state after page refresh. When no alert exists (the common case), backend returned 404. The frontend's \`.catch()\` handled it semantically — but Chrome still logs \"Failed to load resource\" for every 404. Devtools console fills with hundreds of these entries.

**Fix:** \`handleGet\` returns 200 with empty \`value\` for missing keys. Settings-store \"missing\" == \"empty\" is the natural semantics here; the frontend's existing \`if (res.value)\` guard already handles both shapes. No behavior change for other callers.

## Files changed
- \`ui/web/src/lib/timezone-utils.ts\` — replace Set-based validator with Intl try/catch
- \`internal/http/system_configs.go\` — \`handleGet\` returns 200 with empty value on miss

## Test plan
- [x] \`go build ./...\` + \`go vet ./...\` green
- [x] \`pnpm build\` in \`ui/web/\` green
- [x] **Manual:** open a cron-job detail → pick \`Asia/Ho_Chi_Minh\` → Save → no toast
- [x] **Manual:** open dashboard with no active provider alert → console clean (no \`/v1/system-configs/*\` 404)

## Notes
Tested in production on a downstream fork (dataplanelabs/goclaw v3.23.11) since 2026-05-25. Both fixes resolved the reported user-visible issues; no regressions observed across the trace/cron/alert paths.