### PR TITLE
fix(tts): wire dashboard tts.timeout_ms through ApplySystemConfigs + seed

### DIFF
--- a/cmd/gateway_system_config_sync.go
+++ b/cmd/gateway_system_config_sync.go
@@ -121,6 +121,7 @@ func seedConfigForContext(ctx context.Context, sc store.SystemConfigStore, cfg *
 	set("tts.auto", cfg.Tts.Auto)
 	set("tts.mode", cfg.Tts.Mode)
 	setInt("tts.max_length", cfg.Tts.MaxLength)
+	setInt("tts.timeout_ms", cfg.Tts.TimeoutMs)
 
 	// Cron
 	setInt("cron.max_retries", cfg.Cron.MaxRetries)

--- a/internal/config/config_system.go
+++ b/internal/config/config_system.go
@@ -67,6 +67,7 @@ func (c *Config) ApplySystemConfigs(configs map[string]string) {
 	str("tts.auto", &c.Tts.Auto)
 	str("tts.mode", &c.Tts.Mode)
 	integer("tts.max_length", &c.Tts.MaxLength)
+	integer("tts.timeout_ms", &c.Tts.TimeoutMs)
 
 	// Cron
 	integer("cron.max_retries", &c.Cron.MaxRetries)


### PR DESCRIPTION
## Bug
\`ApplySystemConfigs\` and \`seedConfigForContext\` both handle \`tts.provider\`, \`tts.auto\`, \`tts.mode\`, \`tts.max_length\` — but neither carries \`tts.timeout_ms\`. Result: the dashboard /tts page **Timeout (ms)** input is inert; \`cfg.Tts.TimeoutMs\` stays at config.json default; \`setupTTS\` passes 0 to provider constructors; each provider falls back to its hardcoded default (Edge = 30s).

## Real-world impact
Tenant configures Timeout=300000 (5 min) on the dashboard for long-form TTS. Saves. Trace still shows \`tts failed: edge-tts failed: signal: killed\` at exactly 30s. The dashboard value never reached the provider.

## Fix
Two-line addition mirroring the existing pattern for the other \`tts.*\` keys:
- \`internal/config/config_system.go\`: \`integer(\"tts.timeout_ms\", &c.Tts.TimeoutMs)\`
- \`cmd/gateway_system_config_sync.go\`: \`setInt(\"tts.timeout_ms\", cfg.Tts.TimeoutMs)\`

Hot-reload (\`tts-config-reload\` subscriber in lifecycle) re-builds the manager + Edge provider, so the dashboard change now propagates without restart.

## Test plan
- [x] \`go build ./...\` + \`-tags sqliteonly\` + \`go vet\` green
- [ ] Manual: dashboard set Timeout (ms) = 300000 → save → trigger long-form TTS → edge-tts succeeds within the 300s window