### PR TITLE
feat(agent): honor per-agent tools.rate_limit_per_hour

### DIFF
--- a/internal/agent/loop_context.go
+++ b/internal/agent/loop_context.go
@@ -113,6 +113,9 @@ func (l *Loop) injectContext(ctx context.Context, req *RunRequest) (contextSetup
 		waitToolCfg = l.agentToolPolicy.Wait
 		ctx = tools.WithWaitToolConfig(ctx, waitToolCfg)
 	}
+	if l.agentToolPolicy != nil && l.agentToolPolicy.RateLimitPerHour > 0 {
+		ctx = tools.WithToolRateLimitOverride(ctx, l.agentToolPolicy.RateLimitPerHour)
+	}
 	if l.sandboxCfg != nil {
 		ctx = tools.WithSandboxConfig(ctx, l.sandboxCfg)
 	}

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -537,6 +537,9 @@ type ToolPolicySpec struct {
 	ByProvider     map[string]*ToolPolicySpec `json:"byProvider,omitempty"`
 	Wait           *WaitToolPolicy            `json:"wait,omitempty"`
 	ToolCallPrefix string                     `json:"toolCallPrefix,omitempty"` // prefix to strip from model's tool call names before registry lookup
+	// RateLimitPerHour overrides the global tools.rate_limit_per_hour for this
+	// agent (applied per session key). 0 = inherit the global limit.
+	RateLimitPerHour int `json:"rate_limit_per_hour,omitempty"`
 }
 
 // WaitToolPolicy configures per-agent safety bounds for the wait tool.

--- a/internal/tools/context_keys.go
+++ b/internal/tools/context_keys.go
@@ -34,6 +34,10 @@ const (
 	ctxRunKind     toolContextKey = "tool_run_kind"    // "notification", "announce", "delegation"
 )
 
+// ctxRateLimitOverride carries a per-agent tool rate limit (calls/hour) that
+// overrides the global tools.rate_limit_per_hour. 0 means "use the global".
+const ctxRateLimitOverride toolContextKey = "tool_rate_limit_override"
+
 // Well-known channel names used for routing and access control.
 const (
 	ChannelSystem    = "system"
@@ -157,6 +161,18 @@ func WithToolSessionKey(ctx context.Context, key string) context.Context {
 
 func ToolSessionKeyFromCtx(ctx context.Context) string {
 	v, _ := ctx.Value(ctxSessionKey).(string)
+	return v
+}
+
+// WithToolRateLimitOverride sets a per-agent tool rate limit (calls/hour) that
+// overrides the global tools.rate_limit_per_hour for tools executed under ctx.
+func WithToolRateLimitOverride(ctx context.Context, perHour int) context.Context {
+	return context.WithValue(ctx, ctxRateLimitOverride, perHour)
+}
+
+// ToolRateLimitOverrideFromCtx returns the per-agent override, or 0 if unset.
+func ToolRateLimitOverrideFromCtx(ctx context.Context) int {
+	v, _ := ctx.Value(ctxRateLimitOverride).(int)
 	return v
 }
 

--- a/internal/tools/rate_limiter.go
+++ b/internal/tools/rate_limiter.go
@@ -28,11 +28,23 @@ func NewToolRateLimiter(maxPerHour int) *ToolRateLimiter {
 	}
 }
 
-// Allow checks if a tool execution is allowed for the given key.
-// Returns nil if allowed, or an error describing the rate limit.
+// Allow checks if a tool execution is allowed for the given key against the
+// limiter's configured max. Returns nil if allowed, or an error.
 func (rl *ToolRateLimiter) Allow(key string) error {
+	return rl.AllowWithLimit(key, 0)
+}
+
+// AllowWithLimit is Allow with a per-call max override (calls/hour). When
+// maxOverride > 0 it replaces the configured max for this check — used for the
+// per-agent tools.rate_limit_per_hour. maxOverride <= 0 uses the configured max.
+func (rl *ToolRateLimiter) AllowWithLimit(key string, maxOverride int) error {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
+
+	max := rl.maxPerHr
+	if maxOverride > 0 {
+		max = maxOverride
+	}
 
 	now := time.Now()
 	cutoff := now.Add(-rl.window)
@@ -45,8 +57,8 @@ func (rl *ToolRateLimiter) Allow(key string) error {
 	}
 	entries = entries[start:]
 
-	if len(entries) >= rl.maxPerHr {
-		return fmt.Errorf("tool rate limit exceeded: %d actions/hour for key %s", rl.maxPerHr, key)
+	if len(entries) >= max {
+		return fmt.Errorf("tool rate limit exceeded: %d actions/hour for key %s", max, key)
 	}
 
 	// Record this action

--- a/internal/tools/rate_limiter_test.go
+++ b/internal/tools/rate_limiter_test.go
@@ -61,6 +61,28 @@ func TestToolRateLimiter_SeparateKeys(t *testing.T) {
 	}
 }
 
+func TestToolRateLimiter_AllowWithLimit_Override(t *testing.T) {
+	rl := NewToolRateLimiter(100) // global default 100
+
+	// A per-agent override of 2 caps this key at 2, regardless of the global 100.
+	if err := rl.AllowWithLimit("agentA", 2); err != nil {
+		t.Fatalf("call 1 should be allowed: %v", err)
+	}
+	if err := rl.AllowWithLimit("agentA", 2); err != nil {
+		t.Fatalf("call 2 should be allowed: %v", err)
+	}
+	if err := rl.AllowWithLimit("agentA", 2); err == nil {
+		t.Error("call 3 should be blocked by the override of 2")
+	}
+
+	// maxOverride <= 0 falls back to the configured global (100), on its own key.
+	for i := range 3 {
+		if err := rl.AllowWithLimit("agentB", 0); err != nil {
+			t.Fatalf("agentB call %d should use global 100: %v", i, err)
+		}
+	}
+}
+
 func TestToolRateLimiter_WindowExpiry(t *testing.T) {
 	rl := &ToolRateLimiter{
 		windows:  make(map[string][]time.Time),

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -200,9 +200,10 @@ func (r *Registry) ExecuteWithContext(ctx context.Context, name string, args map
 		ctx = WithToolAsyncCB(ctx, asyncCB)
 	}
 
-	// Rate limit check (per session key)
+	// Rate limit check (per session key). A per-agent override
+	// (tools.rate_limit_per_hour, threaded via context) wins over the global max.
 	if r.rateLimiter != nil && sessionKey != "" {
-		if err := r.rateLimiter.Allow(sessionKey); err != nil {
+		if err := r.rateLimiter.AllowWithLimit(sessionKey, ToolRateLimitOverrideFromCtx(ctx)); err != nil {
 			return ErrorResult(err.Error())
 		}
 	}

--- a/ui/web/src/types/agent.ts
+++ b/ui/web/src/types/agent.ts
@@ -13,6 +13,7 @@ export interface ToolPolicyConfig {
     max_ms?: number;
   };
   toolCallPrefix?: string; // prefix to strip from model's tool call names
+  rate_limit_per_hour?: number; // per-agent tool calls/hour (0 = use global)
 }
 
 export interface SubagentsConfig {


### PR DESCRIPTION
## Problem

The agent config dashboard (`tools-profile-section.tsx`) and i18n (en/vi/zh) already render a per-agent **"Rate Limit (per hour)"** input that saves `rate_limit_per_hour` into the agent's `tools_config`. But the backend never read it: the tool rate limiter (`ToolRateLimiter`) only used the global `tools.rate_limit_per_hour` (config / `system_configs`), keyed per session. So an operator could set a per-agent limit in the UI and nothing happened — the only knob that worked was the global one (shared by every agent).

## Fix

Wire the existing field through, end to end:

- `config.ToolPolicySpec` gains `RateLimitPerHour int` (`rate_limit_per_hour`), parsed from the per-agent `tools_config` JSONB — no migration (additive).
- The agent loop (`loop_context.go`) threads it into the tool-execution context (`WithToolRateLimitOverride`) when set, mirroring the existing per-agent `wait` config.
- `Registry.ExecuteWithContext` reads the override from context and passes it to the limiter.
- `ToolRateLimiter.AllowWithLimit(key, maxOverride)` uses `maxOverride` (calls/hour) when `> 0`, else the configured global; `Allow(key)` delegates with `0`, so existing callers are unchanged.
- `ui/web/src/types/agent.ts`: add `rate_limit_per_hour?` to `ToolPolicyConfig` (the UI already binds it via `Record<string, any>`).

`0`/unset inherits the global `tools.rate_limit_per_hour`. The limit stays per-session-key, so a per-agent value just gives that agent more headroom without affecting others.

## Test

`internal/tools/rate_limiter_test.go` → `TestToolRateLimiter_AllowWithLimit_Override`: an override of 2 caps a key at 2 regardless of the global 100; `maxOverride <= 0` falls back to the global.

```
go build ./...                                                  ✅
go build -tags sqliteonly ./...                                 ✅
go vet ./internal/tools/ ./internal/agent/ ./internal/config/   ✅
go test -race ./internal/tools/ ./internal/agent/               ✅
```

No migration / schema change. i18n keys already present in en/vi/zh.
