### PR TITLE
fix(cron): reset session for stateless cron jobs, not stateful ones

### DIFF
--- a/cmd/gateway_cron.go
+++ b/cmd/gateway_cron.go
@@ -25,6 +25,11 @@ import (
 // Safe because cron jobs only fire after Start(), well after this is set.
 var cronHeartbeatWakeFn func(agentID string)
 
+// cronCLISessionReset clears the Claude CLI on-disk session (.jsonl + CLAUDE.md)
+// for a session key, mirroring the sessions.reset RPC. Indirected through a var
+// so the stateless-reset behavior can be unit-tested without filesystem effects.
+var cronCLISessionReset = providers.ResetCLISession
+
 func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg *config.Config, channelMgr *channels.Manager, sessionMgr store.SessionStore, agentStore store.AgentStore, providerStore store.ProviderStore, providerReg *providers.Registry) func(job *store.CronJob) (*store.CronJobResult, error) {
 	return func(job *store.CronJob) (*store.CronJobResult, error) {
 		agentID := job.AgentID
@@ -89,13 +94,25 @@ func makeCronJobHandler(sched *scheduler.Scheduler, msgBus *bus.MessageBus, cfg 
 			cronCtx = store.WithCredentialUserID(cronCtx, job.Payload.CredentialUserID)
 		}
 
-		// Reset session before each cron run to prevent tool errors from previous
-		// runs from polluting the context and blocking future executions (#294).
-		// Save() persists the empty session to DB so stale data won't reload after restart.
-		// Stateless jobs skip this — they intentionally carry no session history.
-		if !job.Stateless {
-			sessionMgr.Reset(cronCtx, sessionKey)
-			sessionMgr.Save(cronCtx, sessionKey)
+		// Reset the session before each STATELESS cron run so the run starts fresh:
+		// no carried-over history (the whole point of stateless — saves tokens) and
+		// no tool errors from a previous run polluting the context (#294). Clear BOTH
+		// layers — the goclaw session store AND the Claude CLI's own on-disk session —
+		// because a claude-cli agent resumes its .jsonl by a deterministic per-key
+		// UUID and would otherwise replay the full accumulated history every run
+		// regardless of this flag (i.e. "stateless" had no effect on what the model
+		// actually sees). Stateful jobs (stateless=false) intentionally keep their
+		// session across runs.
+		//
+		// NOTE: this condition was previously `!job.Stateless`, which inverted the
+		// flag — stateless jobs accumulated unbounded history while stateful jobs were
+		// wiped each run.
+		if job.Stateless {
+			if sessionMgr != nil {
+				sessionMgr.Reset(cronCtx, sessionKey)
+				sessionMgr.Save(cronCtx, sessionKey)
+			}
+			cronCLISessionReset("", sessionKey)
 		}
 
 		// Resolve per-job provider/model override (mirrors heartbeat). Unset → agent default.

--- a/cmd/gateway_cron_test.go
+++ b/cmd/gateway_cron_test.go
@@ -181,3 +181,73 @@ func TestCronJobHandlerSuppressesNoReplyDelivery(t *testing.T) {
 		})
 	}
 }
+
+// fakeCronSessionStore records Reset calls. The embedded nil SessionStore
+// satisfies the interface; the cron handler only calls Reset/Save.
+type fakeCronSessionStore struct {
+	store.SessionStore
+	resetCount int
+}
+
+func (f *fakeCronSessionStore) Reset(context.Context, string)      { f.resetCount++ }
+func (f *fakeCronSessionStore) Save(context.Context, string) error { return nil }
+
+// A stateless cron run must start fresh by clearing BOTH the goclaw session
+// store and the Claude CLI on-disk session; a stateful run must keep both.
+func TestCronJobHandler_StatelessResetsSession(t *testing.T) {
+	cases := []struct {
+		name      string
+		stateless bool
+		wantReset bool
+	}{
+		{name: "stateless resets both layers", stateless: true, wantReset: true},
+		{name: "stateful keeps session", stateless: false, wantReset: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cliResetKeys []string
+			orig := cronCLISessionReset
+			cronCLISessionReset = func(_, key string) { cliResetKeys = append(cliResetKeys, key) }
+			defer func() { cronCLISessionReset = orig }()
+
+			fakeStore := &fakeCronSessionStore{}
+
+			sched := scheduler.NewScheduler(
+				scheduler.DefaultLanes(),
+				scheduler.QueueConfig{
+					Mode:          scheduler.QueueModeQueue,
+					Cap:           1,
+					Drop:          scheduler.DropOld,
+					DebounceMs:    0,
+					MaxConcurrent: 1,
+				},
+				func(context.Context, agent.RunRequest) (*agent.RunResult, error) {
+					return &agent.RunResult{Content: "ok"}, nil
+				},
+			)
+			defer sched.Stop()
+
+			handler := makeCronJobHandler(sched, nil, &config.Config{}, nil, fakeStore, nil, nil, nil)
+
+			if _, err := handler(&store.CronJob{
+				ID:        uuid.NewString(),
+				TenantID:  uuid.New(),
+				Name:      "j",
+				AgentID:   "reporter",
+				UserID:    "user-1",
+				Stateless: tc.stateless,
+				Payload:   store.CronPayload{Kind: "agent_turn", Message: "m"},
+			}); err != nil {
+				t.Fatalf("cron handler error: %v", err)
+			}
+
+			if gotStore := fakeStore.resetCount > 0; gotStore != tc.wantReset {
+				t.Errorf("session store reset called=%v, want %v", gotStore, tc.wantReset)
+			}
+			if gotCLI := len(cliResetKeys) > 0; gotCLI != tc.wantReset {
+				t.Errorf("CLI session reset called=%v, want %v", gotCLI, tc.wantReset)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Cron runs reset the session before each run (so a previous run's tool errors can't pollute the next — #294). That reset was gated on `if !job.Stateless`, which **inverts the flag**:

- `stateless = true` (the default, documented as "saves tokens" / fresh each run) → reset **skipped** → session **accumulates unbounded history** across runs.
- `stateless = false` (stateful, wants memory) → reset **runs every time** → session **wiped each run**.

Observed in production: a frequently-firing `stateless=true` cron grew its Claude CLI session `.jsonl` to ~30 MB, replaying the whole history on every run (large token cost) until the model started emitting malformed tool calls.

There's a second layer: the cron reset only cleared the **goclaw session store**, never the **Claude CLI on-disk session**. claude-cli resumes its own `.jsonl` by a deterministic per-key UUID (`--resume`), so even when the reset fired the model still saw the full accumulated history — i.e. `stateless` had no effect on the actual model context for claude-cli agents.

## Fix

- Gate the reset on `if job.Stateless` (correct direction).
- In that branch, also clear the CLI session via `ResetCLISession` (indirected through an overridable package var for testing), so a stateless run truly starts fresh on both layers.
- Guard `sessionMgr != nil` (it is nil in some unit-test setups).

Stateful jobs (`stateless=false`) now correctly keep their session across runs. Non-claude-cli providers are unaffected — `ResetCLISession` is a no-op when no CLI session file exists.

## Test

`cmd/gateway_cron_test.go`: new `TestCronJobHandler_StatelessResetsSession` asserts a stateless run clears both the session store and the CLI session, and a stateful run clears neither (via a fake `SessionStore` + an overridden `cronCLISessionReset`).

```
go build ./...                     ✅
go build -tags sqliteonly ./...     ✅
go vet ./cmd/                        ✅
go test -race ./cmd/                 ✅
```

No migration / schema / i18n change.

## Note for operators

Behavior change: any cron currently set `stateless=false` that was relying on the (buggy) per-run wipe will now retain its session. Re-check the flag on existing crons — set `stateless=true` for jobs that should start fresh each run.
