### PR TITLE
fix(mcp): expose delegate tool via MCP bridge

### DIFF
--- a/internal/mcp/bridge_server.go
+++ b/internal/mcp/bridge_server.go
@@ -17,6 +17,8 @@ import (
 
 // BridgeToolNames is the subset of GoClaw tools exposed via the MCP bridge.
 // Excluded: spawn (agent loop), create_forum_topic (channels).
+// delegate is included: it self-gates via CanDelegate/agent_links and resolves
+// its source agent from the X-Agent-ID header context, same as team_tasks.
 var BridgeToolNames = map[string]bool{
 	// Filesystem
 	"read_file":  true,
@@ -48,6 +50,8 @@ var BridgeToolNames = map[string]bool{
 	"sessions_send":    true,
 	// Team tools (context from X-Agent-ID/X-Channel/X-Chat-ID headers)
 	"team_tasks": true,
+	// Inter-agent delegation (self-gates via CanDelegate / agent_links)
+	"delegate": true,
 }
 
 // NewBridgeServer creates a StreamableHTTPServer that exposes GoClaw tools as MCP tools.


### PR DESCRIPTION
## Problem

`BridgeToolNames` (the allowlist of GoClaw tools exposed over the MCP bridge) omitted `delegate`. As a result, claude-cli / Claude-Code-backed agents never received the `delegate` tool — even when their orchestration mode correctly resolved to `delegate` with active `agent_links`.

The native agent loop injects `delegate` per orchestration mode (`orchModeDenyTools`), but bridge-backed sessions only ever see the curated `BridgeToolNames` set. So two linked agents would show `delegate` mode + delegate targets in the dashboard, yet inter-agent delegation was impossible from any bridge-backed (claude-cli) session.

## Fix

Add `delegate` to `BridgeToolNames`.

It is safe to expose unconditionally, mirroring `team_tasks` (already bridged):
- It **self-gates** via `CanDelegate` / `agent_links` — an agent with no delegate targets simply can't delegate.
- It resolves its **source agent from the `X-Agent-ID` header context** (`store.AgentIDFromContext`), the same mechanism `team_tasks` uses, which the bridge handler already populates.

## Test

- `go build ./...` ✅
- `go test ./internal/mcp/` ✅
- gofmt clean

No migration / schema change.