### PR TITLE
feat: preserve telegram custom emoji markup

### DIFF
--- a/internal/channels/telegram/format.go
+++ b/internal/channels/telegram/format.go
@@ -63,7 +63,6 @@ func markdownToTelegramHTML(text string) string {
 	inlineCodes := extractInlineCodes(text)
 	text = inlineCodes.text
 
-
 	// Extract and protect bare URLs from italic parsing.
 	// URLs with underscores (e.g. syngas_dailymail_2026_ai) get broken by
 	// the italic regex which matches _text_ patterns inside URLs.
@@ -74,6 +73,12 @@ func markdownToTelegramHTML(text string) string {
 		urlPlaceholders = append(urlPlaceholders, s)
 		return fmt.Sprintf("\x00URL%d\x00", idx)
 	})
+
+	// Extract and protect Telegram custom emoji tags. These are valid
+	// Telegram HTML entities, but arbitrary HTML must still be escaped.
+	customEmojis := extractCustomEmojiTags(text)
+	text = customEmojis.text
+
 	// Strip markdown headers
 	text = regexp.MustCompile(`(?m)^#{1,6}\s+(.+)$`).ReplaceAllString(text, "$1")
 
@@ -152,6 +157,12 @@ func markdownToTelegramHTML(text string) string {
 		text = strings.ReplaceAll(text, fmt.Sprintf("\x00TB%d\x00", i), fmt.Sprintf("<pre>%s</pre>", escaped))
 	}
 
+	// Restore vetted Telegram custom emoji entities after all generic
+	// escaping and markdown conversion has completed.
+	for i, emoji := range customEmojis.tags {
+		text = strings.ReplaceAll(text, fmt.Sprintf("\x00CE%d\x00", i), emoji)
+	}
+
 	return text
 }
 
@@ -177,6 +188,57 @@ func extractCodeBlocks(text string) codeBlockMatch {
 	})
 
 	return codeBlockMatch{text: text, codes: codes}
+}
+
+type customEmojiMatch struct {
+	text string
+	tags []string
+}
+
+var (
+	reTelegramCustomEmojiTag      = regexp.MustCompile(`<tg-emoji\s+emoji-id="([0-9]{1,32})">([^<>&]+)</tg-emoji>`)
+	reTelegramCustomEmojiImg      = regexp.MustCompile(`<img\s+src="tg://emoji\?id=([0-9]{1,32})"\s+alt="([^<>&"]+)"\s*/>`)
+	reTelegramCustomEmojiMarkdown = regexp.MustCompile(`!\[([^\]<>&]+)\]\(tg://emoji\?id=([0-9]{1,32})\)`)
+)
+
+func extractCustomEmojiTags(text string) customEmojiMatch {
+	var tags []string
+
+	replace := func(id, fallback string) string {
+		idx := len(tags)
+		tags = append(tags, fmt.Sprintf(
+			`<tg-emoji emoji-id="%s">%s</tg-emoji>`,
+			id,
+			fallback,
+		))
+		return fmt.Sprintf("\x00CE%d\x00", idx)
+	}
+
+	text = reTelegramCustomEmojiTag.ReplaceAllStringFunc(text, func(s string) string {
+		match := reTelegramCustomEmojiTag.FindStringSubmatch(s)
+		if len(match) != 3 {
+			return s
+		}
+		return replace(match[1], match[2])
+	})
+
+	text = reTelegramCustomEmojiImg.ReplaceAllStringFunc(text, func(s string) string {
+		match := reTelegramCustomEmojiImg.FindStringSubmatch(s)
+		if len(match) != 3 {
+			return s
+		}
+		return replace(match[1], match[2])
+	})
+
+	text = reTelegramCustomEmojiMarkdown.ReplaceAllStringFunc(text, func(s string) string {
+		match := reTelegramCustomEmojiMarkdown.FindStringSubmatch(s)
+		if len(match) != 3 {
+			return s
+		}
+		return replace(match[2], match[1])
+	})
+
+	return customEmojiMatch{text: text, tags: tags}
 }
 
 type inlineCodeMatch struct {

--- a/internal/channels/telegram/format_extended_test.go
+++ b/internal/channels/telegram/format_extended_test.go
@@ -442,3 +442,43 @@ func TestHTMLTagToMarkdown(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkdownToTelegramHTML_CustomEmoji(t *testing.T) {
+	t.Run("preserves safe tg emoji tag", func(t *testing.T) {
+		input := `Status <tg-emoji emoji-id="5368324170671202286">🤖</tg-emoji> thinking`
+		got := markdownToTelegramHTML(input)
+		want := `<tg-emoji emoji-id="5368324170671202286">🤖</tg-emoji>`
+		if !strings.Contains(got, want) {
+			t.Fatalf("custom emoji tag not preserved:\n got: %q\nwant substring: %q", got, want)
+		}
+	})
+
+	t.Run("normalizes tg emoji image syntax", func(t *testing.T) {
+		input := `Status <img src="tg://emoji?id=5368324170671202286" alt="🤖"/> thinking`
+		got := markdownToTelegramHTML(input)
+		want := `<tg-emoji emoji-id="5368324170671202286">🤖</tg-emoji>`
+		if !strings.Contains(got, want) {
+			t.Fatalf("custom emoji image syntax not normalized:\n got: %q\nwant substring: %q", got, want)
+		}
+	})
+
+	t.Run("normalizes markdown custom emoji syntax", func(t *testing.T) {
+		input := `Status ![🤖](tg://emoji?id=5368324170671202286) thinking`
+		got := markdownToTelegramHTML(input)
+		want := `<tg-emoji emoji-id="5368324170671202286">🤖</tg-emoji>`
+		if !strings.Contains(got, want) {
+			t.Fatalf("custom emoji markdown syntax not normalized:\n got: %q\nwant substring: %q", got, want)
+		}
+	})
+
+	t.Run("escapes unsafe custom emoji attributes", func(t *testing.T) {
+		input := `<tg-emoji emoji-id="5368324170671202286" onclick="alert(1)">🤖</tg-emoji>`
+		got := markdownToTelegramHTML(input)
+		if strings.Contains(got, `<tg-emoji`) {
+			t.Fatalf("unsafe custom emoji tag should not be preserved: %q", got)
+		}
+		if !strings.Contains(got, `&lt;tg-emoji`) {
+			t.Fatalf("unsafe custom emoji tag should be escaped: %q", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Preserve Telegram custom emoji HTML tags in the Telegram formatter.
- Normalize `tg://emoji` HTML image and Markdown custom emoji syntax to safe `<tg-emoji>` tags.
- Keep arbitrary/unsafe custom emoji attributes escaped instead of passing raw HTML through.

## Why
Telegram Bot API supports custom emoji entities in HTML parse mode, but GoClaw escaped `<tg-emoji>` and `tg://emoji` markup before sending, so premium AI status/action emojis rendered as plain text.

## Validation
- `docker run --rm -v "$PWD":/src -w /src -e GOMODCACHE=/tmp/gomod -e GOCACHE=/tmp/gocache golang:1.26 go test ./internal/channels/telegram -run "TestMarkdownToTelegramHTML_CustomEmoji" -count=1`
- `docker run --rm -v "$PWD":/src -w /src -e GOMODCACHE=/tmp/gomod -e GOCACHE=/tmp/gocache golang:1.26 go test ./internal/channels/telegram -count=1`
