### PR TITLE
fix(bitrix24): normalize ws/wss scheme in public URL detection

### DIFF
--- a/internal/channels/bitrix24/public_url.go
+++ b/internal/channels/bitrix24/public_url.go
@@ -24,7 +24,10 @@ var (
 // the URL Bitrix24 will use for all subsequent event callbacks.
 //
 // Scheme resolution priority:
-//  1. X-Forwarded-Proto header (set by Cloudflare Tunnel / nginx)
+//  1. X-Forwarded-Proto header (set by Cloudflare Tunnel / nginx), normalized:
+//     "http"/"https" pass through as-is; "ws"/"wss" map to "http"/"https"
+//     (same transport, describes a WebSocket upgrade rather than a scheme
+//     change); any other value is ignored.
 //  2. r.TLS != nil → https
 //  3. Otherwise → http (honest to what we observed). If a reverse proxy is
 //     terminating TLS without forwarding the proto header, fix the proxy
@@ -40,10 +43,19 @@ var (
 // authorizing via a Tailscale URL when the public ingress is elsewhere).
 func derivePublicURL(r *http.Request) (string, error) {
 	scheme := "https"
-	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
-		scheme = strings.ToLower(proto)
-	} else if r.TLS == nil {
+	if r.TLS == nil {
 		scheme = "http"
+	}
+	if proto := strings.ToLower(strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))); proto != "" {
+		switch proto {
+		case "http", "https":
+			scheme = proto
+		case "ws":
+			scheme = "http"
+		case "wss":
+			scheme = "https"
+		}
+		// any other value is left ignored — keeps the TLS-derived default
 	}
 
 	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))

--- a/internal/channels/bitrix24/public_url_test.go
+++ b/internal/channels/bitrix24/public_url_test.go
@@ -117,6 +117,18 @@ func TestDerivePublicURL_TableDriven(t *testing.T) {
 			proto:   "https",
 			wantErr: errPublicURLEmpty,
 		},
+		{
+			name:  "websocket_upgrade_wss_normalizes_to_https",
+			host:  "goclaw.tamgiac.com",
+			proto: "wss",
+			want:  "https://goclaw.tamgiac.com",
+		},
+		{
+			name:  "websocket_upgrade_ws_normalizes_to_http",
+			host:  "goclaw.tamgiac.com",
+			proto: "ws",
+			want:  "http://goclaw.tamgiac.com",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/gateway/public_url_snapshot.go
+++ b/internal/gateway/public_url_snapshot.go
@@ -136,10 +136,19 @@ func (s *PublicURLSnapshot) Middleware(next http.Handler) http.Handler {
 // shared package just for one function.
 func derivePublicURLFromRequest(r *http.Request) string {
 	scheme := "https"
-	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
-		scheme = strings.ToLower(proto)
-	} else if r.TLS == nil {
+	if r.TLS == nil {
 		scheme = "http"
+	}
+	if proto := strings.ToLower(strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))); proto != "" {
+		switch proto {
+		case "http", "https":
+			scheme = proto
+		case "ws":
+			scheme = "http"
+		case "wss":
+			scheme = "https"
+		}
+		// any other value is left ignored — keeps the TLS-derived default
 	}
 	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
 	if host == "" {

--- a/internal/gateway/public_url_snapshot_test.go
+++ b/internal/gateway/public_url_snapshot_test.go
@@ -65,6 +65,20 @@ func TestPublicURLSnapshot_Update_FromRequest(t *testing.T) {
 			fwdProto: "https",
 			wantURL:  "https://edge1.example.com",
 		},
+		{
+			name:     "websocket_upgrade_wss_normalizes_to_https",
+			host:     "internal-lb:8080",
+			fwdHost:  "goclaw.tamgiac.com",
+			fwdProto: "wss",
+			wantURL:  "https://goclaw.tamgiac.com",
+		},
+		{
+			name:     "websocket_upgrade_ws_normalizes_to_http",
+			host:     "internal-lb:8080",
+			fwdHost:  "goclaw.tamgiac.com",
+			fwdProto: "ws",
+			wantURL:  "http://goclaw.tamgiac.com",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- The gateway's public-URL snapshot (used to build the Bitrix24 OAuth install link) trusted `X-Forwarded-Proto` verbatim. When a WebSocket upgrade request (`/ws`) passes through a proxy that sets `X-Forwarded-Proto: wss`, the snapshot got poisoned with scheme `wss://`, producing an unreachable install URL (`ERR_UNKNOWN_URL_SCHEME` in the browser).
- Same bug duplicated in `internal/channels/bitrix24/public_url.go` (used directly by the install handler to persist the portal's public URL).
- Fix: normalize `ws`/`wss` to `http`/`https` (same transport, just describes a WebSocket upgrade) instead of trusting the header value as-is; unrecognized values fall back to the TLS-derived default as before.

## Test plan
- [x] `go build ./internal/gateway/... ./internal/channels/bitrix24/...`
- [x] `go test ./internal/gateway/... ./internal/channels/bitrix24/...` — includes new `websocket_upgrade_wss_normalizes_to_https` / `websocket_upgrade_ws_normalizes_to_http` cases in both packages' existing table-driven tests
- [x] Verified live on a tose.sh deployment: Bitrix24 portal authorize link now resolves to `https://` instead of `wss://`