### PR TITLE
fix(discord): preserve channel agent routing

### DIFF
--- a/cmd/gateway_consumer.go
+++ b/cmd/gateway_consumer.go
@@ -147,7 +147,7 @@ func consumeInboundMessages(ctx context.Context, msgBus *bus.MessageBus, agents 
 		}
 
 		// --- Normal messages: route through debouncer ---
-		prepareInboundDebounceMessage(&msg, deps)
+		prepareInboundDebounceMessage(ctx, &msg, deps)
 		debouncer.Push(msg)
 	}
 }

--- a/cmd/gateway_consumer_debounce.go
+++ b/cmd/gateway_consumer_debounce.go
@@ -18,11 +18,12 @@ import (
 // debouncing (issue #63). See plans/260528-1351-multi-attachment-debounce/.
 const mediaDebounceFloorMs = 1000
 
-func prepareInboundDebounceMessage(msg *bus.InboundMessage, deps *ConsumerDeps) {
+func prepareInboundDebounceMessage(ctx context.Context, msg *bus.InboundMessage, deps *ConsumerDeps) {
 	if msg == nil || deps == nil || deps.Cfg == nil || msg.AgentID != "" {
 		return
 	}
-	msg.AgentID = resolveAgentRoute(deps.Cfg, msg.Channel, msg.ChatID, msg.PeerKind)
+	routeCtx := inboundMessageTenantContext(ctx, *msg)
+	msg.AgentID = resolveAgentRouteForInbound(routeCtx, deps.Cfg, deps.AgentStore, msg.Channel, msg.ChatID, msg.PeerKind)
 }
 
 func resolveInboundDebounceDelay(ctx context.Context, msg bus.InboundMessage, deps *ConsumerDeps) time.Duration {

--- a/cmd/gateway_consumer_handlers.go
+++ b/cmd/gateway_consumer_handlers.go
@@ -401,7 +401,8 @@ func handleResetCommand(
 
 	agentID := msg.AgentID
 	if agentID == "" {
-		agentID = resolveAgentRoute(deps.Cfg, msg.Channel, msg.ChatID, msg.PeerKind)
+		ctx := inboundMessageTenantContext(context.Background(), msg)
+		agentID = resolveAgentRouteForInbound(ctx, deps.Cfg, deps.AgentStore, msg.Channel, msg.ChatID, msg.PeerKind)
 	}
 	peerKind := msg.PeerKind
 	if peerKind == "" {
@@ -437,7 +438,8 @@ func handleStopCommand(
 
 	agentID := msg.AgentID
 	if agentID == "" {
-		agentID = resolveAgentRoute(deps.Cfg, msg.Channel, msg.ChatID, msg.PeerKind)
+		ctx := inboundMessageTenantContext(context.Background(), msg)
+		agentID = resolveAgentRouteForInbound(ctx, deps.Cfg, deps.AgentStore, msg.Channel, msg.ChatID, msg.PeerKind)
 	}
 	peerKind := msg.PeerKind
 	if peerKind == "" {

--- a/cmd/gateway_consumer_helpers.go
+++ b/cmd/gateway_consumer_helpers.go
@@ -1,16 +1,20 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"mime"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/nextlevelbuilder/goclaw/internal/agent"
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/sessions"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/internal/tools"
 )
 
@@ -19,24 +23,58 @@ import (
 // Matching TS resolve-route.ts binding resolution.
 func resolveAgentRoute(cfg *config.Config, channel, chatID, peerKind string) string {
 	for _, binding := range cfg.Bindings {
-		match := binding.Match
-		if match.Channel != channel {
-			continue
+		if bindingMatchesInbound(binding, channel, chatID, peerKind) {
+			return config.NormalizeAgentID(binding.AgentID)
 		}
-
-		// Peer-level match (most specific)
-		if match.Peer != nil {
-			if match.Peer.Kind == peerKind && match.Peer.ID == chatID {
-				return config.NormalizeAgentID(binding.AgentID)
-			}
-			continue // has peer constraint but doesn't match — skip
-		}
-
-		// Channel-level match (least specific, no peer constraint)
-		return config.NormalizeAgentID(binding.AgentID)
 	}
 
 	return cfg.ResolveDefaultAgentID()
+}
+
+type defaultAgentGetter interface {
+	GetDefault(ctx context.Context) (*store.AgentData, error)
+}
+
+func resolveAgentRouteForInbound(ctx context.Context, cfg *config.Config, agentStore defaultAgentGetter, channel, chatID, peerKind string) string {
+	if cfg == nil {
+		return config.DefaultAgentID
+	}
+	for _, binding := range cfg.Bindings {
+		if bindingMatchesInbound(binding, channel, chatID, peerKind) {
+			return config.NormalizeAgentID(binding.AgentID)
+		}
+	}
+	if agentStore != nil {
+		if ag, err := agentStore.GetDefault(ctx); err == nil && ag != nil && ag.AgentKey != "" {
+			return ag.AgentKey
+		}
+	}
+	return cfg.ResolveDefaultAgentID()
+}
+
+func bindingMatchesInbound(binding config.AgentBinding, channel, chatID, peerKind string) bool {
+	match := binding.Match
+	if match.Channel != channel {
+		return false
+	}
+
+	// Peer-level match (most specific)
+	if match.Peer != nil {
+		return match.Peer.Kind == peerKind && match.Peer.ID == chatID
+	}
+
+	// Channel-level match (least specific, no peer constraint)
+	return true
+}
+
+func inboundMessageTenantContext(ctx context.Context, msg bus.InboundMessage) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if msg.TenantID != uuid.Nil {
+		return store.WithTenantID(ctx, msg.TenantID)
+	}
+	return store.WithTenantID(ctx, store.MasterTenantID)
 }
 
 // overrideSessionKeyFromLocalKey extracts topic/thread ID from the composite

--- a/cmd/gateway_consumer_normal.go
+++ b/cmd/gateway_consumer_normal.go
@@ -40,12 +40,25 @@ func processNormalMessage(
 	// Determine target agent via bindings or explicit AgentID
 	agentID := msg.AgentID
 	if agentID == "" {
-		agentID = resolveAgentRoute(deps.Cfg, msg.Channel, msg.ChatID, msg.PeerKind)
+		agentID = resolveAgentRouteForInbound(ctx, deps.Cfg, deps.AgentStore, msg.Channel, msg.ChatID, msg.PeerKind)
 	}
 
 	agentLoop, err := deps.Agents.Get(ctx, agentID)
 	if err != nil {
-		slog.Warn("inbound: agent not found", "agent", agentID, "channel", msg.Channel)
+		slog.Warn("inbound: agent not found", "agent", agentID, "channel", msg.Channel, "error", err)
+		errContent := formatAgentError(err)
+		if deps.ChannelMgr != nil {
+			if ct := deps.ChannelMgr.ChannelTypeForName(msg.Channel); isExternalChannel(ct) {
+				errContent = ""
+			}
+		}
+		deps.MsgBus.PublishOutbound(bus.OutboundMessage{
+			Channel:  msg.Channel,
+			ChatID:   msg.ChatID,
+			Content:  errContent,
+			Metadata: msg.Metadata,
+			TenantID: msg.TenantID,
+		})
 		return
 	}
 

--- a/cmd/gateway_consumer_normal_test.go
+++ b/cmd/gateway_consumer_normal_test.go
@@ -1,12 +1,18 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/nextlevelbuilder/goclaw/internal/agent"
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/bitrix24"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/sessions"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
 // TestIsSafeBitrixEntityToken pins the validation contract for webhook-sourced
@@ -150,4 +156,113 @@ func TestResolveSenderNameTruncatesLongMetadata(t *testing.T) {
 	if len([]rune(got)) != 100 {
 		t.Fatalf("resolveSenderName() length = %d, want 100", len([]rune(got)))
 	}
+}
+
+func TestResolveAgentRouteForInbound_FallsBackToDBDefaultAgent(t *testing.T) {
+	cfg := &config.Config{}
+	got := resolveAgentRouteForInbound(context.Background(), cfg, defaultAgentGetterStub{
+		agent: &store.AgentData{AgentKey: "co-assistant"},
+	}, "co-assistant-2-0", "channel-1", string(sessions.PeerDirect))
+	if got != "co-assistant" {
+		t.Fatalf("resolveAgentRouteForInbound() = %q, want DB default agent key", got)
+	}
+}
+
+func TestResolveAgentRouteForInbound_BindingWinsOverDBDefault(t *testing.T) {
+	cfg := &config.Config{
+		Bindings: []config.AgentBinding{{
+			AgentID: "bound-agent",
+			Match: config.BindingMatch{
+				Channel: "co-assistant-2-0",
+			},
+		}},
+	}
+	got := resolveAgentRouteForInbound(context.Background(), cfg, defaultAgentGetterStub{
+		agent: &store.AgentData{AgentKey: "co-assistant"},
+	}, "co-assistant-2-0", "channel-1", string(sessions.PeerDirect))
+	if got != "bound-agent" {
+		t.Fatalf("resolveAgentRouteForInbound() = %q, want binding agent", got)
+	}
+}
+
+func TestProcessNormalMessage_AgentLookupFailurePublishesExternalCleanup(t *testing.T) {
+	msgBus := bus.New()
+	channelMgr := channels.NewManager(msgBus)
+	channelMgr.RegisterChannel("discord-prod", consumerTestChannel{
+		name:        "discord-prod",
+		channelType: channels.TypeDiscord,
+		running:     true,
+	})
+
+	metadata := map[string]string{
+		"message_id":      "discord-message-1",
+		"placeholder_key": "discord-message-1",
+	}
+
+	processNormalMessage(context.Background(), bus.InboundMessage{
+		Channel:  "discord-prod",
+		SenderID: "user-1",
+		ChatID:   "channel-1",
+		Content:  "hello",
+		PeerKind: string(sessions.PeerDirect),
+		AgentID:  "missing-agent",
+		Metadata: metadata,
+	}, &ConsumerDeps{
+		Cfg:        &config.Config{},
+		Agents:     agent.NewRouter(),
+		ChannelMgr: channelMgr,
+		MsgBus:     msgBus,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, ok := msgBus.SubscribeOutbound(ctx)
+	if !ok {
+		t.Fatal("expected outbound cleanup message")
+	}
+	if got.Content != "" {
+		t.Fatalf("outbound content = %q, want empty cleanup for external Discord channel", got.Content)
+	}
+	if got.Channel != "discord-prod" || got.ChatID != "channel-1" {
+		t.Fatalf("outbound route = %s/%s, want discord-prod/channel-1", got.Channel, got.ChatID)
+	}
+	if got.Metadata["placeholder_key"] != "discord-message-1" {
+		t.Fatalf("placeholder_key = %q, want metadata preserved", got.Metadata["placeholder_key"])
+	}
+}
+
+type consumerTestChannel struct {
+	name        string
+	channelType string
+	running     bool
+}
+
+func (c consumerTestChannel) Name() string { return c.name }
+func (c consumerTestChannel) Type() string { return c.channelType }
+func (c consumerTestChannel) Start(context.Context) error {
+	return nil
+}
+func (c consumerTestChannel) Stop(context.Context) error {
+	return nil
+}
+func (c consumerTestChannel) Send(context.Context, bus.OutboundMessage) error {
+	return nil
+}
+func (c consumerTestChannel) IsRunning() bool {
+	return c.running
+}
+func (c consumerTestChannel) IsAllowed(string) bool {
+	return true
+}
+
+type defaultAgentGetterStub struct {
+	agent *store.AgentData
+	err   error
+}
+
+func (s defaultAgentGetterStub) GetDefault(context.Context) (*store.AgentData, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.agent, nil
 }

--- a/internal/channels/discord/handler.go
+++ b/internal/channels/discord/handler.go
@@ -304,30 +304,7 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 		}
 	}
 
-	// PATCHED: Clear AgentID so the gateway consumer's resolveAgentRoute
-	// (cmd/gateway_consumer_normal.go:40-43) matches via cfg.Bindings.
-	// The consumer checks: if msg.AgentID == "" → resolveAgentRoute(cfg, msg.Channel, msg.ChatID, msg.PeerKind)
-	// Bindings in config.json match by channel name + peer.kind + peer.id.
-	// If no binding matches, resolveAgentRoute falls back to cfg.ResolveDefaultAgentID().
-	targetAgentID := ""
-	slog.Info("discord: binding routing enabled",
-		"channel_id", channelID,
-		"channel_name", c.Name(),
-		"peer_kind", peerKind,
-	)
-
-	// Voice agent routing
-	if c.config.VoiceAgentID != "" {
-		for _, mi := range mediaList {
-			if mi.Type == media.TypeAudio || mi.Type == media.TypeVoice {
-				targetAgentID = c.config.VoiceAgentID
-				slog.Debug("discord: routing voice inbound to speaking agent",
-					"agent_id", targetAgentID, "media_type", mi.Type,
-				)
-				break
-			}
-		}
-	}
+	targetAgentID := c.targetAgentID(mediaList)
 
 	// Collect contact for processed messages (DM + group-mentioned).
 	if cc := c.ContactCollector(); cc != nil {
@@ -355,6 +332,22 @@ func (c *Channel) handleMessage(_ *discordgo.Session, m *discordgo.MessageCreate
 	if peerKind == "group" {
 		c.GroupHistory().Clear(channelID)
 	}
+}
+
+func (c *Channel) targetAgentID(mediaList []media.MediaInfo) string {
+	targetAgentID := c.AgentID()
+	if c.config.VoiceAgentID == "" {
+		return targetAgentID
+	}
+	for _, mi := range mediaList {
+		if mi.Type == media.TypeAudio || mi.Type == media.TypeVoice {
+			slog.Debug("discord: routing voice inbound to speaking agent",
+				"agent_id", c.config.VoiceAgentID, "media_type", mi.Type,
+			)
+			return c.config.VoiceAgentID
+		}
+	}
+	return targetAgentID
 }
 
 // checkGroupPolicy evaluates the group policy for a sender, with pairing support.

--- a/internal/channels/discord/handler_test.go
+++ b/internal/channels/discord/handler_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/media"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
 )
 
 // --- resolveDisplayName ---
@@ -68,6 +70,30 @@ func TestResolveCachedChannelTitle(t *testing.T) {
 	}
 	if got := ch.resolveCachedChannelTitle("missing"); got != "" {
 		t.Fatalf("missing channel title = %q, want empty", got)
+	}
+}
+
+func TestTargetAgentIDUsesConfiguredChannelAgent(t *testing.T) {
+	ch := &Channel{BaseChannel: channels.NewBaseChannel(channels.TypeDiscord, nil, nil)}
+	ch.SetAgentID("co-assistant")
+
+	if got := ch.targetAgentID(nil); got != "co-assistant" {
+		t.Fatalf("targetAgentID() = %q, want configured channel agent", got)
+	}
+}
+
+func TestTargetAgentIDVoiceOverrideOnlyForAudio(t *testing.T) {
+	ch := &Channel{
+		BaseChannel: channels.NewBaseChannel(channels.TypeDiscord, nil, nil),
+		config:      config.DiscordConfig{VoiceAgentID: "voice-agent"},
+	}
+	ch.SetAgentID("co-assistant")
+
+	if got := ch.targetAgentID([]media.MediaInfo{{Type: media.TypeImage}}); got != "co-assistant" {
+		t.Fatalf("image targetAgentID() = %q, want channel agent", got)
+	}
+	if got := ch.targetAgentID([]media.MediaInfo{{Type: media.TypeVoice}}); got != "voice-agent" {
+		t.Fatalf("voice targetAgentID() = %q, want voice override", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1264.

This restores Discord channel-instance agent routing that was accidentally bypassed by [`bdc9abd5`](https://github.com/nextlevelbuilder/goclaw/commit/bdc9abd5768bdbcea55f437375fe3fa748fa0fee) (`feat(discord): enable binding-based agent routing`, [#1243](https://github.com/nextlevelbuilder/goclaw/pull/1243)). That commit changed Discord inbound handling from using the channel instance's configured `AgentID` to always publishing an empty `AgentID`, forcing the gateway consumer to resolve via top-level `cfg.Bindings`.

That broke dashboard-configured Discord channels because Admin UI channel setup stores the selected agent in `channel_instances.agent_id`, and `InstanceLoader` resolves that UUID to `BaseChannel.SetAgentID(agent_key)`. If no separate config-file binding matched the Discord instance, the consumer fell back to the literal agent key `default`. Deployments without an agent keyed `default` then logged `inbound: agent not found agent=default`, never entered `loop.Run`, never created traces, and left the Discord `Thinking...` placeholder in place.

## Root cause

Before [`bdc9abd5`](https://github.com/nextlevelbuilder/goclaw/commit/bdc9abd5768bdbcea55f437375fe3fa748fa0fee), Discord followed the same model as Telegram/Feishu/WhatsApp:

```go
targetAgentID := c.AgentID()
```

[`bdc9abd5`](https://github.com/nextlevelbuilder/goclaw/commit/bdc9abd5768bdbcea55f437375fe3fa748fa0fee) replaced that with:

```go
targetAgentID := ""
```

That made binding-based routing possible, but it silently discarded the explicit agent configured on the Discord channel instance. The fallback chain then became:

1. ignore channel instance `AgentID`
2. try `cfg.Bindings`
3. fall back to config default literal `default`

For DB-managed channels, step 1 is the normal and expected route, so this regressed existing Discord setups.

## Changes

- Restore Discord's default target to `c.AgentID()` via `targetAgentID`.
- Preserve `voice_agent_id` behavior: audio/voice inbound still overrides the channel agent.
- Keep binding routing for cases where a channel has no explicit agent.
- Add DB-default fallback for inbound routing before falling back to literal `default`.
- Ensure pre-runtime agent lookup failures publish an outbound cleanup message, so external channels can remove placeholders instead of hanging.
- Add regression tests for:
  - Discord preserving the configured channel agent.
  - Discord voice-agent override only applying to audio/voice.
  - Inbound route fallback using DB default agent.
  - Binding rules taking precedence over DB default.
  - External-channel cleanup on agent lookup failure.

## Effective routing order after this PR

1. If the channel instance has `AgentID`, use it.
2. If the message is voice/audio and `voice_agent_id` is configured, override to that agent.
3. If no channel agent is present, use `cfg.Bindings`.
4. If no binding matches, use the tenant-scoped DB default agent.
5. Last resort: fall back to literal `default` for legacy config-only installs.

## Verification

- `go test ./cmd ./internal/channels/discord`
- `git diff --check -- cmd/gateway_consumer.go cmd/gateway_consumer_debounce.go cmd/gateway_consumer_handlers.go cmd/gateway_consumer_helpers.go cmd/gateway_consumer_normal.go cmd/gateway_consumer_normal_test.go internal/channels/discord/handler.go internal/channels/discord/handler_test.go`

## Risk

Low. This restores the pre-[`bdc9abd5`](https://github.com/nextlevelbuilder/goclaw/commit/bdc9abd5768bdbcea55f437375fe3fa748fa0fee) Discord channel-agent behavior and matches the routing pattern already used by Telegram, Feishu, and WhatsApp. Binding-based routing still works when no explicit channel agent is set, and tests pin the precedence.