### PR TITLE
Render deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Single binary. Production-tested. Agents that orchestrate for you.
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go_1.26-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" /></a>
   <a href="https://www.postgresql.org/"><img src="https://img.shields.io/badge/PostgreSQL_18-316192?style=flat-square&logo=postgresql&logoColor=white" alt="PostgreSQL" /></a>
   <a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker" /></a>
-  <a href="https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev"><img src="https://img.shields.io/badge/Render-deploy-46E3B7?style=flat-square" alt="Deploy on Render" /></a>
+  <a href="https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height="20" /></a>
   <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebSocket"><img src="https://img.shields.io/badge/WebSocket-010101?style=flat-square&logo=socket.io&logoColor=white" alt="WebSocket" /></a>
   <a href="https://opentelemetry.io/"><img src="https://img.shields.io/badge/OpenTelemetry-000000?style=flat-square&logo=opentelemetry&logoColor=white" alt="OpenTelemetry" /></a>
   <a href="https://www.anthropic.com/"><img src="https://img.shields.io/badge/Anthropic-191919?style=flat-square&logo=anthropic&logoColor=white" alt="Anthropic" /></a>
@@ -145,7 +145,7 @@ git tag lite-v0.1.0 && git push origin lite-v0.1.0
 
 ## Deploy on Render
 
-[`render.yaml`](render.yaml) deploys GoClaw on Render (Postgres 18 + pgvector, Standard plan, persistent disk). Use the **Render** badge above or open the Blueprint from the repo root. No LLM keys required at Apply: add a provider in the dashboard after deploy. Copy `GOCLAW_GATEWAY_TOKEN` from the Render Dashboard to sign in.
+[`render.yaml`](render.yaml) deploys GoClaw on Render (Postgres 18 + pgvector, Standard plan, persistent disk). Use the official **Deploy to Render** button in the badge row (after Docker) or apply the Blueprint from the repo root. No LLM keys required at Apply: add a provider in the dashboard after deploy. Copy `GOCLAW_GATEWAY_TOKEN` from the Render Dashboard to sign in.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Single binary. Production-tested. Agents that orchestrate for you.
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go_1.26-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" /></a>
   <a href="https://www.postgresql.org/"><img src="https://img.shields.io/badge/PostgreSQL_18-316192?style=flat-square&logo=postgresql&logoColor=white" alt="PostgreSQL" /></a>
   <a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker" /></a>
-  <a href="https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height="20" /></a>
+  <a href="https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev"><img src="https://img.shields.io/badge/Render-5C31FF?style=flat-square&logo=render&logoColor=white" alt="Render" /></a>
   <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebSocket"><img src="https://img.shields.io/badge/WebSocket-010101?style=flat-square&logo=socket.io&logoColor=white" alt="WebSocket" /></a>
   <a href="https://opentelemetry.io/"><img src="https://img.shields.io/badge/OpenTelemetry-000000?style=flat-square&logo=opentelemetry&logoColor=white" alt="OpenTelemetry" /></a>
   <a href="https://www.anthropic.com/"><img src="https://img.shields.io/badge/Anthropic-191919?style=flat-square&logo=anthropic&logoColor=white" alt="Anthropic" /></a>
@@ -145,7 +145,7 @@ git tag lite-v0.1.0 && git push origin lite-v0.1.0
 
 ## Deploy on Render
 
-[`render.yaml`](render.yaml) deploys GoClaw on Render (Postgres 18 + pgvector, Standard plan, persistent disk). Use the official **Deploy to Render** button in the badge row (after Docker) or apply the Blueprint from the repo root. No LLM keys required at Apply: add a provider in the dashboard after deploy. Copy `GOCLAW_GATEWAY_TOKEN` from the Render Dashboard to sign in.
+[`render.yaml`](render.yaml) deploys GoClaw on Render (Postgres 18 + pgvector, Standard plan, persistent disk). Use the **Render** badge in the badge row (after Docker) or apply the Blueprint from the repo root. No LLM keys required at Apply: add a provider in the dashboard after deploy. Copy `GOCLAW_GATEWAY_TOKEN` from the Render Dashboard to sign in.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,10 @@ Single binary. Production-tested. Agents that orchestrate for you.
 </p>
 
 <p align="center">
-  <a href="https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev">
-    <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" />
-  </a>
-</p>
-
-<p align="center">
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go_1.26-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" /></a>
   <a href="https://www.postgresql.org/"><img src="https://img.shields.io/badge/PostgreSQL_18-316192?style=flat-square&logo=postgresql&logoColor=white" alt="PostgreSQL" /></a>
   <a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker" /></a>
+  <a href="https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev"><img src="https://img.shields.io/badge/Render-deploy-46E3B7?style=flat-square" alt="Deploy on Render" /></a>
   <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebSocket"><img src="https://img.shields.io/badge/WebSocket-010101?style=flat-square&logo=socket.io&logoColor=white" alt="WebSocket" /></a>
   <a href="https://opentelemetry.io/"><img src="https://img.shields.io/badge/OpenTelemetry-000000?style=flat-square&logo=opentelemetry&logoColor=white" alt="OpenTelemetry" /></a>
   <a href="https://www.anthropic.com/"><img src="https://img.shields.io/badge/Anthropic-191919?style=flat-square&logo=anthropic&logoColor=white" alt="Anthropic" /></a>
@@ -150,21 +145,7 @@ git tag lite-v0.1.0 && git push origin lite-v0.1.0
 
 ## Deploy on Render
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev)
-
-This fork includes a production-hardened [`render.yaml`](render.yaml): GoClaw web service (Standard), Render Postgres 18 (pgvector), and a 10 GB persistent disk.
-
-**At Blueprint Apply you do not enter any LLM API keys.** Leave provider fields empty. Add one provider key after deploy.
-
-1. Click **Deploy to Render** and connect this repo (`dev` branch).
-2. Click **Apply** with no provider keys filled in.
-3. When the deploy is `live`, open the web service URL.
-4. Copy **`GOCLAW_GATEWAY_TOKEN`** from Environment in the [Render Dashboard](https://dashboard.render.com/) and sign in to the GoClaw dashboard.
-5. Add **one** LLM provider in GoClaw Settings (or set e.g. `GOCLAW_ANTHROPIC_API_KEY` in Render env vars and redeploy).
-
-New to Render? [Sign up](https://dashboard.render.com/register?utm_source=github&utm_medium=referral&utm_campaign=ojus_demos&utm_content=hero_cta).
-
-**Plan floor:** Standard (2 GB). Starter will OOM. **Not supported:** Docker sandbox, Tailscale, browser sidecar without extra services. See [`render.yaml`](render.yaml) comments and [template README](https://github.com/ojusave/goclaw/blob/dev/render.yaml) for troubleshooting (including the `exit 127` dockerCommand pitfall).
+[`render.yaml`](render.yaml) deploys GoClaw on Render (Postgres 18 + pgvector, Standard plan, persistent disk). Use the **Render** badge above or open the Blueprint from the repo root. No LLM keys required at Apply: add a provider in the dashboard after deploy. Copy `GOCLAW_GATEWAY_TOKEN` from the Render Dashboard to sign in.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Single binary. Production-tested. Agents that orchestrate for you.
 </p>
 
 <p align="center">
+  <a href="https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev">
+    <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go_1.26-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" /></a>
   <a href="https://www.postgresql.org/"><img src="https://img.shields.io/badge/PostgreSQL_18-316192?style=flat-square&logo=postgresql&logoColor=white" alt="PostgreSQL" /></a>
   <a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker" /></a>
@@ -141,6 +147,21 @@ git tag lite-v0.1.0 && git push origin lite-v0.1.0
 <p align="center">
   <img src="_statics/Mode Prompt System.jpg" alt="4-Mode Prompt System" width="800" />
 </p>
+
+## Deploy on Render
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev)
+
+This fork includes a [`render.yaml`](render.yaml) Blueprint: GoClaw web service, Render Postgres 18 (pgvector), and a persistent disk for config and agent workspaces.
+
+1. Click **Deploy to Render** and connect this GitHub repo.
+2. After the deploy finishes, open the web service URL.
+3. Copy `GOCLAW_GATEWAY_TOKEN` from the service's environment variables in the [Render Dashboard](https://dashboard.render.com/) and sign in to the dashboard.
+4. Set at least one LLM provider key (`GOCLAW_OPENROUTER_API_KEY`, `GOCLAW_ANTHROPIC_API_KEY`, or `GOCLAW_OPENAI_API_KEY`) in the Dashboard or in Render env vars.
+
+New to Render? [Sign up](https://dashboard.render.com/register?utm_source=github&utm_medium=referral&utm_campaign=ojus_demos&utm_content=hero_cta).
+
+**Not supported on Render:** Docker sandbox, Tailscale overlay, and docker-compose browser sidecars. See comments in `render.yaml` for details.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -152,16 +152,19 @@ git tag lite-v0.1.0 && git push origin lite-v0.1.0
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev)
 
-This fork includes a [`render.yaml`](render.yaml) Blueprint: GoClaw web service, Render Postgres 18 (pgvector), and a persistent disk for config and agent workspaces.
+This fork includes a production-hardened [`render.yaml`](render.yaml): GoClaw web service (Standard), Render Postgres 18 (pgvector), and a 10 GB persistent disk.
 
-1. Click **Deploy to Render** and connect this GitHub repo.
-2. After the deploy finishes, open the web service URL.
-3. Copy `GOCLAW_GATEWAY_TOKEN` from the service's environment variables in the [Render Dashboard](https://dashboard.render.com/) and sign in to the dashboard.
-4. Set at least one LLM provider key (`GOCLAW_OPENROUTER_API_KEY`, `GOCLAW_ANTHROPIC_API_KEY`, or `GOCLAW_OPENAI_API_KEY`) in the Dashboard or in Render env vars.
+**At Blueprint Apply you do not enter any LLM API keys.** Leave provider fields empty. Add one provider key after deploy.
+
+1. Click **Deploy to Render** and connect this repo (`dev` branch).
+2. Click **Apply** with no provider keys filled in.
+3. When the deploy is `live`, open the web service URL.
+4. Copy **`GOCLAW_GATEWAY_TOKEN`** from Environment in the [Render Dashboard](https://dashboard.render.com/) and sign in to the GoClaw dashboard.
+5. Add **one** LLM provider in GoClaw Settings (or set e.g. `GOCLAW_ANTHROPIC_API_KEY` in Render env vars and redeploy).
 
 New to Render? [Sign up](https://dashboard.render.com/register?utm_source=github&utm_medium=referral&utm_campaign=ojus_demos&utm_content=hero_cta).
 
-**Not supported on Render:** Docker sandbox, Tailscale overlay, and docker-compose browser sidecars. See comments in `render.yaml` for details.
+**Plan floor:** Standard (2 GB). Starter will OOM. **Not supported:** Docker sandbox, Tailscale, browser sidecar without extra services. See [`render.yaml`](render.yaml) comments and [template README](https://github.com/ojusave/goclaw/blob/dev/render.yaml) for troubleshooting (including the `exit 127` dockerCommand pitfall).
 
 ## Quick Start
 

--- a/render.yaml
+++ b/render.yaml
@@ -29,9 +29,6 @@ projects:
             image:
               url: ghcr.io/nextlevelbuilder/goclaw:latest
             healthCheckPath: /health
-            # GoClaw reads GOCLAW_PORT, not Render's PORT — map at container start.
-            dockerCommand: sh -c 'export GOCLAW_PORT="${PORT:-10000}" && exec /app/docker-entrypoint.sh serve'
-            initialDeployHook: psql "$GOCLAW_POSTGRES_DSN" -c 'CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pgcrypto;'
             disk:
               name: goclaw-data
               mountPath: /app/data
@@ -39,6 +36,9 @@ projects:
             envVars:
               - key: GOCLAW_HOST
                 value: "0.0.0.0"
+              # Render web services listen on port 10000 by default.
+              - key: GOCLAW_PORT
+                value: "10000"
               - key: GOCLAW_CONFIG
                 value: /app/data/config.json
               - key: GOCLAW_DATA_DIR

--- a/render.yaml
+++ b/render.yaml
@@ -2,16 +2,21 @@
 #
 # GoClaw on Render — Blueprint for https://github.com/ojusave/goclaw
 # Upstream: https://github.com/nextlevelbuilder/goclaw
+# Template docs: https://github.com/ojusave/goclaw/blob/dev/render.yaml
 #
 # Pattern: image-wrapper (official ghcr.io image with embedded web UI + Python).
-# Render Blueprints do not pass Docker build-args; building Dockerfile from this
-# repo without args skips the embedded dashboard (ENABLE_EMBEDUI defaults false).
 #
-# Not supported on Render: Docker sandbox (WITH_SANDBOX), Tailscale overlay,
-# docker-compose sidecars. Browser automation requires a separate private service.
+# Port contract: GoClaw binds GOCLAW_HOST + GOCLAW_PORT (not Render's PORT).
+# Render web services default to port 10000 — set GOCLAW_PORT=10000 explicitly.
+# Do NOT use dockerCommand shell wrappers here; Render image services pass the
+# full string as a single argv and startup fails with exit 127.
 #
-# After deploy: open the web dashboard, sign in with GOCLAW_GATEWAY_TOKEN, add
-# an LLM provider API key in Settings, then create agents.
+# Database: migrations run on boot (docker-entrypoint.sh → goclaw upgrade) and
+# create pgvector/pgcrypto extensions. Do NOT use initialDeployHook with psql —
+# the upstream image does not ship a PostgreSQL client.
+#
+# LLM provider keys are NOT listed in this Blueprint (avoids empty required fields
+# at Apply time). Add GOCLAW_*_API_KEY vars in the Dashboard after deploy.
 
 previews:
   generation: off
@@ -27,8 +32,9 @@ projects:
             plan: standard
             region: oregon
             image:
-              url: ghcr.io/nextlevelbuilder/goclaw:latest
+              url: ghcr.io/nextlevelbuilder/goclaw:v3.12.0
             healthCheckPath: /health
+            maxShutdownDelaySeconds: 120
             disk:
               name: goclaw-data
               mountPath: /app/data
@@ -36,7 +42,6 @@ projects:
             envVars:
               - key: GOCLAW_HOST
                 value: "0.0.0.0"
-              # Render web services listen on port 10000 by default.
               - key: GOCLAW_PORT
                 value: "10000"
               - key: GOCLAW_CONFIG
@@ -55,14 +60,6 @@ projects:
                 fromDatabase:
                   name: goclaw-db
                   property: connectionString
-              # Optional: set one provider key to auto-onboard on first boot.
-              # Add more keys from docs.goclaw.sh after deploy if needed.
-              - key: GOCLAW_OPENROUTER_API_KEY
-                sync: false
-              - key: GOCLAW_ANTHROPIC_API_KEY
-                sync: false
-              - key: GOCLAW_OPENAI_API_KEY
-                sync: false
 
         databases:
           - name: goclaw-db

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+#
+# GoClaw on Render — Blueprint for https://github.com/ojusave/goclaw
+# Upstream: https://github.com/nextlevelbuilder/goclaw
+#
+# Pattern: image-wrapper (official ghcr.io image with embedded web UI + Python).
+# Render Blueprints do not pass Docker build-args; building Dockerfile from this
+# repo without args skips the embedded dashboard (ENABLE_EMBEDUI defaults false).
+#
+# Not supported on Render: Docker sandbox (WITH_SANDBOX), Tailscale overlay,
+# docker-compose sidecars. Browser automation requires a separate private service.
+#
+# After deploy: open the web dashboard, sign in with GOCLAW_GATEWAY_TOKEN, add
+# an LLM provider API key in Settings, then create agents.
+
+previews:
+  generation: off
+
+projects:
+  - name: goclaw
+    environments:
+      - name: production
+        services:
+          - type: web
+            name: goclaw
+            runtime: image
+            plan: standard
+            region: oregon
+            image:
+              url: ghcr.io/nextlevelbuilder/goclaw:latest
+            healthCheckPath: /health
+            # GoClaw reads GOCLAW_PORT, not Render's PORT — map at container start.
+            dockerCommand: sh -c 'export GOCLAW_PORT="${PORT:-10000}" && exec /app/docker-entrypoint.sh serve'
+            initialDeployHook: psql "$GOCLAW_POSTGRES_DSN" -c 'CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pgcrypto;'
+            disk:
+              name: goclaw-data
+              mountPath: /app/data
+              sizeGB: 10
+            envVars:
+              - key: GOCLAW_HOST
+                value: "0.0.0.0"
+              - key: GOCLAW_CONFIG
+                value: /app/data/config.json
+              - key: GOCLAW_DATA_DIR
+                value: /app/data
+              - key: GOCLAW_WORKSPACE
+                value: /app/data/workspace
+              - key: GOCLAW_SKILLS_DIR
+                value: /app/data/skills
+              - key: GOCLAW_GATEWAY_TOKEN
+                generateValue: true
+              - key: GOCLAW_ENCRYPTION_KEY
+                generateValue: true
+              - key: GOCLAW_POSTGRES_DSN
+                fromDatabase:
+                  name: goclaw-db
+                  property: connectionString
+              # Optional: set one provider key to auto-onboard on first boot.
+              # Add more keys from docs.goclaw.sh after deploy if needed.
+              - key: GOCLAW_OPENROUTER_API_KEY
+                sync: false
+              - key: GOCLAW_ANTHROPIC_API_KEY
+                sync: false
+              - key: GOCLAW_OPENAI_API_KEY
+                sync: false
+
+        databases:
+          - name: goclaw-db
+            plan: basic-256mb
+            region: oregon
+            databaseName: goclaw
+            postgresMajorVersion: "18"
+            ipAllowList: []


### PR DESCRIPTION
Add a Render Blueprint (`render.yaml`) and README deploy instructions so GoClaw can be deployed on Render with one click: official GHCR image, Postgres 18, persistent disk, and auto-generated gateway/encryption secrets.

## Summary

Adds `render.yaml` for one-click Render deployment using the official `ghcr.io/nextlevelbuilder/goclaw` image, plus a short README section and badge-row link. The Blueprint wires Postgres 18, a 10GB persistent disk for agent workspaces, `GOCLAW_PORT=10000` (GoClaw does not use Render's `PORT`), and `generateValue` for `GOCLAW_GATEWAY_TOKEN` and `GOCLAW_ENCRYPTION_KEY`. LLM provider keys are intentionally omitted from the Blueprint so Apply does not prompt for empty API keys.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch

`dev`

## Checklist

- [x] `go build ./...` passes — N/A, no Go changes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes) — N/A
- [x] `go vet ./...` passes — N/A
- [x] Tests pass: `go test -race ./...` — N/A
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes) — N/A
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1`, `$2` (no string concat) — N/A
- [x] New user-facing strings added to all 3 locales (en/vi/zh) — N/A
- [x] Migration version bumped in `internal/upgrade/version.go` (if new migration) — N/A

## Test Plan

- Applied Blueprint from repo root; web service and Postgres 18 database provision successfully.
- Verified startup without `dockerCommand` shell wrapper (earlier `dockerCommand` caused exit 127); service binds on `GOCLAW_PORT=10000` and passes `/health`.
- Confirmed migrations run on boot and create required extensions (no `initialDeployHook` / `psql` needed).
- Live deploy: `https://goclaw-h5su.onrender.com` — dashboard loads, gateway token auth works after copying `GOCLAW_GATEWAY_TOKEN` from Dashboard.
- Deploy button/badge links to `https://render.com/deploy?repo=https://github.com/ojusave/goclaw&branch=dev`.
- Post-deploy: add LLM provider API key in Settings (not required at Blueprint Apply time).