### PR TITLE
fix: require usage event cache token schema

### DIFF
--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -6,6 +6,19 @@ Significant changes, features, and fixes in reverse chronological order.
 
 ## 2026-07-01
 
+### Usage event analytics schema gate
+
+**Fixes**
+
+- Bumped required PostgreSQL schema version to include the usage event cache and
+  thinking token migration required by Resource Event Analytics.
+- Added a migration-version regression test so new SQL migrations cannot ship
+  without updating the binary schema gate.
+
+**Tests**
+
+- Added `internal/upgrade` coverage for required schema version parity.
+
 ### Paired DM routing after policy checks
 
 **Fixes**

--- a/internal/upgrade/version.go
+++ b/internal/upgrade/version.go
@@ -2,4 +2,4 @@ package upgrade
 
 // RequiredSchemaVersion is the schema migration version this binary requires.
 // Bump this whenever adding a new SQL migration file.
-const RequiredSchemaVersion uint = 87
+const RequiredSchemaVersion uint = 88

--- a/internal/upgrade/version_test.go
+++ b/internal/upgrade/version_test.go
@@ -1,0 +1,38 @@
+package upgrade
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRequiredSchemaVersionMatchesLatestMigration(t *testing.T) {
+	matches, err := filepath.Glob(filepath.Join("..", "..", "migrations", "*.up.sql"))
+	if err != nil {
+		t.Fatalf("glob migrations: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("no up migrations found")
+	}
+
+	var latest uint64
+	for _, match := range matches {
+		base := filepath.Base(match)
+		prefix, _, ok := strings.Cut(base, "_")
+		if !ok {
+			t.Fatalf("migration %q missing numeric prefix", base)
+		}
+		version, err := strconv.ParseUint(prefix, 10, 64)
+		if err != nil {
+			t.Fatalf("parse migration prefix %q: %v", base, err)
+		}
+		if version > latest {
+			latest = version
+		}
+	}
+
+	if RequiredSchemaVersion != uint(latest) {
+		t.Fatalf("RequiredSchemaVersion = %d, latest migration = %d", RequiredSchemaVersion, latest)
+	}
+}


### PR DESCRIPTION
## Summary
- Bump the required PostgreSQL schema version to include usage event cache/thinking token columns.
- Add a regression test that keeps RequiredSchemaVersion aligned with the latest up migration.
- Document the Resource Event Analytics schema gate fix in the project changelog.

## Root cause
The binary allowed startup against schema version 87 even though Resource Event Analytics now reads columns introduced by migration 000088_usage_events_cache_tokens.up.sql.

## Test plan
- [x] go test ./internal/upgrade
- [x] go build ./...
- [x] go build -tags sqliteonly ./...
- [x] go vet ./...
- [x] go test ./...

Related issues: none found in GitHub issue search.