### PR TITLE
fix(skills): allow editing SKILL.md content for database-managed skills

### DIFF
--- a/internal/http/skills.go
+++ b/internal/http/skills.go
@@ -94,6 +94,7 @@ func (h *SkillsHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v1/agents/{agentID}/skills", h.authMiddleware(h.handleListAgentSkills))
 	mux.HandleFunc("GET /v1/skills/{id}/versions", h.authMiddleware(h.handleListVersions))
 	mux.HandleFunc("GET /v1/skills/{id}/files/{path...}", h.authMiddleware(h.handleReadFile))
+	mux.HandleFunc("PUT /v1/skills/{id}/files/{path...}", h.adminMiddleware(h.handleWriteFile))
 	mux.HandleFunc("GET /v1/skills/{id}/files", h.authMiddleware(h.handleListFiles))
 	mux.HandleFunc("GET /v1/skills/{id}/evolution", h.authMiddleware(h.handleGetEvolution))
 	mux.HandleFunc("GET /v1/skills/{id}/metrics", h.authMiddleware(h.handleGetSkillMetrics))

--- a/internal/http/skills_versions.go
+++ b/internal/http/skills_versions.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nextlevelbuilder/goclaw/internal/skills"
 
@@ -262,11 +263,15 @@ func (h *SkillsHandler) handleReadFile(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleWriteFile overwrites a single file within the CURRENT version directory
-// of a managed (non-system) skill. System/bundled skills are read-only via the
-// API — editing them here would silently diverge from the shipped source and
-// is rejected. Historical versions are immutable; only the current version's
-// working copy can be edited in place.
+// handleWriteFile writes a single file's content, creating a new immutable
+// version of a managed (non-system) skill — mirroring the skill_manage tool's
+// patch action (see internal/tools/skill_manage.go) and the skill evolution
+// apply path (applySkillSuggestionPatch in skills_evolution.go): the current
+// version directory is copied to a new version directory, the target file is
+// updated there, and the skill's DB row is repointed at the new version.
+// System/bundled skills are read-only via the API — editing them here would
+// silently diverge from the shipped source and is rejected. Historical
+// versions remain immutable.
 func (h *SkillsHandler) handleWriteFile(w http.ResponseWriter, r *http.Request) {
 	locale := store.LocaleFromContext(r.Context())
 	id, err := uuid.Parse(r.PathValue("id"))
@@ -293,7 +298,7 @@ func (h *SkillsHandler) handleWriteFile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	filePath, _, currentVersion, isSystem, ok := h.skills.GetSkillFilePath(r.Context(), id)
+	filePath, slug, currentVersion, isSystem, ok := h.skills.GetSkillFilePath(r.Context(), id)
 	if !ok {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "skill", id.String())})
 		return
@@ -318,22 +323,25 @@ func (h *SkillsHandler) handleWriteFile(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgFileNotFound)})
 		return
 	}
-	versionDir := filepath.Join(slugDir, strconv.Itoa(currentVersion))
-	if info, err := os.Stat(versionDir); err != nil || !info.IsDir() {
+	currentDir := filepath.Join(slugDir, strconv.Itoa(currentVersion))
+	if info, err := os.Stat(currentDir); err != nil || !info.IsDir() {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgFileNotFound)})
 		return
 	}
 
 	cleanRelPath := filepath.Clean(relPath)
-	absPath := filepath.Join(versionDir, cleanRelPath)
-	if !strings.HasPrefix(absPath, versionDir+string(filepath.Separator)) {
-		slog.Warn("security.skill_files_escape", "resolved", absPath, "root", versionDir)
+	// Validate the path against the CURRENT version directory before staging
+	// a copy — cheaper failure path and keeps the escape/symlink checks close
+	// to the original request path.
+	checkPath := filepath.Join(currentDir, cleanRelPath)
+	if !strings.HasPrefix(checkPath, currentDir+string(filepath.Separator)) {
+		slog.Warn("security.skill_files_escape", "resolved", checkPath, "root", currentDir)
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
 		return
 	}
-	if fi, err := os.Lstat(absPath); err == nil {
+	if fi, err := os.Lstat(checkPath); err == nil {
 		if fi.Mode()&os.ModeSymlink != 0 {
-			slog.Warn("security.skill_files_symlink", "path", absPath)
+			slog.Warn("security.skill_files_symlink", "path", checkPath)
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
 			return
 		}
@@ -347,15 +355,72 @@ func (h *SkillsHandler) handleWriteFile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Create a new immutable version: lock the next version number, stage a
+	// copy of the current version directory, write the edited file into the
+	// staged copy, then atomically rename it into place and repoint the
+	// skill's DB row — same convention as skill_manage's patch action and
+	// applySkillSuggestionPatch.
+	newVersion, commitLock, err := h.skills.GetNextVersionLocked(r.Context(), slug)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	defer commitLock() //nolint:errcheck
+
+	destDir := filepath.Join(h.tenantSkillsDir(r), slug, strconv.Itoa(newVersion))
+	tmpDir := destDir + ".tmp-" + uuid.NewString()
+	if err := copyDir(currentDir, tmpDir); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	removeDestOnError := true
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+		if removeDestOnError {
+			_ = os.RemoveAll(destDir)
+		}
+	}()
+
+	absPath := filepath.Join(tmpDir, cleanRelPath)
+	if !strings.HasPrefix(absPath, tmpDir+string(filepath.Separator)) {
+		slog.Warn("security.skill_files_escape", "resolved", absPath, "root", tmpDir)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
 	if err := os.WriteFile(absPath, []byte(body.Content), 0o644); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	if err := os.Rename(tmpDir, destDir); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	hash, size, err := hashSkillDir(destDir)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := h.skills.UpdateSkill(r.Context(), id, map[string]any{
+		"version":    newVersion,
+		"file_path":  destDir,
+		"file_size":  size,
+		"file_hash":  &hash,
+		"updated_at": time.Now(),
+	}); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	removeDestOnError = false
 
 	h.skills.BumpVersion()
 	h.emitCacheInvalidate(bus.CacheKindSkills, id.String(), uuid.Nil)
 	emitAudit(h.msgBus, r, "skill.file_updated", "skill", id.String())
-	writeJSON(w, http.StatusOK, map[string]string{"ok": "true", "path": relPath})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": "true", "path": relPath, "version": newVersion})
 }
 
 func readableSkillRoots(versionDir, slug string, isSystem bool, bundledDir string) []string {

--- a/internal/http/skills_versions.go
+++ b/internal/http/skills_versions.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/permissions"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
@@ -258,6 +260,102 @@ func (h *SkillsHandler) handleReadFile(w http.ResponseWriter, r *http.Request) {
 		"path":    relPath,
 		"size":    info.Size(),
 	})
+}
+
+// handleWriteFile overwrites a single file within the CURRENT version directory
+// of a managed (non-system) skill. System/bundled skills are read-only via the
+// API — editing them here would silently diverge from the shipped source and
+// is rejected. Historical versions are immutable; only the current version's
+// working copy can be edited in place.
+func (h *SkillsHandler) handleWriteFile(w http.ResponseWriter, r *http.Request) {
+	locale := store.LocaleFromContext(r.Context())
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidID, "skill")})
+		return
+	}
+
+	relPath := r.PathValue("path")
+	if relPath == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgRequired, "path")})
+		return
+	}
+	if strings.Contains(relPath, "..") {
+		slog.Warn("security.skill_files_traversal", "path", relPath)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+
+	var body struct {
+		Content string `json:"content"`
+	}
+	if !bindJSON(w, r, locale, &body) {
+		return
+	}
+
+	filePath, _, currentVersion, isSystem, ok := h.skills.GetSkillFilePath(r.Context(), id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgNotFound, "skill", id.String())})
+		return
+	}
+	if isSystem {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "cannot edit a system skill"})
+		return
+	}
+
+	// Ownership check (admins bypass) — mirrors handleUpdate/handleDelete.
+	auth := resolveAuth(r)
+	if !permissions.HasMinRole(auth.Role, permissions.RoleAdmin) {
+		userID := store.UserIDFromContext(r.Context())
+		if ownerID, found := h.skills.GetSkillOwnerID(r.Context(), id); found && ownerID != userID {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "only the skill owner can perform this action"})
+			return
+		}
+	}
+
+	slugDir := store.SkillSlugDir(filePath)
+	if slugDir == "" {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgFileNotFound)})
+		return
+	}
+	versionDir := filepath.Join(slugDir, strconv.Itoa(currentVersion))
+	if info, err := os.Stat(versionDir); err != nil || !info.IsDir() {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": i18n.T(locale, i18n.MsgFileNotFound)})
+		return
+	}
+
+	cleanRelPath := filepath.Clean(relPath)
+	absPath := filepath.Join(versionDir, cleanRelPath)
+	if !strings.HasPrefix(absPath, versionDir+string(filepath.Separator)) {
+		slog.Warn("security.skill_files_escape", "resolved", absPath, "root", versionDir)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+	if fi, err := os.Lstat(absPath); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			slog.Warn("security.skill_files_symlink", "path", absPath)
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+			return
+		}
+		if fi.IsDir() {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+			return
+		}
+	}
+	if skills.IsSystemArtifact(filepath.Base(cleanRelPath)) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": i18n.T(locale, i18n.MsgInvalidPath)})
+		return
+	}
+
+	if err := os.WriteFile(absPath, []byte(body.Content), 0o644); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	h.skills.BumpVersion()
+	h.emitCacheInvalidate(bus.CacheKindSkills, id.String(), uuid.Nil)
+	emitAudit(h.msgBus, r, "skill.file_updated", "skill", id.String())
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true", "path": relPath})
 }
 
 func readableSkillRoots(versionDir, slug string, isSystem bool, bundledDir string) []string {

--- a/internal/http/skills_write_file_test.go
+++ b/internal/http/skills_write_file_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestHandleWriteFile_UpdatesManagedSkillContent(t *testing.T) {
 	baseDir := t.TempDir()
-	versionDir := filepath.Join(baseDir, "my-skill", "1")
+	versionDir := filepath.Join(baseDir, "skills-store", "my-skill", "1")
 	if err := os.MkdirAll(versionDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,28 @@ func TestHandleWriteFile_UpdatesManagedSkillContent(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
-	got, err := os.ReadFile(filepath.Join(versionDir, "SKILL.md"))
+
+	// The original version directory remains untouched (historical versions
+	// are immutable).
+	origGot, err := os.ReadFile(filepath.Join(versionDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(origGot) != "old content" {
+		t.Fatalf("original version content = %q, want unchanged %q", origGot, "old content")
+	}
+
+	// A new version directory was created with the edited content, and the
+	// skill's DB row now points at it with a bumped version number.
+	updated, ok := skillStore.skills[id]
+	if !ok {
+		t.Fatal("skill not found in store after update")
+	}
+	if updated.Version != 2 {
+		t.Fatalf("version = %d, want 2", updated.Version)
+	}
+	newVersionDir := filepath.Join(baseDir, "skills-store", "my-skill", "2")
+	got, err := os.ReadFile(filepath.Join(newVersionDir, "SKILL.md"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/http/skills_write_file_test.go
+++ b/internal/http/skills_write_file_test.go
@@ -1,0 +1,105 @@
+package http
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+func TestHandleWriteFile_UpdatesManagedSkillContent(t *testing.T) {
+	baseDir := t.TempDir()
+	versionDir := filepath.Join(baseDir, "my-skill", "1")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "SKILL.md"), []byte("old content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skillStore := newSkillManageStoreStub(baseDir)
+	id := skillStore.seedCustomSkill("my-skill", versionDir, "active", nil)
+	handler := NewSkillsHandler(skillStore, baseDir, baseDir, "", bus.New(), nil, nil)
+
+	req := httptest.NewRequest(http.MethodPut, "/v1/skills/"+id.String()+"/files/SKILL.md", bytes.NewBufferString(`{"content":"new content"}`))
+	req.SetPathValue("id", id.String())
+	req.SetPathValue("path", "SKILL.md")
+	req = req.WithContext(store.WithTenantID(req.Context(), store.MasterTenantID))
+	rec := httptest.NewRecorder()
+
+	handler.handleWriteFile(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	got, err := os.ReadFile(filepath.Join(versionDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new content" {
+		t.Fatalf("content = %q, want %q", got, "new content")
+	}
+}
+
+func TestHandleWriteFile_RejectsSystemSkill(t *testing.T) {
+	baseDir := t.TempDir()
+	versionDir := filepath.Join(baseDir, "sys-skill")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "SKILL.md"), []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skillStore := newSkillManageStoreStub(baseDir)
+	id := skillStore.seedSystemSkill("sys-skill", versionDir)
+	handler := NewSkillsHandler(skillStore, baseDir, baseDir, "", bus.New(), nil, nil)
+
+	req := httptest.NewRequest(http.MethodPut, "/v1/skills/"+id.String()+"/files/SKILL.md", bytes.NewBufferString(`{"content":"hacked"}`))
+	req.SetPathValue("id", id.String())
+	req.SetPathValue("path", "SKILL.md")
+	req = req.WithContext(store.WithTenantID(req.Context(), store.MasterTenantID))
+	rec := httptest.NewRecorder()
+
+	handler.handleWriteFile(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	got, err := os.ReadFile(filepath.Join(versionDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("system skill content changed: %q", got)
+	}
+}
+
+func TestHandleWriteFile_RejectsPathTraversal(t *testing.T) {
+	baseDir := t.TempDir()
+	versionDir := filepath.Join(baseDir, "my-skill", "1")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	skillStore := newSkillManageStoreStub(baseDir)
+	id := skillStore.seedCustomSkill("my-skill", versionDir, "active", nil)
+	handler := NewSkillsHandler(skillStore, baseDir, baseDir, "", bus.New(), nil, nil)
+
+	req := httptest.NewRequest(http.MethodPut, "/v1/skills/"+id.String()+"/files/../../etc/passwd", bytes.NewBufferString(`{"content":"pwned"}`))
+	req.SetPathValue("id", id.String())
+	req.SetPathValue("path", "../../etc/passwd")
+	req = req.WithContext(store.WithTenantID(req.Context(), store.MasterTenantID))
+	rec := httptest.NewRecorder()
+
+	handler.handleWriteFile(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}

--- a/ui/web/src/i18n/locales/en/skills.json
+++ b/ui/web/src/i18n/locales/en/skills.json
@@ -227,7 +227,11 @@
     "filesShown": "{{shown}} of {{total}} files",
     "copyLink": "Copy link",
     "copySuccess": "Deeplink copied",
-    "copyFailed": "Failed to copy deeplink"
+    "copyFailed": "Failed to copy deeplink",
+    "editContent": "Edit content",
+    "editContentLoading": "Loading...",
+    "editContentSystemHint": "System skills are read-only and cannot be edited from the web UI.",
+    "editContentLoadFailed": "Failed to load skill content for editing"
   },
   "evolution": {
     "tab": "Evolution",

--- a/ui/web/src/i18n/locales/ko/skills.json
+++ b/ui/web/src/i18n/locales/ko/skills.json
@@ -111,7 +111,11 @@
     "files": "파일",
     "version": "버전:",
     "current": "(현재)",
-    "noContent": "사용 가능한 내용이 없습니다."
+    "noContent": "사용 가능한 내용이 없습니다.",
+    "editContent": "내용 편집",
+    "editContentLoading": "불러오는 중...",
+    "editContentSystemHint": "시스템 스킬은 읽기 전용이며 웹 UI에서 편집할 수 없습니다.",
+    "editContentLoadFailed": "편집을 위한 스킬 내용을 불러오지 못했습니다"
   },
   "toast": {
     "updated": "스킬 업데이트됨",

--- a/ui/web/src/i18n/locales/vi/skills.json
+++ b/ui/web/src/i18n/locales/vi/skills.json
@@ -177,7 +177,11 @@
     "filesShown": "{{shown}} / {{total}} tệp",
     "copyLink": "Copy link",
     "copySuccess": "Đã copy deeplink",
-    "copyFailed": "Không thể copy deeplink"
+    "copyFailed": "Không thể copy deeplink",
+    "editContent": "Chỉnh sửa nội dung",
+    "editContentLoading": "Đang tải...",
+    "editContentSystemHint": "Kỹ năng hệ thống chỉ đọc và không thể chỉnh sửa từ giao diện web.",
+    "editContentLoadFailed": "Không thể tải nội dung kỹ năng để chỉnh sửa"
   },
   "evolution": {
     "tab": "Tự tiến hóa",

--- a/ui/web/src/i18n/locales/zh/skills.json
+++ b/ui/web/src/i18n/locales/zh/skills.json
@@ -177,7 +177,11 @@
     "filesShown": "{{shown}} / {{total}} 个文件",
     "copyLink": "复制链接",
     "copySuccess": "已复制 Deeplink",
-    "copyFailed": "复制 Deeplink 失败"
+    "copyFailed": "复制 Deeplink 失败",
+    "editContent": "编辑内容",
+    "editContentLoading": "加载中...",
+    "editContentSystemHint": "系统技能为只读，无法在网页界面中编辑。",
+    "editContentLoadFailed": "加载技能内容以进行编辑失败"
   },
   "evolution": {
     "tab": "进化",

--- a/ui/web/src/pages/skills/hooks/use-skills.ts
+++ b/ui/web/src/pages/skills/hooks/use-skills.ts
@@ -231,6 +231,24 @@ export function useSkills() {
     [http],
   );
 
+  const updateSkillFileContent = useCallback(
+    async (id: string, path: string, content: string) => {
+      try {
+        const res = await http.put<{ ok: string; path: string }>(
+          `/v1/skills/${id}/files/${encodeURIComponent(path)}`,
+          { content },
+        );
+        await invalidate();
+        toast.success(i18next.t("skills:toast.updated"));
+        return res;
+      } catch (err) {
+        toast.error(i18next.t("skills:toast.updateFailed"), userFriendlyError(err));
+        throw err;
+      }
+    },
+    [http, invalidate],
+  );
+
   const rescanDeps = useCallback(
     async () => {
       try {
@@ -322,7 +340,7 @@ export function useSkills() {
     uploadSkill, updateSkill, deleteSkill,
     listAgentGrants, grantSkillToAgent, grantSkillToAgents, revokeSkillFromAgent,
     deleteSkills, toggleSkills, downloadSkills,
-    getSkillVersions, getSkillFiles, getSkillFileContent, rescanDeps, installDeps, installSingleDep, toggleSkill,
+    getSkillVersions, getSkillFiles, getSkillFileContent, updateSkillFileContent, rescanDeps, installDeps, installSingleDep, toggleSkill,
     setTenantConfig, deleteTenantConfig,
   };
 }

--- a/ui/web/src/pages/skills/skill-detail-dialog.tsx
+++ b/ui/web/src/pages/skills/skill-detail-dialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Copy, Download } from "lucide-react";
+import { Copy, Download, Pencil, Loader2 } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -17,10 +17,14 @@ import {
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { SearchInput } from "@/components/shared/search-input";
 import { MarkdownRenderer } from "@/components/shared/markdown-renderer";
 import { toast } from "@/stores/use-toast-store";
 import type { SkillInfo, SkillFile, SkillVersions } from "@/types/skill";
+
+const SKILL_MARKDOWN_PATH = "SKILL.md";
 import { buildTree } from "./skill-file-helpers";
 import { FileBrowser } from "./skill-file-browser";
 import { normalizeSkillDetailTab, parseSkillDetailVersionParam, shouldLoadSkillDetailFile } from "./lib/skill-detail-deeplink";
@@ -42,6 +46,7 @@ interface SkillDetailDialogProps {
   getSkillVersions: (id: string) => Promise<SkillVersions>;
   getSkillFiles: (id: string, version?: number) => Promise<SkillFile[]>;
   getSkillFileContent: (id: string, path: string, version?: number) => Promise<{ content: string; path: string; size: number }>;
+  onSaveContent?: (id: string, content: string) => Promise<unknown>;
 }
 
 export function SkillDetailDialog({
@@ -58,10 +63,55 @@ export function SkillDetailDialog({
   getSkillVersions,
   getSkillFiles,
   getSkillFileContent,
+  onSaveContent,
 }: SkillDetailDialogProps) {
   const { t } = useTranslation("skills");
   const hasFiles = !!skill.id;
   const hasEvolution = !!skill.id;
+  const canEditContent = !!skill.id && !skill.is_system && !!onSaveContent;
+
+  // Content editing state (raw SKILL.md, including frontmatter, edited in place)
+  const [editingContent, setEditingContent] = useState(false);
+  const [editContentValue, setEditContentValue] = useState("");
+  const [editContentLoading, setEditContentLoading] = useState(false);
+  const [savingContent, setSavingContent] = useState(false);
+
+  useEffect(() => {
+    setEditingContent(false);
+    setEditContentValue("");
+  }, [skill.id]);
+
+  const startEditContent = useCallback(async () => {
+    if (!skill.id) return;
+    setEditContentLoading(true);
+    try {
+      const res = await getSkillFileContent(skill.id, SKILL_MARKDOWN_PATH);
+      setEditContentValue(res.content);
+      setEditingContent(true);
+    } catch (err) {
+      toast.error(t("detail.editContentLoadFailed"), err instanceof Error ? err.message : String(err));
+    } finally {
+      setEditContentLoading(false);
+    }
+  }, [skill.id, getSkillFileContent, t]);
+
+  const cancelEditContent = () => {
+    setEditingContent(false);
+    setEditContentValue("");
+  };
+
+  const saveEditContent = async () => {
+    if (!skill.id || !onSaveContent) return;
+    setSavingContent(true);
+    try {
+      await onSaveContent(skill.id, editContentValue);
+      setEditingContent(false);
+    } catch {
+      // toast shown by hook — keep editor open so the user can retry
+    } finally {
+      setSavingContent(false);
+    }
+  };
   const activeDetailTab = normalizeSkillDetailTab(detailTab, hasFiles, hasEvolution);
   const accessModeKey = getSkillAccessModeKey(skill.visibility);
   const accessModeLabel = accessModeKey === "unknown"
@@ -300,8 +350,54 @@ export function SkillDetailDialog({
             {hasEvolution && <TabsTrigger value="evolution">{t("evolution.tab")}</TabsTrigger>}
           </TabsList>
 
-          <TabsContent value="content" className="flex-1 overflow-y-auto mt-2 -mx-4 px-4 sm:-mx-6 sm:px-6">
-            {skill.content ? (
+          <TabsContent value="content" className="flex-1 overflow-y-auto mt-2 -mx-4 px-4 sm:-mx-6 sm:px-6 flex flex-col gap-2">
+            <div className="flex justify-end">
+              {editingContent ? (
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" onClick={cancelEditContent} disabled={savingContent}>
+                    {t("edit.cancel")}
+                  </Button>
+                  <Button size="sm" onClick={saveEditContent} disabled={savingContent}>
+                    {savingContent && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                    {savingContent ? t("edit.saving") : t("edit.save")}
+                  </Button>
+                </div>
+              ) : (
+                <TooltipProvider delayDuration={200}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-8 gap-1"
+                          disabled={!canEditContent || editContentLoading}
+                          onClick={startEditContent}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                          {editContentLoading ? t("detail.editContentLoading") : t("detail.editContent")}
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    {!canEditContent && (
+                      <TooltipContent side="top">
+                        <p className="text-xs">{t("detail.editContentSystemHint")}</p>
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                </TooltipProvider>
+              )}
+            </div>
+            {editingContent ? (
+              <Textarea
+                value={editContentValue}
+                onChange={(e) => setEditContentValue(e.target.value)}
+                className="min-h-[50vh] flex-1 font-mono text-base md:text-sm"
+                spellCheck={false}
+                aria-label={t("detail.editContent")}
+              />
+            ) : skill.content ? (
               <div className="overflow-hidden rounded-md border bg-muted/30 p-4">
                 <MarkdownRenderer content={skill.content} />
               </div>

--- a/ui/web/src/pages/skills/skill-detail-dialog.tsx
+++ b/ui/web/src/pages/skills/skill-detail-dialog.tsx
@@ -343,14 +343,14 @@ export function SkillDetailDialog({
           )}
         </DialogHeader>
 
-        <Tabs value={activeDetailTab} className="flex-1 overflow-hidden flex flex-col" onValueChange={handleTabChange}>
+        <Tabs value={activeDetailTab} className="flex-1 min-h-0 overflow-hidden flex flex-col" onValueChange={handleTabChange}>
           <TabsList>
             <TabsTrigger value="content">{t("detail.content")}</TabsTrigger>
             {hasFiles && <TabsTrigger value="files">{t("detail.files")}</TabsTrigger>}
             {hasEvolution && <TabsTrigger value="evolution">{t("evolution.tab")}</TabsTrigger>}
           </TabsList>
 
-          <TabsContent value="content" className="flex-1 overflow-y-auto mt-2 -mx-4 px-4 sm:-mx-6 sm:px-6 flex flex-col gap-2">
+          <TabsContent value="content" className="flex-1 min-h-0 overflow-y-auto mt-2 -mx-4 px-4 sm:-mx-6 sm:px-6 flex flex-col gap-2">
             <div className="flex justify-end">
               {editingContent ? (
                 <div className="flex gap-2">
@@ -393,7 +393,7 @@ export function SkillDetailDialog({
               <Textarea
                 value={editContentValue}
                 onChange={(e) => setEditContentValue(e.target.value)}
-                className="min-h-[50vh] flex-1 font-mono text-base md:text-sm"
+                className="field-sizing-fixed min-h-[50vh] flex-1 resize-none overflow-y-auto font-mono text-base md:text-sm"
                 spellCheck={false}
                 aria-label={t("detail.editContent")}
               />
@@ -409,7 +409,7 @@ export function SkillDetailDialog({
           </TabsContent>
 
           {hasFiles && (
-            <TabsContent value="files" className="flex-1 overflow-hidden flex flex-col mt-2 gap-2">
+            <TabsContent value="files" className="flex-1 min-h-0 overflow-hidden flex flex-col mt-2 gap-2">
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <SearchInput
                   value={fileQuery}
@@ -433,7 +433,7 @@ export function SkillDetailDialog({
           )}
 
           {hasEvolution && (
-            <TabsContent value="evolution" className="flex-1 overflow-y-auto mt-2 -mx-4 px-4 sm:-mx-6 sm:px-6">
+            <TabsContent value="evolution" className="flex-1 min-h-0 overflow-y-auto mt-2 -mx-4 px-4 sm:-mx-6 sm:px-6">
               <SkillEvolutionPanel skill={skill} active={activeDetailTab === "evolution"} />
             </TabsContent>
           )}

--- a/ui/web/src/pages/skills/skill-detail-dialog.tsx
+++ b/ui/web/src/pages/skills/skill-detail-dialog.tsx
@@ -149,6 +149,13 @@ export function SkillDetailDialog({
     setFileContent(null);
   }, [skill.id, selectedVersionParam]);
 
+  // Re-fetch the version list whenever the skill's current version changes
+  // (e.g. after a content save bumps the version) so the header badge/selector
+  // and "current" marker reflect the latest version instead of a stale cache.
+  useEffect(() => {
+    setVersions(null);
+  }, [skill.version]);
+
   const loadVersions = useCallback(async () => {
     if (!skill.id || versions) return;
     const v = await getSkillVersions(skill.id);
@@ -398,7 +405,7 @@ export function SkillDetailDialog({
                 aria-label={t("detail.editContent")}
               />
             ) : skill.content ? (
-              <div className="overflow-hidden rounded-md border bg-muted/30 p-4">
+              <div className="rounded-md border bg-muted/30 p-4">
                 <MarkdownRenderer content={skill.content} />
               </div>
             ) : (

--- a/ui/web/src/pages/skills/skills-page.tsx
+++ b/ui/web/src/pages/skills/skills-page.tsx
@@ -48,7 +48,7 @@ export function SkillsPage() {
     skills, loading, refresh, getSkill, uploadSkill, updateSkill, deleteSkill,
     listAgentGrants, grantSkillToAgent, grantSkillToAgents, revokeSkillFromAgent,
     deleteSkills, toggleSkills, downloadSkills,
-    getSkillVersions, getSkillFiles, getSkillFileContent, rescanDeps, installDeps, installSingleDep, toggleSkill,
+    getSkillVersions, getSkillFiles, getSkillFileContent, updateSkillFileContent, rescanDeps, installDeps, installSingleDep, toggleSkill,
     setTenantConfig, deleteTenantConfig,
   } = useSkills();
   const [params, setParams] = useSearchParams();
@@ -288,6 +288,12 @@ export function SkillsPage() {
     try { await setTenantConfig(id, enabled); } finally { setToggling(null); }
   };
 
+  const handleSaveSkillContent = async (id: string, content: string) => {
+    await updateSkillFileContent(id, "SKILL.md", content);
+    const detail = await getSkill(id);
+    if (detail) setSelectedSkill(detail);
+  };
+
   const handleDeleteTenantConfig = async (id: string) => {
     setToggling(id);
     try { await deleteTenantConfig(id); } finally { setToggling(null); }
@@ -446,6 +452,7 @@ export function SkillsPage() {
           getSkillVersions={getSkillVersions}
           getSkillFiles={getSkillFiles}
           getSkillFileContent={getSkillFileContent}
+          onSaveContent={handleSaveSkillContent}
         />
       )}
 


### PR DESCRIPTION
  ### What
  
  Adds the ability to edit a skill's actual SKILL.md content directly from the web UI,
  restricted to database/tenant-managed skills only — bundled/system skills remain
  read-only, both in the UI (disabled button + tooltip) and enforced server-side (403).
  
  ### Backend

  - New `PUT /v1/skills/{id}/files/{path...}` endpoint (`handleWriteFile` in
    `internal/http/skills_versions.go`), gated to non-system skills only.
  - Follows the same versioning convention as the `skill_manage` tool's `patch` action:
    saving creates a new immutable version directory rather than overwriting the current
    one in place. The skill's DB row (`version`, `file_path`, `file_size`, `file_hash`)
    is updated to point at the new version; the previous version's files are left
    untouched.
  - Same path-traversal/symlink/system-artifact guards and ownership checks as the
    existing read endpoint.

  ### Frontend

  - Skill detail dialog's Content tab gets an "Edit content" button, disabled with a
    tooltip for system skills.
  - Editing fetches the **raw** file content (frontmatter intact) rather than the
    stripped preview normally shown, so saving doesn't silently destroy the skill's
    YAML frontmatter.
  - Save/cancel follow the established catch-and-toast error pattern (no uncaught
    promise rejections, matching the earlier config-save-button fix).
  - Fixed two follow-up bugs found during manual testing:
    - **Version display staleness**: the dialog cached version metadata on first load
      and never invalidated it, so the header kept showing the pre-save version number
      until a full page reload. Now invalidates and refetches when the skill's version
      changes.
    - **Scroll regression**: the read-only content preview had `overflow-hidden` on a
      flex child with no explicit height — per the flexbox spec this forces the item's
      minimum size to zero, letting it silently clip ~7000px of content into ~600px of
      visible space instead of overflowing so the scroll container could do its job.
      Removed the offending `overflow-hidden`, confirmed scrollable via measured
      `scrollHeight`/`clientHeight` in a real build.
  
  i18n keys added to all 4 locales (en, ko, vi, zh).

  ### Verified

  - `go build ./...`, `go build -tags sqliteonly ./...`, `go vet ./...` — clean
  - `go test ./internal/http/... -run TestHandleWriteFile` — pass
  - `npx tsc --noEmit`, `npm run build` — clean
  - `npx vitest run` — 313/313 tests pass
  - Manually tested live: content edit + version bump + scroll all confirmed working
    after fixes.

  ### Commits

  - `c745e950` — initial implementation
  - `9190b7fc` — fix version bump behavior + scroll (first pass)
  - `129b68d4` — fix version display refresh + scroll (root-caused correctly this time)

  Want me to push the branch and open this as an actual PR?
