### PR TITLE
fix(memory): guide recency recall tool calls

### DIFF
--- a/cmd/gateway_builtin_tools_test.go
+++ b/cmd/gateway_builtin_tools_test.go
@@ -19,6 +19,46 @@ func TestBuiltinToolSeedDataIncludesWait(t *testing.T) {
 	t.Fatal("builtinToolSeedData() missing wait")
 }
 
+func TestBuiltinToolSeedDataIncludesMemoryExpand(t *testing.T) {
+	t.Parallel()
+	for _, def := range builtinToolSeedData() {
+		if def.Name != "memory_expand" {
+			continue
+		}
+		if def.Category != "memory" {
+			t.Fatalf("memory_expand category = %q, want memory", def.Category)
+		}
+		if !def.Enabled {
+			t.Fatal("memory_expand should be enabled by default")
+		}
+		if len(def.Requires) != 1 || def.Requires[0] != "memory" {
+			t.Fatalf("memory_expand requires = %#v, want [memory]", def.Requires)
+		}
+		return
+	}
+	t.Fatal("builtinToolSeedData() missing memory_expand")
+}
+
+func TestBuiltinToolSeedDataMemoryCategoryIncludesRecallTools(t *testing.T) {
+	t.Parallel()
+	got := map[string]bool{}
+	for _, def := range builtinToolSeedData() {
+		if def.Category == "memory" {
+			got[def.Name] = true
+		}
+	}
+	for _, want := range []string{
+		"memory_search",
+		"memory_get",
+		"memory_expand",
+		"knowledge_graph_search",
+	} {
+		if !got[want] {
+			t.Fatalf("memory category missing %s; got %#v", want, got)
+		}
+	}
+}
+
 func TestBuiltinToolSeedDataDoesNotIncludeTelegramManager(t *testing.T) {
 	t.Parallel()
 	for _, def := range builtinToolSeedData() {

--- a/docs/03-tools-system.md
+++ b/docs/03-tools-system.md
@@ -362,7 +362,7 @@ flowchart TD
 | `fs` | `read_file`, `write_file`, `list_files`, `edit`, `send_file` |
 | `runtime` | `exec` |
 | `web` | `web_search`, `web_fetch` |
-| `memory` | `memory_search`, `memory_get` |
+| `memory` | `memory_search`, `memory_get`, `memory_expand`, `knowledge_graph_search` |
 | `sessions` | `sessions_list`, `sessions_history`, `sessions_send`, `spawn`, `session_status` |
 | `automation` | `cron` |
 | `messaging` | `message`, `create_forum_topic`, `list_group_members` |

--- a/internal/agent/systemprompt.go
+++ b/internal/agent/systemprompt.go
@@ -186,7 +186,7 @@ var coreToolSummaries = map[string]string{
 	"send_file":              "Send an EXISTING workspace file as a chat attachment — use to resend/share files; does NOT create or modify the file (use write_file for that)",
 	"list_files":             "List directory contents",
 	"exec":                   "Run shell commands",
-	"memory_search":          "Search indexed memory files (MEMORY.md + memory/*.md)",
+	"memory_search":          "Search memory docs + episodic memory; time filters for dates/recency",
 	"memory_get":             "Read specific sections of memory files",
 	"spawn":                  "Spawn a self-clone subagent to handle a task in the background",
 	"web_search":             "Search the web",

--- a/internal/agent/systemprompt_mode_test.go
+++ b/internal/agent/systemprompt_mode_test.go
@@ -51,6 +51,22 @@ func TestFullModeToolCallStyleGuidesNaturalProgress(t *testing.T) {
 	}
 }
 
+func TestFullModeMemoryRecallGuidesRecencyFilters(t *testing.T) {
+	prompt := BuildSystemPrompt(fullTestConfig())
+	for _, want := range []string{
+		"recency/date questions",
+		"query:\"*\"",
+		"createdAfter/createdBefore",
+		"timeRange",
+		"Do not put date words or guessed topics into query",
+		"second semantic search",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("full mode memory recall missing %q", want)
+		}
+	}
+}
+
 // --- Minimal mode tests ---
 
 func TestMinimalModeExclusions(t *testing.T) {
@@ -135,6 +151,22 @@ func TestTaskModeMemorySlim(t *testing.T) {
 	// Should NOT have verbose memory recall section
 	if strings.Contains(prompt, "## Memory Recall") {
 		t.Error("task mode should not have verbose Memory Recall section")
+	}
+}
+
+func TestTaskModeMemorySlimGuidesRecencyFilters(t *testing.T) {
+	cfg := fullTestConfig()
+	cfg.Mode = PromptTask
+	prompt := BuildSystemPrompt(cfg)
+	for _, want := range []string{
+		"query:\"*\"",
+		"createdAfter/createdBefore",
+		"timeRange",
+		"do not put date words into query",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("task mode memory instruction missing %q", want)
+		}
 	}
 }
 

--- a/internal/agent/systemprompt_sections.go
+++ b/internal/agent/systemprompt_sections.go
@@ -165,7 +165,7 @@ func buildSafetySlimSection() []string {
 
 // buildMemoryRecallSlimSection generates a concise memory instruction for task mode.
 func buildMemoryRecallSlimSection(hasMemoryExpand bool) []string {
-	line := "Before answering about prior work/decisions: call memory_search."
+	line := "Before answering about prior work/decisions: call memory_search. For today/yesterday/last 24h style questions, use query:\"*\" with createdAfter/createdBefore or timeRange; do not put date words into query."
 	if hasMemoryExpand {
 		line += " Use memory_expand(id) for full session details from episodic results."
 	}
@@ -176,7 +176,7 @@ func buildMemoryRecallSlimSection(hasMemoryExpand bool) []string {
 // buildMemoryRecallMinimalSection generates a 1-line memory instruction for minimal mode.
 func buildMemoryRecallMinimalSection() []string {
 	return []string{
-		"If you need context from past sessions: call memory_search.",
+		"If you need context from past sessions: call memory_search; for recency/date questions use query:\"*\" with time filters.",
 		"",
 	}
 }
@@ -353,6 +353,10 @@ func buildMemoryRecallSection(hasMemoryGet, hasMemoryExpand, hasKG bool) []strin
 				"call memory_search with a relevant query and answer from the matching results. "+
 				"If no relevant results found, say so naturally without mentioning tool names.")
 	}
+	lines = append(lines,
+		"For recency/date questions (today, yesterday, last 24h, this week, \"hom nay\", \"hom qua\", \"24h gan nhat\"), "+
+			"compute the time window and call memory_search with query:\"*\" plus createdAfter/createdBefore or timeRange. "+
+			"Do not put date words or guessed topics into query. First retrieve the broad time window, then run a second semantic search only if the user asks for a narrower topic.")
 
 	if hasMemoryExpand {
 		lines = append(lines,

--- a/internal/tools/memory.go
+++ b/internal/tools/memory.go
@@ -49,7 +49,7 @@ func (t *MemorySearchTool) SetHasKG(has bool) {
 func (t *MemorySearchTool) Name() string { return "memory_search" }
 
 func (t *MemorySearchTool) Description() string {
-	return "Mandatory recall step: semantically search MEMORY.md + memory/*.md before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user. IMPORTANT: Always query in the SAME language as the stored memory content. If the user speaks Vietnamese, search in Vietnamese. If memory was written in English, search in English. Matching the language dramatically improves search accuracy. If no relevant results found or confidence is low, tell the user you checked but found nothing — do not fabricate or guess memories."
+	return "Mandatory recall step: search memory documents and episodic memory before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. For recency/date questions such as today, yesterday, last 24h, this week, \"hom nay\", \"hom qua\", or \"24h gan nhat\": do NOT put date words or guessed topics into query. Use query=\"*\" with createdAfter/createdBefore for calendar windows, or query=\"*\" with timeRange for relative windows; then run a second semantic search only if the user asks for a narrower topic. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user. IMPORTANT: Always query in the SAME language as the stored memory content. If the user speaks Vietnamese, search in Vietnamese. If memory was written in English, search in English. Matching the language dramatically improves search accuracy. If no relevant results found or confidence is low, tell the user you checked but found nothing — do not fabricate or guess memories."
 }
 
 func (t *MemorySearchTool) Parameters() map[string]any {
@@ -58,7 +58,7 @@ func (t *MemorySearchTool) Parameters() map[string]any {
 		"properties": map[string]any{
 			"query": map[string]any{
 				"type":        "string",
-				"description": "Natural language search query. Must be in the same language as the stored memory content (e.g., Vietnamese if memory is in Vietnamese).",
+				"description": "Natural language search query. Must be in the same language as the stored memory content. Use query=\"*\" with timeRange or createdAfter/createdBefore to list episodic memories for a time window; do not put date words such as today/yesterday/hom qua into query.",
 			},
 			"maxResults": map[string]any{
 				"type":        "number",
@@ -75,15 +75,15 @@ func (t *MemorySearchTool) Parameters() map[string]any {
 			},
 			"timeRange": map[string]any{
 				"type":        "string",
-				"description": "Optional episodic-only relative created_at filter such as 24h, 7d, or 2w. Use query='*' with timeRange to list recent episodic memories.",
+				"description": "Optional episodic-only relative created_at filter such as 24h, 7d, or 2w. Use query=\"*\" with timeRange for relative recency requests like last 24h or recent memories. For calendar windows like yesterday/today, prefer createdAfter and createdBefore.",
 			},
 			"createdAfter": map[string]any{
 				"type":        "string",
-				"description": "Optional episodic-only created_at lower bound as an RFC3339 timestamp.",
+				"description": "Optional episodic-only created_at lower bound as an RFC3339 timestamp. Use with query=\"*\" and createdBefore for explicit calendar windows such as yesterday, today, or a named date range.",
 			},
 			"createdBefore": map[string]any{
 				"type":        "string",
-				"description": "Optional episodic-only created_at upper bound as an RFC3339 timestamp.",
+				"description": "Optional episodic-only created_at upper bound as an RFC3339 timestamp. Use with query=\"*\" and createdAfter for explicit calendar windows such as yesterday, today, or a named date range.",
 			},
 			"includeExpired": map[string]any{
 				"type":        "boolean",

--- a/internal/tools/memory_search_topics_test.go
+++ b/internal/tools/memory_search_topics_test.go
@@ -31,6 +31,45 @@ type memorySearchFakeEpisodicStore struct {
 	opts    store.EpisodicSearchOptions
 }
 
+func TestMemorySearchDescriptionGuidesRecencyFilters(t *testing.T) {
+	tool := NewMemorySearchTool()
+	desc := tool.Description()
+	for _, want := range []string{
+		"recency/date questions",
+		"query=\"*\"",
+		"createdAfter/createdBefore",
+		"timeRange",
+		"do NOT put date words",
+		"second semantic search",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("description missing %q:\n%s", want, desc)
+		}
+	}
+
+	props, ok := tool.Parameters()["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("tool parameters missing properties")
+	}
+	for name, wants := range map[string][]string{
+		"query":         {"query=\"*\"", "createdAfter/createdBefore", "do not put date words"},
+		"timeRange":     {"query=\"*\"", "relative recency requests", "createdAfter and createdBefore"},
+		"createdAfter":  {"query=\"*\"", "calendar windows"},
+		"createdBefore": {"query=\"*\"", "calendar windows"},
+	} {
+		param, ok := props[name].(map[string]any)
+		if !ok {
+			t.Fatalf("parameter %q missing", name)
+		}
+		got, _ := param["description"].(string)
+		for _, want := range wants {
+			if !strings.Contains(got, want) {
+				t.Fatalf("%s description missing %q:\n%s", name, want, got)
+			}
+		}
+	}
+}
+
 func (f *memorySearchFakeEpisodicStore) Search(_ context.Context, query string, _ string, _ string, opts store.EpisodicSearchOptions) ([]store.EpisodicSearchResult, error) {
 	f.query = query
 	f.opts = opts

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -13,7 +13,7 @@ import (
 // builtinToolGroups is const-like seed data for per-Registry tool groups.
 // Do NOT modify at runtime — each Registry gets a deep copy in NewRegistry().
 var builtinToolGroups = map[string][]string{
-	"memory":     {"memory_search", "memory_get"},
+	"memory":     {"memory_search", "memory_get", "memory_expand", "knowledge_graph_search"},
 	"web":        {"web_search", "web_fetch"},
 	"fs":         {"read_file", "write_file", "list_files", "edit"},
 	"runtime":    {"exec", "wait"},

--- a/internal/tools/policy_race_test.go
+++ b/internal/tools/policy_race_test.go
@@ -152,6 +152,15 @@ func TestToolGroups_BuiltinGroups_Seeded(t *testing.T) {
 	if !containsTool(memory, "memory_search") {
 		t.Errorf("memory group should contain memory_search, got: %v", memory)
 	}
+	if !containsTool(memory, "memory_get") {
+		t.Errorf("memory group should contain memory_get, got: %v", memory)
+	}
+	if !containsTool(memory, "memory_expand") {
+		t.Errorf("memory group should contain memory_expand, got: %v", memory)
+	}
+	if !containsTool(memory, "knowledge_graph_search") {
+		t.Errorf("memory group should contain knowledge_graph_search, got: %v", memory)
+	}
 
 	web, ok := reg.GetToolGroup("web")
 	if !ok {

--- a/ui/web/src/i18n/locales/en/tools.json
+++ b/ui/web/src/i18n/locales/en/tools.json
@@ -96,6 +96,7 @@
       "runtime": "Runtime",
       "web": "Web",
       "memory": "Memory",
+      "vault": "Vault",
       "media": "Media",
       "browser": "Browser",
       "sessions": "Sessions",

--- a/ui/web/src/i18n/locales/ko/tools.json
+++ b/ui/web/src/i18n/locales/ko/tools.json
@@ -92,6 +92,7 @@
       "runtime": "런타임",
       "web": "웹",
       "memory": "메모리",
+      "vault": "지식 저장소",
       "media": "미디어",
       "browser": "브라우저",
       "sessions": "세션",

--- a/ui/web/src/i18n/locales/vi/tools.json
+++ b/ui/web/src/i18n/locales/vi/tools.json
@@ -96,6 +96,7 @@
       "runtime": "Thời gian chạy",
       "web": "Web",
       "memory": "Bộ nhớ",
+      "vault": "Kho tri thức",
       "media": "Phương tiện",
       "browser": "Trình duyệt",
       "sessions": "Session",

--- a/ui/web/src/i18n/locales/zh/tools.json
+++ b/ui/web/src/i18n/locales/zh/tools.json
@@ -6,6 +6,7 @@
       "filesystem": "文件系统",
       "media": "媒体",
       "memory": "内存",
+      "vault": "知识库",
       "messaging": "消息",
       "runtime": "运行时",
       "scheduling": "调度",

--- a/ui/web/src/pages/builtin-tools/builtin-tools-page.tsx
+++ b/ui/web/src/pages/builtin-tools/builtin-tools-page.tsx
@@ -15,7 +15,7 @@ import { useTenants } from "@/hooks/use-tenants";
 import { CategoryGroup } from "./builtin-tool-category-group";
 
 const CATEGORY_ORDER = [
-  "filesystem", "runtime", "web", "memory", "media", "browser",
+  "filesystem", "runtime", "web", "memory", "vault", "media", "browser",
   "sessions", "messaging", "scheduling", "subagents", "skills", "delegation", "teams",
 ];
 
@@ -204,4 +204,3 @@ export function BuiltinToolsPage() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- Updates `memory_search` guidance so recency/date questions use structured episodic time filters instead of date words in the semantic query.
- Teaches full, task, and minimal system prompts to call `memory_search` with `query:"*"` plus `createdAfter`/`createdBefore` or `timeRange` for windows such as today, yesterday, or last 24h.
- Refreshes the core tool summary to describe episodic search and date-filter usage.
- Aligns the built-in `group:memory` policy group with the Memory category shown in `/builtin-tools`: `memory_search`, `memory_get`, `memory_expand`, and `knowledge_graph_search`.
- Adds Vault category ordering and labels on `/builtin-tools` so `vault_search` and `vault_read` appear as a named Vault group when seeded.
- Adds regression coverage for tool schema descriptions, generated agent prompts, built-in tool seed data, and built-in memory policy groups.

## Why
Agents were treating date-bounded recall requests as ordinary semantic search, which can miss passive episodic memories and over-constrain results with guessed topics. The intended flow is broad time-window recall first, followed by a narrower semantic search only when the user asks for a specific topic.

The built-in tool catalog also had a mismatch between the UI category and policy groups: the Memory category includes episodic and knowledge-graph recall tools, while `group:memory` previously expanded to only the document memory tools. This keeps the policy group, backend seed expectations, docs, and `/builtin-tools` grouping consistent.

## Built-in tools visibility check
- Backend seed catalog currently defines 46 built-in tools.
- `/builtin-tools` intentionally hides only `tts`, because TTS has a dedicated `/tts` configuration surface.
- All seeded categories are represented in the UI category order, including `vault`.
- Expected visible count on `/builtin-tools`: 45 seeded tools, plus `tts` available through `/tts`.

## Test plan
- [x] `go test ./cmd`
- [x] `go test ./internal/tools`
- [x] `go test ./internal/agent`
- [x] `go build ./...`
- [x] `go build -tags sqliteonly ./...`
- [x] `go vet ./...`
- [x] `cd ui/web && pnpm install --frozen-lockfile`
- [x] `cd ui/web && pnpm build`

## Surface parity
- Gateway/tooling: updated `memory_search` tool description and parameter guidance; aligned built-in memory policy group.
- Agent runtime: updated system prompt memory-recall guidance across full/task/minimal modes.
- API contract: no request/response shape changes; built-in tool seed metadata and policy grouping only.
- Web UI: added Vault category ordering and i18n labels for `/builtin-tools`.
- CLI/runtime package: N/A because no CLI command or runtime package surface changes.
