### PR TITLE
fix(gateway): inject agent key in MCP bridge so session tools resolve identity

### DIFF
--- a/internal/gateway/bridge_context_test.go
+++ b/internal/gateway/bridge_context_test.go
@@ -1,0 +1,90 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
+)
+
+// stubAgentKeyStore satisfies store.AgentStore via an embedded (nil) interface and
+// implements only GetByIDUnscoped — the single method bridgeContextMiddleware calls.
+type stubAgentKeyStore struct {
+	store.AgentStore
+	ag *store.AgentData
+}
+
+func (s *stubAgentKeyStore) GetByIDUnscoped(context.Context, uuid.UUID) (*store.AgentData, error) {
+	return s.ag, nil
+}
+
+// TestBridgeContextMiddleware_InjectsAgentKey guards the MCP bridge identity path:
+// a signed X-Agent-ID must put the agent key into the tool context
+// (tools.ToolAgentKeyFromCtx). Session tools (sessions_list/history/send) resolve the
+// caller via that key and otherwise fail with "agent context required".
+func TestBridgeContextMiddleware_InjectsAgentKey(t *testing.T) {
+	const (
+		gatewayToken = "test-gateway-token"
+		wantKey      = "vault-keeper"
+	)
+	agentID := uuid.New()
+	agentStore := &stubAgentKeyStore{ag: &store.AgentData{AgentKey: wantKey}}
+
+	var handlerCalled bool
+	var gotKey string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		gotKey = tools.ToolAgentKeyFromCtx(r.Context())
+	})
+
+	mw := bridgeContextMiddleware(gatewayToken, agentStore, next)
+
+	// Sign X-Agent-ID exactly as the claude-cli provider does: empty user/channel/
+	// chat/peer/workspace/tenant plus the two trailing extras (localKey, sessionKey).
+	sig := providers.SignBridgeContext(gatewayToken, agentID.String(), "", "", "", "", "", "", "", "")
+	req := httptest.NewRequest(http.MethodPost, "/mcp/bridge", nil)
+	req.Header.Set("X-Agent-ID", agentID.String())
+	req.Header.Set("X-Bridge-Sig", sig)
+
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !handlerCalled {
+		t.Fatal("next handler was not called: middleware rejected the signed request")
+	}
+	if gotKey != wantKey {
+		t.Errorf("ToolAgentKeyFromCtx = %q, want %q", gotKey, wantKey)
+	}
+}
+
+// TestBridgeContextMiddleware_NoStore_NoAgentKey is the negative control: with no
+// agent store wired (or an unsigned request), the agent key must stay empty so the
+// regression that motivated this fix cannot silently reappear masked by a default.
+func TestBridgeContextMiddleware_NoStore_NoAgentKey(t *testing.T) {
+	const gatewayToken = "test-gateway-token"
+	agentID := uuid.New()
+
+	var gotKey string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotKey = tools.ToolAgentKeyFromCtx(r.Context())
+	})
+
+	// agentStore == nil: middleware injects the UUID but has no row to recover the key from.
+	mw := bridgeContextMiddleware(gatewayToken, nil, next)
+
+	sig := providers.SignBridgeContext(gatewayToken, agentID.String(), "", "", "", "", "", "", "", "")
+	req := httptest.NewRequest(http.MethodPost, "/mcp/bridge", nil)
+	req.Header.Set("X-Agent-ID", agentID.String())
+	req.Header.Set("X-Bridge-Sig", sig)
+
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if gotKey != "" {
+		t.Errorf("ToolAgentKeyFromCtx = %q, want empty when no agent store is wired", gotKey)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -279,6 +279,11 @@ func bridgeContextMiddleware(gatewayToken string, agentStore store.AgentStore, n
 					if agentStore != nil {
 						ag, err := agentStore.GetByIDUnscoped(ctx, id)
 						if err == nil && ag != nil {
+							// Propagate the agent key so bridged session tools (sessions_list/
+							// history/send) can resolve identity via ToolAgentKeyFromCtx. The MCP
+							// bridge otherwise injects only the agent UUID, leaving the key empty
+							// -> session tools fail with "agent context required".
+							ctx = tools.WithToolAgentKey(ctx, ag.AgentKey)
 							groups := ag.ParseShellDenyGroups()
 							if groups != nil {
 								ctx = store.WithShellDenyGroups(ctx, groups)


### PR DESCRIPTION
## Problem

Builtin session tools (`sessions_list`, `sessions_history`, `sessions_send`, `session_status`) always fail with `"agent context required"` when invoked through the MCP bridge (e.g. by a `claude-cli` provider agent). They are enabled and callable, but unusable over `/mcp/bridge`.

## Root cause

`bridgeContextMiddleware` (`internal/gateway/server.go`) injects the agent **UUID** via `store.WithAgentID(ctx, id)` but never the agent **key**. The session tools resolve the caller via `tools.ToolAgentKeyFromCtx(ctx)` — the agent *key*, because session keys are namespaced by key (`agent:<key>:...`), not UUID — and over the bridge there is no `RunContext` fallback, so it returns `""` and every tool short-circuits:

```go
agentKey := ToolAgentKeyFromCtx(ctx)
if agentKey == "" {
    return ErrorResult("agent context required")
}
```

## Fix

The middleware already fetches the agent (`ag`) in the same block to apply shell-deny-group overrides. Inject the key right there, symmetric with the existing `store.WithShellDenyGroups(ctx, groups)`:

```go
if err == nil && ag != nil {
    ctx = tools.WithToolAgentKey(ctx, ag.AgentKey)
    groups := ag.ParseShellDenyGroups()
    ...
}
```

No extra DB round-trip (reuses the existing `GetByIDUnscoped`), no new imports (`tools` is already used here for `WithToolChannel` / `WithToolChatID`).

## Scope vs #1094

**Correction (was inaccurate in the original description):** #1094 *does* touch this same `bridgeContextMiddleware` block — it adds `ctx = tools.WithToolAgentKey(ctx, ag.AgentKey)` at the same `GetByIDUnscoped` site. So the server-path fix overlaps; my earlier claim that it "does not touch this path" was wrong. Thanks to the reviewer for catching it.

This PR is the **minimal, isolated extraction of exactly that slice**, intended as the deliberate successor for it:

- **#1094 is a 70+ file, ~7.3k-line PR** bundling an ACP/Gemini provider refactor, a full Korean i18n catalog, and `BuiltinToolStore` plumbing. It is currently **`CONFLICTING` against `dev` and last updated 2026-05-04** (stale), so the load-bearing 5-line bridge fix is blocked behind unrelated work that is unlikely to land soon.
- This PR changes **only** `internal/gateway/server.go` (+5) plus a regression test, so it can merge independently and immediately unblock session tools over `/mcp/bridge`.
- It also intentionally **omits** #1094's companion `store.WithAgentKey(ctx, ag.AgentKey)` write: nothing on `dev` reads the store-level key (`store.AgentKeyFromCtx` has no callers), while every session tool reads `tools.ToolAgentKeyFromCtx`. Keeping the change to exactly what is load-bearing.

I can't edit/close #1094 (different author). Suggested resolution: land this minimal PR, and drop the `internal/gateway/server.go` slice from #1094 when it rebases — the rest of #1094 is independent.

## Testing

- **New regression test** `internal/gateway/bridge_context_test.go` exercises the bridge propagation that regressed here: a signed `X-Agent-ID` + a stub `AgentStore` returning an `AgentKey`, asserting the downstream handler sees `tools.ToolAgentKeyFromCtx(ctx)` populated, plus a negative control (no store → empty key). Mutation-checked: removing the fix line makes `TestBridgeContextMiddleware_InjectsAgentKey` fail with `ToolAgentKeyFromCtx = ""`.
- Existing tool tests already cover both states: `TestSessionStatus_EmptyAgentID_Error` (no key → `"agent context required"`) and the positive cases via the `agentCtx()` helper. This PR makes the bridge actually supply the key those tools expect.
- Verified in production (`v3.13.2` + this patch): `sessions_list` / `sessions_history` now return the agent's sessions over the bridge instead of erroring.
