### PR TITLE
fix(bitrix24): make pending-portal delete button clickable in Radix Select

### DIFF
--- a/ui/web/src/pages/channels/bitrix24/bitrix-portal-select.tsx
+++ b/ui/web/src/pages/channels/bitrix24/bitrix-portal-select.tsx
@@ -150,9 +150,16 @@ export function BitrixPortalSelect({ value, onChange, onCreateRequest, onResumeA
                         type="button"
                         aria-label={t("bitrix24.portalSelect.deleteAria", { name: p.name, defaultValue: `Delete portal ${p.name}` })}
                         className="ml-auto rounded p-1 text-muted-foreground hover:text-destructive"
+                        // Trigger on pointerdown, not click: Radix Select closes
+                        // the popover on the SelectItem's own pointerdown, so
+                        // by the time click fires the item is gone. stopPropagation
+                        // keeps the parent SelectItem from selecting the pending
+                        // portal; the paired click handler stays for keyboard-
+                        // driven activation (Enter/Space on focused button).
                         onPointerDown={(e) => {
                           e.stopPropagation();
                           e.preventDefault();
+                          setPendingDeleteName(p.name);
                         }}
                         onClick={(e) => {
                           e.stopPropagation();


### PR DESCRIPTION
## Problem

The delete affordance next to each **pending** portal on the Bitrix24 channel create form is dead for mouse users. Clicking the trash icon does nothing — no confirmation dialog, no feedback. Only Delete/Backspace on a focused item works, because that path uses a different handler on the SelectItem itself.

Repro: open **Channels → + Add Channel → Bitrix24**, pick a portal with the "⚠ Pending install" badge, hover the trash icon, click. Expected the confirm-delete dialog; got nothing.

## Root cause

Two things stack:

1. Radix `Select` closes its popover on the `SelectItem`'s own `onPointerDown`. By the time the browser would synthesise a `click` on the nested button, the popover — and the button — are gone.
2. The button's `onPointerDown` explicitly called `e.preventDefault()`, which additionally suppresses `click` even when the DOM is still intact.

Net effect: `onClick` was wired to `setPendingDeleteName(p.name)`, but the handler was unreachable via mouse.

## Fix

Fire `setPendingDeleteName` from `onPointerDown` (with `stopPropagation` + `preventDefault` so the parent `SelectItem` doesn't also select the pending portal), and keep the `onClick` handler so the button stays activatable when a keyboard user focuses it and presses Enter/Space. This is the pattern Radix uses for its own nested interactive elements (see `DropdownMenu.CheckboxItem`).

```tsx
onPointerDown={(e) => {
  e.stopPropagation();
  e.preventDefault();
  setPendingDeleteName(p.name);
}}
onClick={(e) => {
  e.stopPropagation();
  e.preventDefault();
  setPendingDeleteName(p.name);
}}
```

## Verification

- `pnpm tsc --noEmit` in `ui/web` passes
- Live-tested against a local docker build on `goclaw-deploy`: clicking the trash on a `Pending install` portal now opens the "Delete pending portal" confirm dialog. Typing the portal name and pressing Delete removes it and refreshes the list.
- Keyboard path unchanged: focusing a pending item and pressing Delete/Backspace still opens the same dialog via the SelectItem's `onKeyDown`.

## Surface parity

- **Gateway server**: N/A because the change is UI-only.
- **API contract**: N/A because `bitrix.portals.delete` already exists.
- **Web UI**: the single component that owned the broken handler.
- **CLI/runtime**: N/A because no CLI reads this UI state.

[B24:2794]
