### PR TITLE
fix(discord): honor disabled group history limit

### DIFF
--- a/internal/channels/discord/discord.go
+++ b/internal/channels/discord/discord.go
@@ -61,11 +61,6 @@ func New(cfg config.DiscordConfig, msgBus *bus.MessageBus, pairingSvc store.Pair
 		requireMention = *cfg.RequireMention
 	}
 
-	historyLimit := cfg.HistoryLimit
-	if historyLimit == 0 {
-		historyLimit = channels.DefaultGroupHistoryLimit
-	}
-
 	ch := &Channel{
 		BaseChannel:     base,
 		session:         session,
@@ -77,7 +72,7 @@ func New(cfg config.DiscordConfig, msgBus *bus.MessageBus, pairingSvc store.Pair
 	ch.SetRequireMention(requireMention)
 	ch.SetPairingService(pairingSvc)
 	ch.SetGroupHistory(channels.MakeHistory(channels.TypeDiscord, pendingStore, base.TenantID()))
-	ch.SetHistoryLimit(historyLimit)
+	ch.SetHistoryLimit(cfg.HistoryLimit)
 	return ch, nil
 }
 

--- a/internal/channels/discord/discord_config_test.go
+++ b/internal/channels/discord/discord_config_test.go
@@ -1,0 +1,47 @@
+package discord
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+)
+
+func TestNewPreservesExplicitZeroHistoryLimit(t *testing.T) {
+	ch, err := New(config.DiscordConfig{Token: "token", HistoryLimit: 0}, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	if got := ch.HistoryLimit(); got != 0 {
+		t.Fatalf("HistoryLimit() = %d, want 0", got)
+	}
+}
+
+func TestFactoryDefaultsMissingHistoryLimitButPreservesExplicitZero(t *testing.T) {
+	creds := json.RawMessage(`{"token":"token"}`)
+
+	defaulted, err := Factory("discord-main", creds, json.RawMessage(`{}`), nil, nil)
+	if err != nil {
+		t.Fatalf("Factory default config returned error: %v", err)
+	}
+	defaultedDiscord, ok := defaulted.(*Channel)
+	if !ok {
+		t.Fatalf("Factory returned %T, want *discord.Channel", defaulted)
+	}
+	if got := defaultedDiscord.HistoryLimit(); got != channels.DefaultGroupHistoryLimit {
+		t.Fatalf("default HistoryLimit() = %d, want %d", got, channels.DefaultGroupHistoryLimit)
+	}
+
+	disabled, err := Factory("discord-disabled", creds, json.RawMessage(`{"history_limit":0}`), nil, nil)
+	if err != nil {
+		t.Fatalf("Factory explicit zero returned error: %v", err)
+	}
+	disabledDiscord, ok := disabled.(*Channel)
+	if !ok {
+		t.Fatalf("Factory returned %T, want *discord.Channel", disabled)
+	}
+	if got := disabledDiscord.HistoryLimit(); got != 0 {
+		t.Fatalf("explicit zero HistoryLimit() = %d, want 0", got)
+	}
+}

--- a/internal/channels/discord/factory.go
+++ b/internal/channels/discord/factory.go
@@ -22,7 +22,7 @@ type discordInstanceConfig struct {
 	GroupPolicy       string                     `json:"group_policy,omitempty"`
 	AllowFrom         []string                   `json:"allow_from,omitempty"`
 	RequireMention    *bool                      `json:"require_mention,omitempty"`
-	HistoryLimit      int                        `json:"history_limit,omitempty"`
+	HistoryLimit      *int                       `json:"history_limit,omitempty"`
 	BlockReply        *bool                      `json:"block_reply,omitempty"`
 	ChatBehavior      *config.ChatBehaviorConfig `json:"chat_behavior,omitempty"`
 	MediaMaxBytes     int64                      `json:"media_max_bytes,omitempty"`
@@ -81,7 +81,7 @@ func buildChannel(name string, creds json.RawMessage, cfg json.RawMessage,
 		DMPolicy:          ic.DMPolicy,
 		GroupPolicy:       ic.GroupPolicy,
 		RequireMention:    ic.RequireMention,
-		HistoryLimit:      ic.HistoryLimit,
+		HistoryLimit:      resolveHistoryLimit(ic.HistoryLimit),
 		BlockReply:        ic.BlockReply,
 		ChatBehavior:      ic.ChatBehavior,
 		MediaMaxBytes:     ic.MediaMaxBytes,
@@ -104,4 +104,11 @@ func buildChannel(name string, creds json.RawMessage, cfg json.RawMessage,
 
 	ch.SetName(name)
 	return ch, nil
+}
+
+func resolveHistoryLimit(limit *int) int {
+	if limit == nil {
+		return channels.DefaultGroupHistoryLimit
+	}
+	return *limit
 }

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -152,7 +152,7 @@ type DiscordConfig struct {
 	DMPolicy          string              `json:"dm_policy,omitempty"`       // "open" (default), "allowlist", "disabled"
 	GroupPolicy       string              `json:"group_policy,omitempty"`    // "open" (default), "allowlist", "disabled"
 	RequireMention    *bool               `json:"require_mention,omitempty"` // require @bot mention in groups (default true)
-	HistoryLimit      int                 `json:"history_limit,omitempty"`   // max pending group messages for context (default 50, 0=disabled)
+	HistoryLimit      int                 `json:"history_limit,omitempty"`   // max pending group messages for context (default 200, 0=disabled)
 	BlockReply        *bool               `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
 	ChatBehavior      *ChatBehaviorConfig `json:"chat_behavior,omitempty"`   // override gateway chat behavior (nil = inherit)
 	MediaMaxBytes     int64               `json:"media_max_bytes,omitempty"` // max media download size (default 25MB)

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -97,6 +97,9 @@ func Default() *Config {
 			Telegram: TelegramConfig{
 				ReactionLevel: "full",
 			},
+			Discord: DiscordConfig{
+				HistoryLimit: 200,
+			},
 		},
 		Gateway: GatewayConfig{
 			Host:            "0.0.0.0",

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -40,6 +40,9 @@ func TestDefault_SensibleDefaults(t *testing.T) {
 	if cfg.Skills.SlashCommands.EffectivePrefix() != "/" {
 		t.Fatalf("slash command prefix = %q, want /", cfg.Skills.SlashCommands.EffectivePrefix())
 	}
+	if cfg.Channels.Discord.HistoryLimit != 200 {
+		t.Fatalf("default discord history limit: got %d, want 200", cfg.Channels.Discord.HistoryLimit)
+	}
 
 }
 
@@ -52,6 +55,9 @@ func TestLoad_MissingFile_UsesDefaults(t *testing.T) {
 	}
 	if cfg.Gateway.Port != 18790 {
 		t.Fatalf("expected default port, got %d", cfg.Gateway.Port)
+	}
+	if cfg.Channels.Discord.HistoryLimit != 200 {
+		t.Fatalf("expected default discord history limit, got %d", cfg.Channels.Discord.HistoryLimit)
 	}
 }
 
@@ -84,6 +90,28 @@ func TestLoad_ValidJSON5(t *testing.T) {
 	// Unset fields should retain defaults
 	if cfg.Agents.Defaults.Provider != "anthropic" {
 		t.Fatalf("default provider should be preserved: got %q", cfg.Agents.Defaults.Provider)
+	}
+}
+
+func TestLoad_DiscordHistoryLimitExplicitZeroDisables(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json5")
+
+	content := `{
+		"channels": {
+			"discord": {
+				"history_limit": 0,
+			},
+		},
+	}`
+	os.WriteFile(cfgPath, []byte(content), 0644)
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if cfg.Channels.Discord.HistoryLimit != 0 {
+		t.Fatalf("discord history_limit explicit zero: got %d, want 0", cfg.Channels.Discord.HistoryLimit)
 	}
 }
 

--- a/ui/desktop/frontend/src/components/channels/channel-schemas.ts
+++ b/ui/desktop/frontend/src/components/channels/channel-schemas.ts
@@ -84,7 +84,7 @@ export const configSchema: Record<string, FieldDef[]> = {
     { key: 'dm_policy', label: 'DM Policy', type: 'select', options: dmPolicyOptions, defaultValue: 'pairing' },
     { key: 'group_policy', label: 'Group Policy', type: 'select', options: groupPolicyOptions, defaultValue: 'pairing' },
     { key: 'require_mention', label: 'Require @mention in groups', type: 'boolean', defaultValue: true },
-    { key: 'history_limit', label: 'Group History Limit', type: 'number', defaultValue: 50, help: 'Max pending group messages for context (0 = disabled)' },
+    { key: 'history_limit', label: 'Group History Limit', type: 'number', defaultValue: 200, help: 'Max pending group messages for context (0 = disabled)' },
     { key: 'allow_from', label: 'Allowed Users', type: 'tags', help: 'Discord user IDs' },
     { key: 'block_reply', label: 'Block Reply', type: 'select', options: blockReplyOptions, defaultValue: 'inherit', help: 'Deliver intermediate text during tool iterations' },
   ],

--- a/ui/web/src/pages/channels/channel-schemas.test.ts
+++ b/ui/web/src/pages/channels/channel-schemas.test.ts
@@ -73,6 +73,17 @@ describe("telegram configSchema", () => {
   });
 });
 
+describe("discord configSchema", () => {
+  const discordConfig = configSchema["discord"]!;
+
+  it("matches the backend pending group history default", () => {
+    const historyLimit = discordConfig.find((field) => field.key === "history_limit");
+    expect(historyLimit).toBeDefined();
+    expect(historyLimit!.defaultValue).toBe(200);
+    expect(historyLimit!.help).toMatch(/0 = disabled/i);
+  });
+});
+
 describe("pancake configSchema", () => {
   const pancakeConfig = configSchema["pancake"]!;
 

--- a/ui/web/src/pages/channels/channel-schemas.ts
+++ b/ui/web/src/pages/channels/channel-schemas.ts
@@ -173,7 +173,7 @@ export const configSchema: Record<string, FieldDef[]> = {
     { key: "dm_policy", label: "DM Policy", type: "select", options: dmPolicyOptions, defaultValue: "pairing" },
     { key: "group_policy", label: "Group Policy", type: "select", options: groupPolicyOptions, defaultValue: "pairing" },
     { key: "require_mention", label: "Require @mention in groups", type: "boolean", defaultValue: true },
-    { key: "history_limit", label: "Group History Limit", type: "number", defaultValue: 50, help: "Max pending group messages for context (0 = disabled)" },
+    { key: "history_limit", label: "Group History Limit", type: "number", defaultValue: 200, help: "Max pending group messages for context (0 = disabled)" },
     { key: "allow_from", label: "Allowed Users", type: "tags", help: "Discord user IDs" },
     ...chatBehaviorOverrideFields,
   ],


### PR DESCRIPTION
## Summary
- Make Discord preserve explicit `history_limit: 0` so pending group/channel history is actually disabled.
- Keep the omitted Discord `history_limit` default at `200` for config-file and DB-backed channel instances.
- Update Web and Desktop channel schemas so Discord shows the backend default `200` instead of `50`.
- Add regression tests for config loading, Discord factory behavior, and Web schema default.

## Bug
The channel UI documented Group History Limit as `0 = disabled`, but Discord runtime did not honor that value. `internal/channels/discord/discord.go` mapped `cfg.HistoryLimit == 0` back to `channels.DefaultGroupHistoryLimit` (`200`), so saving `0` in the UI still kept up to 200 pending group messages for context.

That made the UI contract false: operators could set Discord Group History Limit to `0`, see the config save, and still have pending group history included when the bot was later mentioned.

## Fix
For Discord:
- Config-file defaults now start with `history_limit: 200`, so omitted config keeps the existing default.
- DB-backed instance config now distinguishes omitted `history_limit` from explicit `0` using a pointer during JSON decode.
- The Discord constructor no longer rewrites `0` to `200`; `PendingHistory.Record()` already treats `limit <= 0` as disabled.

## Verification
- `go test ./internal/config ./internal/channels/discord`
- `cd ui/web && pnpm test -- channel-schemas.test.ts` (51 files / 340 tests passed)
- `cd ui/web && pnpm lint` (0 errors; 4 unrelated existing warnings)
- `cd ui/web && pnpm build`

## Known verification note
- `cd ui/desktop/frontend && pnpm build` is blocked in this fresh worktree because generated Wails bindings are absent: `../../../wailsjs/go/main/App` and `../../../wailsjs/runtime/runtime`. The touched desktop file is a schema constant only; Web schema build/test covers the same value change.

## Surface parity
- Gateway server: updated Discord runtime mapping and DB instance default handling.
- API contract: unchanged; `history_limit` remains the same JSON field.
- Web UI: Discord default corrected to `200`.
- Desktop UI: Discord default corrected to `200`.
- CLI/runtime package: N/A because this is channel runtime + UI schema behavior, not CLI command behavior.
