### PR TITLE
fix(tools): avoid panic in StripToolPrefix on overlapping prefix+suffix

### DIFF
--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -527,7 +527,11 @@ func StripToolPrefix(tmpl, name string) string {
 	if strings.Contains(tmpl, placeholder) {
 		parts := strings.SplitN(tmpl, placeholder, 2)
 		prefix, suffix := parts[0], parts[1]
-		if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, suffix) {
+		// Require the name to be at least as long as prefix+suffix so an
+		// overlapping match (e.g. tmpl "pre_{tool_name}_suf", name "pre_suf")
+		// doesn't slice with a negative length and panic.
+		if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, suffix) &&
+			len(prefix)+len(suffix) <= len(name) {
 			result := name[len(prefix):]
 			if suffix != "" {
 				result = result[:len(result)-len(suffix)]

--- a/internal/tools/policy_prefix_test.go
+++ b/internal/tools/policy_prefix_test.go
@@ -16,6 +16,7 @@ func TestStripToolPrefix(t *testing.T) {
 		{"template no match", "proxy_{tool_name}", "other_exec", "other_exec"},
 		{"template empty result", "proxy_{tool_name}", "proxy_", "proxy_"},
 		{"template exact placeholder", "{tool_name}", "exec", "exec"},
+		{"template prefix+suffix overlap (regression)", "pre_{tool_name}_suf", "pre_suf", "pre_suf"},
 
 		// Literal prefix
 		{"literal prefix with separator", "proxy_", "proxy_exec", "exec"},


### PR DESCRIPTION
## Problem

`StripToolPrefix` (`internal/tools/policy.go`) panics for a `{tool_name}` template that has **both** a prefix and a suffix when the tool-call name's ends overlap.

```go
prefix, suffix := parts[0], parts[1]
if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, suffix) {
    result := name[len(prefix):]
    if suffix != "" {
        result = result[:len(result)-len(suffix)]   // negative length -> panic
    }
```

For template `"pre_{tool_name}_suf"` (prefix `pre_`, suffix `_suf`), a name like `"pre_suf"` satisfies both `HasPrefix` and `HasSuffix`, but after stripping the prefix `result` is `"suf"` (3 bytes), and `3 - len("_suf")` = `-1`, so `result[:-1]` panics with `slice bounds out of range [:-1]`.

This runs in the agent turn loop on **model-emitted** tool-call names (`internal/agent/loop.go` `resolveToolCallName` → `StripToolPrefix(policy.ToolCallPrefix, tc.Name)`), so a degenerate/crafted name crashes the turn. The `prefix{tool_name}suffix` template shape is explicitly exercised by the repo's own tests (`policy_prefix_test.go`).

## Fix

Only strip when the name is at least as long as `prefix+suffix`; otherwise fall through to returning the name unchanged (consistent with the existing no-match / empty-result fallbacks):

```go
if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, suffix) &&
    len(prefix)+len(suffix) <= len(name) {
```

## Verification

I ran the exact `StripToolPrefix` logic in a standalone Go harness:

- **Before:** `StripToolPrefix("pre_{tool_name}_suf", "pre_suf")` → `panic: slice bounds out of range [:-1]`.
- **After:** returns `"pre_suf"` unchanged, and every existing shape still passes — `proxy_{tool_name}`/`proxy_exec`→`exec`, `{tool_name}_v2`/`exec_v2`→`exec`, `pre_{tool_name}_suf`/`pre_exec_suf`→`exec`, no-match and exact-placeholder cases unchanged.

Added a regression row to `TestStripToolPrefix` in `internal/tools/policy_prefix_test.go` (`"pre_{tool_name}_suf"`, `"pre_suf"` → `"pre_suf"`).

(Note: `go test ./internal/tools` currently doesn't build on Windows due to a pre-existing `//go:build !windows` helper referenced by an unconstrained test file — unrelated to this change; the new row runs on Linux CI.)
