### PR TITLE
fix(whatsapp): add missing protobuf import breaking dev build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -218,5 +218,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/grpc v1.78.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
+	google.golang.org/protobuf v1.36.11
 )

--- a/internal/channels/whatsapp/outbound.go
+++ b/internal/channels/whatsapp/outbound.go
@@ -11,6 +11,7 @@ import (
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 )


### PR DESCRIPTION
## What changed

Adds the missing `google.golang.org/protobuf/proto` import in `internal/channels/whatsapp/outbound.go`.

## Why

` sendText ` calls ` proto.String(text) ` (added in #819) without importing the ` proto ` package, breaking ` go build ./... ` on ` dev ` since that merge. This currently fails CI on every open PR against ` dev ` (confirmed on #1425's ` go ` check and on ` dev `'s own CI run).

## Validation

- ` go build ./... ` and ` go build -tags sqliteonly ./... ` — both clean
- ` go vet ./internal/channels/whatsapp/... ` — clean
- ` go test ./internal/channels/whatsapp/... ` — pass