### PR TITLE
fix(mcp): Update button silently doing nothing due to hidden Zod vali…

### DIFF
--- a/ui/web/src/pages/mcp/mcp-connection-fields.tsx
+++ b/ui/web/src/pages/mcp/mcp-connection-fields.tsx
@@ -90,7 +90,7 @@ export function McpConnectionFields({ form }: McpConnectionFieldsProps) {
             <Label>{t("form.headers")}</Label>
             <KeyValueEditor
               value={headers}
-              onChange={(v) => setValue("headers", v)}
+              onChange={(v) => setValue("headers", v, { shouldDirty: true, shouldValidate: true })}
               keyPlaceholder={t("form.headerKeyPlaceholder")}
               valuePlaceholder={t("form.headerValuePlaceholder")}
               addLabel={t("form.addHeader")}

--- a/ui/web/src/pages/mcp/mcp-form-dialog.tsx
+++ b/ui/web/src/pages/mcp/mcp-form-dialog.tsx
@@ -46,6 +46,7 @@ export function MCPFormDialog({ open, onOpenChange, server, onSubmit, onTest, on
   const [createdServer, setCreatedServer] = useState<MCPServerData | null>(null);
 
   const form = useForm<MCPFormData>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolver: zodResolver(mcpFormSchema),
     mode: "onChange",
     defaultValues: {
@@ -286,6 +287,11 @@ export function MCPFormDialog({ open, onOpenChange, server, onSubmit, onTest, on
           <McpConnectionFields form={form} />
           <McpSettingsFields form={form} isEditing={!!server} />
           {error && <p className="text-sm text-destructive">{error}</p>}
+          {Object.keys(form.formState.errors).length > 0 && !error && (
+            <p className="text-sm text-destructive">
+              {Object.values(form.formState.errors).map(e => e?.message).filter(Boolean).join(", ")}
+            </p>
+          )}
         </div>
 
         <DialogFooter className="flex-col sm:flex-row gap-2">
@@ -321,7 +327,7 @@ export function MCPFormDialog({ open, onOpenChange, server, onSubmit, onTest, on
             <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
               {t("form.cancel")}
             </Button>
-            <Button onClick={handleSubmit} disabled={loading}>
+            <Button type="button" onClick={handleSubmit} disabled={loading}>
               {loading ? t("form.saving") : (server || createdServer) ? t("form.update") : t("form.create")}
             </Button>
           </div>

--- a/ui/web/src/pages/mcp/mcp-settings-fields.tsx
+++ b/ui/web/src/pages/mcp/mcp-settings-fields.tsx
@@ -49,7 +49,7 @@ export function McpSettingsFields({ form, isEditing }: McpSettingsFieldsProps) {
         <Label>{t("form.env")}</Label>
         <KeyValueEditor
           value={env}
-          onChange={(v) => setValue("env", v)}
+          onChange={(v) => setValue("env", v, { shouldDirty: true, shouldValidate: true })}
           keyPlaceholder={t("form.envKeyPlaceholder")}
           valuePlaceholder={t("form.envValuePlaceholder")}
           addLabel={t("form.addVariable")}
@@ -246,7 +246,7 @@ export function McpSettingsFields({ form, isEditing }: McpSettingsFieldsProps) {
           id="mcp-timeout"
           type="number"
           value={timeout}
-          onChange={(e) => setValue("timeout", Number(e.target.value))}
+          onChange={(e) => setValue("timeout", parseInt(e.target.value, 10) || 60, { shouldValidate: true })}
           min={1}
         />
       </div>


### PR DESCRIPTION
  fix(mcp): Update button silently doing nothing when editing MCP servers

  Problem

  Clicking Update after adding headers (e.g. Authorization / Bearer token) to an MCP server did nothing — no spinner, no error, no dialog close. Clicking Test worked fine.

  Root cause: The Update button calls rhfHandleSubmit(callback) from react-hook-form. Before invoking the callback, RHF runs full Zod validation on all fields. If any field fails, RHF calls
  the (implicit) no-op error handler — completely silently. The Test button bypasses RHF entirely via a direct handleTest() call, which is why it worked.

  Three silent failure paths were identified:

  1. timeout field — the input's onChange called setValue("timeout", Number(e.target.value)). Number("") === 0, which fails z.number().min(1). If the user cleared the field even briefly, the
  form was permanently invalid until the dialog was closed and reopened.
  2. headers / env fields — setValue("headers", v) was called without { shouldDirty: true, shouldValidate: true }, meaning RHF did not re-validate after headers changed. On certain form
  states this left the form in a stale invalid state.
  3. No error surface — formState.errors from RHF were never displayed to the user. Only the manual error state (set inside the callback) was shown, but the callback was never reached.

#  Changes

 - mcp-form-dialog.tsx: Display RHF formState.errors inline so Zod failures are visible; add type="button" to Update/Create button
 - mcp-connection-fields.tsx: Add { shouldDirty: true, shouldValidate: true } to setValue("headers", v)
 - mcp-settings-fields.tsx: Same for setValue("env", v); guard timeout with parseInt(..., 10) || 60 to prevent 0/NaN entering RHF
 - mcp.schema.ts: No schema change (kept z.number().min(1); input-layer guard is the right fix