### PR TITLE
fix panic error timeout

### DIFF
--- a/internal/agent/image_gen_gate_test.go
+++ b/internal/agent/image_gen_gate_test.go
@@ -9,8 +9,10 @@ package agent
 // Additionally: final-iteration stripping takes priority — all tools removed.
 
 import (
+	"context"
 	"testing"
 
+	"github.com/nextlevelbuilder/goclaw/internal/pipeline"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 )
 
@@ -113,5 +115,26 @@ func TestImageGenGate_FinalIteration_AllToolsStripped(t *testing.T) {
 
 	if len(defs) != 0 {
 		t.Errorf("final iteration must strip all tools; got %d: %v", len(defs), defs)
+	}
+}
+
+// Regression: imageGenToolDef has Function=nil; makeBuildFilteredTools must not panic
+// when counting MCP tools after injection (loop_pipeline_callbacks.go).
+func TestMakeBuildFilteredTools_WithImageGen_NoPanic(t *testing.T) {
+	t.Parallel()
+	prov := &imageCapableProvider{imageGen: true}
+	l := buildImageGenLoop(true, prov)
+	cb := l.makeBuildFilteredTools(&RunRequest{ChannelType: "facebook"})
+	state := &pipeline.RunState{
+		Input:    &pipeline.RunInput{UserID: "u1", ChannelType: "facebook"},
+		Messages: pipeline.NewMessageBuffer(providers.Message{}),
+		Ctx:      context.Background(),
+	}
+	defs, err := cb(state)
+	if err != nil {
+		t.Fatalf("makeBuildFilteredTools: %v", err)
+	}
+	if !hasImageGenTool(defs) {
+		t.Fatal("expected image_generation tool in filtered defs")
 	}
 }

--- a/internal/agent/loop_pipeline_callbacks.go
+++ b/internal/agent/loop_pipeline_callbacks.go
@@ -540,7 +540,7 @@ func (l *Loop) makeFlushMessages(req *RunRequest) func(ctx context.Context, sess
 
 func (l *Loop) makeUpdateMetadata(req *RunRequest) func(ctx context.Context, sessionKey string, usage providers.Usage) error {
 	return func(ctx context.Context, sessionKey string, usage providers.Usage) error {
-		l.sessions.UpdateMetadata(ctx, sessionKey, l.model, l.provider.Name(), req.Channel)
+		l.sessions.UpdateMetadata(ctx, sessionKey, l.model, l.ProviderName(), req.Channel)
 		l.sessions.AccumulateTokens(ctx, sessionKey, int64(usage.PromptTokens), int64(usage.CompletionTokens))
 		// Persist session to DB (matching v2 finalizeRun behavior).
 		// FlushMessages already ran, so all pending messages are in the cache.

--- a/internal/agent/loop_pipeline_callbacks.go
+++ b/internal/agent/loop_pipeline_callbacks.go
@@ -237,7 +237,7 @@ func (l *Loop) makeBuildFilteredTools(req *RunRequest) func(state *pipeline.RunS
 		}
 		mcpDefs := 0
 		for _, td := range toolDefs {
-			if strings.HasPrefix(strings.TrimSpace(td.Function.Name), "mcp_") {
+			if name := toolDefinitionName(td); strings.HasPrefix(strings.TrimSpace(name), "mcp_") {
 				mcpDefs++
 			}
 		}
@@ -437,7 +437,7 @@ func (l *Loop) makeCallLLM(req *RunRequest, emitRun func(AgentEvent)) func(ctx c
 func shouldRetryTaskMCP(chatReq providers.ChatRequest) bool {
 	hasTaskMCPTool := false
 	for _, td := range chatReq.Tools {
-		name := strings.TrimSpace(td.Function.Name)
+		name := strings.TrimSpace(toolDefinitionName(td))
 		if strings.HasPrefix(name, "mcp_bx24__") && (strings.Contains(name, "search") || strings.Contains(name, "execute")) {
 			hasTaskMCPTool = true
 			break

--- a/internal/agent/loop_tool_filter.go
+++ b/internal/agent/loop_tool_filter.go
@@ -24,7 +24,7 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	var toolDefs []providers.ToolDefinition
 	var allowedTools map[string]bool
 	if l.toolPolicy != nil {
-		toolDefs = l.toolPolicy.FilterTools(l.tools, l.id, l.provider.Name(), l.agentToolPolicy, req.ToolAllow, false, false)
+		toolDefs = l.toolPolicy.FilterTools(l.tools, l.id, l.ProviderName(), l.agentToolPolicy, req.ToolAllow, false, false)
 		allowedTools = make(map[string]bool, len(toolDefs))
 		for _, td := range toolDefs {
 			allowedTools[td.Function.Name] = true

--- a/internal/agent/loop_tracing.go
+++ b/internal/agent/loop_tracing.go
@@ -74,7 +74,7 @@ func (l *Loop) resolveSpan(opts []spanOption) (string, string) {
 }
 
 func (l *Loop) resolveSpanOverrides(opts []spanOption) spanOverrides {
-	o := spanOverrides{model: l.model, provider: l.provider.Name()}
+	o := spanOverrides{model: l.model, provider: l.ProviderName()}
 	for _, fn := range opts {
 		fn(&o)
 	}

--- a/internal/agent/loop_utils.go
+++ b/internal/agent/loop_utils.go
@@ -173,6 +173,15 @@ func (l *Loop) ProviderName() string {
 	return l.provider.Name()
 }
 
+// toolDefinitionName returns the function tool name, or empty for native provider tools
+// (e.g. image_generation) whose Function field is nil per providers.ToolDefinition.
+func toolDefinitionName(td providers.ToolDefinition) string {
+	if td.Function != nil {
+		return td.Function.Name
+	}
+	return ""
+}
+
 // uniquifyToolCallIDs ensures all tool call IDs are globally unique across the
 // transcript by hashing the original ID with run-ID, iteration, and index.
 // Returns a new slice (does not mutate the input).

--- a/internal/agent/memoryflush.go
+++ b/internal/agent/memoryflush.go
@@ -178,7 +178,7 @@ func (l *Loop) runMemoryFlush(ctx context.Context, sessionKey string, settings *
 	// Build tool list — only file tools needed for memory flush
 	var toolDefs []providers.ToolDefinition
 	if l.toolPolicy != nil {
-		toolDefs = l.toolPolicy.FilterTools(l.tools, l.id, l.provider.Name(), nil, nil, false, false)
+		toolDefs = l.toolPolicy.FilterTools(l.tools, l.id, l.ProviderName(), nil, nil, false, false)
 	} else {
 		toolDefs = l.tools.ProviderDefs()
 	}

--- a/internal/agent/usage_caps_runtime.go
+++ b/internal/agent/usage_caps_runtime.go
@@ -43,6 +43,9 @@ func (l *Loop) reserveInternalLLMUsageFor(ctx context.Context, chatReq providers
 }
 
 func (l *Loop) callInternalLLMWithUsage(ctx context.Context, chatReq providers.ChatRequest, purpose string) (*providers.ChatResponse, error) {
+	if l.provider == nil {
+		return nil, fmt.Errorf("callInternalLLMWithUsage: provider is nil (purpose=%s)", purpose)
+	}
 	if fallbackProvider, ok := l.provider.(*providers.ModelFallbackProvider); ok {
 		before := func(callCtx context.Context, entry providers.FallbackCandidate, actualReq providers.ChatRequest) (providers.FallbackAfterCall, error) {
 			candidatePurpose := fmt.Sprintf("%s:%s:%s", purpose, entry.ProviderName, actualReq.Model)

--- a/internal/scheduler/queue.go
+++ b/internal/scheduler/queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -299,7 +300,7 @@ func (sq *SessionQueue) executeRun(ctx context.Context, runID string, runGenerat
 	// ensure cleanup still runs so the session queue doesn't orphan this run.
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("scheduler: executeRun panicked", "run_id", runID, "panic", fmt.Sprint(r))
+			slog.Error("scheduler: executeRun panicked", "run_id", runID, "panic", fmt.Sprint(r), "stack", string(debug.Stack()))
 			pending.ResultCh <- RunOutcome{Err: fmt.Errorf("run panic: %v", r)}
 			close(pending.ResultCh)
 			sq.mu.Lock()


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: What does this PR do and why? -->
Lỗi  panickedpanic=runtime error khi agent nhận webhook từ FB 
scheduler: executeRun panickedpanic=runtime error: invalid memory address or nil pointer dereferencerun_id=inbound-fb-best-sport-page-3689135964538760-d3541dc1
1:19:54 PM [ERROR] inbound: agent run failedchannel=fb-best-sport-pageerror=run panic: runtime error: invalid memory address or nil pointer dereference
## Type
<!-- Check one -->
- [ ] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->

## Checklist
- [ ] `go build ./...` passes
- [ ] `go build -tags sqliteonly ./...` passes (if Go changes)
- [ ] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [ ] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
