### PR TITLE
fix(pipeline): aggregate cache tokens across agent turns

### DIFF
--- a/internal/pipeline/think_stage.go
+++ b/internal/pipeline/think_stage.go
@@ -81,12 +81,20 @@ func (s *ThinkStage) Execute(ctx context.Context, state *RunState) error {
 		return fmt.Errorf("llm call: %w", err)
 	}
 
-	// 5. Accumulate usage (including ThinkingTokens for reasoning models)
+	// 5. Accumulate usage across turns: base tokens, ThinkingTokens for reasoning
+	// models, and cache tokens. Cache read/creation must be summed too — otherwise
+	// the aggregated RunResult.Usage (and thus webhook usage + usage_events) reports
+	// zero cache even when each turn hit the prompt cache heavily.
 	if resp.Usage != nil {
 		state.Think.TotalUsage.PromptTokens += resp.Usage.PromptTokens
 		state.Think.TotalUsage.CompletionTokens += resp.Usage.CompletionTokens
 		state.Think.TotalUsage.TotalTokens += resp.Usage.TotalTokens
 		state.Think.TotalUsage.ThinkingTokens += resp.Usage.ThinkingTokens
+		state.Think.TotalUsage.CacheReadTokens += resp.Usage.CacheReadTokens
+		state.Think.TotalUsage.CacheCreationTokens += resp.Usage.CacheCreationTokens
+		if resp.Usage.PromptTokensIncludeCachedSegments {
+			state.Think.TotalUsage.PromptTokensIncludeCachedSegments = true
+		}
 	}
 
 	if isEmptyLengthResponse(resp) {

--- a/internal/pipeline/think_stage_usage_cache_test.go
+++ b/internal/pipeline/think_stage_usage_cache_test.go
@@ -1,0 +1,58 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+)
+
+// TestThinkStage_AccumulatesCacheTokens guards the pipeline aggregation of cache
+// tokens across turns. Regression: async agent runs reported 0 cache tokens in
+// webhook usage / usage_events despite traces showing heavy cache use, because
+// ThinkStage summed only prompt/completion/total/thinking and dropped the cache
+// fields when folding each turn's usage into state.Think.TotalUsage.
+func TestThinkStage_AccumulatesCacheTokens(t *testing.T) {
+	t.Parallel()
+	deps := &PipelineDeps{
+		Config: PipelineConfig{MaxIterations: 10, MaxTokens: 1000},
+		CallLLM: func(_ context.Context, _ *RunState, _ providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{
+				FinishReason: "stop",
+				Content:      "done",
+				Usage: &providers.Usage{
+					PromptTokens:                      100,
+					CompletionTokens:                  20,
+					TotalTokens:                       120,
+					CacheReadTokens:                   80,
+					CacheCreationTokens:               10,
+					PromptTokensIncludeCachedSegments: true,
+				},
+			}, nil
+		},
+	}
+	stage := NewThinkStage(deps)
+	state := defaultState()
+
+	// Two iterations to prove accumulation (+=), not assignment.
+	if err := stage.Execute(context.Background(), state); err != nil {
+		t.Fatalf("Execute() 1: %v", err)
+	}
+	if err := stage.Execute(context.Background(), state); err != nil {
+		t.Fatalf("Execute() 2: %v", err)
+	}
+
+	u := state.Think.TotalUsage
+	if u.CacheReadTokens != 160 {
+		t.Errorf("CacheReadTokens = %d, want 160", u.CacheReadTokens)
+	}
+	if u.CacheCreationTokens != 20 {
+		t.Errorf("CacheCreationTokens = %d, want 20", u.CacheCreationTokens)
+	}
+	if !u.PromptTokensIncludeCachedSegments {
+		t.Error("PromptTokensIncludeCachedSegments = false, want true")
+	}
+	if u.PromptTokens != 200 || u.CompletionTokens != 40 {
+		t.Errorf("base tokens = %d/%d, want 200/40", u.PromptTokens, u.CompletionTokens)
+	}
+}


### PR DESCRIPTION
## Summary
Async multi-turn agent runs reported **0 cache tokens** in webhook `usage` responses and in `usage_events` analytics, even when the run heavily used prompt caching (the trace for the same run showed hundreds of thousands of cached tokens). Root cause: the v3 pipeline folded each LLM turn's usage into `state.Think.TotalUsage` but summed only `PromptTokens`/`CompletionTokens`/`TotalTokens`/`ThinkingTokens`, dropping `CacheReadTokens`, `CacheCreationTokens`, and the `PromptTokensIncludeCachedSegments` flag. Since `RunResult.Usage` is that aggregate, every downstream consumer saw zero cache. (Traces looked correct because they read per-response usage per span, never the aggregate.)

This sums the cache read/creation tokens across turns and OR's the include-cached flag. Complements PR #1345 (which surfaces cache fields in the webhook envelope) — that change was correct but received an aggregate that had already zeroed the cache fields upstream.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
`dev` — bug fix.

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes
- [x] `go vet ./...` passes — for the changed package (`internal/pipeline`); repo-wide `go vet ./...` has a pre-existing failure in `internal/tools/document_parser_test.go` unrelated to this change
- [ ] Tests pass: `go test -race ./...` — `-race` not runnable locally (no CGO/gcc on the Windows dev box); CI runs it on Linux. `go test ./internal/pipeline/` passes.
- [ ] Web UI builds — N/A, no UI changes
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` — N/A, no SQL
- [ ] New user-facing strings added to all 3 locales — N/A
- [ ] Migration version bumped — N/A, no schema change (restores correct data into existing fields)

**Surface parity:** server-only. Web UI / Desktop / CLI N/A — no surface constructs pipeline usage. Migration N/A — no schema change. No API envelope change; this restores correct cache values into the webhook `usage` fields and `usage_events` columns that already exist.

## Test Plan
- New regression test `TestThinkStage_AccumulatesCacheTokens` (`internal/pipeline/think_stage_usage_cache_test.go`): drives `ThinkStage.Execute` twice with a mock `CallLLM` returning cache usage, asserting the aggregate accumulates `cache_read=160` (80×2), `cache_creation=20` (10×2), `include_cached=true`, and that base tokens still sum to 200/40 — proving `+=` accumulation across turns, not single assignment. Confirmed RED without the fix (all three cache assertions fail at 0/0/false), GREEN with it.
- `go build ./...` + `go build -tags sqliteonly ./...` + `go test ./internal/pipeline/` all green.
- Verified `think_stage.go` is the sole per-turn usage aggregation site feeding `RunResult.Usage` (via `run_state.go` → `loop_pipeline_adapter.go`), so the fix is complete, not partial.
