### PR TITLE
fix(exec): Unicode-aware boundary for privilege-escalation `su` deny (fixes non-ASCII false positives)

### DIFF
--- a/internal/tools/shell_deny_groups.go
+++ b/internal/tools/shell_deny_groups.go
@@ -4,6 +4,17 @@ import (
 	"regexp"
 )
 
+// unicodeCmdWord matches a command name (or alternation) as a standalone
+// word using a Unicode-aware boundary. Go's RE2 \b is ASCII-only, so a
+// pattern like \bsu\b matches the "su" inside non-ASCII words such as the
+// Vietnamese "suất" (the accented 'ấ' is not an ASCII word char, so \b
+// sees a spurious boundary right after "su"). Treating Unicode letters and
+// digits (\pL, \pN) as word chars avoids those false positives while still
+// matching the real `su` command.
+func unicodeCmdWord(alt string) *regexp.Regexp {
+	return regexp.MustCompile(`(?:^|[^\pL\pN_])(?:` + alt + `)(?:[^\pL\pN_]|$)`)
+}
+
 // DenyGroup is a named set of shell command deny patterns.
 type DenyGroup struct {
 	Name        string           // machine name: "package_install"
@@ -83,7 +94,7 @@ var DenyGroupRegistry = map[string]*DenyGroup{
 		Default:     true,
 		Patterns: []*regexp.Regexp{
 			regexp.MustCompile(`\bsudo\b`),
-			regexp.MustCompile(`\bsu\b`),
+			unicodeCmdWord("su"),
 			regexp.MustCompile(`\bdoas\b`),
 			regexp.MustCompile(`\bpkexec\b`),
 			regexp.MustCompile(`\brunuser\b`),

--- a/internal/tools/shell_deny_test.go
+++ b/internal/tools/shell_deny_test.go
@@ -130,14 +130,19 @@ func TestPrivilegeEscalationGaps(t *testing.T) {
 	)
 
 	mustAllow(t, patterns,
-		"summit",    // not "su"
-		"sugar",     // not "su"
-		"surplus",   // not "su"
-		"issue",     // not "su"
-		"result",    // not "su"
-		"resume",    // not "su"
-		"visual",    // not "su"
-		"sushi",     // not "su"
+		"summit",  // not "su"
+		"sugar",   // not "su"
+		"surplus", // not "su"
+		"issue",   // not "su"
+		"result",  // not "su"
+		"resume",  // not "su"
+		"visual",  // not "su"
+		"sushi",   // not "su"
+		// non-ASCII (Vietnamese) text: ASCII "su" adjacent to an accented
+		// vowel must NOT match the su command (Go RE2 word boundaries are ASCII-only).
+		"hiệu suất",
+		"năng suất",
+		"báo cáo hiệu suất tháng",
 		"doaspkg",   // not "doas" (no word boundary)
 		"pkexecute", // not "pkexec" (no word boundary)
 	)


### PR DESCRIPTION
Fixes #1388

### Problem

`privilege_escalation`'s deny pattern `` `\bsu\b` `` (in `internal/tools/shell_deny_groups.go`) uses Go RE2's ASCII-only `\b`. It matches the ASCII `su` inside non-ASCII words — e.g. the Vietnamese `suất` (`hiệu suất`, `năng suất`) — because the accented `ấ` is not an ASCII word char, so `\b` sees a spurious boundary right after `su`. Any exec command containing such a word (e.g. a Vietnamese document embedded in a `python3 … <<'PY'` heredoc to render a PDF) is wrongly rejected with `command denied by safety policy: matches pattern \bsu\b`.

### Fix

Add a small `unicodeCmdWord` helper that builds a **Unicode-aware** word boundary from `\pL`/`\pN` and use it for the `su` pattern:

```go
`(?:^|[^\pL\pN_])(?:su)(?:[^\pL\pN_]|$)`
```

Accented letters adjacent to the token now count as word characters, so `suất` no longer matches while the real `su` command (bounded by start/space/`;`/`&&`/newline/EOF) still does. Scope is intentionally limited to `su`, the only short bare-word pattern observed to collide with real text; the helper is reusable for other patterns if similar reports appear.

### Tests

Extended `TestPrivilegeEscalationGaps`:
- **still denied:** `su`, `su -`, `su root`, `su -l postgres`, `su admin` (existing cases unchanged)
- **now allowed (new):** `hiệu suất`, `năng suất`, `báo cáo hiệu suất tháng`

`go test ./internal/tools/ -run PrivilegeEscalation` passes. The `su` matching behaviour for real commands is unchanged.