### PR TITLE
fix(hooks): populate tenant_id from context for agent-scoped hooks

### DIFF
--- a/internal/gateway/methods/hooks.go
+++ b/internal/gateway/methods/hooks.go
@@ -145,8 +145,8 @@ func (m *HookMethods) handleCreate(ctx context.Context, client *gateway.Client, 
 			i18n.T(locale, i18n.MsgMasterScopeRequired)))
 		return
 	}
-	// For tenant/agent scope, fill TenantID from ctx if not provided.
-	if cfg.Scope != hooks.ScopeGlobal && cfg.TenantID == uuid.Nil {
+	// For tenant/agent scope, fill TenantID from ctx if not provided or if sentinel.
+	if cfg.Scope != hooks.ScopeGlobal && (cfg.TenantID == uuid.Nil || cfg.TenantID == hooks.SentinelTenantID) {
 		cfg.TenantID = store.TenantIDFromContext(ctx)
 	}
 	if cfg.Scope == hooks.ScopeGlobal {


### PR DESCRIPTION
## Problem

Creating an agent-scoped hook in the Web UI fails with error:
```
hook: agent scope requires a real tenant_id
```

## Root Cause

In `handleCreate()` (line 149), the code only checks if `cfg.TenantID == uuid.Nil` before filling from context:

```go
if cfg.Scope != hooks.ScopeGlobal && cfg.TenantID == uuid.Nil {
    cfg.TenantID = store.TenantIDFromContext(ctx)
}
```

However, when creating an agent-scoped hook without an explicit `tenant_id`, the config may be initialized with `SentinelTenantID`. The condition doesn't catch this case, so the sentinel value is passed to validation, which then fails.

## Fix

Check for **both** `uuid.Nil` AND `SentinelTenantID`:

```go
if cfg.Scope != hooks.ScopeGlobal && (cfg.TenantID == uuid.Nil || cfg.TenantID == hooks.SentinelTenantID) {
    cfg.TenantID = store.TenantIDFromContext(ctx)
}
```

This ensures agent-scoped hooks properly inherit tenant context from the request, matching behavior of tenant-scoped hooks.

## Changes

- **File**: `internal/gateway/methods/hooks.go:149`
- **Change**: Added sentinel value check to tenant_id context-fill logic
- **Result**: Agent-scoped hooks can now be created without explicit tenant_id parameter

## Test Plan

- [x] Fix is minimal (2-line change)
- [x] Matches validation logic which rejects sentinel for agent scope
- [x] Consistent with tenant-scope hook behavior
- [x] No new dependencies or side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)