### PR TITLE
fix: honor model override for sync subagents

### DIFF
--- a/internal/tools/subagent_spawn.go
+++ b/internal/tools/subagent_spawn.go
@@ -127,7 +127,7 @@ func (sm *SubagentManager) RunSync(
 	ctx context.Context,
 	parentID string,
 	depth int,
-	task, label string,
+	task, label, modelOverride string,
 	channel, chatID string,
 ) (string, int, error) {
 	cfg := sm.effectiveConfig(ctx)
@@ -160,6 +160,7 @@ func (sm *SubagentManager) RunSync(
 		Label:            label,
 		Status:           "running",
 		Depth:            depth + 1,
+		Model:            modelOverride,
 		OriginChannel:    channel,
 		OriginChatID:     chatID,
 		OriginLocalKey:   ToolLocalKeyFromCtx(ctx),

--- a/internal/tools/subagent_spawn_test.go
+++ b/internal/tools/subagent_spawn_test.go
@@ -1,0 +1,48 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+type recordingSubagentProvider struct {
+	model string
+}
+
+func (p *recordingSubagentProvider) Name() string         { return "recording" }
+func (p *recordingSubagentProvider) DefaultModel() string { return "provider-default" }
+func (p *recordingSubagentProvider) Chat(_ context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+	p.model = req.Model
+	return &providers.ChatResponse{Content: "done", FinishReason: "stop"}, nil
+}
+func (p *recordingSubagentProvider) ChatStream(ctx context.Context, req providers.ChatRequest, _ func(providers.StreamChunk)) (*providers.ChatResponse, error) {
+	return p.Chat(ctx, req)
+}
+
+func TestRunSyncHonorsPerTaskModelOverride(t *testing.T) {
+	provider := &recordingSubagentProvider{}
+	manager := NewSubagentManager(provider, nil, "manager-default", nil, NewRegistry, SubagentConfig{
+		MaxConcurrent:       4,
+		MaxSpawnDepth:       3,
+		MaxChildrenPerAgent: 8,
+		Model:               "configured-model",
+	})
+
+	ctx := store.WithTenantID(context.Background(), uuid.New())
+	ctx = WithParentModel(ctx, "parent-model")
+
+	result, _, err := manager.RunSync(ctx, "parent", 0, "test task", "test", "requested-model", "test", "chat")
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+	if result != "done" {
+		t.Fatalf("RunSync() result = %q, want %q", result, "done")
+	}
+	if provider.model != "requested-model" {
+		t.Fatalf("provider model = %q, want per-task override %q", provider.model, "requested-model")
+	}
+}

--- a/internal/tools/subagent_spawn_tool.go
+++ b/internal/tools/subagent_spawn_tool.go
@@ -153,6 +153,7 @@ After all spawn tool calls in this turn are complete, briefly tell the user what
 // executeSubagentSync runs a sync self-clone.
 func (t *SpawnTool) executeSubagentSync(ctx context.Context, args map[string]any, task string) *Result {
 	label, _ := args["label"].(string)
+	modelOverride, _ := args["model"].(string)
 	if label == "" {
 		label = truncate(task, 50)
 	}
@@ -165,7 +166,7 @@ func (t *SpawnTool) executeSubagentSync(ctx context.Context, args map[string]any
 		parentID = t.parentID
 	}
 
-	result, iterations, err := t.subagentMgr.RunSync(ctx, parentID, t.depth, task, label,
+	result, iterations, err := t.subagentMgr.RunSync(ctx, parentID, t.depth, task, label, modelOverride,
 		channel, chatID)
 	if err != nil {
 		return ErrorResult(fmt.Sprintf("Subagent '%s' failed: %v", label, err))


### PR DESCRIPTION
## Summary
Fix synchronous `spawn` calls silently ignoring their per-task `model` override. The sync path now passes the requested model into `SubagentTask`, matching the existing async behavior and preserving the documented model precedence.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
`dev`

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [x] New user-facing strings added to all 3 locales (en/vi/zh)
- [x] Migration version bumped in `internal/upgrade/version.go` (if new migration)

The focused regression test passes with the race detector. A full `go test -race ./...` run was also allowed to complete; it failed in pre-existing long-running tests outside this change: `internal/hooks/handlers` exceeded 11 minutes, and `internal/providers` timed out after 10 minutes in `TestOpenAIEmbedding_BatchSplitting`. The changed `internal/tools` package passed.

## Test Plan
- `go build ./...`
- `go build -tags sqliteonly ./...`
- `go vet ./...`
- `go test ./internal/tools -run TestRunSyncHonorsPerTaskModelOverride -count=1`
- `go test -race ./internal/tools -run TestRunSyncHonorsPerTaskModelOverride -count=1`
- `go test -race ./...` — completed with unrelated timeouts in `internal/hooks/handlers` and `internal/providers`; `internal/tools` passed
- Added `TestRunSyncHonorsPerTaskModelOverride`, which configures conflicting manager, parent, and subagent-config models and verifies that the explicit per-task model reaches the provider.
