### PR TITLE
fix(skills): allow archived skills to be found by slug/name lookup, matching UUID lookup and ListSkills behavior

### DIFF
--- a/internal/store/pg/skills_content.go
+++ b/internal/store/pg/skills_content.go
@@ -135,13 +135,17 @@ func (s *PGSkillStore) GetSkill(ctx context.Context, name string) (*store.SkillI
 		return &enriched[0], true
 	}
 
+	// "archived" means a system skill has missing dependencies (see seeder.go); it does not
+	// mean the skill is hidden from lookup. ListSkills() and GetSkillByID() both include
+	// active + archived skills, so name/slug lookup must match to avoid 404s on archived
+	// skills that are otherwise still enabled.
 	if id, err := uuid.Parse(name); err == nil {
 		return scan(baseSelect+"id = $"+fmt.Sprint(len(args)+1)+" AND status IN ('active', 'archived')"+scope, append(args, id)...)
 	}
-	if info, ok := scan(baseSelect+"slug = $"+fmt.Sprint(len(args)+1)+" AND status = 'active'"+scope, append(args, name)...); ok {
+	if info, ok := scan(baseSelect+"slug = $"+fmt.Sprint(len(args)+1)+" AND status IN ('active', 'archived')"+scope, append(args, name)...); ok {
 		return info, true
 	}
-	return scan(baseSelect+"name = $"+fmt.Sprint(len(args)+1)+" AND status = 'active'"+scope+" ORDER BY id LIMIT 1", append(args, name)...)
+	return scan(baseSelect+"name = $"+fmt.Sprint(len(args)+1)+" AND status IN ('active', 'archived')"+scope+" ORDER BY id LIMIT 1", append(args, name)...)
 }
 
 func (s *PGSkillStore) FilterSkills(ctx context.Context, allowList []string) []store.SkillInfo {

--- a/internal/store/sqlitestore/skills_content.go
+++ b/internal/store/sqlitestore/skills_content.go
@@ -129,13 +129,17 @@ func (s *SQLiteSkillStore) GetSkill(ctx context.Context, name string) (*store.Sk
 		return &enriched[0], true
 	}
 
+	// "archived" means a system skill has missing dependencies (see seeder.go); it does not
+	// mean the skill is hidden from lookup. ListSkills() and GetSkillByID() both include
+	// active + archived skills, so name/slug lookup must match to avoid 404s on archived
+	// skills that are otherwise still enabled.
 	if id, err := uuid.Parse(name); err == nil {
 		return scan(baseSelect+"id = ? AND status IN ('active', 'archived')"+scope, append([]any{id}, args...)...)
 	}
-	if info, ok := scan(baseSelect+"slug = ? AND status = 'active'"+scope, append([]any{name}, args...)...); ok {
+	if info, ok := scan(baseSelect+"slug = ? AND status IN ('active', 'archived')"+scope, append([]any{name}, args...)...); ok {
 		return info, true
 	}
-	return scan(baseSelect+"name = ? AND status = 'active'"+scope+" ORDER BY id LIMIT 1", append([]any{name}, args...)...)
+	return scan(baseSelect+"name = ? AND status IN ('active', 'archived')"+scope+" ORDER BY id LIMIT 1", append([]any{name}, args...)...)
 }
 
 func (s *SQLiteSkillStore) FilterSkills(ctx context.Context, allowList []string) []store.SkillInfo {

--- a/internal/store/sqlitestore/skills_test.go
+++ b/internal/store/sqlitestore/skills_test.go
@@ -70,7 +70,12 @@ func TestSQLiteSkillStore_CreateSkillManaged_PersistsArchivedDependencyState(t *
 	}
 }
 
-func TestSQLiteSkillStore_GetSkill_UUIDCanReadArchivedSlugStaysActiveOnly(t *testing.T) {
+func TestSQLiteSkillStore_GetSkill_ArchivedFoundByUUIDAndSlugAndName(t *testing.T) {
+	// "archived" means a system skill has missing dependencies (see internal/skills/seeder.go);
+	// it is still enabled and must be discoverable the same way as via ListSkills() and
+	// GetSkillByID(), which both include active + archived skills. Regression test for a bug
+	// where archived-but-enabled skills (e.g. docx, pdf, pptx, skill-creator, xlsx when deps
+	// are missing) 404'd when looked up by name/slug while UUID lookup worked fine.
 	ctx, skillStore := newTestSQLiteSkillStore(t)
 	skillID, err := skillStore.CreateSkillManaged(ctx, store.SkillCreateParams{
 		Name:       "Archived Detail",
@@ -84,15 +89,28 @@ func TestSQLiteSkillStore_GetSkill_UUIDCanReadArchivedSlugStaysActiveOnly(t *tes
 		t.Fatalf("CreateSkillManaged error: %v", err)
 	}
 
-	if _, ok := skillStore.GetSkill(ctx, "archived-detail"); ok {
-		t.Fatal("GetSkill by slug returned archived skill; want active-only slug lookup")
-	}
 	info, ok := skillStore.GetSkill(ctx, skillID.String())
 	if !ok {
 		t.Fatal("GetSkill by UUID returned !ok for archived skill")
 	}
 	if info.Status != "archived" {
 		t.Fatalf("Status = %q, want archived", info.Status)
+	}
+
+	slugInfo, ok := skillStore.GetSkill(ctx, "archived-detail")
+	if !ok {
+		t.Fatal("GetSkill by slug returned !ok for archived skill; want consistency with ListSkills/GetSkillByID inclusion policy")
+	}
+	if slugInfo.Status != "archived" {
+		t.Fatalf("Status = %q, want archived", slugInfo.Status)
+	}
+
+	nameInfo, ok := skillStore.GetSkill(ctx, "Archived Detail")
+	if !ok {
+		t.Fatal("GetSkill by name returned !ok for archived skill; want consistency with ListSkills/GetSkillByID inclusion policy")
+	}
+	if nameInfo.Status != "archived" {
+		t.Fatalf("Status = %q, want archived", nameInfo.Status)
 	}
 }
 


### PR DESCRIPTION
  Bug

  GetSkill(ctx, name)'s slug and name lookup branches filtered status = 'active' only. Any archived-but-enabled skill (e.g. in this environment: docx, pdf, pptx, skill-creator, xlsx) always 404'd when looked up by name/slug — even with correct tenant
  context — while lookup by UUID worked fine, and ListSkills() already included archived skills.

  Root cause

  Three places disagreed on which skills a caller should be able to see:

  - GetSkill UUID branch: status IN ('active', 'archived')
  - GetSkill slug/name branches: status = 'active' only ← the bug
  - ListSkills(): status IN ('active', 'archived'), with an existing code comment noting archived skills are "shown dimmed in the UI so admins can see missing deps and re-activate after installing them"

  Per docs/15-core-skills-system.md, "archived" means a system skill is enabled but has missing dependencies — a dependency-check outcome, not a user-intent "hide this" state. Visibility is already gated separately by the Enabled flag (FilterSkills), not
  by status. So filtering out archived skills specifically on the name/slug path was an inconsistency, not intentional behavior — confirmed by the docs, the ListSkills comment, and the UUID branch's own inclusive filter.

  There was even a pre-existing test asserting the buggy behavior (TestSQLiteSkillStore_GetSkill_UUIDCanReadArchivedSlugStaysActiveOnly), which is replaced by this PR.

  Fix

  Changed the slug and name WHERE clauses in both store backends to status IN ('active', 'archived'), matching the UUID branch and ListSkills():
  - internal/store/pg/skills_content.go
  - internal/store/sqlitestore/skills_content.go

  (Dual-DB fix, per repo convention — PostgreSQL and SQLite kept in sync.)

  Test

  Replaced the old (bug-asserting) test with TestSQLiteSkillStore_GetSkill_ArchivedFoundByUUIDAndSlugAndName in internal/store/sqlitestore/skills_test.go: creates an archived skill and asserts it's found via UUID, slug, and name lookup, all returning
  Status == "archived".

  Verification

  - go build ./... — pass
  - go build -tags sqliteonly ./... — pass
  - go vet ./... — pass
  - go test ./internal/skills/... — pass
  - go test -tags sqlite ./internal/store/sqlitestore/... -run GetSkill -v — pass
  - PG-side change is a direct mirror of the verified SQLite fix; no live PG integration DB was available in this environment to additionally exercise it there.

  Files changed

  - internal/store/pg/skills_content.go
  - internal/store/sqlitestore/skills_content.go
  - internal/store/sqlitestore/skills_test.go
