### PR TITLE
fix(agent): prevent nil-pointer panic on native image_generation tool def

### DIFF
--- a/internal/agent/loop_tool_filter.go
+++ b/internal/agent/loop_tool_filter.go
@@ -11,7 +11,7 @@ import (
 // imageGenToolDef is the native image_generation tool sentinel. Its Type-only form
 // is passed through by the Codex/OpenAI request builder as a bare {"type":"image_generation"}
 // object — no "function" wrapper, no parameters.
-var imageGenToolDef = providers.ToolDefinition{Type: "image_generation"}
+var imageGenToolDef = providers.ToolDefinition{Type: "image_generation", Function: &providers.ToolFunctionSchema{Name: "image_generation"}}
 
 // buildFilteredTools resolves the per-iteration tool definitions based on policy,
 // disabled tools, bootstrap mode, skill visibility, channel type, and iteration budget.


### PR DESCRIPTION
## Summary

`imageGenToolDef` (the native `image_generation` tool sentinel) is a `Type`-only `ToolDefinition` whose `Function` pointer is `nil`. Several agent-side tool helpers dereference `td.Function.Name` **without a nil check**, so any agent that runs on a provider exposing the native image-generation capability (e.g. **Codex / `gpt-5.5`**) panics with a nil-pointer dereference in `ContextStage` on **every** inbound run — the agent never replies.

## Symptom

- Agent configured with `provider=openai-codex`, `model=gpt-5.5`.
- On every inbound message (tested via Telegram DM), the run dies in ~7 ms with `llm_call_count: 0`. The channel only shows a status reaction; **no reply is ever sent**.
- Trace status: `error: "trace finalized by safety net (likely panic or goroutine leak)"`.
- Gateway log:

```
level=INFO  msg="resolved agent from DB" agent=tra-tra model=gpt-5.5 provider=openai-codex
level=INFO  msg="system prompt built" ... promptLen=31377
level=ERROR msg="scheduler: executeRun panicked"
            panic="runtime error: invalid memory address or nil pointer dereference"
```

## Root cause

`internal/agent/loop_tool_filter.go`

```go
var imageGenToolDef = providers.ToolDefinition{Type: "image_generation"} // Function == nil
```

When the provider advertises the `ImageGeneration` capability and `allowImageGeneration` is on (default), this sentinel is appended to the agent's tool list. Downstream, tool filtering/counting code accesses `td.Function.Name` assuming every `ToolDefinition` is a function tool:

- `internal/agent/loop_pipeline_callbacks.go` — `makeBuildFilteredTools` (mcp-prefix counting) **← crash site**, and the tool-name diagnostics
- `internal/agent/loop_tool_filter.go` — `FilterTools` (allowlist / deny / disabled checks)
- `internal/pipeline/think_stage.go` — `AllowedTools` map build
- `internal/agent/loop_history_toolnames.go` — tool-name extraction

Because `ToolDefinition.Function` is documented as `nil when Type != "function"`, the native image-generation tool trips the first unguarded deref. The first hit is in `ContextStage.Execute` → `BuildFilteredTools`.

### Captured stack trace

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/nextlevelbuilder/goclaw/internal/agent.(*Loop).makeBuildFilteredTools.func9()
        internal/agent/loop_pipeline_callbacks.go (td.Function.Name deref)
github.com/nextlevelbuilder/goclaw/internal/pipeline.(*ContextStage).Execute()
        internal/pipeline/context_stage.go (BuildFilteredTools)
github.com/nextlevelbuilder/goclaw/internal/pipeline.(*Pipeline).Run()
github.com/nextlevelbuilder/goclaw/internal/agent.(*Loop).runViaPipeline()
github.com/nextlevelbuilder/goclaw/internal/agent.(*Loop).Run()
github.com/nextlevelbuilder/goclaw/internal/scheduler.(*SessionQueue).executeRun()
```

(Line numbers from the `v3.14.0` release build; symbols are stable on `dev`.)

## Reproduction

1. Configure a Codex provider (`provider_type=claude.../chatgpt_oauth`, model `gpt-5.5`) and bind an agent to it.
2. Leave image generation enabled (default `allow_image_generation = true`).
3. Send the agent any message (DM or channel).
4. → `scheduler: executeRun panicked` (nil pointer), no response.

Agents on providers **without** the native image-generation capability (e.g. Anthropic, Claude CLI) are unaffected, because the sentinel is never appended and `Function` is always non-nil for function tools.

## Fix

Give the sentinel a `Function` carrying its canonical name so every downstream `td.Function.Name` resolves safely:

```go
var imageGenToolDef = providers.ToolDefinition{
    Type:     "image_generation",
    Function: &providers.ToolFunctionSchema{Name: "image_generation"},
}
```

This is a minimal, source-level fix (one definition) rather than scattering nil guards across every call site. Wire behaviour is unchanged: the request builders (`codex_build.go`, etc.) still branch on `Type == "image_generation"` and pass the bare `{"type":"image_generation"}` object through, so they never read `Function` for this tool.

## Testing

- Rebuilt and deployed; the same agent on `openai-codex` / `gpt-5.5` now completes the run and replies normally over Telegram — no panic.
- Agents on other providers continue to work unchanged.

## Notes

No public contract change (`ToolDefinition` shape, request payloads, exported APIs all unchanged). Single-line behavioural fix.
