### PR TITLE
refactor(protocol): centralize tenants.* RPC method names as constants

### DIFF
--- a/internal/gateway/methods/tenants.go
+++ b/internal/gateway/methods/tenants.go
@@ -34,14 +34,14 @@ func NewTenantsMethods(tenantStore store.TenantStore, msgBus *bus.MessageBus, wo
 
 // Register registers tenant management RPC methods.
 func (m *TenantsMethods) Register(router *gateway.MethodRouter) {
-	router.Register("tenants.list", m.handleList)
-	router.Register("tenants.get", m.handleGet)
-	router.Register("tenants.create", m.handleCreate)
-	router.Register("tenants.update", m.handleUpdate)
-	router.Register("tenants.users.list", m.handleUsersList)
-	router.Register("tenants.users.add", m.handleUsersAdd)
-	router.Register("tenants.users.remove", m.handleUsersRemove)
-	router.Register("tenants.mine", m.handleMine)
+	router.Register(protocol.MethodTenantsList, m.handleList)
+	router.Register(protocol.MethodTenantsGet, m.handleGet)
+	router.Register(protocol.MethodTenantsCreate, m.handleCreate)
+	router.Register(protocol.MethodTenantsUpdate, m.handleUpdate)
+	router.Register(protocol.MethodTenantsUsersList, m.handleUsersList)
+	router.Register(protocol.MethodTenantsUsersAdd, m.handleUsersAdd)
+	router.Register(protocol.MethodTenantsUsersRemove, m.handleUsersRemove)
+	router.Register(protocol.MethodTenantsMine, m.handleMine)
 }
 
 func (m *TenantsMethods) handleList(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {

--- a/internal/permissions/policy.go
+++ b/internal/permissions/policy.go
@@ -279,10 +279,10 @@ func isAdminMethod(method string) bool {
 		protocol.MethodTeamsTaskDeleteBulk,
 
 		// Tenants — write paths.
-		"tenants.create",
-		"tenants.update",
-		"tenants.users.add",
-		"tenants.users.remove",
+		protocol.MethodTenantsCreate,
+		protocol.MethodTenantsUpdate,
+		protocol.MethodTenantsUsersAdd,
+		protocol.MethodTenantsUsersRemove,
 
 		// API keys expose secret material — gate list + mutations as admin.
 		protocol.MethodAPIKeysList,
@@ -434,10 +434,10 @@ func isReadMethod(method string) bool {
 		protocol.MethodVoicesList,
 
 		// Tenants read
-		"tenants.list",
-		"tenants.get",
-		"tenants.users.list",
-		"tenants.mine",
+		protocol.MethodTenantsList,
+		protocol.MethodTenantsGet,
+		protocol.MethodTenantsUsersList,
+		protocol.MethodTenantsMine,
 
 		// Teams read
 		protocol.MethodTeamsList,

--- a/pkg/protocol/methods.go
+++ b/pkg/protocol/methods.go
@@ -165,6 +165,18 @@ const (
 	MethodTeamsEventsList = "teams.events.list"
 )
 
+// Tenants (multi-tenant management)
+const (
+	MethodTenantsList        = "tenants.list"
+	MethodTenantsGet         = "tenants.get"
+	MethodTenantsCreate      = "tenants.create"
+	MethodTenantsUpdate      = "tenants.update"
+	MethodTenantsUsersList   = "tenants.users.list"
+	MethodTenantsUsersAdd    = "tenants.users.add"
+	MethodTenantsUsersRemove = "tenants.users.remove"
+	MethodTenantsMine        = "tenants.mine"
+)
+
 // API key management
 const (
 	MethodAPIKeysList   = "api_keys.list"


### PR DESCRIPTION
## Summary

The `tenants.*` methods were the **only** RPC group without `MethodXxx` constants in `pkg/protocol/methods.go`. Their wire names were hardcoded as raw string literals across the method-identifier call sites, inconsistent with the other 147 methods and prone to silent drift — a typo in an allowlist string is not caught by the compiler and would fail-closed (deny) at runtime, which is hard to diagnose.

## Changes

- **`pkg/protocol/methods.go`** — add `MethodTenants{List,Get,Create,Update,UsersList,UsersAdd,UsersRemove,Mine}` constants (single source of truth).
- **`internal/permissions/policy.go`** — replace raw `"tenants.*"` literals in the admin (write) and read allowlists with the constants.
- **`internal/gateway/methods/tenants.go`** — replace raw literals in `router.Register(...)` with the constants.

## Notes / scope

- **No behavior change** — string values are byte-identical; runtime routing and permission decisions are unchanged.
- Human-facing error labels and `slog` log prefixes in `internal/http/tenants.go` are **intentionally left as free-form text**, matching the sibling HTTP handler convention (they pass descriptive strings like `"session"`, `"API key"`, not wire method names).

## Test plan

- [x] `go build ./...` (PostgreSQL build)
- [x] `go build -tags sqliteonly ./...` (Desktop/SQLite build)
- [x] `go vet ./internal/permissions/... ./pkg/protocol/... ./internal/gateway/methods/...`
- [x] `go test ./internal/permissions/...` (passes)

Surface parity: Web UI / CLI / API contract N/A — this is an internal Go constant refactor; no wire names, request/response shapes, or client-visible strings change.