### PR TITLE
fix(vault): preserve team-scoped docs on team delete (#1077)

### DIFF
--- a/internal/store/sqlitestore/teams.go
+++ b/internal/store/sqlitestore/teams.go
@@ -91,16 +91,46 @@ func (s *SQLiteTeamStore) UpdateTeam(ctx context.Context, teamID uuid.UUID, upda
 }
 
 func (s *SQLiteTeamStore) DeleteTeam(ctx context.Context, teamID uuid.UUID) error {
-	if store.IsCrossTenant(ctx) {
-		_, err := s.db.ExecContext(ctx, `DELETE FROM agent_teams WHERE id = ?`, teamID)
-		return err
-	}
+	crossTenant := store.IsCrossTenant(ctx)
 	tid := store.TenantIDFromContext(ctx)
-	if tid == uuid.Nil {
+	if !crossTenant && tid == uuid.Nil {
 		return fmt.Errorf("tenant_id required for delete")
 	}
-	_, err := s.db.ExecContext(ctx, `DELETE FROM agent_teams WHERE id = ? AND tenant_id = ?`, teamID, tid)
-	return err
+
+	// Team deletion must not fail when the team owns vault documents (issue #1077).
+	// The team_id FK is ON DELETE SET NULL, but SQLite fires no scope-fixing trigger
+	// during the FK action, so a team-scoped doc would be left as scope='team' with a
+	// NULL team_id and abort the delete on the vault_documents_scope_consistency CHECK.
+	// Convert team-scoped docs first (agent_id IS NULL -> 'shared'; the CASE guards
+	// any legacy 'team' rows that carry an agent_id). Custom-scope docs are left as-is;
+	// the FK SET NULL clears their team_id and 'custom' has no consistency constraint.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	const fixScopeSQL = `UPDATE vault_documents
+		SET scope = CASE WHEN agent_id IS NOT NULL THEN 'personal' ELSE 'shared' END,
+		    team_id = NULL
+		WHERE team_id = ? AND scope = 'team'`
+	if crossTenant {
+		if _, err := tx.ExecContext(ctx, fixScopeSQL, teamID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM agent_teams WHERE id = ?`, teamID); err != nil {
+			return err
+		}
+		return tx.Commit()
+	}
+
+	if _, err := tx.ExecContext(ctx, fixScopeSQL+` AND tenant_id = ?`, teamID, tid); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_teams WHERE id = ? AND tenant_id = ?`, teamID, tid); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *SQLiteTeamStore) ListTeams(ctx context.Context) ([]store.TeamData, error) {

--- a/internal/store/sqlitestore/teams_delete_vault_scope_test.go
+++ b/internal/store/sqlitestore/teams_delete_vault_scope_test.go
@@ -1,0 +1,94 @@
+//go:build sqlite || sqliteonly
+
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// TestSQLiteDeleteTeam_PreservesTeamVaultDocs is a regression test for issue #1077.
+//
+// Deleting a team must not fail when the team owns vault documents. Team-scoped
+// docs (scope='team', agent_id IS NULL) must be preserved by converting them to
+// scope='shared' with team_id NULL. Without the fix, the FK ON DELETE SET NULL
+// leaves scope='team' with a NULL team_id, which violates the
+// vault_documents_scope_consistency CHECK and aborts the whole delete.
+func TestSQLiteDeleteTeam_PreservesTeamVaultDocs(t *testing.T) {
+	db := newTeamVaultScopeDB(t)
+	tenantID := store.GenNewID()
+	mustExec(t, db, `INSERT INTO tenants (id, name, slug, status, settings, created_at, updated_at)
+		VALUES (?, 'test-tenant', 'test-tenant', 'active', '{}', datetime('now'), datetime('now'))`, tenantID)
+	agentID := store.GenNewID()
+	mustExec(t, db, `INSERT INTO agents (id, agent_key, owner_id, model, tenant_id)
+		VALUES (?, 'lead', 'owner', 'gpt', ?)`, agentID, tenantID)
+
+	teamID := store.GenNewID()
+	mustExec(t, db, `INSERT INTO agent_teams (id, name, lead_agent_id, created_by, tenant_id)
+		VALUES (?, 'team-a', ?, 'owner', ?)`, teamID, agentID, tenantID)
+
+	// Team-scoped doc (agent_id NULL) — the exact shape that triggers the bug.
+	teamDocID := store.GenNewID()
+	mustExec(t, db, `INSERT INTO vault_documents (id, tenant_id, team_id, scope, path)
+		VALUES (?, ?, ?, 'team', 'teams/a/note.md')`, teamDocID, tenantID, teamID)
+
+	// Custom-scope doc carrying team_id + agent_id — must NOT be clobbered.
+	customDocID := store.GenNewID()
+	mustExec(t, db, `INSERT INTO vault_documents (id, tenant_id, agent_id, team_id, scope, path)
+		VALUES (?, ?, ?, ?, 'custom', 'teams/a/custom.md')`, customDocID, tenantID, agentID, teamID)
+
+	teamStore := NewSQLiteTeamStore(db)
+	ctx := store.WithTenantID(context.Background(), tenantID)
+
+	if err := teamStore.DeleteTeam(ctx, teamID); err != nil {
+		t.Fatalf("DeleteTeam failed: %v", err)
+	}
+
+	// Team was actually deleted.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM agent_teams WHERE id = ?`, teamID).Scan(&count); err != nil {
+		t.Fatalf("count teams: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("team not deleted, count=%d", count)
+	}
+
+	// Team doc preserved as 'shared'.
+	assertVaultScope(t, db, teamDocID, "shared", false)
+	// Custom doc keeps its scope; team_id cleared by FK SET NULL.
+	assertVaultScope(t, db, customDocID, "custom", false)
+}
+
+func assertVaultScope(t *testing.T, db *sql.DB, docID uuid.UUID, wantScope string, wantTeam bool) {
+	t.Helper()
+	var scope string
+	var teamID sql.NullString
+	if err := db.QueryRow(`SELECT scope, team_id FROM vault_documents WHERE id = ?`, docID).Scan(&scope, &teamID); err != nil {
+		t.Fatalf("query doc %s: %v", docID, err)
+	}
+	if scope != wantScope {
+		t.Errorf("doc %s scope = %q, want %q", docID, scope, wantScope)
+	}
+	if teamID.Valid != wantTeam {
+		t.Errorf("doc %s team_id present = %v, want %v (value=%q)", docID, teamID.Valid, wantTeam, teamID.String)
+	}
+}
+
+func newTeamVaultScopeDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := OpenDB(filepath.Join(t.TempDir(), "team_vault_scope.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	return db
+}

--- a/internal/upgrade/version.go
+++ b/internal/upgrade/version.go
@@ -2,4 +2,4 @@ package upgrade
 
 // RequiredSchemaVersion is the schema migration version this binary requires.
 // Bump this whenever adding a new SQL migration file.
-const RequiredSchemaVersion uint = 88
+const RequiredSchemaVersion uint = 89

--- a/migrations/000089_vault_team_delete_scope_fix.down.sql
+++ b/migrations/000089_vault_team_delete_scope_fix.down.sql
@@ -1,0 +1,13 @@
+-- Revert to the migration 000043 behavior: unconditionally coerce scope to
+-- 'personal' when a team_id is cleared. NOTE: this reintroduces issue #1077 —
+-- team-scoped docs (agent_id IS NULL) will again violate the scope-consistency
+-- CHECK on team deletion.
+CREATE OR REPLACE FUNCTION vault_docs_team_null_scope_fix()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.team_id IS NULL AND OLD.team_id IS NOT NULL THEN
+        NEW.scope := 'personal';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/000089_vault_team_delete_scope_fix.up.sql
+++ b/migrations/000089_vault_team_delete_scope_fix.up.sql
@@ -1,0 +1,22 @@
+-- Fix issue #1077: deleting a team fails when it owns team-scoped vault docs.
+--
+-- vault_documents.team_id is a FK with ON DELETE SET NULL. When team_id becomes
+-- NULL, the trg_vault_docs_team_null_scope trigger auto-corrects scope. The original
+-- function (migration 000043) set scope='personal' unconditionally, but team-scoped
+-- docs have agent_id IS NULL, so the resulting (scope='personal', agent_id IS NULL)
+-- row violates vault_documents_scope_consistency (migration 000055/000056) and aborts
+-- the whole delete with SQLSTATE 23514.
+--
+-- Pick a scope that keeps the ownership invariant, and only rewrite genuinely
+-- team-scoped rows so scope='custom' docs that merely carry a team_id are left intact:
+--   agent_id IS NOT NULL -> 'personal' (defensive: tolerate legacy dirty rows)
+--   agent_id IS NULL     -> 'shared'   (normal team docs; the common case)
+CREATE OR REPLACE FUNCTION vault_docs_team_null_scope_fix()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.team_id IS NULL AND OLD.team_id IS NOT NULL AND OLD.scope = 'team' THEN
+        NEW.scope := CASE WHEN NEW.agent_id IS NOT NULL THEN 'personal' ELSE 'shared' END;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/tests/integration/v3_vault_scope_check_test.go
+++ b/tests/integration/v3_vault_scope_check_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/google/uuid"
@@ -77,5 +78,65 @@ func TestStoreVault_ScopeCheck(t *testing.T) {
 				t.Errorf("expected no error, got: %v", err)
 			}
 		})
+	}
+}
+
+// TestStoreVault_TeamDeletePreservesDocs is a regression test for issue #1077.
+//
+// Deleting a team that owns vault documents must succeed. Team-scoped docs
+// (scope='team', agent_id IS NULL) are preserved as scope='shared' via the
+// vault_docs_team_null_scope_fix() trigger. Before the fix the trigger forced
+// scope='personal' unconditionally, which — combined with agent_id IS NULL —
+// violated vault_documents_scope_consistency and aborted the delete (SQLSTATE 23514).
+func TestStoreVault_TeamDeletePreservesDocs(t *testing.T) {
+	db := testDB(t)
+	tenantID, agentID := seedTenantAgent(t, db)
+	teamID, _ := seedTeam(t, db, tenantID, agentID)
+
+	suffix := uuid.New().String()[:8]
+	teamDocID := uuid.New().String()
+	customDocID := uuid.New().String()
+	t.Cleanup(func() {
+		db.Exec(`DELETE FROM vault_documents WHERE id IN ($1, $2)`, teamDocID, customDocID)
+	})
+
+	// Team-scoped doc (agent_id NULL) — the exact shape that triggers the bug.
+	if _, err := db.Exec(`INSERT INTO vault_documents
+		(id, tenant_id, team_id, scope, path, title, doc_type, content_hash)
+		VALUES ($1, $2, $3, 'team', $4, 'team-doc', 'note', 'h1')`,
+		teamDocID, tenantID, teamID, "team-del/"+suffix+"-team.md"); err != nil {
+		t.Fatalf("insert team doc: %v", err)
+	}
+	// Custom-scope doc carrying team_id + agent_id — must NOT be clobbered.
+	if _, err := db.Exec(`INSERT INTO vault_documents
+		(id, tenant_id, agent_id, team_id, scope, path, title, doc_type, content_hash)
+		VALUES ($1, $2, $3, $4, 'custom', $5, 'custom-doc', 'note', 'h2')`,
+		customDocID, tenantID, agentID, teamID, "team-del/"+suffix+"-custom.md"); err != nil {
+		t.Fatalf("insert custom doc: %v", err)
+	}
+
+	// Delete the team: exercises FK ON DELETE SET NULL → scope-fix trigger → CHECK.
+	if _, err := db.Exec(`DELETE FROM agent_teams WHERE id = $1`, teamID); err != nil {
+		t.Fatalf("delete team failed (issue #1077 regression): %v", err)
+	}
+
+	// Team doc preserved as 'shared', team_id cleared.
+	assertPGVaultScope(t, db, teamDocID, "shared")
+	// Custom doc keeps its scope, team_id cleared by FK SET NULL.
+	assertPGVaultScope(t, db, customDocID, "custom")
+}
+
+func assertPGVaultScope(t *testing.T, db *sql.DB, docID, wantScope string) {
+	t.Helper()
+	var scope string
+	var teamID sql.NullString
+	if err := db.QueryRow(`SELECT scope, team_id FROM vault_documents WHERE id = $1`, docID).Scan(&scope, &teamID); err != nil {
+		t.Fatalf("query doc %s: %v", docID, err)
+	}
+	if scope != wantScope {
+		t.Errorf("doc %s scope = %q, want %q", docID, scope, wantScope)
+	}
+	if teamID.Valid {
+		t.Errorf("doc %s team_id should be NULL after team delete, got %q", docID, teamID.String)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1077: deleting a team failed with `SQLSTATE 23514` whenever it owned a team-scoped vault document. The `vault_documents.team_id` FK is `ON DELETE SET NULL`; when `team_id` became NULL the `vault_docs_team_null_scope_fix()` trigger (migration 000043) unconditionally set `scope='personal'`, but team docs have `agent_id IS NULL`, so the resulting row violated `vault_documents_scope_consistency` and aborted the whole delete. Team-scoped docs are now preserved by converting them to `scope='shared'`.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch

`dev`

## Root cause & fix

| DB | Mechanism | Fix |
|----|-----------|-----|
| **PostgreSQL** | FK SET NULL → trigger forced `scope='personal'` → `(personal, agent_id NULL)` violates CHECK | Migration **000089** rewrites the trigger fn: pick a valid scope by ownership, and only touch genuinely `scope='team'` rows so `custom` docs carrying a `team_id` are left intact (`agent_id NOT NULL → personal`, else `shared`). |
| **SQLite** | FK SET NULL leaves `scope='team'` with NULL `team_id` → aborts on the same CHECK. SQLite fires **no trigger** during an FK action, so a DB-level fix is impossible. | `SQLiteTeamStore.DeleteTeam` converts team-scoped docs in the **same transaction** before deleting the team, scoped by `tenant_id` in the tenant path to preserve tenant isolation. No SQLite schema migration needed (fix is in Go). |

**Design note beyond the issue's proposal:** a `scope='team'` row can never carry an `agent_id` (the CHECK forbids it), so team docs always convert to `shared`; the `personal` branch only guards legacy dirty rows. Added an `OLD.scope='team'` guard so `custom`-scope docs that merely reference a team are not clobbered.

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes
- [x] `go vet ./...` — changed files clean (2 pre-existing warnings remain in unrelated files: `internal/tools/document_parser_test.go`, `tests/integration/git_adapter_ssh_test.go`)
- [x] Tests pass — SQLite + PG regression tests go RED→GREEN (see Test Plan). ⚠️ `-race` not run locally (Windows env has CGO disabled); CI runs it on Linux.
- [x] Web UI builds — N/A, no UI changes
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized placeholders (no string concat)
- [x] New user-facing strings — N/A, no new strings
- [x] Migration version bumped in `internal/upgrade/version.go` (88 → 89)

## Surface parity
- Gateway/store: PostgreSQL + SQLite both fixed.
- API contract / Web UI / CLI: **N/A** — behavior fix only, no request/response, UI, or command changes.

## Test Plan

**Automated (observed RED → GREEN on both engines):**
- **PostgreSQL** — `TestStoreVault_TeamDeletePreservesDocs` (`tests/integration/v3_vault_scope_check_test.go`): seeds a team-scoped doc (`agent_id NULL`) + a `custom` doc, deletes the team, asserts success and that the team doc becomes `scope='shared'` (team_id NULL) while the `custom` doc is untouched. RED before migration 089 reproduced `SQLSTATE 23514`; GREEN after.
- **SQLite** — `TestSQLiteDeleteTeam_PreservesTeamVaultDocs` (`internal/store/sqlitestore/teams_delete_vault_scope_test.go`): same scenario against in-memory SQLite. RED reproduced `CHECK constraint failed: vault_documents_scope_consistency`; GREEN after the `DeleteTeam` fix.
- Migration `000089` down/up roundtrip verified reversible against a live PG.

**Manual end-to-end (standard edition, real gateway + web UI):**
- Applied migrations to a dev PG (schema now 89), launched the gateway + web UI, seeded a `test-delete-1077` team with a team-scoped vault doc, deleted it from the Teams UI. Delete succeeded; the vault doc ended as `scope='shared', team_id=NULL` with its path preserved; no orphaned members; zero `ERROR`/`23514` lines in the gateway log.
