### PR TITLE
fix(agent): make compaction timeout configurable

### DIFF
--- a/internal/agent/loop_compact.go
+++ b/internal/agent/loop_compact.go
@@ -37,6 +37,8 @@ Conversation to summarize:
 
 `
 
+const defaultCompactionTimeout = 120 * time.Second
+
 // compactMessagesInPlace summarizes the first ~70% of messages into a condensed
 // summary, keeping the last ~30% intact. Operates purely on the local messages
 // slice — no session state touched, no locks needed.
@@ -84,7 +86,7 @@ func (l *Loop) compactMessagesInPlace(ctx context.Context, messages []providers.
 		}
 	}
 
-	sctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	sctx, cancel := context.WithTimeout(ctx, l.compactionTimeout())
 	defer cancel()
 
 	inTokens := l.estimateSummaryInputTokens(toSummarize)
@@ -131,6 +133,13 @@ func (l *Loop) compactMessagesInPlace(ctx context.Context, messages []providers.
 		"kept", len(result))
 
 	return result
+}
+
+func (l *Loop) compactionTimeout() time.Duration {
+	if l.compactionCfg != nil && l.compactionCfg.TimeoutSeconds > 0 {
+		return time.Duration(l.compactionCfg.TimeoutSeconds) * time.Second
+	}
+	return defaultCompactionTimeout
 }
 
 // dynamicSummaryMax returns the output-token budget for a compaction or

--- a/internal/agent/loop_compact_timeout_test.go
+++ b/internal/agent/loop_compact_timeout_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+)
+
+func TestLoopCompactionTimeoutDefaultsToTwoMinutes(t *testing.T) {
+	loop := &Loop{}
+
+	if got := loop.compactionTimeout(); got != 120*time.Second {
+		t.Fatalf("compactionTimeout() = %v, want %v", got, 120*time.Second)
+	}
+}
+
+func TestLoopCompactionTimeoutIgnoresNonPositiveConfig(t *testing.T) {
+	for _, timeoutSeconds := range []int{0, -1} {
+		loop := &Loop{compactionCfg: &config.CompactionConfig{TimeoutSeconds: timeoutSeconds}}
+
+		if got := loop.compactionTimeout(); got != 120*time.Second {
+			t.Fatalf("compactionTimeout() with timeoutSeconds=%d = %v, want %v", timeoutSeconds, got, 120*time.Second)
+		}
+	}
+}
+
+func TestLoopCompactionTimeoutUsesConfiguredSeconds(t *testing.T) {
+	loop := &Loop{compactionCfg: &config.CompactionConfig{TimeoutSeconds: 45}}
+
+	if got := loop.compactionTimeout(); got != 45*time.Second {
+		t.Fatalf("compactionTimeout() = %v, want %v", got, 45*time.Second)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -265,6 +265,7 @@ type CompactionConfig struct {
 	ReserveTokensFloor int                `json:"reserveTokensFloor,omitempty"` // min reserve tokens (default 20000)
 	MaxHistoryShare    float64            `json:"maxHistoryShare,omitempty"`    // max share of context for history (default 0.85)
 	KeepLastMessages   int                `json:"keepLastMessages,omitempty"`   // messages to keep after compaction (default 4)
+	TimeoutSeconds     int                `json:"timeoutSeconds,omitempty"`     // per-compaction LLM timeout (default 120)
 	MemoryFlush        *MemoryFlushConfig `json:"memoryFlush,omitempty"`        // pre-compaction flush
 }
 

--- a/ui/web/src/i18n/locales/en/agents.json
+++ b/ui/web/src/i18n/locales/en/agents.json
@@ -812,6 +812,8 @@
       "maxHistoryShareTip": "Maximum fraction of context window for conversation history (e.g. 0.85 = 85%). Compaction triggers when exceeded.",
       "keepLastMessages": "Keep Last Messages",
       "keepLastMessagesTip": "Recent messages kept after compaction. Older messages are replaced by a summary.",
+      "timeoutSeconds": "Compaction Timeout (seconds)",
+      "timeoutSecondsTip": "Maximum time to wait for the compaction summarization call. Leave empty to use the default 120 seconds.",
       "memoryFlush": "Memory Flush",
       "memoryFlushTip": "Before compaction, the agent gets a turn to save important context to memory files. Also triggers Knowledge Graph extraction."
     },

--- a/ui/web/src/i18n/locales/en/config.json
+++ b/ui/web/src/i18n/locales/en/config.json
@@ -100,6 +100,8 @@
   "agents.compaction.reserveTokensFloorTip": "Minimum token buffer to reserve for new responses before compacting.",
   "agents.compaction.maxHistoryShare": "Max History Share (0-1)",
   "agents.compaction.maxHistoryShareTip": "Fraction of the context window that conversation history can occupy.",
+  "agents.compaction.timeoutSeconds": "Compaction Timeout (seconds)",
+  "agents.compaction.timeoutSecondsTip": "Maximum time to wait for compaction summarization. Leave empty to use the default 120 seconds.",
 
   "agents.pruning.title": "Context Pruning",
   "agents.pruning.desc": "Trim old tool results to free context space",

--- a/ui/web/src/i18n/locales/vi/agents.json
+++ b/ui/web/src/i18n/locales/vi/agents.json
@@ -797,6 +797,8 @@
       "maxHistoryShareTip": "Tỷ lệ tối đa của cửa sổ ngữ cảnh dành cho lịch sử hội thoại (vd: 0.85 = 85%). Nén kích hoạt khi vượt quá.",
       "keepLastMessages": "Giữ tin nhắn cuối",
       "keepLastMessagesTip": "Số tin nhắn gần nhất giữ lại sau khi nén. Các tin nhắn cũ hơn được thay thế bằng bản tóm tắt.",
+      "timeoutSeconds": "Timeout nén (giây)",
+      "timeoutSecondsTip": "Thời gian tối đa chờ lượt tóm tắt nén. Để trống để dùng mặc định 120 giây.",
       "memoryFlush": "Ghi nhớ trước nén",
       "memoryFlushTip": "Trước khi nén, agent được một lượt để lưu ngữ cảnh quan trọng vào file bộ nhớ. Cũng kích hoạt trích xuất Knowledge Graph."
     },

--- a/ui/web/src/i18n/locales/vi/config.json
+++ b/ui/web/src/i18n/locales/vi/config.json
@@ -100,6 +100,8 @@
   "agents.compaction.reserveTokensFloorTip": "Bộ đệm token tối thiểu cần dự trữ cho phản hồi mới trước khi nén.",
   "agents.compaction.maxHistoryShare": "Phần lịch sử tối đa (0-1)",
   "agents.compaction.maxHistoryShareTip": "Tỷ lệ cửa sổ ngữ cảnh mà lịch sử cuộc trò chuyện có thể chiếm.",
+  "agents.compaction.timeoutSeconds": "Timeout nén (giây)",
+  "agents.compaction.timeoutSecondsTip": "Thời gian tối đa chờ tóm tắt nén. Để trống để dùng mặc định 120 giây.",
 
   "agents.pruning.title": "Cắt bớt ngữ cảnh",
   "agents.pruning.desc": "Cắt bỏ kết quả công cụ cũ để giải phóng không gian ngữ cảnh",

--- a/ui/web/src/i18n/locales/zh/agents.json
+++ b/ui/web/src/i18n/locales/zh/agents.json
@@ -797,6 +797,8 @@
       "maxHistoryShareTip": "上下文窗口用于对话历史的最大比例（如0.85 = 85%）。超过时触发压缩。",
       "keepLastMessages": "保留最后消息数",
       "keepLastMessagesTip": "压缩后保留的最近消息数。旧消息被摘要替换。",
+      "timeoutSeconds": "压缩超时（秒）",
+      "timeoutSecondsTip": "等待压缩摘要调用的最长时间。留空则使用默认 120 秒。",
       "memoryFlush": "压缩前记忆",
       "memoryFlushTip": "压缩前，Agent可以将重要上下文保存到记忆文件。同时触发知识图谱提取。"
     },

--- a/ui/web/src/i18n/locales/zh/config.json
+++ b/ui/web/src/i18n/locales/zh/config.json
@@ -100,6 +100,8 @@
   "agents.compaction.reserveTokensFloorTip": "压缩前为新响应保留的最小 Token 缓冲区。",
   "agents.compaction.maxHistoryShare": "最大历史占比（0-1）",
   "agents.compaction.maxHistoryShareTip": "对话历史可占用的上下文窗口比例。",
+  "agents.compaction.timeoutSeconds": "压缩超时（秒）",
+  "agents.compaction.timeoutSecondsTip": "等待压缩摘要的最长时间。留空则使用默认 120 秒。",
 
   "agents.pruning.title": "上下文裁剪",
   "agents.pruning.desc": "裁剪旧工具结果以释放上下文空间",

--- a/ui/web/src/pages/agents/agent-detail/config-sections/compaction-section.tsx
+++ b/ui/web/src/pages/agents/agent-detail/config-sections/compaction-section.tsx
@@ -39,6 +39,16 @@ export function CompactionSection({ value, onChange }: CompactionSectionProps) {
             onChange={(e) => onChange({ ...value, keepLastMessages: numOrUndef(e.target.value) })}
           />
         </div>
+        <div className="space-y-2">
+          <InfoLabel tip={t(`${s}.timeoutSecondsTip`)}>{t(`${s}.timeoutSeconds`)}</InfoLabel>
+          <Input
+            type="number"
+            placeholder="120"
+            min={1}
+            value={value.timeoutSeconds ?? ""}
+            onChange={(e) => onChange({ ...value, timeoutSeconds: numOrUndef(e.target.value) })}
+          />
+        </div>
       </div>
       <div className="flex items-center gap-2">
         <Switch

--- a/ui/web/src/pages/config/sections/ai-defaults-section.tsx
+++ b/ui/web/src/pages/config/sections/ai-defaults-section.tsx
@@ -196,6 +196,7 @@ export function AiDefaultsSection({ data, onSave, saving }: Props) {
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Field label={t("agents.compaction.reserveTokensFloor")} tip={t("agents.compaction.reserveTokensFloorTip")} type="number" value={compaction.reserveTokensFloor} onChange={(v) => updateNested("compaction", { reserveTokensFloor: Number(v) })} placeholder="20000" />
             <Field label={t("agents.compaction.maxHistoryShare")} tip={t("agents.compaction.maxHistoryShareTip")} type="number" step="0.05" value={compaction.maxHistoryShare} onChange={(v) => updateNested("compaction", { maxHistoryShare: Number(v) })} placeholder="0.75" />
+            <Field label={t("agents.compaction.timeoutSeconds")} tip={t("agents.compaction.timeoutSecondsTip")} type="number" value={compaction.timeoutSeconds} onChange={(v) => updateNested("compaction", { timeoutSeconds: Number(v) })} placeholder="120" />
           </div>
         </SubSection>
 
@@ -263,4 +264,3 @@ export function AiDefaultsSection({ data, onSave, saving }: Props) {
     </Card>
   );
 }
-

--- a/ui/web/src/types/agent.ts
+++ b/ui/web/src/types/agent.ts
@@ -28,6 +28,7 @@ export interface CompactionConfig {
   reserveTokensFloor?: number;
   maxHistoryShare?: number;
   keepLastMessages?: number;
+  timeoutSeconds?: number;
   memoryFlush?: {
     enabled?: boolean;
     softThresholdTokens?: number;


### PR DESCRIPTION
## Summary
- Add optional compaction timeout configuration for mid-loop compaction LLM calls.
- Increase the default timeout used by compaction from 30s to 120s for larger agent sessions.
- Expose the setting in agent defaults and per-agent compaction UI.

This is a clean replacement for #1151. The previous PR branch accidentally included an unrelated Discord commit; this branch is based on current upstream main and contains only the compaction timeout changes.

## Verification
- Not run locally: this Tiny server does not currently have the Go toolchain installed (`go: command not found`).
