### PR TITLE
fix: cannot import if file is over 1MB

### DIFF
--- a/ui/web/nginx.conf
+++ b/ui/web/nginx.conf
@@ -36,6 +36,7 @@ server {
 
     # API proxy
     location /v1/ {
+        client_max_body_size 500M;
         proxy_pass $upstream_backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

Fix import error when uploaded file is larger than 1MB.

<img width="946" height="323" alt="image" src="https://github.com/user-attachments/assets/f69c93d2-ae7f-44f9-803d-dd3937821ff4" />

While GoClaw Web accept max filesize of 500MB by default, nginx only accepts up to 1MB, which causes the file to be rejected before reaching the backend.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Checklist

- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials

## Test Plan

Manual testing by uploading a file larger than 1MB when importing Agents.
