### PR TITLE
fix(agent): fix race in TestMaybeSummarize_LogsTriggerDecisionOverThreshold

### DIFF
--- a/internal/agent/loop_history_sanitize_max_tokens_test.go
+++ b/internal/agent/loop_history_sanitize_max_tokens_test.go
@@ -234,13 +234,19 @@ func TestMaybeSummarize_LogsTriggerDecisionOverThreshold(t *testing.T) {
 
 	logs := captureSlog(t, func() {
 		loop.maybeSummarize(context.Background(), "test-session-key")
-	})
 
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for maybeSummarize to call provider.Chat")
-	}
+		// Wait for the background summarize goroutine to reach the point where it
+		// calls provider.Chat (which happens strictly after the "compact_budget"
+		// slog.Info write). This must happen INSIDE the captureSlog closure so the
+		// buffer is not read until the background goroutine's logging is done —
+		// otherwise buf.String() races with the goroutine's concurrent slog.Info
+		// write to the same bytes.Buffer under -race.
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for maybeSummarize to call provider.Chat")
+		}
+	})
 
 	assertLogContains(t, logs,
 		"compaction_decision",


### PR DESCRIPTION
## Problem

Surfaced by CI on an unrelated PR (#1346) -- confirmed this test failure is
unrelated to that PR's changes (which only touch ui/web/ TypeScript files).

`TestMaybeSummarize_LogsTriggerDecisionOverThreshold` fails under `go test -race`:
maybeSummarize spawns a background goroutine that logs via slog.Info before
calling the LLM provider. The test read the shared log buffer immediately
after maybeSummarize returned -- i.e. right after the goroutine was merely
spawned, not after it finished logging -- an unsynchronized concurrent
read/write on bytes.Buffer.

## Fix

Test-only change. Moved the existing done-channel wait inside captureSlog's
closure, so the buffer read only happens after the background goroutine has
signalled it reached provider.Chat -- strictly after the slog.Info write on
this path. Proper happens-before via the channel, no sleep/poll hack, no
production code changed (the async goroutine design in maybeSummarize is
correct and intentional).

## Verified

- `go test -race -run TestMaybeSummarize_LogsTriggerDecisionOverThreshold -count=10` -- 10/10 pass, no race detected
- Full `internal/agent` package regression run clean