### PR TITLE
fix(bitrix24): skip native-group mention gate for Open Channel sessions

### DIFF
--- a/internal/channels/bitrix24/handle.go
+++ b/internal/channels/bitrix24/handle.go
@@ -164,13 +164,23 @@ func (c *Channel) handleMessage(ctx context.Context, evt *Event) {
 		}
 	}
 	if isGroup {
+		// Mention DROP CHECK is scoped to native group chats (CRM deal/task,
+		// plain groups) only. Open Channel sessions own their mention policy
+		// via shouldRequireMentionForOpenline above — re-applying the channel-
+		// level RequireMention flag here would silently drop, e.g., every
+		// Facebook Messenger customer turn (whose connector isn't in the
+		// require-mention whitelist) even though the upstream gate let it
+		// through. Text processing below (mention strip + readable rewrite)
+		// stays unconditional so Openline staff messages with bot BBCode tags
+		// still get cleaned up.
+		//
 		// Authority-ordered fallback: structured MENTIONED_LIST → raw
 		// MESSAGE_ORIGINAL → stripped MESSAGE. In group chats Bitrix24 strips
 		// the @mention from MESSAGE before sending the webhook, so checking
 		// MESSAGE alone misses every group mention. See
 		// plans/bitrix24-mcp-refactor/reports/retrospective.md §2 for context.
 		mentioned := c.isMentionedParams(&evt.Params)
-		if c.RequireMention() && !mentioned {
+		if !isOpenChannel && c.RequireMention() && !mentioned {
 			slog.Info("bitrix24 message: dropped missing mention",
 				"from_user_id", evt.Params.FromUserID,
 				"dialog_id", evt.Params.DialogID,


### PR DESCRIPTION
## Problem

Follow-up to #1295. After scoping the Open Channel mention gate by connector, **customer messages on 1-to-1 connectors (Facebook Messenger, Zalo OA, …) are still being silently dropped** — by the second mention-gate stanza further down in `handleMessage`, which checks the channel-level `c.RequireMention()` flag without distinguishing Open Channel traffic from native group chats (CRM deal/task chats).

For a channel like `nguyen-dao-openline` configured with `RequireMention=true`, the flow was:

1. `isOpenChannel` block → `shouldRequireMentionForOpenline("facebook|…")` returns `false` (facebook isn't in the whitelist) → no drop.
2. `isGroup` block (`isOpenChannel` implies `isGroup`) → `c.RequireMention()=true` AND `mentioned=false` → **DROP**.

Net effect: the gate-by-connector decision from #1295 was overridden one stanza later, and every Facebook customer turn disappeared. Reproduced live: customer sends "alo" from the Facebook Open Channel, payload arrives at goclaw (`mime=audio/mpeg` not relevant; same for plain text), and the bot stays silent.

## Fix

Scope the drop check inside the `isGroup` block to **native-group chats only** (`!isOpenChannel`). Open Channel sessions already own their mention policy in the earlier `isOpenChannel` block; re-applying the channel-level `RequireMention` flag here second-guesses that decision.

```go
if isGroup {
    mentioned := c.isMentionedParams(&evt.Params)
    if !isOpenChannel && c.RequireMention() && !mentioned {  // ← was: if c.RequireMention() && !mentioned
        // drop
        return
    }
    // text processing (MessageOriginal, stripMention, bxConvertUserMentionsToReadable)
    // stays unconditional so Openline staff turns with [USER=<botID>] BBCode still get cleaned up.
}
```

Importantly, the text-processing that follows the drop check (`MessageOriginal` fallback, `stripMention`, `bxConvertUserMentionsToReadable`) stays unconditional, so an Open Channel **staff** turn that does come in with `[USER=<botID>]Bot[/USER]` BBCode still gets cleaned up the same way it always did. The only thing the new guard suppresses is the drop itself.

## Verification

```
go build ./... && go build -tags sqliteonly ./...
go vet ./internal/channels/bitrix24/...
go test ./internal/channels/bitrix24/...   → ok
```

Live-tested against `tamgiac.bitrix24.com` after deploying a local image build:
- Facebook Messenger customer turn (`IS_CONNECTOR=Y`, `CHAT_ENTITY_ID=facebook|34|…`) now reaches the agent loop. Bot replies, matching the intent from #1295.
- Zalo personal customer turn (whitelisted connector) without `@mention` still drops at the earlier gate — no regression.
- Native group chats (CRM deal chats) without `@mention` still drop here when channel `RequireMention=true` — no regression.

## Surface parity

Backend-only. No API contract / web UI / CLI change.

[B24:2794]
