### PR TITLE
fix(setup): enable scrolling on mobile setup page

### DIFF
--- a/ui/web/src/pages/setup/setup-layout.tsx
+++ b/ui/web/src/pages/setup/setup-layout.tsx
@@ -4,8 +4,8 @@ export function SetupLayout({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation("setup");
 
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-background px-4 py-8">
-      <div className="w-full max-w-2xl space-y-6">
+    <div className="flex min-h-dvh items-start justify-center bg-background px-4 py-8 sm:items-center">
+      <div className="w-full max-w-2xl space-y-6 overflow-y-auto max-h-dvh sm:max-h-none">
         <div className="text-center">
           <img src="/goclaw-icon.svg" alt="GoClaw" className="mx-auto mb-4 h-16 w-16" />
           <h1 className="text-4xl font-bold tracking-tight">GoClaw Setup</h1>


### PR DESCRIPTION
## Problem
The initial onboard setup page (/setup) does not have a scrolling mechanism on mobile devices. Users must zoom out to see all content.

## Root Cause
The SetupLayout component uses `items-center justify-center` with `min-h-dvh`, which attempts to center content vertically. This prevents scrolling when content exceeds the viewport height on small screens.

## Solution
- Change outer container from `items-center` to `items-start sm:items-center` for mobile-first layout
- Add `overflow-y-auto max-h-dvh sm:max-h-none` to inner content div on mobile
- Desktop (sm breakpoint) retains centered layout with no scroll constraint

## Changes
- **File:** `ui/web/src/pages/setup/setup-layout.tsx`
- Outer container: `items-center` → `items-start sm:items-center`
- Inner content: Added `overflow-y-auto max-h-dvh sm:max-h-none`

## Mobile UI Compliance
✅ Uses `h-dvh` (dynamic viewport height) instead of `h-screen`  
✅ Mobile-first responsive design with Tailwind breakpoints  
✅ Content scrolls naturally on small screens without zoom requirement

Closes #1219