### PR TITLE
fix(providers): omit temperature for Claude Opus/Sonnet 4.6+

### DIFF
--- a/internal/providers/adapter_anthropic_test.go
+++ b/internal/providers/adapter_anthropic_test.go
@@ -150,6 +150,48 @@ func TestAnthropicAdapterToRequest_Thinking(t *testing.T) {
 	}
 }
 
+func TestAnthropicAdapterToRequest_SkipsTemperatureForClaude46(t *testing.T) {
+	adapter, _ := NewAnthropicAdapter(ProviderConfig{APIKey: "sk-test"})
+
+	for _, model := range []string{"claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-7-20260501"} {
+		t.Run(model, func(t *testing.T) {
+			req := ChatRequest{
+				Model:    model,
+				Messages: []Message{{Role: "user", Content: "hi"}},
+				Options:  map[string]any{OptTemperature: 0.7},
+			}
+			data, _, err := adapter.ToRequest(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var body map[string]any
+			if err := json.Unmarshal(data, &body); err != nil {
+				t.Fatal(err)
+			}
+			if _, hasTemp := body["temperature"]; hasTemp {
+				t.Errorf("model %q: temperature should be omitted", model)
+			}
+		})
+	}
+
+	req := ChatRequest{
+		Model:    "claude-sonnet-4-5-20250929",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Options:  map[string]any{OptTemperature: 0.7},
+	}
+	data, _, err := adapter.ToRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["temperature"] != 0.7 {
+		t.Errorf("sonnet 4.5 should keep temperature, got %v", body["temperature"])
+	}
+}
+
 func TestAnthropicAdapterFromResponse_ToolCalls(t *testing.T) {
 	adapter, _ := NewAnthropicAdapter(ProviderConfig{APIKey: "sk-test"})
 

--- a/internal/providers/anthropic_request.go
+++ b/internal/providers/anthropic_request.go
@@ -213,7 +213,9 @@ func (p *AnthropicProvider) buildRequestBody(model string, req ChatRequest, stre
 		body["max_tokens"] = v
 	}
 	if v, ok := req.Options[OptTemperature]; ok {
-		body["temperature"] = v
+		if !anthropicSkipsTemperature(model) {
+			body["temperature"] = v
+		}
 	}
 
 	// Enable extended thinking if thinking_level is set
@@ -232,6 +234,30 @@ func (p *AnthropicProvider) buildRequestBody(model string, req ChatRequest, stre
 	}
 
 	return body
+}
+
+// anthropicSkipsTemperature reports whether the Messages API rejects sampling
+// parameters for this model. Claude Opus/Sonnet 4.6+ and Opus 4.7+ return HTTP
+// 400 when temperature (and top_p/top_k) are included; omit them entirely.
+func anthropicSkipsTemperature(model string) bool {
+	m := strings.ToLower(model)
+	for _, family := range []string{"claude-opus-4-", "claude-sonnet-4-"} {
+		after, ok := strings.CutPrefix(m, family)
+		if !ok {
+			continue
+		}
+		minor := 0
+		for _, c := range after {
+			if c < '0' || c > '9' {
+				break
+			}
+			minor = minor*10 + int(c-'0')
+		}
+		if minor >= 6 {
+			return true
+		}
+	}
+	return false
 }
 
 // anthropicThinkingBudget maps a thinking level to a token budget.


### PR DESCRIPTION
Anthropic returns HTTP 400 when `temperature` is sent to `claude-opus-4-6`, `claude-sonnet-4-6`, and newer 4.x models. Agent summoning and chat both hardcode temperature; skip the field for affected model IDs.

## Summary

Omit `temperature` from Anthropic Messages API request bodies when the model is Claude Opus/Sonnet 4.6 or newer. Summoning (`temperature: 0.7` in `summoner_regenerate.go`) and chat paths both flow through `buildRequestBody`; filtering at the provider adapter fixes both without changing every call site.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch

`dev`

## Checklist

- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes) — N/A, no UI changes
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1`, `$2` (no string concat) — N/A, no SQL changes
- [x] New user-facing strings added to all 3 locales (en/vi/zh) — N/A, no new strings
- [x] Migration version bumped in `internal/upgrade/version.go` (if new migration) — N/A, no migration

## Test Plan

- Added `TestAnthropicAdapterToRequest_SkipsTemperatureForClaude46`: asserts `temperature` is omitted for `claude-opus-4-6`, `claude-sonnet-4-6`, and `claude-opus-4-7-*`, and still sent for `claude-sonnet-4-5-20250929`.
- Ran `go build ./...`, `go build -tags sqliteonly ./...`, `go vet ./...`, and `go test -race ./...` locally; all pass.
- Manual repro (pre-fix): agent summoning with `claude-opus-4-6` returned Anthropic 400 (`temperature is deprecated for this model`). Post-fix: request omits `temperature` and summoning succeeds.