### PR TITLE
fix: persist explicit None TTS provider instead of dropping it

### DIFF
--- a/internal/http/tts_config.go
+++ b/internal/http/tts_config.go
@@ -220,7 +220,7 @@ func (h *TTSConfigHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 
 // ttsConfigSaveRequest is the request body for POST /v1/tts/config.
 type ttsConfigSaveRequest struct {
-	Provider   string                  `json:"provider"`
+	Provider   *string                 `json:"provider"`
 	Auto       string                  `json:"auto"`
 	Mode       string                  `json:"mode"`
 	MaxLength  int                     `json:"max_length"`
@@ -269,7 +269,7 @@ func (h *TTSConfigHandler) handleSave(w http.ResponseWriter, r *http.Request) {
 		set := func(key, val, label string) bool {
 			return saveOrFail(w, ctx, h.systemConfigs.Set, key, val, label)
 		}
-		if req.Provider != "" && !set("tts.provider", req.Provider, "provider") {
+		if req.Provider != nil && !set("tts.provider", *req.Provider, "provider") {
 			return
 		}
 		if req.Auto != "" && !set("tts.auto", req.Auto, "auto") {
@@ -407,7 +407,11 @@ func (h *TTSConfigHandler) handleSave(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	slog.Info("tts.config: saved", "tenant", tid, "provider", req.Provider)
+	provider := ""
+	if req.Provider != nil {
+		provider = *req.Provider
+	}
+	slog.Info("tts.config: saved", "tenant", tid, "provider", provider)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }

--- a/internal/http/tts_config_test.go
+++ b/internal/http/tts_config_test.go
@@ -207,6 +207,102 @@ func TestTTSConfigSave_AcceptsLegacyAndUISchemaAliases(t *testing.T) {
 	}
 }
 
+func TestTTSConfigSave_ProviderPresenceSemantics(t *testing.T) {
+	setupTestToken(t, "")
+
+	t.Run("explicit empty provider disables TTS without clearing provider config", func(t *testing.T) {
+		sc := &validationSystemConfigStore{data: map[string]string{
+			"tts.provider":    "edge",
+			"tts.edge.voice":  "en-US-AvaMultilingualNeural",
+			"tts.edge.rate":   "+15%",
+			"tts.edge.params": `{"pitch":10,"volume":20}`,
+		}}
+		cs := &validationSecretsStore{data: map[string]string{
+			"tts.openai.api_key": "sk-existing",
+		}}
+		mux := newValidationTTSConfigMux(sc, cs)
+
+		req := httptest.NewRequest("POST", "/v1/tts/config", ttsBody(t, map[string]any{
+			"provider": "",
+			"edge": map[string]any{
+				"voice":  "",
+				"rate":   "",
+				"params": nil,
+			},
+			"openai": map[string]string{
+				"api_key": "***",
+			},
+		}))
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("save: want 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if got := sc.data["tts.provider"]; got != "" {
+			t.Fatalf("tts.provider = %q, want empty", got)
+		}
+		if got := sc.data["tts.edge.voice"]; got != "en-US-AvaMultilingualNeural" {
+			t.Errorf("tts.edge.voice = %q, want existing value preserved", got)
+		}
+		if got := sc.data["tts.edge.rate"]; got != "+15%" {
+			t.Errorf("tts.edge.rate = %q, want existing value preserved", got)
+		}
+		if got := sc.data["tts.edge.params"]; got != `{"pitch":10,"volume":20}` {
+			t.Errorf("tts.edge.params = %q, want existing value preserved", got)
+		}
+		if got := cs.data["tts.openai.api_key"]; got != "sk-existing" {
+			t.Errorf("tts.openai.api_key = %q, want existing secret preserved", got)
+		}
+
+		getReq := httptest.NewRequest("GET", "/v1/tts/config", nil)
+		getRR := httptest.NewRecorder()
+		mux.ServeHTTP(getRR, getReq)
+		if getRR.Code != http.StatusOK {
+			t.Fatalf("get: want 200, got %d: %s", getRR.Code, getRR.Body.String())
+		}
+		var response ttsConfigResponse
+		if err := json.Unmarshal(getRR.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if response.Provider != "" {
+			t.Fatalf("GET provider = %q, want empty", response.Provider)
+		}
+	})
+
+	t.Run("omitted provider leaves existing value unchanged", func(t *testing.T) {
+		sc := &validationSystemConfigStore{data: map[string]string{"tts.provider": "edge"}}
+		mux := newValidationTTSConfigMux(sc, &validationSecretsStore{data: map[string]string{}})
+
+		req := httptest.NewRequest("POST", "/v1/tts/config", strings.NewReader(`{}`))
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if got := sc.data["tts.provider"]; got != "edge" {
+			t.Fatalf("tts.provider = %q, want edge", got)
+		}
+	})
+
+	t.Run("non-empty provider still replaces existing value", func(t *testing.T) {
+		sc := &validationSystemConfigStore{data: map[string]string{"tts.provider": "edge"}}
+		mux := newValidationTTSConfigMux(sc, &validationSecretsStore{data: map[string]string{}})
+
+		req := httptest.NewRequest("POST", "/v1/tts/config", strings.NewReader(`{"provider":"openai"}`))
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if got := sc.data["tts.provider"]; got != "openai" {
+			t.Fatalf("tts.provider = %q, want openai", got)
+		}
+	})
+}
+
 func TestTTSConfigGet_RoundTripsCompatibilityFields(t *testing.T) {
 	setupTestToken(t, "")
 


### PR DESCRIPTION
## Summary
Setting the TTS provider to None (empty/explicit no-provider) now persists correctly instead of being silently dropped, so a user who disables TTS keeps that setting after save.

## Type
- [x] Bug fix

## Target Branch
Targets `dev` (default for bugfixes).

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes) — N/A, no UI change
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [x] New user-facing strings added to all 3 locales (en/vi/zh) — N/A, no new strings
- [x] Migration version bumped in `internal/upgrade/version.go` (if new migration) — N/A, no migration

## Test Plan
Reported in #1080: the TTS config update path in `internal/http/tts_config.go` guarded the provider write with `if req.Provider != ""`, so an explicit empty/None provider was never written and the previous value stuck. The field is now a `*string` pointer so an explicitly-provided empty value is distinguished from "field omitted" and persisted. Added a regression test in `internal/http/tts_config_test.go` asserting that submitting an empty provider clears the stored value, while omitting the field leaves it unchanged. `go test -race ./internal/http/...` passes.

Fixes #1080
