### PR TITLE
fix(zalo): preserve nested reply context

### DIFF
--- a/internal/channels/replycontext/reply-context-cache.go
+++ b/internal/channels/replycontext/reply-context-cache.go
@@ -1,0 +1,178 @@
+package replycontext
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultMaxDepth           = 8
+	defaultMaxTotalChars      = 6000
+	defaultMaxCharsPerMessage = 1000
+	defaultMaxEntries         = 5000
+	defaultTTL                = 24 * time.Hour
+)
+
+// Scope isolates reply context by tenant, channel instance, and conversation.
+type Scope struct {
+	TenantID  string
+	ChannelID string
+	ThreadID  string
+}
+
+// Message is a platform-normalized accepted message stored for future replies.
+type Message struct {
+	IDs       []string
+	ParentIDs []string
+	Sender    string
+	Body      string
+	CreatedAt time.Time
+}
+
+// Quote is the platform-normalized immediate quote payload on a reply.
+type Quote struct {
+	IDs    []string
+	Sender string
+	Body   string
+}
+
+type Options struct {
+	MaxDepth           int
+	MaxTotalChars      int
+	MaxCharsPerMessage int
+	MaxEntries         int
+	TTL                time.Duration
+}
+
+type Cache struct {
+	mu      sync.Mutex
+	nodes   map[cacheKey]*node
+	aliases map[cacheKey]cacheKey
+	opts    Options
+	now     func() time.Time
+}
+
+type cacheKey struct {
+	tenant  string
+	channel string
+	thread  string
+	message string
+}
+
+type node struct {
+	key       cacheKey
+	ids       []string
+	parentIDs []string
+	sender    string
+	body      string
+	createdAt time.Time
+}
+
+func DefaultOptions() Options {
+	return Options{
+		MaxDepth:           defaultMaxDepth,
+		MaxTotalChars:      defaultMaxTotalChars,
+		MaxCharsPerMessage: defaultMaxCharsPerMessage,
+		MaxEntries:         defaultMaxEntries,
+		TTL:                defaultTTL,
+	}
+}
+
+func NewCache(opts Options) *Cache {
+	opts = opts.withDefaults()
+	return &Cache{
+		nodes:   make(map[cacheKey]*node),
+		aliases: make(map[cacheKey]cacheKey),
+		opts:    opts,
+		now:     time.Now,
+	}
+}
+
+func (o Options) withDefaults() Options {
+	def := DefaultOptions()
+	if o.MaxDepth <= 0 {
+		o.MaxDepth = def.MaxDepth
+	}
+	if o.MaxTotalChars <= 0 {
+		o.MaxTotalChars = def.MaxTotalChars
+	}
+	if o.MaxCharsPerMessage <= 0 {
+		o.MaxCharsPerMessage = def.MaxCharsPerMessage
+	}
+	if o.MaxEntries <= 0 {
+		o.MaxEntries = def.MaxEntries
+	}
+	if o.TTL <= 0 {
+		o.TTL = def.TTL
+	}
+	return o
+}
+
+func (c *Cache) Store(scope Scope, msg Message) {
+	if c == nil {
+		return
+	}
+	ids := NormalizeIDs(msg.IDs)
+	body := truncateText(strings.TrimSpace(msg.Body), c.opts.MaxCharsPerMessage)
+	if len(ids) == 0 || body == "" {
+		return
+	}
+	now := c.now()
+	createdAt := msg.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.purgeExpiredLocked(now)
+	key := scopedKey(scope, ids[0])
+	if old := c.nodes[key]; old != nil {
+		c.deleteNodeLocked(key, old)
+	}
+	n := &node{
+		key:       key,
+		ids:       ids,
+		parentIDs: NormalizeIDs(msg.ParentIDs),
+		sender:    strings.TrimSpace(msg.Sender),
+		body:      body,
+		createdAt: createdAt,
+	}
+	c.nodes[key] = n
+	for _, id := range ids {
+		c.aliases[scopedKey(scope, id)] = key
+	}
+	c.evictLocked()
+}
+
+func (c *Cache) Build(scope Scope, quote Quote) string {
+	if c == nil {
+		return RenderQuote(quote)
+	}
+	quote.IDs = NormalizeIDs(quote.IDs)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.purgeExpiredLocked(c.now())
+	if n := c.lookupLocked(scope, quote.IDs); n != nil {
+		if chain := c.collectChainLocked(scope, n); len(chain) > 0 {
+			if rendered := renderChain(chain, c.opts); rendered != "" {
+				return rendered
+			}
+		}
+	}
+	return renderQuote(quote, c.opts)
+}
+
+func (c *Cache) Clear() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	clear(c.nodes)
+	clear(c.aliases)
+}

--- a/internal/channels/replycontext/reply-context-cache_test.go
+++ b/internal/channels/replycontext/reply-context-cache_test.go
@@ -1,0 +1,121 @@
+package replycontext
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCacheBuild_MultiLevelReplyChain(t *testing.T) {
+	cache := NewCache(Options{MaxDepth: 8, MaxTotalChars: 6000, MaxCharsPerMessage: 1000})
+	scope := Scope{TenantID: "tenant-a", ChannelID: "zalo-main", ThreadID: "thread-1"}
+
+	cache.Store(scope, Message{IDs: []string{"a"}, Sender: "Alice", Body: "original"})
+	cache.Store(scope, Message{IDs: []string{"b"}, ParentIDs: []string{"a"}, Sender: "Bob", Body: "reply 1"})
+	cache.Store(scope, Message{IDs: []string{"c"}, ParentIDs: []string{"b"}, Sender: "Carol", Body: "reply 2"})
+	cache.Store(scope, Message{IDs: []string{"d"}, ParentIDs: []string{"c"}, Sender: "Dan", Body: "reply 3"})
+	cache.Store(scope, Message{IDs: []string{"e"}, ParentIDs: []string{"d"}, Sender: "Eve", Body: "reply 4"})
+	cache.Store(scope, Message{IDs: []string{"f"}, ParentIDs: []string{"e"}, Sender: "Frank", Body: "reply 5"})
+
+	got := cache.Build(scope, Quote{IDs: []string{"f"}, Sender: "Frank", Body: "direct fallback"})
+	for _, want := range []string{"original", "reply 1", "reply 2", "reply 3", "reply 4", "reply 5"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in %q", want, got)
+		}
+	}
+	assertOrder(t, got, "original", "reply 1", "reply 2", "reply 3", "reply 4", "reply 5")
+	if strings.Contains(got, "direct fallback") {
+		t.Fatalf("used fallback despite cache hit: %q", got)
+	}
+}
+
+func TestCacheBuild_FallbackOnCacheMiss(t *testing.T) {
+	cache := NewCache(Options{})
+	scope := Scope{TenantID: "tenant-a", ChannelID: "zalo-main", ThreadID: "thread-1"}
+
+	got := cache.Build(scope, Quote{IDs: []string{"missing"}, Sender: "Alice", Body: "quoted text"})
+	want := "[Replying to Alice]\nquoted text\n[/Replying]"
+	if got != want {
+		t.Fatalf("Build() = %q, want %q", got, want)
+	}
+}
+
+func TestCacheBuild_IsolatedByScope(t *testing.T) {
+	cache := NewCache(Options{})
+	scopeA := Scope{TenantID: "tenant-a", ChannelID: "zalo-main", ThreadID: "thread-1"}
+	scopeB := Scope{TenantID: "tenant-b", ChannelID: "zalo-main", ThreadID: "thread-1"}
+
+	cache.Store(scopeA, Message{IDs: []string{"same-id"}, Sender: "Alice", Body: "tenant a secret"})
+	got := cache.Build(scopeB, Quote{IDs: []string{"same-id"}, Sender: "Bob", Body: "tenant b fallback"})
+	if strings.Contains(got, "tenant a secret") {
+		t.Fatalf("cross-scope context leaked: %q", got)
+	}
+	if !strings.Contains(got, "tenant b fallback") {
+		t.Fatalf("missing fallback in %q", got)
+	}
+}
+
+func TestCacheBuild_LimitsDepthAndStopsCycles(t *testing.T) {
+	cache := NewCache(Options{MaxDepth: 2, MaxTotalChars: 6000, MaxCharsPerMessage: 1000})
+	scope := Scope{TenantID: "tenant-a", ChannelID: "zalo-main", ThreadID: "thread-1"}
+
+	cache.Store(scope, Message{IDs: []string{"a"}, ParentIDs: []string{"c"}, Sender: "Alice", Body: "a"})
+	cache.Store(scope, Message{IDs: []string{"b"}, ParentIDs: []string{"a"}, Sender: "Bob", Body: "b"})
+	cache.Store(scope, Message{IDs: []string{"c"}, ParentIDs: []string{"b"}, Sender: "Carol", Body: "c"})
+
+	got := cache.Build(scope, Quote{IDs: []string{"c"}, Sender: "Carol", Body: "fallback"})
+	if blocks := strings.Count(got, "[Replying to"); blocks != 2 {
+		t.Fatalf("rendered %d blocks, want depth limit 2: %q", blocks, got)
+	}
+}
+
+func TestCacheBuild_EnforcesCharacterCaps(t *testing.T) {
+	cache := NewCache(Options{MaxDepth: 8, MaxTotalChars: 120, MaxCharsPerMessage: 32})
+	scope := Scope{TenantID: "tenant-a", ChannelID: "zalo-main", ThreadID: "thread-1"}
+
+	cache.Store(scope, Message{IDs: []string{"a"}, Sender: "Alice", Body: strings.Repeat("a", 200)})
+	got := cache.Build(scope, Quote{IDs: []string{"a"}})
+	if len(got) > 120 {
+		t.Fatalf("rendered %d bytes, want <= 120: %q", len(got), got)
+	}
+	if !strings.Contains(got, "...") {
+		t.Fatalf("missing truncation marker: %q", got)
+	}
+}
+
+func TestCacheEvictsExpiredMessagesAndClear(t *testing.T) {
+	cache := NewCache(Options{TTL: time.Minute})
+	now := time.Date(2026, 7, 2, 20, 0, 0, 0, time.UTC)
+	cache.now = func() time.Time { return now }
+	scope := Scope{TenantID: "tenant-a", ChannelID: "zalo-main", ThreadID: "thread-1"}
+
+	cache.Store(scope, Message{IDs: []string{"a"}, Sender: "Alice", Body: "old"})
+	cache.now = func() time.Time { return now.Add(2 * time.Minute) }
+
+	got := cache.Build(scope, Quote{IDs: []string{"a"}, Sender: "Alice", Body: "fallback"})
+	if strings.Contains(got, "old") {
+		t.Fatalf("expired context rendered: %q", got)
+	}
+
+	cache.Store(scope, Message{IDs: []string{"b"}, Sender: "Bob", Body: "fresh"})
+	cache.Clear()
+	got = cache.Build(scope, Quote{IDs: []string{"b"}, Sender: "Bob", Body: "fallback"})
+	if strings.Contains(got, "fresh") {
+		t.Fatalf("cleared context rendered: %q", got)
+	}
+}
+
+func assertOrder(t *testing.T, haystack string, values ...string) {
+	t.Helper()
+	last := -1
+	for _, value := range values {
+		idx := strings.Index(haystack, value)
+		if idx < 0 {
+			t.Fatalf("missing %q in %q", value, haystack)
+		}
+		if idx <= last {
+			t.Fatalf("%q appeared out of order in %q", value, haystack)
+		}
+		last = idx
+	}
+}

--- a/internal/channels/replycontext/reply-context-render.go
+++ b/internal/channels/replycontext/reply-context-render.go
@@ -1,0 +1,122 @@
+package replycontext
+
+import "strings"
+
+type renderMessage struct {
+	sender string
+	body   string
+}
+
+func NormalizeIDs(ids []string) []string {
+	out := make([]string, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+func RenderQuote(quote Quote) string {
+	return renderQuote(quote, DefaultOptions())
+}
+
+func renderQuote(quote Quote, opts Options) string {
+	body := strings.TrimSpace(quote.Body)
+	if body == "" {
+		return ""
+	}
+	body = truncateText(body, opts.MaxCharsPerMessage)
+	block, ok := renderReplyBlock(strings.TrimSpace(quote.Sender), body, opts.MaxTotalChars)
+	if !ok {
+		return ""
+	}
+	return block
+}
+
+func Compose(context, body string) string {
+	context = strings.TrimSpace(context)
+	body = strings.TrimSpace(body)
+	switch {
+	case context != "" && body != "":
+		return context + "\n" + body
+	case context != "":
+		return context
+	default:
+		return body
+	}
+}
+
+func renderChain(chain []renderMessage, opts Options) string {
+	remaining := opts.MaxTotalChars
+	var b strings.Builder
+	for i, msg := range chain {
+		if i > 0 {
+			if remaining <= 1 {
+				break
+			}
+			b.WriteByte('\n')
+			remaining--
+		}
+		body := truncateText(msg.body, opts.MaxCharsPerMessage)
+		block, ok := renderReplyBlock(msg.sender, body, remaining)
+		if !ok {
+			break
+		}
+		b.WriteString(block)
+		remaining -= len(block)
+	}
+	return b.String()
+}
+
+func renderReplyBlock(sender, body string, maxBytes int) (string, bool) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return "", false
+	}
+	prefix := "[Replying to"
+	if sender = inlineText(sender); sender != "" {
+		prefix += " " + sender
+	}
+	prefix += "]\n"
+	suffix := "\n[/Replying]"
+	if maxBytes > 0 {
+		bodyBudget := maxBytes - len(prefix) - len(suffix)
+		if bodyBudget <= 0 {
+			return "", false
+		}
+		body = truncateText(body, bodyBudget)
+	}
+	return prefix + body + suffix, true
+}
+
+func truncateText(text string, maxBytes int) string {
+	text = strings.TrimSpace(text)
+	if maxBytes <= 0 || len(text) <= maxBytes {
+		return text
+	}
+	const marker = "..."
+	if maxBytes <= len(marker) {
+		return marker[:maxBytes]
+	}
+	limit := maxBytes - len(marker)
+	var b strings.Builder
+	for _, r := range text {
+		if b.Len()+len(string(r)) > limit {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return strings.TrimSpace(b.String()) + marker
+}
+
+func inlineText(text string) string {
+	return strings.Join(strings.Fields(text), " ")
+}

--- a/internal/channels/replycontext/reply-context-store.go
+++ b/internal/channels/replycontext/reply-context-store.go
@@ -1,0 +1,84 @@
+package replycontext
+
+import (
+	"strings"
+	"time"
+)
+
+func scopedKey(scope Scope, messageID string) cacheKey {
+	return cacheKey{
+		tenant:  strings.TrimSpace(scope.TenantID),
+		channel: strings.TrimSpace(scope.ChannelID),
+		thread:  strings.TrimSpace(scope.ThreadID),
+		message: strings.TrimSpace(messageID),
+	}
+}
+
+func (c *Cache) lookupLocked(scope Scope, ids []string) *node {
+	for _, id := range ids {
+		key := scopedKey(scope, id)
+		if canonical, ok := c.aliases[key]; ok {
+			return c.nodes[canonical]
+		}
+		if n := c.nodes[key]; n != nil {
+			return n
+		}
+	}
+	return nil
+}
+
+func (c *Cache) collectChainLocked(scope Scope, start *node) []renderMessage {
+	visited := make(map[cacheKey]struct{}, c.opts.MaxDepth)
+	reversed := make([]renderMessage, 0, c.opts.MaxDepth)
+	for n := start; n != nil && len(reversed) < c.opts.MaxDepth; {
+		if _, ok := visited[n.key]; ok {
+			break
+		}
+		visited[n.key] = struct{}{}
+		reversed = append(reversed, renderMessage{sender: n.sender, body: n.body})
+		n = c.lookupLocked(scope, n.parentIDs)
+	}
+
+	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+	return reversed
+}
+
+func (c *Cache) purgeExpiredLocked(now time.Time) {
+	if c.opts.TTL <= 0 {
+		return
+	}
+	for key, n := range c.nodes {
+		if now.Sub(n.createdAt) > c.opts.TTL {
+			c.deleteNodeLocked(key, n)
+		}
+	}
+}
+
+func (c *Cache) evictLocked() {
+	for len(c.nodes) > c.opts.MaxEntries {
+		var oldestKey cacheKey
+		var oldest *node
+		for key, n := range c.nodes {
+			if oldest == nil || n.createdAt.Before(oldest.createdAt) {
+				oldestKey = key
+				oldest = n
+			}
+		}
+		if oldest == nil {
+			return
+		}
+		c.deleteNodeLocked(oldestKey, oldest)
+	}
+}
+
+func (c *Cache) deleteNodeLocked(key cacheKey, n *node) {
+	delete(c.nodes, key)
+	for _, id := range n.ids {
+		aliasKey := cacheKey{tenant: key.tenant, channel: key.channel, thread: key.thread, message: id}
+		if c.aliases[aliasKey] == key {
+			delete(c.aliases, aliasKey)
+		}
+	}
+}

--- a/internal/channels/zalo/personal/channel.go
+++ b/internal/channels/zalo/personal/channel.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/replycontext"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/typing"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal/protocol"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
@@ -22,6 +23,7 @@ type Channel struct {
 	*channels.BaseChannel
 	config      config.ZaloPersonalConfig
 	typingCtrls sync.Map // threadID → *typing.Controller
+	replyCache  *replycontext.Cache
 
 	mu       sync.RWMutex // protects sess and listener
 	sess     *protocol.Session
@@ -59,6 +61,7 @@ func New(cfg config.ZaloPersonalConfig, msgBus *bus.MessageBus, pairingSvc store
 	ch := &Channel{
 		BaseChannel: base,
 		config:      cfg,
+		replyCache:  replycontext.NewCache(replycontext.DefaultOptions()),
 		stopCh:      make(chan struct{}),
 	}
 	ch.SetPairingService(pairingSvc)
@@ -153,6 +156,9 @@ func (c *Channel) Stop(_ context.Context) error {
 		c.typingCtrls.Delete(key)
 		return true
 	})
+	if c.replyCache != nil {
+		c.replyCache.Clear()
+	}
 	if ln := c.getListener(); ln != nil {
 		ln.Stop()
 	}

--- a/internal/channels/zalo/personal/content-media.go
+++ b/internal/channels/zalo/personal/content-media.go
@@ -1,0 +1,115 @@
+package personal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels/media"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal/protocol"
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
+)
+
+// extractContentAndMedia returns text content with media tags plus local media paths.
+func extractContentAndMedia(content protocol.Content) (string, []string) {
+	if text := content.Text(); text != "" {
+		return text, nil
+	}
+	att := content.ParseAttachment()
+	if att == nil || att.URL() == "" {
+		return "", nil
+	}
+
+	filePath, err := downloadFile(context.Background(), att.URL())
+	if err != nil {
+		slog.Warn("zalo_personal: failed to download attachment", "url", att.URL(), "error", err)
+		if text := content.AttachmentText(); text != "" {
+			return text, nil
+		}
+		return "", nil
+	}
+
+	mimeType := media.DetectMIMEType(filePath)
+	mediaKind := media.MediaKindFromMime(mimeType)
+	if mediaKind != media.TypeImage && att.IsImage() {
+		mediaKind = media.TypeImage
+	}
+
+	tag := media.BuildMediaTags([]media.MediaInfo{{
+		Type:        mediaKind,
+		FilePath:    filePath,
+		ContentType: mimeType,
+		FileName:    att.Title,
+	}})
+	return tag, []string{filePath}
+}
+
+func cacheBodyForContent(content protocol.Content) string {
+	if text := strings.TrimSpace(content.Text()); text != "" {
+		return text
+	}
+	return content.AttachmentText()
+}
+
+func displayNameOrID(displayName, id string) string {
+	if strings.TrimSpace(displayName) != "" {
+		return displayName
+	}
+	return id
+}
+
+const maxMediaBytes = 20 * 1024 * 1024
+
+// downloadFile validates URL safety and stores the attachment in a bounded temp file.
+func downloadFile(ctx context.Context, fileURL string) (string, error) {
+	if err := tools.CheckSSRF(fileURL); err != nil {
+		return "", fmt.Errorf("ssrf check: %w", err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("download: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download status %d", resp.StatusCode)
+	}
+
+	path := fileURL
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+	ext := filepath.Ext(path)
+	if ext == "" || len(ext) > 5 {
+		ext = ".bin"
+	}
+
+	tmpFile, err := os.CreateTemp("", "goclaw_zca_*"+ext)
+	if err != nil {
+		return "", fmt.Errorf("create temp: %w", err)
+	}
+	defer tmpFile.Close()
+
+	written, err := io.Copy(tmpFile, io.LimitReader(resp.Body, maxMediaBytes+1))
+	if err != nil {
+		os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("save: %w", err)
+	}
+	if written > maxMediaBytes {
+		os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("file too large: %d bytes (max %d)", written, maxMediaBytes)
+	}
+	return tmpFile.Name(), nil
+}

--- a/internal/channels/zalo/personal/handlers.go
+++ b/internal/channels/zalo/personal/handlers.go
@@ -3,20 +3,14 @@ package personal
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
-	"github.com/nextlevelbuilder/goclaw/internal/channels/media"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/replycontext"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/typing"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal/protocol"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
-	"github.com/nextlevelbuilder/goclaw/internal/tools"
 )
 
 func (c *Channel) handleMessage(msg protocol.Message) {
@@ -38,12 +32,13 @@ func (c *Channel) handleDM(msg protocol.UserMessage) {
 	senderID := msg.Data.UIDFrom
 	threadID := msg.ThreadID()
 
-	content, media := extractContentAndMedia(msg.Data.Content)
-	if content == "" {
+	if !c.checkDMPolicy(ctx, senderID, threadID) {
 		return
 	}
 
-	if !c.checkDMPolicy(ctx, senderID, threadID) {
+	body, media := extractContentAndMedia(msg.Data.Content)
+	content := replycontext.Compose(c.buildReplyContext(threadID, msg.Data.Quote), body)
+	if content == "" {
 		return
 	}
 
@@ -52,6 +47,7 @@ func (c *Channel) handleDM(msg protocol.UserMessage) {
 	if senderName != "" {
 		content = fmt.Sprintf("[From: %s]\n%s", senderName, content)
 	}
+	c.rememberReplyContext(threadID, displayNameOrID(senderName, senderID), msg.Data, cacheBodyForContent(msg.Data.Content))
 
 	slog.Debug("zalo_personal DM received",
 		"sender", senderID,
@@ -81,11 +77,6 @@ func (c *Channel) handleGroupMessage(msg protocol.GroupMessage) {
 	senderID := msg.Data.UIDFrom
 	threadID := msg.ThreadID()
 
-	content, media := extractContentAndMedia(msg.Data.Content)
-	if content == "" {
-		return
-	}
-
 	// Step 1: enforce access policy (allowlist/pairing). Hard reject — don't record history.
 	if !c.checkGroupPolicy(ctx, senderID, threadID) {
 		return
@@ -95,6 +86,13 @@ func (c *Channel) handleGroupMessage(msg protocol.GroupMessage) {
 	if senderName == "" {
 		senderName = senderID
 	}
+
+	body, media := extractContentAndMedia(msg.Data.Content)
+	content := replycontext.Compose(c.buildReplyContext(threadID, msg.Data.Quote), body)
+	if content == "" {
+		return
+	}
+	c.rememberReplyContext(threadID, senderName, msg.Data.TMessage, cacheBodyForContent(msg.Data.Content))
 
 	// Step 2: @mention gating — record non-mentioned messages in history and return.
 	if c.RequireMention() {
@@ -179,99 +177,7 @@ func (c *Channel) startTyping(threadID string, threadType protocol.ThreadType) {
 	ctrl.Start()
 }
 
-// extractContentAndMedia returns text content (with <media:*> tags) and optional local media
-// file paths from a Zalo message. For text messages, media is nil. For attachments, the file
-// is downloaded and classified by MIME type, matching the pattern used by Telegram/Discord/Feishu.
-func extractContentAndMedia(content protocol.Content) (string, []string) {
-	if text := content.Text(); text != "" {
-		return text, nil
-	}
-	att := content.ParseAttachment()
-	if att == nil || att.Href == "" {
-		return "", nil
-	}
-
-	// Download the attachment file.
-	filePath, err := downloadFile(context.Background(), att.Href)
-	if err != nil {
-		slog.Warn("zalo_personal: failed to download attachment", "url", att.Href, "error", err)
-		// Return human-readable fallback so the message isn't silently dropped.
-		if text := content.AttachmentText(); text != "" {
-			return text, nil
-		}
-		return "", nil
-	}
-
-	// Classify by MIME type (image, video, audio, document) — same as Discord/Feishu.
-	mimeType := media.DetectMIMEType(filePath)
-	mediaKind := media.MediaKindFromMime(mimeType)
-
-	// For images, also check via Zalo CDN path patterns (e.g. /jpg/, /png/) since
-	// temp files lose the original extension context.
-	if mediaKind != media.TypeImage && att.IsImage() {
-		mediaKind = media.TypeImage
-	}
-
-	// Build the <media:*> tag that the agent loop's enrichImageIDs/enrichMediaIDs expects.
-	tag := media.BuildMediaTags([]media.MediaInfo{{
-		Type:        mediaKind,
-		FilePath:    filePath,
-		ContentType: mimeType,
-		FileName:    att.Title,
-	}})
-
-	return tag, []string{filePath}
-}
-
-const maxMediaBytes = 20 * 1024 * 1024 // 20MB (matches Telegram default)
-
-// downloadFile downloads a URL to a temp file and returns the local path.
-// Validates against SSRF and enforces timeout and size limits.
-func downloadFile(ctx context.Context, fileURL string) (string, error) {
-	if err := tools.CheckSSRF(fileURL); err != nil {
-		return "", fmt.Errorf("ssrf check: %w", err)
-	}
-
-	client := &http.Client{Timeout: 30 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("download: %w", err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("download: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("download status %d", resp.StatusCode)
-	}
-
-	// Strip query params before extracting extension.
-	path := fileURL
-	if i := strings.IndexByte(path, '?'); i >= 0 {
-		path = path[:i]
-	}
-	ext := filepath.Ext(path)
-	if ext == "" || len(ext) > 5 {
-		ext = ".bin"
-	}
-
-	tmpFile, err := os.CreateTemp("", "goclaw_zca_*"+ext)
-	if err != nil {
-		return "", fmt.Errorf("create temp: %w", err)
-	}
-	defer tmpFile.Close()
-
-	written, err := io.Copy(tmpFile, io.LimitReader(resp.Body, maxMediaBytes+1))
-	if err != nil {
-		os.Remove(tmpFile.Name())
-		return "", fmt.Errorf("save: %w", err)
-	}
-	if written > maxMediaBytes {
-		os.Remove(tmpFile.Name())
-		return "", fmt.Errorf("file too large: %d bytes (max %d)", written, maxMediaBytes)
-	}
-
-	return tmpFile.Name(), nil
+func extractContentAndMediaWithQuote(content protocol.Content, quote *protocol.TQuote) (string, []string) {
+	text, media := extractContentAndMedia(content)
+	return replycontext.Compose(formatQuoteContext(quote), text), media
 }

--- a/internal/channels/zalo/personal/handlers_test.go
+++ b/internal/channels/zalo/personal/handlers_test.go
@@ -1,0 +1,200 @@
+package personal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal/protocol"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+)
+
+func TestExtractContentAndMediaWithQuote_TextQuote(t *testing.T) {
+	current := textContent("@Tue Linh Pm - Cppai Task nay cung giao cho Hao luon.")
+	quote := &protocol.TQuote{
+		FromD: "Duc Nguyen CPP",
+		Msg:   "Tao task giao cho Hao.",
+	}
+
+	got, media := extractContentAndMediaWithQuote(current, quote)
+	if len(media) != 0 {
+		t.Fatalf("media = %v, want none", media)
+	}
+	if !strings.Contains(got, "[Replying to Duc Nguyen CPP]\nTao task giao cho Hao.\n[/Replying]") {
+		t.Fatalf("missing quote context: %q", got)
+	}
+	if !strings.Contains(got, "@Tue Linh Pm - Cppai Task nay cung giao cho Hao luon.") {
+		t.Fatalf("missing current reply text: %q", got)
+	}
+}
+
+func TestFormatQuoteContext_AttachmentQuote(t *testing.T) {
+	var attach protocol.QuoteAttachment
+	if err := attach.UnmarshalJSON([]byte(`"{\"title\":\"brief.png\",\"href\":\"https://f20-zpc.zdn.vn/jpg/abc123\"}"`)); err != nil {
+		t.Fatal(err)
+	}
+	quote := &protocol.TQuote{
+		FromD:  "Duc Nguyen CPP",
+		Attach: attach,
+	}
+
+	got := formatQuoteContext(quote)
+	if !strings.Contains(got, "[Replying to Duc Nguyen CPP]") {
+		t.Fatalf("missing quote sender: %q", got)
+	}
+	if !strings.Contains(got, "[Quoted image: brief.png]") {
+		t.Fatalf("missing quote attachment text: %q", got)
+	}
+}
+
+func TestExtractContentAndMediaWithQuote_NestedStyleReply(t *testing.T) {
+	current := textContent("@Tue Linh Pm - Cppai Task nay cung giao cho Hao luon.")
+	quote := &protocol.TQuote{
+		FromD: "Tue Linh Pm - Cppai",
+		Msg:   "@Duong Anh Hao tao task follow Zalo reply context.",
+	}
+
+	got, media := extractContentAndMediaWithQuote(current, quote)
+	if len(media) != 0 {
+		t.Fatalf("media = %v, want none", media)
+	}
+	for _, want := range []string{
+		"@Duong Anh Hao tao task follow Zalo reply context.",
+		"@Tue Linh Pm - Cppai Task nay cung giao cho Hao luon.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestZaloReplyContext_BuildsMultiLevelChainFromCache(t *testing.T) {
+	ch := newTestChannel(t, config.ZaloPersonalConfig{DMPolicy: "open", GroupPolicy: "open"})
+	threadID := "group-1"
+
+	ch.rememberReplyContext(threadID, "Alice", protocol.TMessage{
+		MsgID:    "msg-a",
+		CliMsgID: "cli-a",
+		UIDFrom:  "u-a",
+	}, "original")
+	ch.rememberReplyContext(threadID, "Bob", protocol.TMessage{
+		MsgID:    "msg-b",
+		CliMsgID: "cli-b",
+		UIDFrom:  "u-b",
+		Quote: &protocol.TQuote{
+			OwnerID:     "u-a",
+			CliMsgID:    "cli-a",
+			GlobalMsgID: "msg-a",
+		},
+	}, "reply 1")
+	ch.rememberReplyContext(threadID, "Carol", protocol.TMessage{
+		MsgID:    "msg-c",
+		CliMsgID: "cli-c",
+		UIDFrom:  "u-c",
+		Quote: &protocol.TQuote{
+			OwnerID:     "u-b",
+			CliMsgID:    "cli-b",
+			GlobalMsgID: "msg-b",
+		},
+	}, "reply 2")
+
+	got := ch.buildReplyContext(threadID, &protocol.TQuote{
+		OwnerID:     "u-c",
+		CliMsgID:    "cli-c",
+		GlobalMsgID: "msg-c",
+		FromD:       "Carol",
+		Msg:         "fallback quote text",
+	})
+
+	for _, want := range []string{"original", "reply 1", "reply 2"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in %q", want, got)
+		}
+	}
+	assertContainsInOrder(t, got, "original", "reply 1", "reply 2")
+	if strings.Contains(got, "fallback quote text") {
+		t.Fatalf("used direct fallback despite cache hit: %q", got)
+	}
+}
+
+func TestHandleDM_RejectedMessageDoesNotDownloadAttachment(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("image bytes"))
+	}))
+	defer server.Close()
+
+	msgBus := bus.New()
+	ch, err := New(config.ZaloPersonalConfig{
+		AllowFrom: config.FlexibleStringSlice{"allowed-user"},
+		DMPolicy:  "allowlist",
+	}, msgBus, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch.handleDM(protocol.NewUserMessage("bot", protocol.TMessage{
+		MsgID:   "denied-attachment",
+		UIDFrom: "denied-user",
+		IDTo:    "bot",
+		Content: attachmentContent(t, server.URL+"/secret.png"),
+	}))
+
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("attachment endpoint hit %d times, want 0", got)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if got, ok := msgBus.ConsumeInbound(ctx); ok {
+		t.Fatalf("unexpected inbound for rejected message: %+v", got)
+	}
+}
+
+func textContent(text string) protocol.Content {
+	return protocol.Content{String: &text}
+}
+
+func attachmentContent(t *testing.T, href string) protocol.Content {
+	t.Helper()
+	raw := `{"title":"secret.png","href":` + strconvQuote(href) + `}`
+	var content protocol.Content
+	if err := json.Unmarshal([]byte(raw), &content); err != nil {
+		t.Fatal(err)
+	}
+	return content
+}
+
+func newTestChannel(t *testing.T, cfg config.ZaloPersonalConfig) *Channel {
+	t.Helper()
+	ch, err := New(cfg, bus.New(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ch
+}
+
+func assertContainsInOrder(t *testing.T, text string, values ...string) {
+	t.Helper()
+	last := -1
+	for _, value := range values {
+		idx := strings.Index(text, value)
+		if idx < 0 {
+			t.Fatalf("missing %q in %q", value, text)
+		}
+		if idx <= last {
+			t.Fatalf("%q appears out of order in %q", value, text)
+		}
+		last = idx
+	}
+}
+
+func strconvQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/internal/channels/zalo/personal/protocol/message.go
+++ b/internal/channels/zalo/personal/protocol/message.go
@@ -1,12 +1,6 @@
 package protocol
 
-import (
-	"encoding/json"
-	"fmt"
-	"path/filepath"
-	"slices"
-	"strings"
-)
+import "encoding/json"
 
 // Message is the interface for incoming Zalo messages (DM or group).
 type Message interface {
@@ -17,16 +11,20 @@ type Message interface {
 
 // TMessage is the raw JSON message payload from Zalo WebSocket.
 type TMessage struct {
-	MsgID   string  `json:"msgId"`
-	UIDFrom string  `json:"uidFrom"`
-	IDTo    string  `json:"idTo"`
-	DName   string  `json:"dName"`
-	TS      string  `json:"ts"`
-	Content Content `json:"content"`
-	MsgType string  `json:"msgType"`
-	CMD     int     `json:"cmd"`
-	ST      int     `json:"st"`
-	AT      int     `json:"at"`
+	MsgID       string  `json:"msgId"`
+	CliMsgID    string  `json:"cliMsgId,omitempty"`
+	RealMsgID   string  `json:"realMsgId,omitempty"`
+	GlobalMsgID string  `json:"globalMsgId,omitempty"`
+	UIDFrom     string  `json:"uidFrom"`
+	IDTo        string  `json:"idTo"`
+	DName       string  `json:"dName"`
+	TS          string  `json:"ts"`
+	Content     Content `json:"content"`
+	Quote       *TQuote `json:"quote,omitempty"`
+	MsgType     string  `json:"msgType"`
+	CMD         int     `json:"cmd"`
+	ST          int     `json:"st"`
+	AT          int     `json:"at"`
 }
 
 // TGroupMessage extends TMessage with group-specific fields.
@@ -35,9 +33,62 @@ type TGroupMessage struct {
 	Mentions []*TMention `json:"mentions,omitempty"`
 }
 
+func (m *TMessage) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		MsgID       json.RawMessage `json:"msgId"`
+		CliMsgID    json.RawMessage `json:"cliMsgId"`
+		RealMsgID   json.RawMessage `json:"realMsgId"`
+		GlobalMsgID json.RawMessage `json:"globalMsgId"`
+		UIDFrom     string          `json:"uidFrom"`
+		IDTo        string          `json:"idTo"`
+		DName       string          `json:"dName"`
+		TS          json.RawMessage `json:"ts"`
+		Content     Content         `json:"content"`
+		Quote       *TQuote         `json:"quote,omitempty"`
+		MsgType     string          `json:"msgType"`
+		CMD         int             `json:"cmd"`
+		ST          int             `json:"st"`
+		AT          int             `json:"at"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	m.MsgID = rawJSONToDecimalString(raw.MsgID)
+	m.CliMsgID = rawJSONToDecimalString(raw.CliMsgID)
+	m.RealMsgID = rawJSONToDecimalString(raw.RealMsgID)
+	m.GlobalMsgID = rawJSONToDecimalString(raw.GlobalMsgID)
+	m.UIDFrom = raw.UIDFrom
+	m.IDTo = raw.IDTo
+	m.DName = raw.DName
+	m.TS = rawJSONToDecimalString(raw.TS)
+	m.Content = raw.Content
+	m.Quote = raw.Quote
+	m.MsgType = raw.MsgType
+	m.CMD = raw.CMD
+	m.ST = raw.ST
+	m.AT = raw.AT
+	return nil
+}
+
+func (m *TGroupMessage) UnmarshalJSON(data []byte) error {
+	var base TMessage
+	if err := json.Unmarshal(data, &base); err != nil {
+		return err
+	}
+	var raw struct {
+		Mentions []*TMention `json:"mentions,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	m.TMessage = base
+	m.Mentions = raw.Mentions
+	return nil
+}
+
 // TMention represents an @mention in a group message.
 type TMention struct {
-	UID  string      `json:"uid"`  // user ID or "-1" for @all
+	UID  string      `json:"uid"` // user ID or "-1" for @all
 	Pos  int         `json:"pos"`
 	Len  int         `json:"len"`
 	Type MentionType `json:"type"` // 0=individual, 1=all
@@ -47,103 +98,10 @@ type TMention struct {
 type MentionType int
 
 const (
-	MentionEach MentionType = 0
-	MentionAll  MentionType = 1
-	MentionAllUID           = "-1"
+	MentionEach   MentionType = 0
+	MentionAll    MentionType = 1
+	MentionAllUID             = "-1"
 )
-
-// Content is a union type: can be a plain string or an attachment object.
-// String is set for text messages; Raw is set for non-text (images, stickers, files).
-type Content struct {
-	String *string
-	Raw    json.RawMessage // non-nil when content is a JSON object (attachment)
-}
-
-func (c *Content) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err == nil {
-		c.String = &s
-		return nil
-	}
-	c.Raw = slices.Clone(data) // preserve raw attachment payload
-	return nil
-}
-
-func (c Content) MarshalJSON() ([]byte, error) {
-	if c.String != nil {
-		return json.Marshal(c.String)
-	}
-	return []byte("null"), nil
-}
-
-// Text returns the plain text content, or empty string for non-text.
-func (c Content) Text() string {
-	if c.String != nil {
-		return *c.String
-	}
-	return ""
-}
-
-// Attachment holds parsed fields from a non-text content object.
-type Attachment struct {
-	Title string `json:"title"`
-	Href  string `json:"href"`
-}
-
-// ParseAttachment extracts attachment metadata from non-text content.
-// Returns nil if content is plain text or unrecognized.
-func (c Content) ParseAttachment() *Attachment {
-	if c.Raw == nil {
-		return nil
-	}
-	var att Attachment
-	if json.Unmarshal(c.Raw, &att) != nil {
-		return &Attachment{} // unrecognized but non-text
-	}
-	return &att
-}
-
-// imageExts lists file extensions recognized as images by the agent's vision pipeline.
-var imageExts = map[string]bool{
-	".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".webp": true,
-}
-
-// IsImage reports whether the attachment href points to an image file.
-// Checks both file extension and Zalo CDN path patterns (e.g. /jpg/, /png/).
-func (a *Attachment) IsImage() bool {
-	if a == nil || a.Href == "" {
-		return false
-	}
-	path := strings.SplitN(a.Href, "?", 2)[0]
-	if imageExts[strings.ToLower(filepath.Ext(path))] {
-		return true
-	}
-	// Zalo CDN paths like https://f20-zpc.zdn.vn/jpg/...
-	lower := strings.ToLower(path)
-	return strings.Contains(lower, "/jpg/") || strings.Contains(lower, "/png/") ||
-		strings.Contains(lower, "/gif/") || strings.Contains(lower, "/webp/")
-}
-
-// AttachmentText returns a human-readable placeholder for non-text content.
-func (c Content) AttachmentText() string {
-	att := c.ParseAttachment()
-	if att == nil {
-		return ""
-	}
-	if att.IsImage() {
-		if att.Title != "" {
-			return fmt.Sprintf("[User sent an image: %s]", att.Title)
-		}
-		return "[User sent an image]"
-	}
-	if att.Href != "" {
-		if att.Title != "" {
-			return fmt.Sprintf("[User sent a file: %s]", att.Title)
-		}
-		return "[User sent a file]"
-	}
-	return "[User sent a non-text message]"
-}
 
 // UserMessage represents a DM (type=0).
 type UserMessage struct {

--- a/internal/channels/zalo/personal/protocol/message_content.go
+++ b/internal/channels/zalo/personal/protocol/message_content.go
@@ -1,0 +1,121 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Content is a union type: can be a plain string or an attachment object.
+// String is set for text messages; Raw is set for non-text (images, stickers, files).
+type Content struct {
+	String *string
+	Raw    json.RawMessage // non-nil when content is a JSON object (attachment)
+}
+
+func (c *Content) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		c.String = &s
+		return nil
+	}
+	c.Raw = slices.Clone(data) // preserve raw attachment payload
+	return nil
+}
+
+func (c Content) MarshalJSON() ([]byte, error) {
+	if c.String != nil {
+		return json.Marshal(c.String)
+	}
+	return []byte("null"), nil
+}
+
+// Text returns the plain text content, or empty string for non-text.
+func (c Content) Text() string {
+	if c.String != nil {
+		return *c.String
+	}
+	return ""
+}
+
+// Attachment holds parsed fields from a non-text content object.
+type Attachment struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Href        string `json:"href"`
+	Thumb       string `json:"thumb"`
+	ThumbURL    string `json:"thumbUrl"`
+	OriURL      string `json:"oriUrl"`
+	NormalURL   string `json:"normalUrl"`
+	Type        string `json:"type"`
+}
+
+// ParseAttachment extracts attachment metadata from non-text content.
+// Returns nil if content is plain text or unrecognized.
+func (c Content) ParseAttachment() *Attachment {
+	if c.Raw == nil {
+		return nil
+	}
+	var att Attachment
+	if json.Unmarshal(c.Raw, &att) != nil {
+		return &Attachment{} // unrecognized but non-text
+	}
+	return &att
+}
+
+// URL returns the best available attachment URL across Zalo content variants.
+func (a *Attachment) URL() string {
+	if a == nil {
+		return ""
+	}
+	for _, candidate := range []string{a.Href, a.OriURL, a.NormalURL, a.Thumb, a.ThumbURL} {
+		if strings.TrimSpace(candidate) != "" {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// imageExts lists file extensions recognized as images by the agent's vision pipeline.
+var imageExts = map[string]bool{
+	".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".webp": true,
+}
+
+// IsImage reports whether the attachment href points to an image file.
+// Checks both file extension and Zalo CDN path patterns (e.g. /jpg/, /png/).
+func (a *Attachment) IsImage() bool {
+	if a == nil || a.URL() == "" {
+		return false
+	}
+	path := strings.SplitN(a.URL(), "?", 2)[0]
+	if imageExts[strings.ToLower(filepath.Ext(path))] {
+		return true
+	}
+	// Zalo CDN paths like https://f20-zpc.zdn.vn/jpg/...
+	lower := strings.ToLower(path)
+	return strings.Contains(lower, "/jpg/") || strings.Contains(lower, "/png/") ||
+		strings.Contains(lower, "/gif/") || strings.Contains(lower, "/webp/")
+}
+
+// AttachmentText returns a human-readable placeholder for non-text content.
+func (c Content) AttachmentText() string {
+	att := c.ParseAttachment()
+	if att == nil {
+		return ""
+	}
+	if att.IsImage() {
+		if att.Title != "" {
+			return fmt.Sprintf("[User sent an image: %s]", att.Title)
+		}
+		return "[User sent an image]"
+	}
+	if att.URL() != "" {
+		if att.Title != "" {
+			return fmt.Sprintf("[User sent a file: %s]", att.Title)
+		}
+		return "[User sent a file]"
+	}
+	return "[User sent a non-text message]"
+}

--- a/internal/channels/zalo/personal/protocol/message_quote.go
+++ b/internal/channels/zalo/personal/protocol/message_quote.go
@@ -1,0 +1,164 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// TQuote is the raw quoted message payload attached to Zalo reply messages.
+type TQuote struct {
+	OwnerID     string          `json:"ownerId"`
+	CliMsgID    string          `json:"cliMsgId"`
+	GlobalMsgID string          `json:"globalMsgId"`
+	CliMsgType  int             `json:"cliMsgType"`
+	TS          string          `json:"ts"`
+	Msg         string          `json:"msg"`
+	Attach      QuoteAttachment `json:"attach,omitempty"`
+	FromD       string          `json:"fromD"`
+	TTL         int             `json:"ttl"`
+}
+
+func (q *TQuote) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		OwnerID     json.RawMessage `json:"ownerId"`
+		CliMsgID    json.RawMessage `json:"cliMsgId"`
+		GlobalMsgID json.RawMessage `json:"globalMsgId"`
+		CliMsgType  json.RawMessage `json:"cliMsgType"`
+		TS          json.RawMessage `json:"ts"`
+		Msg         string          `json:"msg"`
+		Attach      QuoteAttachment `json:"attach,omitempty"`
+		FromD       string          `json:"fromD"`
+		TTL         json.RawMessage `json:"ttl"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	q.OwnerID = rawJSONToDecimalString(raw.OwnerID)
+	q.CliMsgID = rawJSONToDecimalString(raw.CliMsgID)
+	q.GlobalMsgID = rawJSONToDecimalString(raw.GlobalMsgID)
+	q.CliMsgType = rawJSONToInt(raw.CliMsgType)
+	q.TS = rawJSONToDecimalString(raw.TS)
+	q.Msg = raw.Msg
+	q.Attach = raw.Attach
+	q.FromD = raw.FromD
+	q.TTL = rawJSONToInt(raw.TTL)
+	return nil
+}
+
+// Text returns the quoted text plus any quoted attachment placeholder.
+func (q *TQuote) Text() string {
+	if q == nil {
+		return ""
+	}
+	var parts []string
+	if msg := strings.TrimSpace(q.Msg); msg != "" {
+		parts = append(parts, msg)
+	}
+	if att := q.Attach.AttachmentText(); att != "" && !slices.Contains(parts, att) {
+		parts = append(parts, att)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// QuoteAttachment preserves quote.attach, which Zalo may send either as a JSON
+// object or as a string containing a JSON object.
+type QuoteAttachment struct {
+	Raw json.RawMessage
+}
+
+func (a *QuoteAttachment) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		return nil
+	}
+
+	var encoded string
+	if err := json.Unmarshal(data, &encoded); err == nil {
+		encoded = strings.TrimSpace(encoded)
+		if encoded == "" {
+			return nil
+		}
+		if json.Valid([]byte(encoded)) {
+			a.Raw = slices.Clone([]byte(encoded))
+			return nil
+		}
+		a.Raw = slices.Clone(data)
+		return nil
+	}
+
+	a.Raw = slices.Clone(data)
+	return nil
+}
+
+func (a QuoteAttachment) MarshalJSON() ([]byte, error) {
+	if len(a.Raw) == 0 {
+		return []byte("null"), nil
+	}
+	return a.Raw, nil
+}
+
+func (a QuoteAttachment) AttachmentText() string {
+	if len(a.Raw) == 0 {
+		return ""
+	}
+	var att Attachment
+	if err := json.Unmarshal(a.Raw, &att); err == nil {
+		if att.IsImage() || strings.Contains(strings.ToLower(att.Type), "image") {
+			if att.Title != "" {
+				return fmt.Sprintf("[Quoted image: %s]", att.Title)
+			}
+			return "[Quoted image]"
+		}
+		if att.URL() != "" {
+			if att.Title != "" {
+				return fmt.Sprintf("[Quoted file: %s]", att.Title)
+			}
+			return "[Quoted file]"
+		}
+		if att.Title != "" {
+			return fmt.Sprintf("[Quoted attachment: %s]", att.Title)
+		}
+	}
+
+	var text string
+	if err := json.Unmarshal(a.Raw, &text); err == nil {
+		if text = strings.TrimSpace(text); text != "" {
+			return text
+		}
+	}
+	return "[Quoted non-text message]"
+}
+
+func rawJSONToDecimalString(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var n json.Number
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&n); err == nil {
+		return n.String()
+	}
+	return string(raw)
+}
+
+func rawJSONToInt(raw json.RawMessage) int {
+	text := rawJSONToDecimalString(raw)
+	if text == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(text)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/channels/zalo/personal/protocol/message_test.go
+++ b/internal/channels/zalo/personal/protocol/message_test.go
@@ -266,10 +266,13 @@ func TestAttachment_IsImage(t *testing.T) {
 func TestTMessage_UnmarshalJSON(t *testing.T) {
 	raw := `{
 		"msgId": "123",
+		"cliMsgId": 9007199254740993,
+		"realMsgId": "9007199254740994",
+		"globalMsgId": 9007199254740995,
 		"uidFrom": "456",
 		"idTo": "789",
 		"dName": "Test User",
-		"ts": "1709300000",
+		"ts": 1709300000,
 		"content": "hello",
 		"msgType": "chat.message",
 		"cmd": 501,
@@ -284,11 +287,66 @@ func TestTMessage_UnmarshalJSON(t *testing.T) {
 	if msg.MsgID != "123" {
 		t.Errorf("MsgID = %q", msg.MsgID)
 	}
+	if msg.CliMsgID != "9007199254740993" {
+		t.Errorf("CliMsgID = %q", msg.CliMsgID)
+	}
+	if msg.RealMsgID != "9007199254740994" {
+		t.Errorf("RealMsgID = %q", msg.RealMsgID)
+	}
+	if msg.GlobalMsgID != "9007199254740995" {
+		t.Errorf("GlobalMsgID = %q", msg.GlobalMsgID)
+	}
+	if msg.TS != "1709300000" {
+		t.Errorf("TS = %q", msg.TS)
+	}
 	if msg.Content.Text() != "hello" {
 		t.Errorf("Content = %q", msg.Content.Text())
 	}
 	if msg.CMD != 501 {
 		t.Errorf("CMD = %d", msg.CMD)
+	}
+}
+
+func TestTMessage_UnmarshalJSON_WithQuote(t *testing.T) {
+	raw := `{
+		"msgId": "124",
+		"uidFrom": "456",
+		"idTo": "789",
+		"dName": "Test User",
+		"ts": "1709300000",
+		"content": "reply text",
+		"quote": {
+			"ownerId": 315077459047,
+			"cliMsgId": 9007199254740993,
+			"globalMsgId": "019f22c1",
+			"cliMsgType": 1,
+			"ts": 1709300001,
+			"msg": "quoted task text",
+			"attach": "{\"title\":\"screen.png\",\"href\":\"https://f20-zpc.zdn.vn/jpg/abc123\"}",
+			"fromD": "Duc Nguyen CPP",
+			"ttl": 0
+		},
+		"msgType": "chat.message",
+		"cmd": 501,
+		"st": 1,
+		"at": 0
+	}`
+
+	var msg TMessage
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg.Quote == nil {
+		t.Fatal("expected quote to be preserved")
+	}
+	if msg.Quote.OwnerID != "315077459047" {
+		t.Errorf("Quote.OwnerID = %q", msg.Quote.OwnerID)
+	}
+	if msg.Quote.CliMsgID != "9007199254740993" {
+		t.Errorf("Quote.CliMsgID = %q", msg.Quote.CliMsgID)
+	}
+	if msg.Quote.Text() != "quoted task text\n[Quoted image: screen.png]" {
+		t.Errorf("Quote.Text() = %q", msg.Quote.Text())
 	}
 }
 

--- a/internal/channels/zalo/personal/reply-context.go
+++ b/internal/channels/zalo/personal/reply-context.go
@@ -1,0 +1,105 @@
+package personal
+
+import (
+	"strings"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels/replycontext"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal/protocol"
+)
+
+func (c *Channel) buildReplyContext(threadID string, quote *protocol.TQuote) string {
+	if quote == nil {
+		return ""
+	}
+	return c.replyCache.Build(c.replyScope(threadID), zaloQuote(quote))
+}
+
+func (c *Channel) rememberReplyContext(threadID, sender string, msg protocol.TMessage, body string) {
+	if c.replyCache == nil {
+		return
+	}
+	c.replyCache.Store(c.replyScope(threadID), replycontext.Message{
+		IDs:       zaloMessageIDs(msg),
+		ParentIDs: zaloQuoteIDs(msg.Quote),
+		Sender:    sender,
+		Body:      body,
+	})
+}
+
+func (c *Channel) replyScope(threadID string) replycontext.Scope {
+	channelID := c.Name()
+	if channelID == "" {
+		channelID = c.Type()
+	}
+	return replycontext.Scope{
+		TenantID:  c.TenantID().String(),
+		ChannelID: channelID,
+		ThreadID:  threadID,
+	}
+}
+
+func formatQuoteContext(quote *protocol.TQuote) string {
+	return replycontext.RenderQuote(zaloQuote(quote))
+}
+
+func zaloQuote(quote *protocol.TQuote) replycontext.Quote {
+	if quote == nil {
+		return replycontext.Quote{}
+	}
+	return replycontext.Quote{
+		IDs:    zaloQuoteIDs(quote),
+		Sender: strings.TrimSpace(quote.FromD),
+		Body:   strings.TrimSpace(quote.Text()),
+	}
+}
+
+func zaloMessageIDs(msg protocol.TMessage) []string {
+	var ids []string
+	ids = append(ids,
+		zaloIDAlias("msg", msg.MsgID),
+		zaloIDAlias("global", msg.MsgID),
+		zaloIDAlias("cli", msg.CliMsgID),
+		zaloIDAlias("real", msg.RealMsgID),
+		zaloIDAlias("global", msg.GlobalMsgID),
+		zaloOwnerCliAlias(msg.UIDFrom, msg.CliMsgID),
+		msg.MsgID,
+		msg.CliMsgID,
+		msg.RealMsgID,
+		msg.GlobalMsgID,
+	)
+	return replycontext.NormalizeIDs(ids)
+}
+
+func zaloQuoteIDs(quote *protocol.TQuote) []string {
+	if quote == nil {
+		return nil
+	}
+	var ids []string
+	ids = append(ids,
+		zaloIDAlias("cli", quote.CliMsgID),
+		zaloIDAlias("msg", quote.GlobalMsgID),
+		zaloIDAlias("global", quote.GlobalMsgID),
+		zaloOwnerCliAlias(quote.OwnerID, quote.CliMsgID),
+		quote.CliMsgID,
+		quote.GlobalMsgID,
+	)
+	return replycontext.NormalizeIDs(ids)
+}
+
+func zaloIDAlias(kind, id string) string {
+	kind = strings.TrimSpace(kind)
+	id = strings.TrimSpace(id)
+	if kind == "" || id == "" {
+		return ""
+	}
+	return "zalo:" + kind + ":" + id
+}
+
+func zaloOwnerCliAlias(ownerID, cliMsgID string) string {
+	ownerID = strings.TrimSpace(ownerID)
+	cliMsgID = strings.TrimSpace(cliMsgID)
+	if ownerID == "" || cliMsgID == "" {
+		return ""
+	}
+	return "zalo:owner-cli:" + ownerID + ":" + cliMsgID
+}


### PR DESCRIPTION
## Summary
- preserve Zalo Personal quote payloads so agents can read nested reply chains
- add bounded channel-agnostic reply context cache with depth, TTL, size, and cycle guards
- parse Zalo quote/protocol payloads more defensively, including string/numeric IDs and attachment placeholders
- run Zalo Personal policy checks before media extraction/download/cache writes

Trace: 019f22c1-3342-7864-9b97-a59fa739cdae

## Test plan
- [x] go test ./internal/channels/replycontext ./internal/channels/zalo/...
- [x] go build ./...