### PR TITLE
fix(docker): add /app to PATH so agents can use the bundled goclaw self-management skill

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,7 +38,7 @@ export PIP_CACHE_DIR="$RUNTIME_DIR/pip-cache"
 # NODE_PATH includes both pre-installed system globals and runtime-installed globals.
 export NPM_CONFIG_PREFIX="$RUNTIME_DIR/npm-global"
 export NODE_PATH="/usr/local/lib/node_modules:$RUNTIME_DIR/npm-global/lib/node_modules:${NODE_PATH:-}"
-export PATH="$RUNTIME_DIR/bin:$RUNTIME_DIR/npm-global/bin:$RUNTIME_DIR/pip/bin:$PATH"
+export PATH="/app:$RUNTIME_DIR/bin:$RUNTIME_DIR/npm-global/bin:$RUNTIME_DIR/pip/bin:$PATH"
 
 # System packages: re-install on-demand packages persisted across recreates.
 # After chown above, root owns .runtime and can create this file.


### PR DESCRIPTION
The gateway binary (/app/goclaw) has embedded operator/admin subcommands (agent list, doctor, skills list, sessions list, providers list, channels list, cron list, traces list, etc) that the bundled goclaw skill teaches agents to use for self-administering the gateway. But /app was never added to PATH -- confirmed live via docker exec: `which goclaw` empty, while `/app/goclaw --help` works fine directly.

Non-sandboxed agent exec runs in the same container as the gateway itself, so /app/goclaw is a real, reachable file for those agents -- the only blocker was PATH resolution for the bare `goclaw` command.

Prepend /app to PATH in docker-entrypoint.sh, ahead of the existing runtime-installed package directories, so bare `goclaw` commands resolve correctly for both operators (docker exec) and agents (exec tool) alike.