### PR TITLE
fix(docker): add tzdata to runtime image for zoneinfo support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,11 +80,12 @@ ARG ENABLE_CLAUDE_CLI=false
 # requirements-skills.txt: additional deps only for ENABLE_FULL_SKILLS.
 COPY docker/requirements-base.txt docker/requirements-skills.txt /tmp/
 
-# Install ca-certificates + wget (healthcheck) + optional runtimes.
+# Install ca-certificates + wget (healthcheck) + tzdata (zoneinfo for Go
+# time.LoadLocation and Python zoneinfo in skill scripts) + optional runtimes.
 # ENABLE_FULL_SKILLS=true pre-installs all skill deps (larger image, no on-demand install needed).
 # Otherwise, skill packages are installed on-demand via the admin UI.
 RUN set -eux; \
-    apk add --no-cache ca-certificates wget su-exec; \
+    apk add --no-cache ca-certificates wget su-exec tzdata; \
     if [ "$ENABLE_SANDBOX" = "true" ]; then \
         apk add --no-cache docker-cli; \
     fi; \


### PR DESCRIPTION
## Summary
Add `tzdata` to the runtime image's base apk deps. Without it, any Python skill script using `zoneinfo` (and Go `time.LoadLocation` with named zones) fails at runtime.

## Symptom (verbatim, ghcr.io/nextlevelbuilder/goclaw:latest built from dev @ af80890e)
```
Traceback (most recent call last):
  File "/usr/lib/python3.12/zoneinfo/_common.py", line 12, in load_tzdata
    return resources.files(package_name).joinpath(resource_name).open("rb")
...
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key Europe/Paris'
```
Hit in production while running an uploaded skill whose script does `ZoneInfo("Europe/Paris")` for calendar math. The agent then attempted `pip install tzdata` on its own, which got stuck behind the package-install exec-approval gate.

## Root cause
`Dockerfile:87` — runtime stage (`FROM alpine:3.23`) installs `ca-certificates wget su-exec` only; alpine does not ship `/usr/share/zoneinfo` by default, so both system and Python zone lookups have no data.

## Fix
One word: add `tzdata` to the always-installed apk set (covers all variants: base/latest/full/claude-cli), plus a comment. ~1.5 MB.

## Why safe
Additive package install in the base layer; no behavior change for code that never touches zoneinfo. No config/API surface affected.

## Testing
- Reproduced on `alpine:3.23`: without tzdata → `ZoneInfoNotFoundError`; with `apk add tzdata` → `ZoneInfo("Europe/Paris")` resolves (CEST).
- `docker build --check .` → no warnings.
