### PR TITLE
fix(agent): nil td.Function panic on native tools — hotfix backport of #1192 to main

### DIFF
--- a/internal/agent/image_gen_gate_test.go
+++ b/internal/agent/image_gen_gate_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
 )
 
 // imageCapableProvider is a stub provider that also implements CapabilitiesAware
@@ -115,3 +116,61 @@ func TestImageGenGate_FinalIteration_AllToolsStripped(t *testing.T) {
 		t.Errorf("final iteration must strip all tools; got %d: %v", len(defs), defs)
 	}
 }
+
+type filteringExecutor struct {
+	stubExecutor
+	defs []providers.ToolDefinition
+}
+
+func (e *filteringExecutor) ProviderDefs() []providers.ToolDefinition {
+	return e.defs
+}
+
+func (e *filteringExecutor) Get(name string) (tools.Tool, bool) {
+	return nil, false
+}
+
+func TestImageGenGate_FilteringNoPanic(t *testing.T) {
+	prov := &imageCapableProvider{imageGen: true}
+
+	exec := &filteringExecutor{
+		defs: []providers.ToolDefinition{
+			{
+				Type: "function",
+				Function: &providers.ToolFunctionSchema{
+					Name: "read_file",
+				},
+			},
+			{
+				Type:     "image_generation",
+				Function: nil,
+			},
+		},
+	}
+
+	l := &Loop{
+		provider:             prov,
+		allowImageGeneration: true,
+		tools:                exec,
+		orchMode:             "spawn",                          // Triggers orchModeDenyTools
+		disabledTools:        map[string]bool{"read_file": true}, // Triggers disabled tools filter
+		agentType:            "open",                           // Triggers bootstrap filter
+		skillEvolve:          false,                            // Triggers skill evolve filter
+	}
+
+	req := &RunRequest{
+		ChannelType: "telegram", // Triggers channel filtering
+	}
+
+	// This should run successfully without panic.
+	defs, allowed, _ := l.buildFilteredTools(req, true, 1, 10, nil)
+
+	if allowed != nil {
+		if _, exists := allowed[""]; exists {
+			t.Error("allowedTools map should not contain empty key for native tools")
+		}
+	}
+
+	_ = defs
+}
+

--- a/internal/agent/loop_history_toolnames.go
+++ b/internal/agent/loop_history_toolnames.go
@@ -31,9 +31,11 @@ func (l *Loop) filteredToolNames() []string {
 		return l.tools.List()
 	}
 	defs := l.toolPolicy.FilterTools(l.tools, l.id, l.provider.Name(), l.agentToolPolicy, nil, false, false)
-	names := make([]string, len(defs))
-	for i, d := range defs {
-		names[i] = d.Function.Name
+	names := make([]string, 0, len(defs))
+	for _, d := range defs {
+		if d.Function != nil {
+			names = append(names, d.Function.Name)
+		}
 	}
 	return names
 }

--- a/internal/agent/loop_pipeline_callbacks.go
+++ b/internal/agent/loop_pipeline_callbacks.go
@@ -239,7 +239,7 @@ func (l *Loop) makeBuildFilteredTools(req *RunRequest) func(state *pipeline.RunS
 		}
 		mcpDefs := 0
 		for _, td := range toolDefs {
-			if strings.HasPrefix(strings.TrimSpace(td.Function.Name), "mcp_") {
+			if td.Function != nil && strings.HasPrefix(strings.TrimSpace(td.Function.Name), "mcp_") {
 				mcpDefs++
 			}
 		}
@@ -508,6 +508,9 @@ func (l *Loop) makeCallLLM(req *RunRequest, emitRun func(AgentEvent)) func(ctx c
 func shouldRetryTaskMCP(chatReq providers.ChatRequest) bool {
 	hasTaskMCPTool := false
 	for _, td := range chatReq.Tools {
+		if td.Function == nil {
+			continue
+		}
 		name := strings.TrimSpace(td.Function.Name)
 		if strings.HasPrefix(name, "mcp_bx24__") && (strings.Contains(name, "search") || strings.Contains(name, "execute")) {
 			hasTaskMCPTool = true

--- a/internal/agent/loop_tool_filter.go
+++ b/internal/agent/loop_tool_filter.go
@@ -27,7 +27,9 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 		toolDefs = l.toolPolicy.FilterTools(l.tools, l.id, l.provider.Name(), l.agentToolPolicy, req.ToolAllow, false, false)
 		allowedTools = make(map[string]bool, len(toolDefs))
 		for _, td := range toolDefs {
-			allowedTools[td.Function.Name] = true
+			if td.Function != nil {
+				allowedTools[td.Function.Name] = true
+			}
 		}
 	} else {
 		toolDefs = l.tools.ProviderDefs()
@@ -38,10 +40,12 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if orchDeny := orchModeDenyTools(l.orchMode); len(orchDeny) > 0 {
 		filtered := toolDefs[:0:0]
 		for _, td := range toolDefs {
-			if !orchDeny[td.Function.Name] {
+			if td.Function == nil || !orchDeny[td.Function.Name] {
 				filtered = append(filtered, td)
 			} else {
-				delete(allowedTools, td.Function.Name)
+				if allowedTools != nil {
+					delete(allowedTools, td.Function.Name)
+				}
 			}
 		}
 		toolDefs = filtered
@@ -51,10 +55,12 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if len(l.disabledTools) > 0 {
 		filtered := toolDefs[:0]
 		for _, td := range toolDefs {
-			if !l.disabledTools[td.Function.Name] {
+			if td.Function == nil || !l.disabledTools[td.Function.Name] {
 				filtered = append(filtered, td)
 			} else {
-				delete(allowedTools, td.Function.Name)
+				if allowedTools != nil {
+					delete(allowedTools, td.Function.Name)
+				}
 			}
 		}
 		toolDefs = filtered
@@ -65,7 +71,7 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if hadBootstrap && l.agentType != store.AgentTypePredefined {
 		var bootstrapDefs []providers.ToolDefinition
 		for _, td := range toolDefs {
-			if bootstrapToolAllowlist[td.Function.Name] {
+			if td.Function != nil && bootstrapToolAllowlist[td.Function.Name] {
 				bootstrapDefs = append(bootstrapDefs, td)
 			}
 		}
@@ -77,7 +83,7 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if !l.skillEvolve {
 		filtered := toolDefs[:0:0]
 		for _, td := range toolDefs {
-			if td.Function.Name != "skill_manage" {
+			if td.Function == nil || td.Function.Name != "skill_manage" {
 				filtered = append(filtered, td)
 			}
 		}
@@ -88,10 +94,12 @@ func (l *Loop) buildFilteredTools(req *RunRequest, hadBootstrap bool, iteration,
 	if req.ChannelType != "" {
 		filtered := toolDefs[:0:0]
 		for _, td := range toolDefs {
-			if tool, ok := l.tools.Get(td.Function.Name); ok {
-				if ca, ok := tool.(tools.ChannelAware); ok {
-					if !slices.Contains(ca.RequiredChannelTypes(), req.ChannelType) {
-						continue
+			if td.Function != nil {
+				if tool, ok := l.tools.Get(td.Function.Name); ok {
+					if ca, ok := tool.(tools.ChannelAware); ok {
+						if !slices.Contains(ca.RequiredChannelTypes(), req.ChannelType) {
+							continue
+						}
 					}
 				}
 			}

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -3212,3 +3212,51 @@ func TestPruneStage_CacheTtlGate_MarkTouchedOnlyOnMutation(t *testing.T) {
 		t.Error("MarkCacheTouched should NOT be called when prune returns no mutation")
 	}
 }
+
+func TestThinkStage_AllowedTools_MixedFunctionAndNativeTools_NoPanic(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		BuildFilteredTools: func(state *RunState) ([]providers.ToolDefinition, error) {
+			return []providers.ToolDefinition{
+				{
+					Type: "function",
+					Function: &providers.ToolFunctionSchema{
+						Name: "read_file",
+					},
+				},
+				{
+					Type:     "image_generation",
+					Function: nil,
+				},
+			}, nil
+		},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{
+				Content:      "ok",
+				FinishReason: "stop",
+			}, nil
+		},
+	}
+	stage := NewThinkStage(deps)
+	state := defaultState()
+
+	err := stage.Execute(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	if state.Tool.AllowedTools == nil {
+		t.Fatal("AllowedTools should not be nil")
+	}
+	if !state.Tool.AllowedTools["read_file"] {
+		t.Error("expected read_file in AllowedTools")
+	}
+	if state.Tool.AllowedTools[""] {
+		t.Error("AllowedTools should not contain empty key for native tools")
+	}
+	if len(state.Tool.AllowedTools) != 1 {
+		t.Errorf("AllowedTools len = %d, want 1", len(state.Tool.AllowedTools))
+	}
+}
+

--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -44,7 +44,9 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		}
 		allowed := make(map[string]bool, len(toolDefs))
 		for _, td := range toolDefs {
-			allowed[td.Function.Name] = true
+			if td.Function != nil {
+				allowed[td.Function.Name] = true
+			}
 		}
 		state.Tool.AllowedTools = allowed
 	} else {

--- a/internal/providers/adapter_anthropic_test.go
+++ b/internal/providers/adapter_anthropic_test.go
@@ -324,3 +324,51 @@ func assertHeader(t *testing.T, h http.Header, key, want string) {
 		t.Errorf("header %q = %q, want %q", key, got, want)
 	}
 }
+
+func TestAnthropicAdapterToRequest_NativeToolIgnored(t *testing.T) {
+	adapter, _ := NewAnthropicAdapter(ProviderConfig{APIKey: "sk-test"})
+
+	req := ChatRequest{
+		Messages: []Message{{Role: "user", Content: "Draw a cat and search"}},
+		Tools: []ToolDefinition{
+			{
+				Type: "function",
+				Function: &ToolFunctionSchema{
+					Name:        "web_search",
+					Description: "Search the web",
+					Parameters:  map[string]any{"type": "object"},
+				},
+			},
+			{
+				Type:     "image_generation",
+				Function: nil,
+			},
+		},
+	}
+
+	data, _, err := adapter.ToRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatal(err)
+	}
+
+	tools, ok := body["tools"].([]any)
+	if !ok {
+		t.Fatal("expected tools array in request body")
+	}
+
+	// Should only serialize function tool, ignoring native tool
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool in Anthropic request, got %d", len(tools))
+	}
+
+	tool := tools[0].(map[string]any)
+	if tool["name"] != "web_search" {
+		t.Errorf("expected tool name 'web_search', got %v", tool["name"])
+	}
+}
+

--- a/internal/providers/anthropic_request.go
+++ b/internal/providers/anthropic_request.go
@@ -194,6 +194,9 @@ func (p *AnthropicProvider) buildRequestBody(model string, req ChatRequest, stre
 	if len(req.Tools) > 0 {
 		var tools []map[string]any
 		for _, t := range req.Tools {
+			if t.Type != "function" || t.Function == nil {
+				continue
+			}
 			cleanedParams := CleanSchemaForProvider("anthropic", t.Function.Parameters)
 			tool := map[string]any{
 				"name":         t.Function.Name,

--- a/internal/providers/codex_build.go
+++ b/internal/providers/codex_build.go
@@ -122,7 +122,7 @@ func (p *CodexProvider) buildRequestBody(req ChatRequest, stream bool) map[strin
 					"output_format":  "png",
 					"partial_images": 1,
 				})
-			} else {
+			} else if t.Function != nil {
 				// Function tool path (default). Works with both value-type and pointer Function
 				// fields — we only access t.Function when type is not "image_generation".
 				tools = append(tools, map[string]any{

--- a/internal/providers/codex_test.go
+++ b/internal/providers/codex_test.go
@@ -1083,3 +1083,43 @@ func TestCodexProviderBuildRequestBodyWithImages(t *testing.T) {
 		t.Errorf("content[1] type = %v, want input_text", content[1]["type"])
 	}
 }
+
+func TestCodexBuildRequestBody_NilFunction_HandlesGracefully(t *testing.T) {
+	p := NewCodexProvider("test", &staticTokenSource{token: "test"}, "", "gpt-4o")
+
+	req := ChatRequest{
+		Messages: []Message{{Role: "user", Content: "Draw and search"}},
+		Tools: []ToolDefinition{
+			{
+				Type:     "some_unsupported_native_tool",
+				Function: nil,
+			},
+			{
+				Type: "function",
+				Function: &ToolFunctionSchema{
+					Name:        "web_search",
+					Description: "Search the web",
+					Parameters:  map[string]any{"type": "object"},
+				},
+			},
+		},
+	}
+
+	body := p.buildRequestBody(req, false)
+
+	tools, ok := body["tools"].([]map[string]any)
+	if !ok {
+		t.Fatalf("tools is not []map[string]any: %T", body["tools"])
+	}
+
+	// Should only serialize the function tool and ignore the native tool with nil Function
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool in Codex request, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool["type"] != "function" || tool["name"] != "web_search" {
+		t.Errorf("expected function tool 'web_search', got: %v", tool)
+	}
+}
+


### PR DESCRIPTION
## Summary
Backport of #1192 to `main`. The released `v3.14.0` images (`:latest` / `:full`, built from `main`) crash with an **unrecovered `SIGSEGV` nil-pointer dereference** whenever an agent run uses a provider that injects **native tool definitions** (e.g. `image_generation` from the Codex / OpenAI provider). Native tools have `Type != "function"` and therefore a `nil` `ToolDefinition.Function`, but several hot paths dereference `td.Function.Name` without a nil check. The panic is on the chat-dispatch goroutine, so it takes down the **whole gateway process**, not just the run. The fix is already on `dev` (#1192) but had not reached `main`.

Observed in production (`provider=openai-codex`, `model=gpt-5.5`):
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 ...]
internal/agent.(*Loop).pipelineCallbacks...makeBuildFilteredTools.func9
    internal/agent/loop_pipeline_callbacks.go:240
```
(The "trace finalized by safety net" WARN seen alongside it is just the deferred trace finalizer firing during stack unwinding — a symptom, not the cause.)

## Type
- [x] Hotfix (targeting `main`)

## Target Branch
`main` — the bug only remains on `main`; `dev` already contains the fix (#1192). Per the hotfix policy this targets `main` directly; no cherry-pick back to `dev` is needed since the fix originated there.

## What changed
Cherry-pick of #1192 (`389640ae`). Adds `td.Function != nil` / `t.Function == nil` guards before dereferencing in every tool-iteration site that native tools flow through:
- `loop_pipeline_callbacks.go` (mcp-tool counting + `shouldRetryTaskMCP`)
- `think_stage.go`, `loop_tool_filter.go`, `loop_history_toolnames.go`
- `anthropic_request.go`, `codex_build.go`
Plus the regression tests from #1192.

**Backport note:** the only deviation from #1192 is in `image_gen_gate_test.go` — one `buildFilteredTools(...)` call was reverted to the 5-arg signature, because the `userTools` parameter (added by #1235 on `dev`) does not exist on `main`. Production code is identical to #1192.

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes
- [x] `go vet ./...` passes (agent/pipeline/providers)
- [x] Tests pass: `go test ./internal/agent/ ./internal/pipeline/ ./internal/providers/`
- [ ] Web UI builds — N/A, backend-only change
- [x] No hardcoded secrets or credentials
- [x] SQL parameterized — N/A, no SQL changes
- [ ] i18n locales — N/A, no user-facing strings
- [ ] Migration version bump — N/A, no migration

Surface parity: web UI / CLI / API contract N/A — this is a backend nil-guard with no schema, protocol, or user-facing surface change.

## Test Plan
1. Added regression tests (from #1192) assert no panic when native (`image_generation`) tool defs are mixed into the tool list across `buildFilteredTools`, `ThinkStage`, and the Anthropic/Codex request builders. All pass.
2. Reproduced the original crash on `main` with a Codex provider + `image_generation` enabled agent (`gpt-5.5`); with this change the run completes instead of segfaulting the gateway.
