### PR TITLE
fix(tracing): dedupe tool_call span rows in hourly snapshot aggregation

### DIFF
--- a/internal/tracing/snapshot_worker.go
+++ b/internal/tracing/snapshot_worker.go
@@ -340,7 +340,7 @@ func querySpanAggregates(ctx context.Context, db *sql.DB, from, to time.Time) ([
 			COALESCE(t.channel, '') as channel,
 			COALESCE(s.provider, '') as provider,
 			COALESCE(s.model, '') as model,
-			COUNT(*) FILTER (WHERE s.span_type = 'llm_call') as llm_call_count,
+			COUNT(*) as llm_call_count,
 			COALESCE(SUM(s.input_tokens), 0) as span_input_tokens,
 			COALESCE(SUM(s.output_tokens), 0) as span_output_tokens,
 			COALESCE(SUM(s.total_cost), 0) as span_cost,
@@ -348,7 +348,7 @@ func querySpanAggregates(ctx context.Context, db *sql.DB, from, to time.Time) ([
 			COALESCE(SUM(CAST(s.metadata->>'cache_creation_tokens' AS INTEGER)), 0) as cache_create_tokens,
 			COALESCE(SUM(CAST(s.metadata->>'thinking_tokens' AS INTEGER)), 0) as thinking_tokens
 		FROM traces t
-		JOIN spans s ON s.trace_id = t.id AND s.span_type IN ('llm_call', 'tool_call')
+		JOIN spans s ON s.trace_id = t.id AND s.span_type = 'llm_call'
 		WHERE t.start_time >= $1 AND t.start_time < $2
 		  AND t.parent_trace_id IS NULL
 		GROUP BY t.agent_id, t.channel, s.provider, s.model`, from, to)
@@ -480,6 +480,27 @@ type agentChannelKey struct {
 	Channel string
 }
 
+// findTotalsSnapshotIndex returns the index of the existing totals row
+// (Provider=="" && Model=="") in snapshots matching key, or -1 if none found.
+func findTotalsSnapshotIndex(snapshots []store.UsageSnapshot, key agentChannelKey) int {
+	for i, snap := range snapshots {
+		if snap.Provider != "" || snap.Model != "" {
+			continue
+		}
+		if snap.Channel != key.Channel {
+			continue
+		}
+		var agentID uuid.UUID
+		if snap.AgentID != nil {
+			agentID = *snap.AgentID
+		}
+		if agentID == key.AgentID {
+			return i
+		}
+	}
+	return -1
+}
+
 func mergeTraceAndSpanRows(
 	bucketStart time.Time,
 	traceRows []traceAggregate,
@@ -526,8 +547,29 @@ func mergeTraceAndSpanRows(
 		snapshots = append(snapshots, snap)
 	}
 
-	// 2. Create detail rows from span data (with actual provider/model)
+	// 2. Create detail rows from span data (with actual provider/model).
+	// Defense in depth: a span row with empty provider/model would collide
+	// with the totals row's conflict-target key (agent_id, provider='',
+	// model='', channel). Instead of appending a duplicate row, merge its
+	// metrics into the existing totals row for that (agent_id, channel).
 	for _, sp := range spanRows {
+		if sp.Provider == "" && sp.Model == "" {
+			key := agentChannelKey{Channel: sp.Channel}
+			if sp.AgentID != nil {
+				key.AgentID = *sp.AgentID
+			}
+			if idx := findTotalsSnapshotIndex(snapshots, key); idx >= 0 {
+				snapshots[idx].LLMCallCount += sp.LLMCallCount
+				snapshots[idx].InputTokens += sp.InputTokens
+				snapshots[idx].OutputTokens += sp.OutputTokens
+				snapshots[idx].TotalCost += sp.TotalCost
+				snapshots[idx].CacheReadTokens += sp.CacheReadTokens
+				snapshots[idx].CacheCreateTokens += sp.CacheCreateTokens
+				snapshots[idx].ThinkingTokens += sp.ThinkingTokens
+				continue
+			}
+		}
+
 		snapshots = append(snapshots, store.UsageSnapshot{
 			BucketHour:        bucketStart,
 			AgentID:           sp.AgentID,

--- a/internal/tracing/snapshot_worker_test.go
+++ b/internal/tracing/snapshot_worker_test.go
@@ -3,6 +3,8 @@ package tracing
 import (
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestUsageCatchUpStartHourRefreshesLatestClosedBucket(t *testing.T) {
@@ -33,5 +35,114 @@ func TestUsageCatchUpStartHourWithoutSnapshotsComputesPreviousHourOnly(t *testin
 	got := usageCatchUpStartHour(nil, target)
 	if !got.Equal(target) {
 		t.Fatalf("start hour = %s, want %s", got, target)
+	}
+}
+
+// TestMergeTraceAndSpanRowsDedupesToolCallProviderModelRow guards against
+// SQLSTATE 21000 ("ON CONFLICT DO UPDATE command cannot affect row a second
+// time"): a span row that resolves to Provider=="" && Model=="" (e.g. from
+// tool_call spans, which never carry provider/model) must be merged into the
+// existing totals row for that (agent_id, channel) instead of appended as a
+// second row sharing the same upsert conflict-target key.
+func TestMergeTraceAndSpanRowsDedupesToolCallProviderModelRow(t *testing.T) {
+	bucketStart := time.Date(2026, 7, 3, 1, 0, 0, 0, time.UTC)
+	agentID := uuid.New()
+
+	traceRows := []traceAggregate{
+		{
+			AgentID:       &agentID,
+			Channel:       "web",
+			RequestCount:  10,
+			ErrorCount:    1,
+			UniqueUsers:   3,
+			InputTokens:   100,
+			OutputTokens:  200,
+			TotalCost:     1.5,
+			ToolCallCount: 4,
+			AvgDurationMS: 500,
+		},
+	}
+
+	spanRows := []spanAggregate{
+		// Simulates leftover/edge-case span row with empty provider/model
+		// (e.g. tool_call-only spans) that would otherwise collide with the
+		// totals row's conflict-target key.
+		{
+			AgentID:           &agentID,
+			Channel:           "web",
+			Provider:          "",
+			Model:             "",
+			LLMCallCount:      2,
+			InputTokens:       10,
+			OutputTokens:      20,
+			TotalCost:         0.1,
+			CacheReadTokens:   1,
+			CacheCreateTokens: 2,
+			ThinkingTokens:    3,
+		},
+		{
+			AgentID:           &agentID,
+			Channel:           "web",
+			Provider:          "anthropic",
+			Model:             "claude-sonnet-4",
+			LLMCallCount:      5,
+			InputTokens:       50,
+			OutputTokens:      60,
+			TotalCost:         0.9,
+			CacheReadTokens:   4,
+			CacheCreateTokens: 5,
+			ThinkingTokens:    6,
+		},
+	}
+
+	snapshots := mergeTraceAndSpanRows(bucketStart, traceRows, spanRows, nil, nil)
+
+	var totalsRows []int
+	for i, snap := range snapshots {
+		if snap.AgentID != nil && *snap.AgentID == agentID && snap.Channel == "web" &&
+			snap.Provider == "" && snap.Model == "" {
+			totalsRows = append(totalsRows, i)
+		}
+	}
+
+	if len(totalsRows) != 1 {
+		t.Fatalf("expected exactly 1 totals row with Provider==\"\" && Model==\"\" for (agentID, web), got %d", len(totalsRows))
+	}
+
+	totals := snapshots[totalsRows[0]]
+	if want := 2; totals.LLMCallCount != want {
+		t.Fatalf("LLMCallCount = %d, want %d", totals.LLMCallCount, want)
+	}
+	if want := int64(10); totals.InputTokens != want {
+		t.Fatalf("InputTokens = %d, want %d", totals.InputTokens, want)
+	}
+	if want := int64(20); totals.OutputTokens != want {
+		t.Fatalf("OutputTokens = %d, want %d", totals.OutputTokens, want)
+	}
+	if want := 0.1; totals.TotalCost != want {
+		t.Fatalf("TotalCost = %v, want %v", totals.TotalCost, want)
+	}
+	if want := int64(1); totals.CacheReadTokens != want {
+		t.Fatalf("CacheReadTokens = %d, want %d", totals.CacheReadTokens, want)
+	}
+	if want := int64(2); totals.CacheCreateTokens != want {
+		t.Fatalf("CacheCreateTokens = %d, want %d", totals.CacheCreateTokens, want)
+	}
+	if want := int64(3); totals.ThinkingTokens != want {
+		t.Fatalf("ThinkingTokens = %d, want %d", totals.ThinkingTokens, want)
+	}
+
+	// The distinct provider/model detail row must still exist separately.
+	var detailFound bool
+	for _, snap := range snapshots {
+		if snap.Provider == "anthropic" && snap.Model == "claude-sonnet-4" {
+			detailFound = true
+			if snap.LLMCallCount != 5 {
+				t.Fatalf("detail row LLMCallCount = %d, want 5", snap.LLMCallCount)
+			}
+		}
+	}
+	if !detailFound {
+		t.Fatal("expected detail row for provider=anthropic model=claude-sonnet-4")
 	}
 }


### PR DESCRIPTION

  Bug

  Production logs showed intermittent hourly backfill failures:

  level=WARN msg="backfill: aggregate hour failed" hour=2026-07-04T22:00:00-04:00 error="ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)"

  Root cause

  In internal/tracing/snapshot_worker.go:

  - querySpanAggregates joined traces to spans with s.span_type IN ('llm_call', 'tool_call'), grouped by t.agent_id, t.channel, s.provider, s.model.
  - tool_call spans always have provider/model = NULL. All such spans for a given (agent_id, channel) in the hour collapsed via GROUP BY into a single row with provider="", model="" (post-COALESCE).
  - mergeTraceAndSpanRows step 1 already builds a "totals" row per (agent_id, channel) from queryTraceAggregates, also keyed at Provider="", Model="" — the identical key.
  - The upsert conflict target (internal/store/pg/snapshot.go, mirrored in internal/store/sqlitestore/snapshots.go) is (bucket_hour, agent_id, provider, model, channel, tenant_id).
  - Result: a single aggregateHour batch could produce two store.UsageSnapshot rows mapping to the same conflict-target key → Postgres rejects the whole statement with 21000. This only surfaces on hours where an agent/channel has tool_call spans, which
  explains the intermittent nature.

  Fix

  1. querySpanAggregates: narrowed the JOIN to s.span_type = 'llm_call' only (dropped 'tool_call'). Tool-call counts are already captured per-trace via traces.tool_call_count in queryTraceAggregates — tool_call spans never carry meaningful provider/model
  to aggregate separately, so including them in this query only produced a colliding duplicate row.
  2. mergeTraceAndSpanRows: added defense-in-depth — if a span row still resolves to Provider=="" && Model=="" for any other reason, its metrics (LLMCallCount, tokens, cost, cache/thinking tokens) are now merged into the existing totals row for that
  (agent_id, channel) key via a new findTotalsSnapshotIndex helper, instead of being appended as a duplicate row.
  3. Confirmed DB-agnostic: SnapshotWorker operates on *sql.DB directly and is shared by both PostgreSQL and SQLite backends — no parallel SQLite-specific aggregation query exists, so no second fix location needed.

  Test

  Added TestMergeTraceAndSpanRowsDedupesToolCallProviderModelRow in internal/tracing/snapshot_worker_test.go: builds trace rows for one agent/channel plus span rows containing a provider="" model="" row (simulating tool_call-only spans) alongside a
  normal provider="anthropic" model="claude-..." row, calls mergeTraceAndSpanRows, and asserts:
  - exactly one row has Provider=="" && Model=="" for that agent/channel (no duplicate conflict-target keys),
  - its LLMCallCount/tokens/cost equal the sum of both contributing rows.

  Verification

  - go build ./... — pass
  - go build -tags sqliteonly ./... — pass
  - go vet ./... — pass
  - go test ./internal/tracing/... — pass

  Files changed

  - internal/tracing/snapshot_worker.go
  - internal/tracing/snapshot_worker_test.go (new test)

  Scope note

  Unrelated to the in-progress feat/mcp-crud-server branch — this is a standalone bugfix off dev.
