### PR TITLE
feat(bitrix24): add delete affordance for pending portals in channel creation form

### DIFF
--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -794,7 +794,15 @@
       "createFirst": "Connect your first Bitrix24 portal",
       "createNew": "Create new portal",
       "pendingBadge": "Pending install — click to resume",
-      "loadError": "Failed to load portals. Refresh to retry."
+      "loadError": "Failed to load portals. Refresh to retry.",
+      "deleteAria": "Delete portal {{name}}",
+      "deleteConfirm": {
+        "title": "Delete pending portal",
+        "description": "Delete pending portal \"{{name}}\"? It hasn't finished install and isn't used by any channel. This cannot be undone.",
+        "confirmLabel": "Delete",
+        "success": "Portal \"{{name}}\" deleted",
+        "error": "Failed to delete portal"
+      }
     },
     "errors": {
       "portalRequired": "Please select a portal.",

--- a/ui/web/src/i18n/locales/vi/channels.json
+++ b/ui/web/src/i18n/locales/vi/channels.json
@@ -793,7 +793,15 @@
       "createFirst": "Kết nối portal Bitrix24 đầu tiên",
       "createNew": "Tạo portal mới",
       "pendingBadge": "Chưa authorize — click để resume",
-      "loadError": "Không tải được danh sách portal. Refresh để thử lại."
+      "loadError": "Không tải được danh sách portal. Refresh để thử lại.",
+      "deleteAria": "Xoá portal {{name}}",
+      "deleteConfirm": {
+        "title": "Xoá portal chờ cài đặt",
+        "description": "Xoá portal chờ cài đặt \"{{name}}\"? Portal chưa hoàn tất cài đặt và chưa được channel nào dùng. Không thể hoàn tác.",
+        "confirmLabel": "Xoá",
+        "success": "Đã xoá portal \"{{name}}\"",
+        "error": "Xoá portal thất bại"
+      }
     },
     "errors": {
       "portalRequired": "Vui lòng chọn portal.",

--- a/ui/web/src/i18n/locales/zh/channels.json
+++ b/ui/web/src/i18n/locales/zh/channels.json
@@ -793,7 +793,15 @@
       "createFirst": "连接第一个 Bitrix24 门户",
       "createNew": "创建新门户",
       "pendingBadge": "等待授权 — 点击继续",
-      "loadError": "门户加载失败，请刷新重试。"
+      "loadError": "门户加载失败，请刷新重试。",
+      "deleteAria": "删除门户 {{name}}",
+      "deleteConfirm": {
+        "title": "删除待安装门户",
+        "description": "删除待安装门户\"{{name}}\"？它尚未完成安装，也未被任何渠道使用。此操作不可撤销。",
+        "confirmLabel": "删除",
+        "success": "已删除门户\"{{name}}\"",
+        "error": "删除门户失败"
+      }
     },
     "errors": {
       "portalRequired": "请选择一个门户。",

--- a/ui/web/src/pages/channels/bitrix24/bitrix-portal-select.test.tsx
+++ b/ui/web/src/pages/channels/bitrix24/bitrix-portal-select.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for bitrix-portal-select delete-affordance logic.
+ *
+ * NOTE: @testing-library/react is not installed in this project (same
+ * constraint as voice-picker.test.tsx) — tests cover pure logic and module
+ * contracts rather than DOM rendering / click simulation. The one thing that
+ * genuinely requires a real browser (trash click not triggering
+ * onResumeAuthorize via Radix's click-hijack) is covered by the plan's
+ * manual smoke step instead (phase-05 T5.11).
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { BitrixPortal } from "./types";
+
+vi.mock("./use-bitrix-portals", () => ({
+  useBitrixPortals: vi.fn(() => ({ data: [], isLoading: false, isError: false })),
+  useBitrixPortalDelete: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
+// Sentinel values mirrored from bitrix-portal-select.tsx (kept in sync by hand
+// — small, stable, not worth exporting just for tests).
+const CREATE_SENTINEL = "__bitrix_portal_create__";
+const RESUME_PREFIX = "__bitrix_portal_resume__:";
+
+/** Mirrors bitrix-portal-select.tsx's itemValue computation. */
+function itemValueFor(p: Pick<BitrixPortal, "name" | "installed">): string {
+  return p.installed ? p.name : `${RESUME_PREFIX}${p.name}`;
+}
+
+/** Mirrors whether a portal row should render the delete/trash affordance —
+ * only pending (not-yet-installed) portals get one (design.md scope change
+ * 2026-07-09: installed-portal delete is out of scope for this dropdown). */
+function showsDeleteAffordance(p: Pick<BitrixPortal, "installed">): boolean {
+  return !p.installed;
+}
+
+describe("bitrix-portal-select — pending vs installed classification", () => {
+  const installed: BitrixPortal = { name: "acme", domain: "acme.bitrix24.com", installed: true, public_url: "https://goclaw.example.com", created_at: "2026-01-01T00:00:00Z" };
+  const pending: BitrixPortal = { name: "web1trang", domain: "web1trang.bitrix24.com", installed: false, public_url: "", created_at: "2026-01-01T00:00:00Z" };
+
+  it("installed portal's item value is the bare name (what onChange stores)", () => {
+    expect(itemValueFor(installed)).toBe("acme");
+  });
+
+  it("pending portal's item value carries the RESUME_PREFIX sentinel, never the bare name", () => {
+    const v = itemValueFor(pending);
+    expect(v.startsWith(RESUME_PREFIX)).toBe(true);
+    expect(v).not.toBe(pending.name);
+    expect(v.slice(RESUME_PREFIX.length)).toBe("web1trang");
+  });
+
+  it("delete affordance shows for pending, not for installed", () => {
+    expect(showsDeleteAffordance(pending)).toBe(true);
+    expect(showsDeleteAffordance(installed)).toBe(false);
+  });
+
+  it("a pending portal's value can never equal the CREATE_SENTINEL or a bare onChange value", () => {
+    const v = itemValueFor(pending);
+    expect(v).not.toBe(CREATE_SENTINEL);
+  });
+});
+
+describe("bitrix-portal-select — safe-by-construction: pending can't be a channel's form value", () => {
+  // Mirrors the Select's onValueChange dispatch (bitrix-portal-select.tsx):
+  // CREATE_SENTINEL -> onCreateRequest, RESUME_PREFIX:* -> onResumeAuthorize,
+  // anything else -> onChange (the actual form field setter).
+  function dispatch(
+    v: string,
+    handlers: { onCreateRequest: () => void; onResumeAuthorize: (name: string) => void; onChange: (v: string) => void },
+  ) {
+    if (v === CREATE_SENTINEL) return handlers.onCreateRequest();
+    if (v.startsWith(RESUME_PREFIX)) return handlers.onResumeAuthorize(v.slice(RESUME_PREFIX.length));
+    return handlers.onChange(v);
+  }
+
+  it("selecting a pending portal's value routes to onResumeAuthorize, never onChange", () => {
+    const onChange = vi.fn();
+    const onResumeAuthorize = vi.fn();
+    const onCreateRequest = vi.fn();
+    const pendingValue = itemValueFor({ name: "web1trang", installed: false } as BitrixPortal);
+
+    dispatch(pendingValue, { onChange, onResumeAuthorize, onCreateRequest });
+
+    expect(onResumeAuthorize).toHaveBeenCalledWith("web1trang");
+    expect(onChange).not.toHaveBeenCalled();
+    // Consequence: findChannelsUsingPortal (backend) can never see a pending
+    // portal name in any channel_instance.config.portal — deleting a pending
+    // portal is safe without an in-use check.
+  });
+
+  it("selecting an installed portal's value routes to onChange (the real form setter)", () => {
+    const onChange = vi.fn();
+    const onResumeAuthorize = vi.fn();
+    const onCreateRequest = vi.fn();
+    const installedValue = itemValueFor({ name: "acme", installed: true } as BitrixPortal);
+
+    dispatch(installedValue, { onChange, onResumeAuthorize, onCreateRequest });
+
+    expect(onChange).toHaveBeenCalledWith("acme");
+    expect(onResumeAuthorize).not.toHaveBeenCalled();
+  });
+});
+
+describe("bitrix-portal-select — delete confirm handler contract", () => {
+  /** Mirrors handleConfirmDelete's success/error branching without the
+   * component's i18n/toast side effects — just the mutateAsync call
+   * contract and state-clearing behavior. */
+  async function confirmDelete(
+    name: string | null,
+    mutateAsync: (name: string) => Promise<unknown>,
+    onSuccess: () => void,
+    onError: (err: { code?: string; message?: string }) => void,
+  ) {
+    if (!name) return;
+    try {
+      await mutateAsync(name);
+      onSuccess();
+    } catch (err) {
+      onError(err as { code?: string; message?: string });
+    }
+  }
+
+  it("calls mutateAsync with the pending portal's name", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({ status: "deleted" });
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    await confirmDelete("web1trang", mutateAsync, onSuccess, onError);
+
+    expect(mutateAsync).toHaveBeenCalledWith("web1trang");
+    expect(onSuccess).toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when name is null (dialog not open / already cleared)", async () => {
+    const mutateAsync = vi.fn();
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    await confirmDelete(null, mutateAsync, onSuccess, onError);
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("routes a rejected mutateAsync (e.g. defensive FAILED_PRECONDITION) to onError, not onSuccess", async () => {
+    const mutateAsync = vi.fn().mockRejectedValue({ code: "FAILED_PRECONDITION", message: "portal is used by channel(s): x" });
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    await confirmDelete("web1trang", mutateAsync, onSuccess, onError);
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "FAILED_PRECONDITION" }),
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("bitrix-portal-select — keyboard delete on pending options", () => {
+  /** Mirrors the SelectItem onKeyDown handler (bitrix-portal-select.tsx):
+   * Radix Select's roving tabindex puts focus on the option itself, not the
+   * nested trash button, so Delete/Backspace is the keyboard-reachable
+   * equivalent of clicking it. Only wired for pending (!installed) portals. */
+  function keyDownHandler(installed: boolean, name: string, setPendingDeleteName: (n: string) => void) {
+    if (installed) return undefined;
+    return (e: { key: string; preventDefault: () => void }) => {
+      if (e.key === "Delete" || e.key === "Backspace") {
+        e.preventDefault();
+        setPendingDeleteName(name);
+      }
+    };
+  }
+
+  it("Delete key on a pending portal's option triggers the delete confirm", () => {
+    const setPendingDeleteName = vi.fn();
+    const handler = keyDownHandler(false, "web1trang", setPendingDeleteName);
+    const preventDefault = vi.fn();
+
+    handler?.({ key: "Delete", preventDefault });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(setPendingDeleteName).toHaveBeenCalledWith("web1trang");
+  });
+
+  it("Backspace key on a pending portal's option also triggers the delete confirm", () => {
+    const setPendingDeleteName = vi.fn();
+    const handler = keyDownHandler(false, "web1trang", setPendingDeleteName);
+    const preventDefault = vi.fn();
+
+    handler?.({ key: "Backspace", preventDefault });
+
+    expect(setPendingDeleteName).toHaveBeenCalledWith("web1trang");
+  });
+
+  it("other keys on a pending portal's option are ignored", () => {
+    const setPendingDeleteName = vi.fn();
+    const handler = keyDownHandler(false, "web1trang", setPendingDeleteName);
+    const preventDefault = vi.fn();
+
+    handler?.({ key: "Enter", preventDefault });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(setPendingDeleteName).not.toHaveBeenCalled();
+  });
+
+  it("installed portals get no keydown handler at all", () => {
+    const setPendingDeleteName = vi.fn();
+    const handler = keyDownHandler(true, "acme", setPendingDeleteName);
+
+    expect(handler).toBeUndefined();
+  });
+});
+
+describe("useBitrixPortalDelete — mock contract", () => {
+  it("exposes mutateAsync and isPending", async () => {
+    const { useBitrixPortalDelete } = await import("./use-bitrix-portals");
+    const result = useBitrixPortalDelete();
+    expect(typeof result.mutateAsync).toBe("function");
+    expect(result.isPending).toBe(false);
+  });
+});

--- a/ui/web/src/pages/channels/bitrix24/bitrix-portal-select.tsx
+++ b/ui/web/src/pages/channels/bitrix24/bitrix-portal-select.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -9,7 +11,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useBitrixPortals } from "./use-bitrix-portals";
+import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
+import { toast } from "@/stores/use-toast-store";
+import { useBitrixPortals, useBitrixPortalDelete } from "./use-bitrix-portals";
 
 // Sentinel values used to detect special items inside the Select
 // onValueChange callback — Radix Select doesn't support per-item onClick, so
@@ -41,6 +45,28 @@ interface BitrixPortalSelectProps {
 export function BitrixPortalSelect({ value, onChange, onCreateRequest, onResumeAuthorize }: BitrixPortalSelectProps) {
   const { t } = useTranslation("channels");
   const { data: portals = [], isLoading, isError } = useBitrixPortals();
+  const [pendingDeleteName, setPendingDeleteName] = useState<string | null>(null);
+  const del = useBitrixPortalDelete();
+
+  // Only pending (not-yet-installed) portals get a delete affordance here —
+  // they can never be referenced by a channel (see onValueChange below: a
+  // pending item's value is the RESUME_PREFIX sentinel, never the bare name
+  // onChange stores), so deleting one is safe without an in-use check.
+  // Installed-portal delete is deferred to a future Settings page.
+  const handleConfirmDelete = () => {
+    const name = pendingDeleteName;
+    if (!name) return;
+    del
+      .mutateAsync(name)
+      .then(() => {
+        toast.success(t("bitrix24.portalSelect.deleteConfirm.success", { name, defaultValue: `Portal "${name}" deleted` }));
+        setPendingDeleteName(null);
+      })
+      .catch((err: { code?: string; message?: string }) => {
+        // Defensive only — not expected for pending portals (safe by construction above).
+        toast.error(err?.message ?? t("bitrix24.portalSelect.deleteConfirm.error", { defaultValue: "Failed to delete portal" }));
+      });
+  };
 
   if (isLoading) {
     return <Skeleton className="h-9 w-full" />;
@@ -69,49 +95,100 @@ export function BitrixPortalSelect({ value, onChange, onCreateRequest, onResumeA
   }
 
   return (
-    <Select
-      value={value}
-      onValueChange={(v) => {
-        if (v === CREATE_SENTINEL) {
-          onCreateRequest();
-          return;
-        }
-        if (v.startsWith(RESUME_PREFIX)) {
-          const portalName = v.slice(RESUME_PREFIX.length);
-          onResumeAuthorize?.(portalName);
-          return;
-        }
-        onChange(v);
-      }}
-    >
-      <SelectTrigger>
-        <SelectValue placeholder={t("bitrix24.portalSelect.placeholder", { defaultValue: "Select a portal..." })} />
-      </SelectTrigger>
-      <SelectContent>
-        {portals.map((p) => {
-          // Pending portals get their own sentinel so we can route the click
-          // to onResumeAuthorize. Installed portals carry the bare name as
-          // value (what the form actually stores).
-          const itemValue = p.installed ? p.name : `${RESUME_PREFIX}${p.name}`;
-          return (
-            <SelectItem key={p.name} value={itemValue}>
-              <div className="flex items-center gap-2">
-                <span>{p.name}</span>
-                <span className="text-xs text-muted-foreground">({p.domain})</span>
-                {!p.installed && (
-                  <span className="text-xs text-amber-600">
-                    ⚠ {t("bitrix24.portalSelect.pendingBadge", { defaultValue: "Pending install — click to resume" })}
-                  </span>
-                )}
-              </div>
-            </SelectItem>
-          );
+    <>
+      <Select
+        value={value}
+        onValueChange={(v) => {
+          if (v === CREATE_SENTINEL) {
+            onCreateRequest();
+            return;
+          }
+          if (v.startsWith(RESUME_PREFIX)) {
+            const portalName = v.slice(RESUME_PREFIX.length);
+            onResumeAuthorize?.(portalName);
+            return;
+          }
+          onChange(v);
+        }}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder={t("bitrix24.portalSelect.placeholder", { defaultValue: "Select a portal..." })} />
+        </SelectTrigger>
+        <SelectContent>
+          {portals.map((p) => {
+            // Pending portals get their own sentinel so we can route the click
+            // to onResumeAuthorize. Installed portals carry the bare name as
+            // value (what the form actually stores).
+            const itemValue = p.installed ? p.name : `${RESUME_PREFIX}${p.name}`;
+            return (
+              <SelectItem
+                key={p.name}
+                value={itemValue}
+                onKeyDown={
+                  !p.installed
+                    ? (e) => {
+                        // Radix Select manages focus on the option itself (roving
+                        // tabindex), not on the nested trash button — Delete/Backspace
+                        // is the keyboard-reachable equivalent of clicking it.
+                        if (e.key === "Delete" || e.key === "Backspace") {
+                          e.preventDefault();
+                          setPendingDeleteName(p.name);
+                        }
+                      }
+                    : undefined
+                }
+              >
+                <div className="flex items-center gap-2">
+                  <span>{p.name}</span>
+                  <span className="text-xs text-muted-foreground">({p.domain})</span>
+                  {!p.installed && (
+                    <>
+                      <span className="text-xs text-amber-600">
+                        ⚠ {t("bitrix24.portalSelect.pendingBadge", { defaultValue: "Pending install — click to resume" })}
+                      </span>
+                      <button
+                        type="button"
+                        aria-label={t("bitrix24.portalSelect.deleteAria", { name: p.name, defaultValue: `Delete portal ${p.name}` })}
+                        className="ml-auto rounded p-1 text-muted-foreground hover:text-destructive"
+                        onPointerDown={(e) => {
+                          e.stopPropagation();
+                          e.preventDefault();
+                        }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          e.preventDefault();
+                          setPendingDeleteName(p.name);
+                        }}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </>
+                  )}
+                </div>
+              </SelectItem>
+            );
+          })}
+          <SelectSeparator />
+          <SelectItem value={CREATE_SENTINEL} className="text-primary">
+            + {t("bitrix24.portalSelect.createNew", { defaultValue: "Create new portal" })}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+      <ConfirmDeleteDialog
+        open={pendingDeleteName !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingDeleteName(null);
+        }}
+        title={t("bitrix24.portalSelect.deleteConfirm.title", { defaultValue: "Delete pending portal" })}
+        description={t("bitrix24.portalSelect.deleteConfirm.description", {
+          name: pendingDeleteName ?? "",
+          defaultValue: `Delete pending portal "${pendingDeleteName ?? ""}"? It hasn't finished install and isn't used by any channel. This cannot be undone.`,
         })}
-        <SelectSeparator />
-        <SelectItem value={CREATE_SENTINEL} className="text-primary">
-          + {t("bitrix24.portalSelect.createNew", { defaultValue: "Create new portal" })}
-        </SelectItem>
-      </SelectContent>
-    </Select>
+        confirmValue={pendingDeleteName ?? ""}
+        confirmLabel={t("bitrix24.portalSelect.deleteConfirm.confirmLabel", { defaultValue: "Delete" })}
+        loading={del.isPending}
+        onConfirm={handleConfirmDelete}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Add a delete icon for **pending** (not-yet-authorized) Bitrix24 portals in the Portal dropdown on the channel-creation form. Installed portals get no delete/edit here (out of scope, deferred to a possible future Settings page).
- Mouse-clickable and keyboard-reachable (Delete/Backspace on the focused option) — a nested `<button>` inside a Radix `SelectItem` isn't reachable via Radix's roving-tabindex keyboard navigation on its own, so an explicit `onKeyDown` handler was added.
- Safe by construction: a pending portal's Select value carries a sentinel prefix (never the bare portal name), so it can never become a channel's stored `config.portal` value — no in-use check needed client-side. Backend `bitrix.portals.delete` RPC keeps its own in-use guard + tenant scope as defense in depth.

## Test plan
- [x] 14 new unit tests (pure-logic, mirrors existing `voice-picker.test.tsx` convention — this project has no `@testing-library/react`)
- [x] Full frontend test suite green, no regressions
- [x] `pnpm build` clean (TypeScript compiles)
- [x] i18n keys added to en/vi/zh, validated as parseable JSON
- [x] Manually verified in browser (mouse click + keyboard Delete) against a live backend — trash icon shows only for pending portals, opens confirm dialog without triggering resume-authorize, cancels cleanly, no console errors
- [x] Two code-review passes (first flagged the keyboard-accessibility gap, second confirmed the fix is correct and robust)