### PR TITLE
fix(gateway): re-apply allowed_paths to filesystem tools after system_configs overlay

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -240,6 +240,17 @@ func runGateway() {
 	} else {
 		toolsReg.SetRateLimiter(nil)
 	}
+
+	// Re-apply user-configured allowed paths for the same reason as the rate
+	// limiter above: setupToolRegistry wired the filesystem tools' AllowPaths
+	// from the JSON5 default before ApplySystemConfigs overlaid
+	// system_configs['allowed_paths'], so DB-driven paths never reached the tools.
+	// Re-run now that cfg reflects the DB value. Safe: server has not started, no
+	// in-flight tool calls.
+	if paths := cfg.Agents.Defaults.AllowedPaths; len(paths) > 0 {
+		applyUserAllowedPaths(toolsReg, paths)
+		slog.Info("filesystem allowed paths reapplied from system_configs", "paths", len(paths))
+	}
 	setupMemoryEmbeddings(pgStores, providerRegistry)
 	usageCapSvc := usagecaps.NewService(pgStores.UsageCaps, pgStores.Providers)
 

--- a/cmd/gateway_tools_wiring.go
+++ b/cmd/gateway_tools_wiring.go
@@ -97,46 +97,30 @@ func wireExtraTools(
 	if pgStores.Skills != nil {
 		skillsAllowPaths = append(skillsAllowPaths, pgStores.Skills.Dirs()...)
 	}
-	// Expand user-configured allowed paths (for cross-drive access on Windows).
-	// These paths are validated per-request in resolvePath for tenant isolation.
-	var userAllowPaths []string
-	for _, p := range agentCfg.AllowedPaths {
-		expanded := config.ExpandHome(p)
-		if expanded != "" {
-			userAllowPaths = append(userAllowPaths, expanded)
-		}
-	}
-
 	if readTool, ok := toolsReg.Get("read_file"); ok {
 		if pa, ok := readTool.(tools.PathAllowable); ok {
 			pa.AllowPaths(skillsAllowPaths...)
 			pa.AllowPaths(filepath.Join(dataDir, "cli-workspaces"))
-			pa.AllowPaths(userAllowPaths...)
 		}
 	}
 	if listTool, ok := toolsReg.Get("list_files"); ok {
 		if pa, ok := listTool.(tools.PathAllowable); ok {
 			pa.AllowPaths(skillsAllowPaths...)
-			pa.AllowPaths(userAllowPaths...)
-		}
-	}
-	// Write and edit tools also get user-configured allowed paths for cross-drive access.
-	if writeTool, ok := toolsReg.Get("write_file"); ok {
-		if pa, ok := writeTool.(tools.PathAllowable); ok {
-			pa.AllowPaths(userAllowPaths...)
-		}
-	}
-	if editTool, ok := toolsReg.Get("edit"); ok {
-		if pa, ok := editTool.(tools.PathAllowable); ok {
-			pa.AllowPaths(userAllowPaths...)
 		}
 	}
 	if sendFileTool, ok := toolsReg.Get("send_file"); ok {
 		if pa, ok := sendFileTool.(tools.PathAllowable); ok {
 			pa.AllowPaths(skillsAllowPaths...)
-			pa.AllowPaths(userAllowPaths...)
 		}
 	}
+
+	// User-configured allowed paths (config agents.defaults.allowed_paths, for
+	// cross-drive access on Windows and shared dirs outside the workspace).
+	// Applied via a helper so cmd/gateway.go can re-apply it after
+	// ApplySystemConfigs overlays system_configs['allowed_paths'] — see
+	// applyUserAllowedPaths. Paths are validated per-request in resolvePath for
+	// tenant isolation.
+	applyUserAllowedPaths(toolsReg, agentCfg.AllowedPaths)
 
 	// Memory tools are PG-backed; always available.
 	hasMemory = true
@@ -160,6 +144,39 @@ func wireExtraTools(
 	}
 
 	return heartbeatTool, hasMemory
+}
+
+// fsAllowPathTools are the filesystem tools that honour user-configured allowed
+// paths beyond the agent workspace (config agents.defaults.allowed_paths).
+var fsAllowPathTools = []string{"read_file", "list_files", "write_file", "edit", "send_file"}
+
+// applyUserAllowedPaths grants the user-configured allowed paths to the
+// filesystem tools. ExpandHome resolves a leading "~".
+//
+// Called twice during startup: once while tools are wired (from config.json),
+// and again from cmd/gateway.go after ApplySystemConfigs overlays
+// system_configs['allowed_paths']. Tool wiring runs before that overlay, so
+// without the re-apply DB-driven allowed paths never reach the tools — the
+// AllowPaths analogue of the rate-limiter re-apply (#1111). Safe to call
+// repeatedly: AllowPaths is additive and the prefix check is membership-based,
+// so a duplicated prefix is harmless.
+func applyUserAllowedPaths(toolsReg *tools.Registry, allowedPaths []string) {
+	var paths []string
+	for _, p := range allowedPaths {
+		if expanded := config.ExpandHome(p); expanded != "" {
+			paths = append(paths, expanded)
+		}
+	}
+	if len(paths) == 0 {
+		return
+	}
+	for _, name := range fsAllowPathTools {
+		if t, ok := toolsReg.Get(name); ok {
+			if pa, ok := t.(tools.PathAllowable); ok {
+				pa.AllowPaths(paths...)
+			}
+		}
+	}
 }
 
 // wireWorkstationTools registers workstation_exec and claude_remote tools (Standard edition only).

--- a/cmd/gateway_tools_wiring_test.go
+++ b/cmd/gateway_tools_wiring_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
+)
+
+// applyUserAllowedPaths must grant the filesystem tools access to paths outside
+// the agent workspace. cmd/gateway.go relies on this to re-apply
+// system_configs['allowed_paths'] after the overlay (tool wiring runs first) —
+// the AllowPaths analogue of the rate-limiter re-apply in #1111.
+func TestApplyUserAllowedPaths_GrantsExternalPathToReadFile(t *testing.T) {
+	ws := t.TempDir()
+	ext := t.TempDir()
+	extFile := filepath.Join(ext, "kb.md")
+	if err := os.WriteFile(extFile, []byte("knowledge"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := tools.NewRegistry()
+	reg.Register(tools.NewReadFileTool(ws, true))
+	read, ok := reg.Get("read_file")
+	if !ok {
+		t.Fatal("read_file not registered")
+	}
+
+	// Before granting: a path outside the workspace is denied.
+	if res := read.Execute(context.Background(), map[string]any{"path": extFile}); !res.IsError {
+		t.Fatalf("expected access denied before allow, got: %s", res.ForLLM)
+	}
+
+	applyUserAllowedPaths(reg, []string{ext})
+
+	// After granting: the external path is readable.
+	if res := read.Execute(context.Background(), map[string]any{"path": extFile}); res.IsError {
+		t.Fatalf("expected success after allow, got error: %s", res.ForLLM)
+	}
+
+	// The grant is scoped — an unrelated external path stays denied.
+	other := t.TempDir()
+	otherFile := filepath.Join(other, "secret.md")
+	if err := os.WriteFile(otherFile, []byte("nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if res := read.Execute(context.Background(), map[string]any{"path": otherFile}); !res.IsError {
+		t.Fatalf("expected unrelated external path to stay denied, got: %s", res.ForLLM)
+	}
+}
+
+// Applying twice (initial wiring + the gateway re-apply after ApplySystemConfigs)
+// must keep the grant working and must not error.
+func TestApplyUserAllowedPaths_RepeatedApplyIsSafe(t *testing.T) {
+	ws := t.TempDir()
+	ext := t.TempDir()
+	extFile := filepath.Join(ext, "kb.md")
+	if err := os.WriteFile(extFile, []byte("knowledge"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := tools.NewRegistry()
+	reg.Register(tools.NewReadFileTool(ws, true))
+	read, ok := reg.Get("read_file")
+	if !ok {
+		t.Fatal("read_file not registered")
+	}
+
+	applyUserAllowedPaths(reg, []string{ext}) // initial wiring (from config.json)
+	applyUserAllowedPaths(reg, []string{ext}) // re-apply after system_configs overlay
+
+	if res := read.Execute(context.Background(), map[string]any{"path": extFile}); res.IsError {
+		t.Fatalf("expected success after repeated allow, got error: %s", res.ForLLM)
+	}
+}
+
+// An empty allow list is a no-op and must not panic (the common case when no
+// allowed_paths are configured).
+func TestApplyUserAllowedPaths_EmptyIsNoop(t *testing.T) {
+	reg := tools.NewRegistry()
+	reg.Register(tools.NewReadFileTool(t.TempDir(), true))
+	applyUserAllowedPaths(reg, nil)
+	applyUserAllowedPaths(reg, []string{})
+}


### PR DESCRIPTION
## Summary
`system_configs['allowed_paths']` never reached the filesystem tools, so agents were denied access to configured shared directories outside their workspace even though the DB value was present. This re-applies the user-configured allowed paths after the `system_configs` overlay — the AllowPaths analogue of the rate-limiter re-apply in #1111.

## Type
- [x] Bug fix

## Root cause
`setupToolRegistry` wires the filesystem tools' `AllowPaths` from the config/JSON5 default **before** `ApplySystemConfigs` overlays `system_configs['allowed_paths']` onto `cfg`. #1111 fixed this exact ordering bug for the tool rate limiter (re-apply after the overlay) but the AllowPaths case was missed, so DB-configured paths never reached `read_file` / `list_files` / `write_file` / `edit` / `send_file`.

Observed in production: setting `system_configs['allowed_paths']` to a path outside the workspace and restarting still produced `read_file: access denied`, and the warn log's `allowedPrefixes` showed only the built-in skill/cli-workspace prefixes — the configured path was absent. `exec` was unaffected (host-native command, no AllowPaths boundary on its working dir target).

## Fix
- Extract the user-allowed-path application from `wireExtraTools` into `applyUserAllowedPaths(toolsReg, allowedPaths)`.
- Re-run it from `runGateway` right after the existing rate-limiter re-apply, using `cfg.Agents.Defaults.AllowedPaths` (now overlaid from the DB).
- The helper is idempotent — `AllowPaths` is additive and the prefix check is membership-based — so the initial wiring call plus the re-apply is safe. Behaviour is unchanged when no allowed paths are configured (empty list → no-op).

Skill/cli-workspace prefixes are unchanged (still applied once during wiring); only the user-configured paths needed re-application because only they are DB-overlaid.

## Target Branch
`dev`

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./cmd/ ./internal/tools/`
- [ ] Web UI builds (no UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no SQL changes)
- [ ] New user-facing strings (none — internal startup log only)
- [ ] Migration version bumped (no migration)

## Test Plan
New `cmd/gateway_tools_wiring_test.go`:
- a path outside the workspace is denied before `applyUserAllowedPaths` and readable after;
- an unrelated external path stays denied (grant is scoped);
- repeated application (initial wiring + the gateway re-apply) keeps the grant working and does not error;
- an empty allow list is a no-op.

Also verified end-to-end on a live deployment: after this change a DB-only `system_configs['allowed_paths']` (no other workaround) makes the configured directory readable/writable by `read_file`/`list_files`/`write_file`, with no new `access denied` logs.