### PR TITLE
feat(providers): add GPT-5.6 Codex models

### DIFF
--- a/internal/http/provider_models_catalog.go
+++ b/internal/http/provider_models_catalog.go
@@ -119,6 +119,8 @@ func acpModels() []ModelInfo {
 // chatGPTOAuthModels returns models available via ChatGPT OAuth integration.
 func chatGPTOAuthModels() []ModelInfo {
 	return withReasoningCapabilities([]ModelInfo{
+		{ID: "gpt-5.6-sol", Name: "GPT-5.6 Sol"},
+		{ID: "gpt-5.6-terra", Name: "GPT-5.6 Terra"},
 		{ID: providers.DefaultCodexModel, Name: "GPT-5.5"},
 		{ID: "gpt-5.4", Name: "GPT-5.4"},
 		{ID: "gpt-5.4-mini", Name: "GPT-5.4 Mini"},

--- a/internal/http/provider_models_test.go
+++ b/internal/http/provider_models_test.go
@@ -112,24 +112,32 @@ func TestProvidersHandlerListProviderModelsChatGPTOAuthIncludesReasoningMetadata
 		t.Fatalf("reasoning_defaults.effort = %q, want high", result.ReasoningDefaults.Effort)
 	}
 
-	var found bool
-	for _, model := range result.Models {
-		if model.ID != "gpt-5.5" {
-			continue
+	assertModelIDsInOrder(t, result.Models, []string{
+		"gpt-5.6-sol",
+		"gpt-5.6-terra",
+		"gpt-5.5",
+	})
+
+	for _, wantID := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5"} {
+		var found bool
+		for _, model := range result.Models {
+			if model.ID != wantID {
+				continue
+			}
+			found = true
+			if model.Reasoning == nil {
+				t.Fatalf("%s reasoning = nil, want capability metadata", wantID)
+			}
+			if model.Reasoning.DefaultEffort != "medium" {
+				t.Fatalf("%s default_effort = %q, want medium", wantID, model.Reasoning.DefaultEffort)
+			}
+			if got := model.Reasoning.Levels; len(got) != 5 || got[4] != "xhigh" {
+				t.Fatalf("%s levels = %#v, want none..xhigh", wantID, got)
+			}
 		}
-		found = true
-		if model.Reasoning == nil {
-			t.Fatal("gpt-5.5 reasoning = nil, want capability metadata")
+		if !found {
+			t.Fatalf("%s not found in ChatGPT OAuth model list", wantID)
 		}
-		if model.Reasoning.DefaultEffort != "medium" {
-			t.Fatalf("gpt-5.5 default_effort = %q, want medium", model.Reasoning.DefaultEffort)
-		}
-		if got := model.Reasoning.Levels; len(got) != 5 || got[4] != "xhigh" {
-			t.Fatalf("gpt-5.5 levels = %#v, want none..xhigh", got)
-		}
-	}
-	if !found {
-		t.Fatal("gpt-5.5 not found in ChatGPT OAuth model list")
 	}
 }
 

--- a/internal/providers/model_registry.go
+++ b/internal/providers/model_registry.go
@@ -154,6 +154,8 @@ func SeedDefaultModels(r *InMemoryRegistry) {
 
 	// OpenAI models
 	for _, s := range []ModelSpec{
+		{ID: "gpt-5.6-sol", Provider: "openai", ContextWindow: 1_050_000, MaxTokens: 128_000, Reasoning: true, Vision: true, TokenizerID: "o200k_base"},
+		{ID: "gpt-5.6-terra", Provider: "openai", ContextWindow: 1_050_000, MaxTokens: 128_000, Reasoning: true, Vision: true, TokenizerID: "o200k_base"},
 		{ID: "gpt-5.5", Provider: "openai", ContextWindow: 1_050_000, MaxTokens: 128_000, Reasoning: true, Vision: true, TokenizerID: "o200k_base"},
 		{ID: "gpt-5.4", Provider: "openai", ContextWindow: 1_000_000, MaxTokens: 100_000, Reasoning: true, Vision: true, TokenizerID: "o200k_base"},
 		{ID: "gpt-5.2", Provider: "openai", ContextWindow: 256_000, MaxTokens: 64_000, Reasoning: true, Vision: true, TokenizerID: "o200k_base"},

--- a/internal/providers/reasoning_capability.go
+++ b/internal/providers/reasoning_capability.go
@@ -25,6 +25,8 @@ type reasoningCapabilityEntry struct {
 }
 
 var reasoningCapabilityEntries = []reasoningCapabilityEntry{
+	{id: "gpt-5.6-sol", capability: ReasoningCapability{Levels: []string{"none", "low", "medium", "high", "xhigh"}, DefaultEffort: "medium"}},
+	{id: "gpt-5.6-terra", capability: ReasoningCapability{Levels: []string{"none", "low", "medium", "high", "xhigh"}, DefaultEffort: "medium"}},
 	{id: "gpt-5.5", capability: ReasoningCapability{Levels: []string{"none", "low", "medium", "high", "xhigh"}, DefaultEffort: "medium"}},
 	{id: "gpt-5.4-mini", capability: ReasoningCapability{Levels: []string{"none", "low", "medium", "high", "xhigh"}, DefaultEffort: "none"}},
 	{id: "gpt-5-mini", capability: ReasoningCapability{Levels: []string{"none", "low", "medium", "high", "xhigh"}, DefaultEffort: "none"}},


### PR DESCRIPTION
## Summary
- add `gpt-5.6-sol` and `gpt-5.6-terra` to the ChatGPT OAuth/Codex model catalog
- seed both models in the OpenAI model registry
- attach reasoning capability metadata for both models
- update the ChatGPT OAuth model list test to cover the new entries

## Validation
- Verified against two ChatGPT OAuth providers with `goclaw providers verify --model`:
  - `gpt-5.6-sol`: OK
  - `gpt-5.6-terra`: OK
  - `gpt-5.6`: rejected as `Model not recognized by provider`
  - `gpt-5.6-luna`: rejected as `Model not found gpt-5.6-luna`
- `go test ./internal/providers ./internal/http -run 'TestProvidersHandlerListProviderModelsChatGPTOAuthIncludesReasoningMetadata|TestProvidersHandlerListProviderModelsOpenAICompatAnnotatesKnownModels|TestReasoning|TestModelRegistry'`

## Notes
`gpt-5.6-luna` is intentionally not added because live verification did not accept it.
