### PR TITLE
fix(sandbox): scope Docker containers to tenant workspaces (fixes #1163)

### DIFF
--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"maps"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -257,17 +258,28 @@ func (m *DockerManager) Get(ctx context.Context, key string, workspace string, c
 
 	m.mu.RLock()
 	if sb, ok := m.sandboxes[key]; ok {
+		if sameWorkspace(sb.workspace, workspace) {
+			m.mu.RUnlock()
+			return sb, nil
+		}
 		m.mu.RUnlock()
-		return sb, nil
+	} else {
+		m.mu.RUnlock()
 	}
-	m.mu.RUnlock()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Double-check
+	// Double-check. If an existing sandbox was created for a different
+	// workspace, destroy it and recreate under the requested tenant workspace.
 	if sb, ok := m.sandboxes[key]; ok {
-		return sb, nil
+		if sameWorkspace(sb.workspace, workspace) {
+			return sb, nil
+		}
+		delete(m.sandboxes, key)
+		if err := sb.Destroy(ctx); err != nil {
+			slog.Warn("sandbox workspace changed; failed to destroy stale container", "key", key, "error", err)
+		}
 	}
 
 	prefix := cfg.ContainerPrefix
@@ -467,4 +479,8 @@ func (lb *limitedBuffer) Write(p []byte) (int, error) {
 
 func (lb *limitedBuffer) String() string {
 	return lb.buf.String()
+}
+
+func sameWorkspace(a, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
 }

--- a/internal/sandbox/docker_test.go
+++ b/internal/sandbox/docker_test.go
@@ -200,3 +200,24 @@ func containsString(values []string, target string) bool {
 	}
 	return false
 }
+
+func TestSameWorkspace(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{name: "same clean path", a: "/app/workspace/tenant-a", b: "/app/workspace/tenant-a", want: true},
+		{name: "equivalent clean path", a: "/app/workspace/tenant-a/.", b: "/app/workspace/tenant-a", want: true},
+		{name: "different tenant", a: "/app/workspace/tenant-a", b: "/app/workspace/tenant-b", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameWorkspace(tt.a, tt.b); got != tt.want {
+				t.Fatalf("sameWorkspace(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/credentialed_exec.go
+++ b/internal/tools/credentialed_exec.go
@@ -623,7 +623,11 @@ func (t *ExecTool) executeCredentialedHost(ctx context.Context, absPath string, 
 func (t *ExecTool) executeCredentialedSandbox(ctx context.Context, absPath string, args []string,
 	cwd string, sandboxKey string, envMap map[string]string, timeout time.Duration) *Result {
 
-	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, t.workspace, SandboxConfigFromCtx(ctx))
+	tenantWs := ToolWorkspaceFromCtx(ctx)
+	if tenantWs == "" {
+		tenantWs = t.workspace
+	}
+	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, tenantWs, SandboxConfigFromCtx(ctx))
 	if err != nil {
 		slog.Warn("security.credentialed_exec_sandbox_unavailable",
 			"binary", absPath, "error", err)

--- a/internal/tools/edit.go
+++ b/internal/tools/edit.go
@@ -207,7 +207,11 @@ func (t *EditTool) Execute(ctx context.Context, args map[string]any) *Result {
 }
 
 func (t *EditTool) executeInSandbox(ctx context.Context, path, oldStr, newStr string, replaceAll bool, sandboxKey string) *Result {
-	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, t.workspace, SandboxConfigFromCtx(ctx))
+	tenantWs := ToolWorkspaceFromCtx(ctx)
+	if tenantWs == "" {
+		tenantWs = t.workspace
+	}
+	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, tenantWs, SandboxConfigFromCtx(ctx))
 	if err != nil {
 		return ErrorResult(fmt.Sprintf("sandbox error: %v", err))
 	}

--- a/internal/tools/filesystem.go
+++ b/internal/tools/filesystem.go
@@ -215,7 +215,11 @@ func (t *ReadFileTool) executeInSandbox(ctx context.Context, path, sandboxKey st
 }
 
 func (t *ReadFileTool) getFsBridge(ctx context.Context, sandboxKey, containerCwd string) (*sandbox.FsBridge, error) {
-	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, t.workspace, SandboxConfigFromCtx(ctx))
+	tenantWs := ToolWorkspaceFromCtx(ctx)
+	if tenantWs == "" {
+		tenantWs = t.workspace
+	}
+	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, tenantWs, SandboxConfigFromCtx(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tools/filesystem_list.go
+++ b/internal/tools/filesystem_list.go
@@ -159,7 +159,11 @@ func (t *ListFilesTool) executeInSandbox(ctx context.Context, path, sandboxKey s
 }
 
 func (t *ListFilesTool) getFsBridge(ctx context.Context, sandboxKey, containerCwd string) (*sandbox.FsBridge, error) {
-	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, t.workspace, SandboxConfigFromCtx(ctx))
+	tenantWs := ToolWorkspaceFromCtx(ctx)
+	if tenantWs == "" {
+		tenantWs = t.workspace
+	}
+	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, tenantWs, SandboxConfigFromCtx(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tools/filesystem_write.go
+++ b/internal/tools/filesystem_write.go
@@ -284,7 +284,11 @@ func (t *WriteFileTool) executeInSandbox(ctx context.Context, path, content, san
 }
 
 func (t *WriteFileTool) getFsBridge(ctx context.Context, sandboxKey, containerCwd string) (*sandbox.FsBridge, error) {
-	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, t.workspace, SandboxConfigFromCtx(ctx))
+	tenantWs := ToolWorkspaceFromCtx(ctx)
+	if tenantWs == "" {
+		tenantWs = t.workspace
+	}
+	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, tenantWs, SandboxConfigFromCtx(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -644,7 +644,11 @@ func buildHostResult(err error, stdout, stderr *limitedBuffer, ctx context.Conte
 
 // executeInSandbox routes a command through a Docker sandbox container.
 func (t *ExecTool) executeInSandbox(ctx context.Context, command, cwd, sandboxKey string) *Result {
-	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, t.workspace, SandboxConfigFromCtx(ctx))
+	tenantWs := ToolWorkspaceFromCtx(ctx)
+	if tenantWs == "" {
+		tenantWs = t.workspace
+	}
+	sb, err := t.sandboxMgr.Get(ctx, sandboxKey, tenantWs, SandboxConfigFromCtx(ctx))
 	if err != nil {
 		if errors.Is(err, sandbox.ErrSandboxDisabled) {
 			return t.executeOnHost(ctx, command, cwd)


### PR DESCRIPTION
# Task #2 — GoClaw Issue #1163 tenant isolation real implementation status

## Status

Implementation prepared locally, but task is **blocked before completion** because required validation and PR/merge steps cannot be performed from this sandbox.

## Local implementation

Repo clone: `goclaw-1163-real`
Branch: `fix/1163-tenant-sandbox-isolation-real`
Local commit: `16253b12e1f682fcc35c10d87308aaed0d20615d`
Commit subject: `fix(sandbox): scope containers to tenant workspaces`
Patch artifact: `T-002-goclaw-1163-real-fix.patch`

## Files changed

- `internal/sandbox/docker.go`
- `internal/sandbox/docker_test.go`
- `internal/tools/credentialed_exec.go`
- `internal/tools/edit.go`
- `internal/tools/filesystem.go`
- `internal/tools/filesystem_list.go`
- `internal/tools/filesystem_write.go`
- `internal/tools/shell.go`

## What changed

1. All sandbox manager call sites in `internal/tools` now pass the effective tenant workspace instead of always passing the global tool workspace.
2. `DockerManager.Get` now detects same sandbox key with a different workspace. If the workspace differs, it removes the stale sandbox from cache, destroys the stale container, and creates a fresh sandbox bound to the requested tenant workspace.
3. Added `sameWorkspace` helper and unit coverage for equivalent/different workspace paths.

## Verification performed

- `git diff --check HEAD~1 HEAD` — PASS.
- Static scan confirmed all `sandboxMgr.Get(ctx, ...)` call sites under `internal/tools` now use `tenantWs`.

## Verification blocked

Required checks could not be completed in this environment:

- `gofmt` — BLOCKED: `gofmt: not found`.
- `go test ./internal/sandbox ./internal/tools` — BLOCKED: `go: not found`.
- Push branch / open PR — BLOCKED:
  - HTTPS push failed: `could not read Username for 'https://github.com'`.
  - SSH push failed: `Host key verification failed`.
  - `gh auth status`: not logged in.
- T-036 runtime regression test currently returns `7 passed, 3 failed` against the existing deployed/runtime environment. This is expected while the new code is not built/deployed; it cannot be used as proof for this local commit until PR/build/deploy succeeds.

## Required next action outside this sandbox

Run from an environment with Go toolchain and GitHub push/PR permissions:

```bash
cd goclaw-1163-real
gofmt -w internal/sandbox/docker.go internal/sandbox/docker_test.go internal/tools/credentialed_exec.go internal/tools/edit.go internal/tools/filesystem.go internal/tools/filesystem_list.go internal/tools/filesystem_write.go internal/tools/shell.go
go test ./internal/sandbox ./internal/tools
git push origin fix/1163-tenant-sandbox-isolation-real
gh pr create --base dev --head fix/1163-tenant-sandbox-isolation-real --title "fix(sandbox): scope containers to tenant workspaces" --body "Fixes #1163. Ensures Docker sandboxes use the effective tenant workspace and invalidates cached containers when a sandbox key is reused with a different workspace."
```

After merge:

```bash
git fetch origin
git rev-parse origin/dev
# compare with merge SHA / PR head as applicable
```

Then build/deploy and rerun T-036 until it is 10/10 PASS.

## Completion state

Do **not** mark the task complete yet. The mandatory acceptance criteria require PR merge and remote SHA validation, and those are blocked by missing GitHub authentication/permissions plus missing Go toolchain in the sandbox.
