### PR TITLE
fix(ui): strip trailing dashes in slugify

### DIFF
--- a/ui/web/src/lib/slug.test.ts
+++ b/ui/web/src/lib/slug.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidSlug, slugify } from "./slug";
+
+describe("slugify", () => {
+  it("does not leave a trailing dash and passes isValidSlug", () => {
+    for (const input of ["hello world!", "My Agent ", "trailing---", "café résumé!", "  spaced  "]) {
+      const s = slugify(input);
+      expect(s.endsWith("-")).toBe(false);
+      expect(isValidSlug(s)).toBe(true);
+    }
+    expect(slugify("hello world!")).toBe("hello-world");
+  });
+
+  it("still handles already-valid slugs and diacritics", () => {
+    expect(slugify("valid-slug")).toBe("valid-slug");
+    expect(slugify("abc")).toBe("abc");
+    expect(slugify("Đà Nẵng")).toBe("da-nang");
+  });
+});

--- a/ui/web/src/lib/slug.ts
+++ b/ui/web/src/lib/slug.ts
@@ -11,7 +11,8 @@ export function slugify(input: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9-]/g, "-")
     .replace(/-{2,}/g, "-")
-    .replace(/^-+/g, "");
+    .replace(/^-+/g, "")
+    .replace(/-+$/g, "");
 }
 
 /**


### PR DESCRIPTION
## Problem

`slugify` (`ui/web/src/lib/slug.ts`) documents "no leading/trailing dashes", and the sibling `isValidSlug` rejects a trailing dash — but `slugify` only strips **leading** dashes (`/^-+/g`), never trailing. So any input ending in a non-`[a-z0-9]` character produces a slug that fails its own validator:

```
slugify("hello world!") -> "hello-world-"   isValidSlug(...) -> false
slugify("My Agent ")    -> "my-agent-"       -> false
slugify("trailing---")  -> "trailing-"       -> false
slugify("café résumé!") -> "cafe-resume-"    -> false
```

`slugify`/`isValidSlug` back the key/name fields (with `shouldValidate`) across agent, channel, provider, cron, and MCP forms and the agent import panel, so typing a name ending in a space or punctuation yields an invalid persisted key and a spurious "invalid slug" error.

## Fix

Add a symmetric trailing-dash strip after the leading one:

```ts
    .replace(/^-+/g, "")
    .replace(/-+$/g, "");
```

This matches the repo's Go helpers, which already trim both sides (`internal/skills/helpers.go` `strings.Trim(s, "-")`), confirming the TS asymmetry was an oversight. All-punctuation input still returns `""` (unchanged; callers already guard with a default).

## Tests

Added `ui/web/src/lib/slug.test.ts` (vitest; no slug test existed). Before the fix the trailing-dash cases fail `isValidSlug`; after, all pass.

```
"hello world!" -> "hello-world"  (valid)
"My Agent "    -> "my-agent"     (valid)
"trailing---"  -> "trailing"     (valid)
"café résumé!" -> "cafe-resume"  (valid)
"Đà Nẵng"      -> "da-nang"      (diacritics preserved)
```
