### PR TITLE
fix(security): block RFC 2544 benchmarking IPs in SSRF protection

### DIFF
--- a/internal/security/ssrf.go
+++ b/internal/security/ssrf.go
@@ -52,6 +52,10 @@ func init() {
 		"172.16.0.0/12",
 		"192.168.0.0/16",
 		"fc00::/7",
+		// Benchmarking (RFC 2544)
+		"198.18.0.0/15",
+		// Reserved for future use
+		"240.0.0.0/4",
 		// Multicast
 		"224.0.0.0/4",
 		"ff00::/8",

--- a/internal/security/ssrf_test.go
+++ b/internal/security/ssrf_test.go
@@ -45,6 +45,20 @@ func TestValidate_RejectsRFC1918(t *testing.T) {
 	}
 }
 
+func TestValidate_RejectsBenchmarking(t *testing.T) {
+	_, _, err := Validate("http://198.18.1.1/")
+	if err == nil {
+		t.Fatal("expected error for benchmarking range (198.18.0.0/15), got nil")
+	}
+}
+
+func TestValidate_RejectsReserved(t *testing.T) {
+	_, _, err := Validate("http://240.1.2.3/")
+	if err == nil {
+		t.Fatal("expected error for reserved range (240.0.0.0/4), got nil")
+	}
+}
+
 func TestValidate_RejectsMulticast(t *testing.T) {
 	_, _, err := Validate("http://224.0.0.1/")
 	if err == nil {

--- a/internal/tools/web_shared.go
+++ b/internal/tools/web_shared.go
@@ -131,7 +131,9 @@ func isPrivateIP(ipStr string) bool {
 		{"169.254.0.0", 16},  // link-local
 		{"172.16.0.0", 12},   // private
 		{"192.168.0.0", 16},  // private
-		{"100.64.0.0", 10},   // carrier-grade NAT
+		{"100.64.0.0", 10},   // carrier-grade NAT (RFC 6598)
+		{"198.18.0.0", 15},   // benchmarking (RFC 2544)
+		{"240.0.0.0", 4},     // reserved for future use
 	}
 
 	for _, r := range privateRanges {

--- a/internal/tools/web_shared_test.go
+++ b/internal/tools/web_shared_test.go
@@ -1,0 +1,47 @@
+package tools
+
+import "testing"
+
+func TestIsPrivateIP(t *testing.T) {
+	blocked := []struct {
+		ip   string
+		desc string
+	}{
+		{"10.0.0.1", "RFC 1918 class A"},
+		{"172.16.5.1", "RFC 1918 class B"},
+		{"192.168.1.1", "RFC 1918 class C"},
+		{"127.0.0.1", "loopback"},
+		{"169.254.169.254", "link-local / cloud metadata"},
+		{"100.64.0.1", "carrier-grade NAT"},
+		{"198.18.1.1", "benchmarking (RFC 2544)"},
+		{"198.19.255.1", "benchmarking upper (RFC 2544)"},
+		{"240.1.2.3", "reserved for future use"},
+		{"255.255.255.255", "reserved broadcast"},
+		{"::1", "IPv6 loopback"},
+		{"fe80::1", "IPv6 link-local"},
+		{"fc00::1", "IPv6 unique local"},
+	}
+	for _, tc := range blocked {
+		t.Run(tc.desc, func(t *testing.T) {
+			if !isPrivateIP(tc.ip) {
+				t.Errorf("expected %s (%s) to be blocked", tc.ip, tc.desc)
+			}
+		})
+	}
+
+	allowed := []struct {
+		ip   string
+		desc string
+	}{
+		{"8.8.8.8", "Google DNS"},
+		{"93.184.216.34", "example.com"},
+		{"198.51.100.1", "public IP near benchmarking range"},
+	}
+	for _, tc := range allowed {
+		t.Run(tc.desc, func(t *testing.T) {
+			if isPrivateIP(tc.ip) {
+				t.Errorf("expected %s (%s) to be allowed", tc.ip, tc.desc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add `198.18.0.0/15` (RFC 2544 benchmarking) and `240.0.0.0/4` (reserved for future use) to both SSRF blocklists to prevent bypass of SSRF protection via these special-use IP ranges.

## Type
Bug fix (security)

## Target branch
`dev`

## Scope
- `internal/security/ssrf.go` — added 2 CIDRs to `blockedCIDRs`
- `internal/tools/web_shared.go` — added 2 ranges to `isPrivateIP()`
- `internal/security/ssrf_test.go` — added 2 test functions
- `internal/tools/web_shared_test.go` — new file, 17 subtests

## Checklist
- [x] Both SSRF blocklists updated (security package + web_fetch tool)
- [x] No breaking changes to existing behavior
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes

## Test plan
- [x] `TestValidate_RejectsBenchmarking` — `198.18.1.1` blocked
- [x] `TestValidate_RejectsReserved` — `240.1.2.3` blocked
- [x] `TestIsPrivateIP` — 17 subtests (all blocked + allowed ranges)
- [x] All existing SSRF tests still pass

Closes #1218