### PR TITLE
fix(providers): only send Codex prompt cache params to native OpenAI endpoints

### DIFF
--- a/internal/providers/adapter_codex_test.go
+++ b/internal/providers/adapter_codex_test.go
@@ -388,18 +388,20 @@ func TestCodexAdapter_FromResponse_PromptTokensDetailsAlias(t *testing.T) {
 }
 
 func TestCodexAdapter_ToRequestPromptCacheControls(t *testing.T) {
-	a, _ := NewCodexAdapter(ProviderConfig{})
-	body, _, err := a.ToRequest(ChatRequest{
+	req := ChatRequest{
 		Messages: []Message{{Role: "user", Content: "hi"}},
 		Options: map[string]any{
 			OptPromptCacheKey:       "tenant/agent/session",
 			OptPromptCacheRetention: "1h",
 		},
-	})
+	}
+
+	// Native OpenAI endpoint accepts prompt cache params.
+	nativeAdapter, _ := NewCodexAdapter(ProviderConfig{BaseURL: "https://api.openai.com/v1"})
+	body, _, err := nativeAdapter.ToRequest(req)
 	if err != nil {
 		t.Fatalf("ToRequest: %v", err)
 	}
-
 	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err != nil {
 		t.Fatalf("decode body: %v", err)
@@ -409,6 +411,23 @@ func TestCodexAdapter_ToRequestPromptCacheControls(t *testing.T) {
 	}
 	if got := payload["prompt_cache_retention"]; got != "1h" {
 		t.Fatalf("prompt_cache_retention = %v, want 1h", got)
+	}
+
+	// Default ChatGPT OAuth backend rejects these params with HTTP 400 — must omit.
+	oauthAdapter, _ := NewCodexAdapter(ProviderConfig{})
+	oauthBody, _, err := oauthAdapter.ToRequest(req)
+	if err != nil {
+		t.Fatalf("ToRequest (oauth): %v", err)
+	}
+	var oauthPayload map[string]any
+	if err := json.Unmarshal(oauthBody, &oauthPayload); err != nil {
+		t.Fatalf("decode oauth body: %v", err)
+	}
+	if _, ok := oauthPayload["prompt_cache_key"]; ok {
+		t.Fatal("prompt_cache_key must not be sent to the ChatGPT OAuth backend")
+	}
+	if _, ok := oauthPayload["prompt_cache_retention"]; ok {
+		t.Fatal("prompt_cache_retention must not be sent to the ChatGPT OAuth backend")
 	}
 }
 

--- a/internal/providers/codex_build.go
+++ b/internal/providers/codex_build.go
@@ -140,11 +140,18 @@ func (p *CodexProvider) buildRequestBody(req ChatRequest, stream bool) map[strin
 		body["reasoning"] = map[string]any{"effort": level}
 	}
 
-	if cacheKey, ok := req.Options[OptPromptCacheKey]; ok {
-		body["prompt_cache_key"] = cacheKey
-	}
-	if retention, ok := req.Options[OptPromptCacheRetention]; ok {
-		body["prompt_cache_retention"] = retention
+	// Prompt caching params (prompt_cache_key, prompt_cache_retention) are accepted
+	// only by native OpenAI endpoints. The ChatGPT subscription OAuth backend
+	// (chatgpt.com/backend-api) rejects them with HTTP 400, so gate on the endpoint —
+	// the same native-only policy CacheMiddleware already applies. Server-side prefix
+	// caching still works on the OAuth backend without these params.
+	if isOpenAINativeEndpoint(p.apiBase) {
+		if cacheKey, ok := req.Options[OptPromptCacheKey]; ok {
+			body["prompt_cache_key"] = cacheKey
+		}
+		if retention, ok := req.Options[OptPromptCacheRetention]; ok {
+			body["prompt_cache_retention"] = retention
+		}
 	}
 
 	return body

--- a/internal/providers/codex_test.go
+++ b/internal/providers/codex_test.go
@@ -1131,21 +1131,33 @@ func TestCodexBuildRequestBody_NilFunction_HandlesGracefully(t *testing.T) {
 }
 
 func TestCodexBuildRequestBodyPromptCacheControls(t *testing.T) {
-	p := NewCodexProvider("test", &staticTokenSource{token: "tok"}, "", "gpt-4o")
-
-	body := p.buildRequestBody(ChatRequest{
+	req := ChatRequest{
 		Messages: []Message{{Role: "user", Content: "Hello"}},
 		Options: map[string]any{
 			OptPromptCacheKey:       "agent/session/provider",
 			OptPromptCacheRetention: "24h",
 		},
-	}, true)
+	}
 
+	// Native OpenAI endpoint accepts prompt cache params.
+	native := NewCodexProvider("test", &staticTokenSource{token: "tok"}, "https://api.openai.com/v1", "gpt-4o")
+	body := native.buildRequestBody(req, true)
 	if got := body["prompt_cache_key"]; got != "agent/session/provider" {
-		t.Fatalf("prompt_cache_key = %v, want agent/session/provider", got)
+		t.Fatalf("native prompt_cache_key = %v, want agent/session/provider", got)
 	}
 	if got := body["prompt_cache_retention"]; got != "24h" {
-		t.Fatalf("prompt_cache_retention = %v, want 24h", got)
+		t.Fatalf("native prompt_cache_retention = %v, want 24h", got)
+	}
+
+	// ChatGPT subscription OAuth backend (default apiBase) rejects these params
+	// with HTTP 400, so they must be omitted.
+	oauth := NewCodexProvider("test", &staticTokenSource{token: "tok"}, "", "gpt-4o")
+	oauthBody := oauth.buildRequestBody(req, true)
+	if _, ok := oauthBody["prompt_cache_key"]; ok {
+		t.Fatal("prompt_cache_key must not be sent to the ChatGPT OAuth backend")
+	}
+	if _, ok := oauthBody["prompt_cache_retention"]; ok {
+		t.Fatal("prompt_cache_retention must not be sent to the ChatGPT OAuth backend")
 	}
 }
 


### PR DESCRIPTION
Fixes #1341.

## Summary

Agents using a ChatGPT OAuth Codex provider (`provider_type: chatgpt_oauth`) fail on **every** LLM call at `iter 0`:

```
llm call: HTTP 400: openai-codex: {"detail":"Unsupported parameter: prompt_cache_retention"}
```

`prompt_cache_retention` is a native OpenAI **platform API** feature; the ChatGPT subscription backend (`https://chatgpt.com/backend-api/codex/responses`) does not accept it, so the agent is unusable.

## Root cause

Introduced by #1310, which adds `prompt_cache_key` + `prompt_cache_retention` to Codex requests (default `24h` retention) and marks the ChatGPT OAuth router as cache-capable.

`internal/providers/codex_build.go` `buildRequestBody` emits these params **unconditionally**, which contradicts the policy already documented and enforced by `internal/providers/middleware_cache.go`:

> `CacheMiddleware injects OpenAI prompt caching params (prompt_cache_key, prompt_cache_retention) for native OpenAI endpoints only.`

`CacheMiddleware` guards on `isOpenAINativeEndpoint(cfg.APIBase)`; the Codex build path did not. For the OAuth backend (`chatgpt.com/backend-api`, not `api.openai.com`), the unsupported param is sent and rejected.

Both request paths were affected, since `CodexAdapter.ToRequest` delegates to the same `CodexProvider.buildRequestBody` (and passes its `apiBase`).

## Fix

Gate the Codex prompt-cache params on `isOpenAINativeEndpoint(p.apiBase)` in `buildRequestBody`, mirroring `CacheMiddleware`'s native-only policy. One change covers both `CodexProvider` and `CodexAdapter`.

Server-side prefix caching still works on the OAuth backend without these params — traces after this change still show non-zero `cache_read_tokens`, so no caching benefit is lost for OAuth users.

## Tests

Updated the two prompt-cache tests to assert both cases:

- native endpoint (`api.openai.com`) → params are included;
- ChatGPT OAuth backend (default `apiBase`) → params are omitted.

`go test ./internal/providers/` passes (go 1.26).

## Notes

- This is scoped to the request-body construction; provider `Capabilities().CacheControl` and the default-option helper in `loop_pipeline_callbacks.go` are left unchanged (they are harmless — the defaults simply aren't serialized for non-native endpoints).
