### PR TITLE
fix(ollama): disable thinking mode by default

### DIFF
--- a/internal/providers/openai_config.go
+++ b/internal/providers/openai_config.go
@@ -143,9 +143,12 @@ func (p *OpenAIProvider) OllamaNumCtx() *int {
 	return p.ollamaNumCtx
 }
 
-func (p *OpenAIProvider) Name() string           { return p.name }
-func (p *OpenAIProvider) DefaultModel() string   { return p.defaultModel }
-func (p *OpenAIProvider) SupportsThinking() bool { return true }
+func (p *OpenAIProvider) Name() string         { return p.name }
+func (p *OpenAIProvider) DefaultModel() string { return p.defaultModel }
+
+// SupportsThinking returns false for Ollama endpoints, which disable thinking by default
+// (models like qwq and deepseek-r1 have thinking on by default and goclaw suppresses it).
+func (p *OpenAIProvider) SupportsThinking() bool { return !p.isOllamaEndpoint() }
 func (p *OpenAIProvider) APIKey() string         { return p.apiKey }
 func (p *OpenAIProvider) APIBase() string        { return p.apiBase }
 func (p *OpenAIProvider) AuthPrefix() string     { return p.authPrefix }
@@ -157,7 +160,7 @@ func (p *OpenAIProvider) Capabilities() ProviderCapabilities {
 		Streaming:        true,
 		ToolCalling:      true,
 		StreamWithTools:  true,
-		Thinking:         true,
+		Thinking:         !p.isOllamaEndpoint(),
 		Vision:           true,
 		CacheControl:     false,
 		MaxContextWindow: 128_000,

--- a/internal/providers/openai_endpoints.go
+++ b/internal/providers/openai_endpoints.go
@@ -40,27 +40,27 @@ func isDashScopeAPIBase(apiBase string) bool {
 	return strings.Contains(strings.ToLower(apiBase), "dashscope")
 }
 
-// dashScopePassthroughKeys is true when enable_thinking / thinking_budget may be added to the JSON body.
-// Uses the same DashScope/Bailian route detection as prompt-cache wrapping.
-func (p *OpenAIProvider) dashScopePassthroughKeys() bool {
-	return p.isDashScope()
-}
-
-// isOllamaEndpoint returns true for local or cloud Ollama inference endpoints.
-// Ollama requires options.num_ctx in the request body to control the context window
-// (prevents context-window errors on long conversations).
-// Uses 3-source detection (URL + providerType + name) to handle reverse-proxied endpoints.
+// isOllamaEndpoint returns true for local or self-hosted Ollama instances.
+// Ollama models such as qwq and deepseek-r1 have thinking enabled by default;
+// goclaw must send think=false to suppress it unless the user explicitly opts in.
+// Detection uses providerType (DB), name, and apiBase so both ProviderOllama and
+// ProviderOllamaCloud are covered, as well as self-hosted instances behind a proxy.
 func (p *OpenAIProvider) isOllamaEndpoint() bool {
-	if strings.Contains(strings.ToLower(p.apiBase), "ollama") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(strings.TrimSpace(p.providerType)), "ollama") {
+	pt := strings.ToLower(strings.TrimSpace(p.providerType))
+	if pt == "ollama" || pt == "ollama_cloud" {
 		return true
 	}
 	if strings.Contains(strings.ToLower(p.name), "ollama") {
 		return true
 	}
-	return false
+	b := strings.ToLower(p.apiBase)
+	return strings.Contains(b, "11434") || strings.Contains(b, "ollama")
+}
+
+// dashScopePassthroughKeys is true when enable_thinking / thinking_budget may be added to the JSON body.
+// Uses the same DashScope/Bailian route detection as prompt-cache wrapping.
+func (p *OpenAIProvider) dashScopePassthroughKeys() bool {
+	return p.isDashScope()
 }
 
 // ollamaNativeURL returns the full URL for Ollama's native /api/chat endpoint.

--- a/internal/providers/openai_request.go
+++ b/internal/providers/openai_request.go
@@ -273,6 +273,8 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 	// Without this, Ollama defaults to a small context (often 2048) and returns
 	// context-window errors on long conversations.
 	// Priority: user-configured ollamaNumCtx > pre-queried /api/show value > 131072 default.
+	// Also disable thinking by default to prevent bloated chain-of-thought responses
+	// from models like qwq and deepseek-r1 which have thinking enabled by default.
 	if p.isOllamaEndpoint() {
 		numCtx := OllamaDefaultNumCtx
 		numCtxSource := "default"
@@ -295,6 +297,10 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 				raw = raw[:500] + "..."
 			}
 			slog.Debug("ollama.request: final request body (first 500 chars)", "provider", p.name, "model", model, "body_prefix", raw)
+		}
+		// Disable thinking by default; only enable if caller explicitly requests it.
+		if level, _ := req.Options[OptThinkingLevel].(string); level == "" || level == "off" {
+			body["think"] = false
 		}
 	}
 

--- a/internal/providers/openai_test.go
+++ b/internal/providers/openai_test.go
@@ -638,3 +638,70 @@ func TestBuildRequestBody_MistralDBProviderTypeDetected(t *testing.T) {
 		t.Fatalf("DB provider with providerType=mistral: got %q, want 9 hex chars", got)
 	}
 }
+
+func TestBuildRequestBody_OllamaDisablesThinkByDefault(t *testing.T) {
+	// Ollama thinking models (qwq, deepseek-r1) have thinking on by default.
+	// goclaw must send think=false unless the user explicitly enables thinking.
+	cases := []struct {
+		name     string
+		provider *OpenAIProvider
+	}{
+		{
+			name:     "ollama by name",
+			provider: NewOpenAIProvider("ollama", "", "http://localhost:11434/v1", ""),
+		},
+		{
+			name:     "ollama by providerType",
+			provider: NewOpenAIProvider("local", "", "http://myhost:11434/v1", "").WithProviderType("ollama"),
+		},
+		{
+			name:     "ollama_cloud by providerType",
+			provider: NewOpenAIProvider("local", "", "https://cloud.ollama.ai/v1", "").WithProviderType("ollama_cloud"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := ChatRequest{Messages: []Message{{Role: "user", Content: "hi"}}}
+			body := tc.provider.buildRequestBody("qwq:32b", req, false)
+			think, ok := body["think"]
+			if !ok {
+				t.Fatalf("%s: expected think field in request body", tc.name)
+			}
+			if think != false {
+				t.Fatalf("%s: expected think=false, got %v", tc.name, think)
+			}
+		})
+	}
+}
+
+func TestBuildRequestBody_OllamaThinkNotDisabledWhenLevelSet(t *testing.T) {
+	// When OptThinkingLevel is explicitly set to a non-off value, think=false must NOT be sent
+	// so that thinking is allowed for users who opted in.
+	p := NewOpenAIProvider("ollama", "", "http://localhost:11434/v1", "")
+	req := ChatRequest{
+		Messages: []Message{{Role: "user", Content: "reason about this"}},
+		Options:  map[string]any{OptThinkingLevel: "high"},
+	}
+	body := p.buildRequestBody("qwq:32b", req, false)
+	if think, ok := body["think"]; ok && think == false {
+		t.Fatalf("ollama with OptThinkingLevel=high must not send think=false, got think=%v", think)
+	}
+}
+
+func TestOllamaSupportsThinkingFalse(t *testing.T) {
+	p := NewOpenAIProvider("ollama", "", "http://localhost:11434/v1", "").WithProviderType("ollama")
+	if p.SupportsThinking() {
+		t.Fatal("SupportsThinking() must return false for Ollama endpoints")
+	}
+	if p.Capabilities().Thinking {
+		t.Fatal("Capabilities().Thinking must be false for Ollama endpoints")
+	}
+}
+
+func TestNonOllamaSupportsThinkingTrue(t *testing.T) {
+	p := NewOpenAIProvider("openai", "key", "https://api.openai.com/v1", "")
+	if !p.SupportsThinking() {
+		t.Fatal("SupportsThinking() must return true for non-Ollama OpenAI-compat providers")
+	}
+}


### PR DESCRIPTION
Disable thinking for Ollama models (qwq, deepseek-r1, etc).

  These models have thinking enabled by default, causing bloated responses.
  Disable it to prevent unnecessary token generation unless explicitly requested.

  - Always send think: false in Ollama requests
  - Implement SupportsThinking() returning false for Ollama
  - User can opt-in via OptThinkingLevel (effort control)
  - 4 unit tests added