### PR TITLE
fix(graph): preserve knowledge graph node colors

### DIFF
--- a/ui/web/src/components/graph/graph-node-colors.ts
+++ b/ui/web/src/components/graph/graph-node-colors.ts
@@ -1,0 +1,11 @@
+import { getVaultNodeColor } from "@/adapters/vault-graph-adapter";
+
+export function resolveGraphNodeDisplayColor(attrs: Record<string, unknown>, isDark: boolean): string {
+  const docType = typeof attrs.docType === "string" ? attrs.docType : "";
+  if (docType) {
+    return getVaultNodeColor(docType, isDark);
+  }
+  return typeof attrs.color === "string" && attrs.color
+    ? attrs.color
+    : getVaultNodeColor("other", isDark);
+}

--- a/ui/web/src/components/graph/sigma-graph-container.test.ts
+++ b/ui/web/src/components/graph/sigma-graph-container.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolveGraphNodeDisplayColor } from "./graph-node-colors";
+
+describe("resolveGraphNodeDisplayColor", () => {
+  it("keeps the adapter-assigned color for knowledge graph entity nodes", () => {
+    expect(resolveGraphNodeDisplayColor({
+      entityType: "person",
+      color: "#E85D24",
+    }, false)).toBe("#E85D24");
+  });
+
+  it("uses theme-aware vault colors for vault document nodes", () => {
+    expect(resolveGraphNodeDisplayColor({
+      docType: "document",
+      entityType: "document",
+      color: "#8b5cf6",
+    }, false)).toBe("#0891b2");
+  });
+});

--- a/ui/web/src/components/graph/sigma-graph-container.tsx
+++ b/ui/web/src/components/graph/sigma-graph-container.tsx
@@ -8,7 +8,7 @@ import noverlap from "graphology-layout-noverlap";
 import type Graph from "graphology";
 import { useUiStore } from "@/stores/use-ui-store";
 import { SIGMA_SETTINGS, getFA2WorkerSettings, ZOOM_TIERS, TIER_MIN_DEGREE, TIER_EDGE_DEGREE } from "./graph-utils";
-import { getVaultNodeColor } from "@/adapters/vault-graph-adapter";
+import { resolveGraphNodeDisplayColor } from "./graph-node-colors";
 
 export type EdgeType = "curvedArrow" | "arrow";
 
@@ -281,7 +281,7 @@ export function SigmaGraphContainer({
 
     sigma.setSetting("nodeReducer", (node, data) => {
       const docType = getNodeType(data);
-      const themedColor = getVaultNodeColor(docType, isDark);
+      const themedColor = resolveGraphNodeDisplayColor(data, isDark);
       const themedData = { ...data, color: themedColor };
 
       // Filter: hide nodes of hidden types


### PR DESCRIPTION
## Summary
- Preserve adapter-assigned colors for Knowledge Graph entity nodes in the shared Sigma graph renderer.
- Keep Vault document nodes using the existing theme-aware Vault color mapping.
- Add regression coverage for KG node colors and Vault node color behavior.

## Related issues
- None found for `knowledge graph color`.

## Test plan
- [x] `cd ui/web && pnpm test -- src/components/graph/sigma-graph-container.test.ts`
- [x] `cd ui/web && pnpm build`