### PR TITLE
fix(browser): prevent "context canceled" on scoped incognito context creation

### DIFF
--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -163,10 +163,15 @@ func (m *Manager) Start(ctx context.Context) error {
 		m.logger.Info("Chrome launched", "cdp", controlURL, "headless", m.headless, "pid", l.PID())
 	}
 
-	connectCtx, connectCancel := context.WithTimeout(ctx, 15*time.Second)
-	defer connectCancel()
-
-	b := rod.New().Context(connectCtx).ControlURL(controlURL)
+	// Connect using a long-lived background context, the same way reconnectLocked
+	// does. Binding m.browser to a timeout/request context here would cancel it
+	// the moment Start returns (via defer), leaving the shared browser handle with
+	// a dead context. Later operations that reuse it — notably m.browser.Incognito()
+	// in tenantBrowserLocked — then fail immediately with "context canceled", which
+	// is why a successful "start" is followed by a failing "open"/tab creation.
+	// resolveRemoteCDP already bounds remote reachability, and the local launcher
+	// path is bounded by launchCtx above.
+	b := rod.New().ControlURL(controlURL)
 	if err := b.Connect(); err != nil {
 		// If local launch succeeded but connect failed, kill the orphan process
 		if m.launcher != nil {


### PR DESCRIPTION
Fixes #1257.

## Summary

The built-in browser tool fails on the first scoped action after a successful `start`:

```
create incognito context for browser scope tenant=…|user=…|agent=…: context canceled
```

## Root cause

`Manager.Start()` binds the shared, long-lived `*rod.Browser` to a timeout context that it then cancels itself:

```go
connectCtx, connectCancel := context.WithTimeout(ctx, 15*time.Second)
defer connectCancel()

b := rod.New().Context(connectCtx).ControlURL(controlURL)
...
m.browser = b
```

`defer connectCancel()` fires the moment `Start()` returns, so `m.browser`'s context is already **canceled** before the tool performs any later operation. This matches the exact symptom pattern:

- `action: "start"` succeeds — it only connects and stores the handle, and never reuses the context.
- The next scoped action (`open` / tab creation) goes through `tenantBrowserLocked()` → `m.browser.Incognito()`, which uses the now-canceled context → `context canceled`.

Because the fault is in `Start()`'s context lifecycle (not in how Chrome runs), it reproduces in **both** environments reported on the issue: rod-launched local Chrome and the Docker sidecar. The `getPage()` path appears to work only because it silently auto-reconnects via `reconnectLocked()`, which connects with a background context; the incognito path has no such recovery.

The sibling `reconnectLocked()` already does it the correct way:

```go
b := rod.New().ControlURL(controlURL) // default (background) context — long-lived
```

## Fix

Connect in `Start()` the same way `reconnectLocked()` does — with the default background context — so the shared browser handle is not tied to a context that is canceled immediately after `Start()` returns. The local launcher path is still bounded by `launchCtx`, and remote reachability by `resolveRemoteCDP`'s HTTP timeout, so no meaningful connect-time guard is lost.

This is a root-cause fix rather than adding retry/reconnect around `Incognito()` (the direction suggested earlier in the thread), which would only work around a browser handle left with a dead context.

## How it was diagnosed

From a captured execution trace of a scoped agent session:

- `browser` call `action=start` → `completed` in ~2 ms (“Browser started successfully”).
- `browser` call `action=open` → `error` in ~2 ms with `create incognito context … context canceled`.

The ~2 ms duration and `context canceled` (not `deadline exceeded`) show the context was already done before the operation ran — i.e. a lifecycle bug, not a timeout or a Chrome/network problem. The fix mirrors the already-working `reconnectLocked()` connect path.

## Tests

`pkg/browser` currently has no CDP websocket mock, so there is no lightweight way to unit-test the connected-browser context lifecycle without adding new test harness. Happy to add a regression test if you'd like a fake-CDP harness introduced; the change itself is a minimal connect fix that mirrors the proven `reconnectLocked` path.
