### PR TITLE
fix(agent): tolerate native non-function tools

### DIFF
--- a/internal/agent/loop_pipeline_callbacks.go
+++ b/internal/agent/loop_pipeline_callbacks.go
@@ -239,7 +239,7 @@ func (l *Loop) makeBuildFilteredTools(req *RunRequest) func(state *pipeline.RunS
 		}
 		mcpDefs := 0
 		for _, td := range toolDefs {
-			if strings.HasPrefix(strings.TrimSpace(td.Function.Name), "mcp_") {
+			if strings.HasPrefix(toolDefFunctionName(td), "mcp_") {
 				mcpDefs++
 			}
 		}
@@ -508,7 +508,7 @@ func (l *Loop) makeCallLLM(req *RunRequest, emitRun func(AgentEvent)) func(ctx c
 func shouldRetryTaskMCP(chatReq providers.ChatRequest) bool {
 	hasTaskMCPTool := false
 	for _, td := range chatReq.Tools {
-		name := strings.TrimSpace(td.Function.Name)
+		name := toolDefFunctionName(td)
 		if strings.HasPrefix(name, "mcp_bx24__") && (strings.Contains(name, "search") || strings.Contains(name, "execute")) {
 			hasTaskMCPTool = true
 			break

--- a/internal/agent/loop_tool_filter.go
+++ b/internal/agent/loop_tool_filter.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
@@ -12,6 +13,13 @@ import (
 // is passed through by the Codex/OpenAI request builder as a bare {"type":"image_generation"}
 // object — no "function" wrapper, no parameters.
 var imageGenToolDef = providers.ToolDefinition{Type: "image_generation"}
+
+func toolDefFunctionName(td providers.ToolDefinition) string {
+	if td.Function == nil {
+		return ""
+	}
+	return strings.TrimSpace(td.Function.Name)
+}
 
 // buildFilteredTools resolves the per-iteration tool definitions based on policy,
 // disabled tools, bootstrap mode, skill visibility, channel type, and iteration budget.
@@ -39,7 +47,9 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 		toolDefs = l.toolPolicy.FilterTools(registry, l.id, l.provider.Name(), l.agentToolPolicy, req.ToolAllow, false, false)
 		allowedTools = make(map[string]bool, len(toolDefs))
 		for _, td := range toolDefs {
-			allowedTools[td.Function.Name] = true
+			if name := toolDefFunctionName(td); name != "" {
+				allowedTools[name] = true
+			}
 		}
 	} else {
 		// No policy → all tools allowed. ProviderDefs() omits per-user MCP tools (not in
@@ -48,8 +58,8 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 		if len(userTools) > 0 {
 			seen := make(map[string]bool, len(toolDefs))
 			for _, td := range toolDefs {
-				if td.Function != nil {
-					seen[td.Function.Name] = true
+				if name := toolDefFunctionName(td); name != "" {
+					seen[name] = true
 				}
 			}
 			for _, t := range userTools {
@@ -67,10 +77,11 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if orchDeny := orchModeDenyTools(l.orchMode); len(orchDeny) > 0 {
 		filtered := toolDefs[:0:0]
 		for _, td := range toolDefs {
-			if !orchDeny[td.Function.Name] {
+			name := toolDefFunctionName(td)
+			if name == "" || !orchDeny[name] {
 				filtered = append(filtered, td)
 			} else {
-				delete(allowedTools, td.Function.Name)
+				delete(allowedTools, name)
 			}
 		}
 		toolDefs = filtered
@@ -80,10 +91,11 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if len(l.disabledTools) > 0 {
 		filtered := toolDefs[:0]
 		for _, td := range toolDefs {
-			if !l.disabledTools[td.Function.Name] {
+			name := toolDefFunctionName(td)
+			if name == "" || !l.disabledTools[name] {
 				filtered = append(filtered, td)
 			} else {
-				delete(allowedTools, td.Function.Name)
+				delete(allowedTools, name)
 			}
 		}
 		toolDefs = filtered
@@ -94,7 +106,7 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if hadBootstrap && l.agentType != store.AgentTypePredefined {
 		var bootstrapDefs []providers.ToolDefinition
 		for _, td := range toolDefs {
-			if bootstrapToolAllowlist[td.Function.Name] {
+			if name := toolDefFunctionName(td); name != "" && bootstrapToolAllowlist[name] {
 				bootstrapDefs = append(bootstrapDefs, td)
 			}
 		}
@@ -106,7 +118,7 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if !l.skillEvolve {
 		filtered := toolDefs[:0:0]
 		for _, td := range toolDefs {
-			if td.Function.Name != "skill_manage" {
+			if toolDefFunctionName(td) != "skill_manage" {
 				filtered = append(filtered, td)
 			}
 		}
@@ -117,10 +129,13 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if req.ChannelType != "" {
 		filtered := toolDefs[:0:0]
 		for _, td := range toolDefs {
-			if tool, ok := l.tools.Get(td.Function.Name); ok {
-				if ca, ok := tool.(tools.ChannelAware); ok {
-					if !slices.Contains(ca.RequiredChannelTypes(), req.ChannelType) {
-						continue
+			name := toolDefFunctionName(td)
+			if name != "" {
+				if tool, ok := l.tools.Get(name); ok {
+					if ca, ok := tool.(tools.ChannelAware); ok {
+						if !slices.Contains(ca.RequiredChannelTypes(), req.ChannelType) {
+							continue
+						}
 					}
 				}
 			}

--- a/internal/pipeline/context_stage_tool_overhead_test.go
+++ b/internal/pipeline/context_stage_tool_overhead_test.go
@@ -96,3 +96,27 @@ func TestContextStage_ToolOverhead_BuildFilteredToolsError_FallsBackToSystemOnly
 			state.Context.OverheadTokens, wantOverhead)
 	}
 }
+
+func TestContextStage_ToolOverhead_NativeToolWithoutFunctionDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	deps := &PipelineDeps{
+		TokenCounter: tokencount.NewFallbackCounter(),
+		BuildMessages: func(_ context.Context, _ *RunInput, _ []providers.Message, _ string) ([]providers.Message, error) {
+			return []providers.Message{{Role: "system", Content: "system"}}, nil
+		},
+		BuildFilteredTools: func(_ *RunState) ([]providers.ToolDefinition, error) {
+			return []providers.ToolDefinition{{Type: "image_generation"}}, nil
+		},
+	}
+
+	stage := NewContextStage(deps)
+	state := defaultState()
+
+	if err := stage.Execute(context.Background(), state); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if len(state.Think.Tools) != 1 {
+		t.Fatalf("state.Think.Tools len = %d, want 1", len(state.Think.Tools))
+	}
+}

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -3183,3 +3183,34 @@ func TestPruneStage_CacheTtlGate_MarkTouchedOnlyOnMutation(t *testing.T) {
 		t.Error("MarkCacheTouched should NOT be called when prune returns no mutation")
 	}
 }
+
+func TestThinkStage_NativeToolWithoutFunctionDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	var allowed map[string]bool
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		BuildFilteredTools: func(_ *RunState) ([]providers.ToolDefinition, error) {
+			return []providers.ToolDefinition{
+				{Type: "image_generation"},
+				{Type: "function", Function: &providers.ToolFunctionSchema{Name: "read_file", Parameters: map[string]any{"type": "object"}}},
+			}, nil
+		},
+		CallLLM: func(_ context.Context, state *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			allowed = state.Tool.AllowedTools
+			return &providers.ChatResponse{Content: "ok", FinishReason: "stop"}, nil
+		},
+	}
+	stage := NewThinkStage(deps)
+	state := defaultState()
+
+	if err := stage.Execute(context.Background(), state); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !allowed["read_file"] {
+		t.Fatalf("read_file missing from allowed tools: %#v", allowed)
+	}
+	if _, ok := allowed[""]; ok {
+		t.Fatalf("native non-function tool created empty-name allowlist entry: %#v", allowed)
+	}
+}

--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -44,6 +44,9 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		}
 		allowed := make(map[string]bool, len(toolDefs))
 		for _, td := range toolDefs {
+			if td.Function == nil {
+				continue
+			}
 			allowed[td.Function.Name] = true
 		}
 		state.Tool.AllowedTools = allowed


### PR DESCRIPTION
## Summary
- tolerate native non-function tool definitions in agent/pipeline tool filtering
- keep function-tool allowlists name-based while letting native tools like `image_generation` pass through safely
- add regression coverage for `ToolDefinition{Type: "image_generation", Function: nil}` in ContextStage and ThinkStage

## Why
Codex/OpenAI Responses native tools are not function tools. In particular, the image generation sentinel is represented as:

```go
providers.ToolDefinition{Type: "image_generation", Function: nil}
```

After switching an agent to a Codex provider with image generation enabled, ContextStage called `BuildFilteredTools` and the debug/tool allowlist paths dereferenced `td.Function.Name`, causing a nil pointer panic before the LLM call.

## Testing
- `env -u GOCLAW_CONFIG -u GOCLAW_DB_DSN -u GOCLAW_ENCRYPTION_KEY -u GOCLAW_DATA_DIR -u GOCLAW_WORKSPACE /usr/local/go/bin/go test ./internal/agent ./internal/pipeline ./internal/providers`
- `env -u GOCLAW_CONFIG -u GOCLAW_DB_DSN -u GOCLAW_ENCRYPTION_KEY -u GOCLAW_DATA_DIR -u GOCLAW_WORKSPACE /usr/local/go/bin/go build ./...`
