### PR TITLE
fix(config): overlay cron command flag from system configs

### DIFF
--- a/internal/config/config_extras_test.go
+++ b/internal/config/config_extras_test.go
@@ -283,6 +283,7 @@ func TestApplySystemConfigs(t *testing.T) {
 		"tools.browser.enabled":     "false",
 		"tools.browser.remote_url":  "ws://chrome:9222",
 		"tools.browser.max_pages":   "9",
+		"cron.command_enabled":      "true",
 	})
 
 	if cfg.Agents.Defaults.Provider != "openai" {
@@ -305,6 +306,9 @@ func TestApplySystemConfigs(t *testing.T) {
 	}
 	if cfg.Tools.Browser.MaxPages != 9 {
 		t.Errorf("tools.browser.max_pages: got %d", cfg.Tools.Browser.MaxPages)
+	}
+	if !cfg.Cron.CommandEnabled {
+		t.Error("cron.command_enabled: got false, want true")
 	}
 }
 

--- a/internal/config/config_system.go
+++ b/internal/config/config_system.go
@@ -95,6 +95,7 @@ func (c *Config) ApplySystemConfigs(configs map[string]string) {
 	// Cron
 	integer("cron.max_retries", &c.Cron.MaxRetries)
 	str("cron.default_timezone", &c.Cron.DefaultTimezone)
+	boolValue("cron.command_enabled", &c.Cron.CommandEnabled)
 
 	// Pending message compaction
 	if _, ok := configs["compaction.threshold"]; ok {


### PR DESCRIPTION
## Summary
Adds `cron.command_enabled` to the DB-backed `system_configs` overlay so trusted deployments can enable deterministic command cron jobs without editing the base config file.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
Targets `dev`.

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [ ] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [x] New user-facing strings added to all 3 locales (en/vi/zh)
- [x] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
- `env -u GOCLAW_CONFIG -u GOCLAW_DATA_DIR -u GOCLAW_HOST -u GOCLAW_PORT -u GOCLAW_PUBLIC_URL -u GOCLAW_ALLOWED_ORIGINS PATH=/usr/local/go/bin:$PATH go test ./internal/config ./internal/gateway/methods ./internal/tools ./cmd`
- `env -u GOCLAW_CONFIG -u GOCLAW_DATA_DIR -u GOCLAW_HOST -u GOCLAW_PORT -u GOCLAW_PUBLIC_URL -u GOCLAW_ALLOWED_ORIGINS PATH=/usr/local/go/bin:$PATH go build ./...`
- `env -u GOCLAW_CONFIG -u GOCLAW_DATA_DIR -u GOCLAW_HOST -u GOCLAW_PORT -u GOCLAW_PUBLIC_URL -u GOCLAW_ALLOWED_ORIGINS PATH=/usr/local/go/bin:$PATH go build -tags sqliteonly ./...`
