### PR TITLE
fix(bitrix24): mount shared webhook route independent of bot readiness

### DIFF
--- a/cmd/gateway_lifecycle.go
+++ b/cmd/gateway_lifecycle.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/cache"
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/bitrix24"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/edition"
 	"github.com/nextlevelbuilder/goclaw/internal/heartbeat"
@@ -257,6 +258,21 @@ func (d *gatewayDeps) runLifecycle(
 	for _, route := range d.channelMgr.WebhookHandlers() {
 		mux.Handle(route.Path, route.Handler)
 		slog.Info("webhook route mounted on gateway", "path", route.Path)
+	}
+
+	// Bitrix24: also claim+mount the shared webhook router directly, even if
+	// no channel_instances row has finished setup yet (bot_code/bot_name
+	// still empty, or the portal hasn't completed OAuth). /bitrix24/install
+	// is what completes portal OAuth — gating the route behind a
+	// fully-configured bot creates a deadlock where an admin can never
+	// finish installing the first portal on a fresh gateway. ClaimWebhookRoute
+	// is idempotent (first-claim-wins via CompareAndSwap), so this is a no-op
+	// if a bitrix24 Channel already claimed the route in the loop above.
+	if router := bitrix24.WebhookRouter(); router != nil {
+		if path, handler := router.ClaimWebhookRoute(); path != "" && handler != nil {
+			mux.Handle(path, handler)
+			slog.Info("webhook route mounted on gateway", "path", path)
+		}
 	}
 
 	tsCleanup := initTailscale(ctx, d.cfg, mux)


### PR DESCRIPTION
## What changed

Mounts the shared Bitrix24 webhook router (`/bitrix24/install`, `/bitrix24/handler`, `/bitrix24/events`) unconditionally at gateway boot, independent of whether any Bitrix24 channel instance loaded successfully.

## Why

The webhook route was only mounted when a Bitrix24 `Channel` loaded via `WebhookHandlers()`, and the channel factory requires `portal` + `bot_code` + `bot_name` to already be set (`internal/channels/bitrix24/factory.go`). Completing portal OAuth requires Bitrix to reach `/bitrix24/install`, and the admin UI won't let you select an uninstalled portal when creating a bot (`bitrix-portal-select.tsx`, shows "Pending install - click to resume" instead).

Net effect: on any fresh deployment, the first Bitrix24 portal can never finish OAuth, because the route it needs isn't mounted until a bot exists, and a bot can't be created until OAuth finishes. Every request to `/bitrix24/*` silently falls through to the SPA catch-all instead (returns the dashboard HTML, no error).

## Fix

Claim and mount `bitrix24.WebhookRouter()` directly in the boot sequence (`cmd/gateway_lifecycle.go`), right after the existing per-channel mount loop. `ClaimWebhookRoute()` is idempotent (first-claim-wins via `CompareAndSwap` on `Router.routeTaken`), so this is a no-op if a real Channel already claimed the route in the loop above - no double-registration risk.

## Validation

- `go build ./...` and `go build -tags sqliteonly ./...` - clean
- `go vet ./cmd/... ./internal/channels/bitrix24/...` - clean
- `go test ./internal/channels/bitrix24/...` - pass
- `go test ./cmd/...` - same single pre-existing failure with and without this change (`TestShellDenyGroupsConfigReload_ReplacesDBClaudeCLIProvider`, missing test fixture binary on Windows, unrelated to this diff)
- Reproduced live on a fresh TOSE deployment: boot log showed `failed to load channel instance ... requires portal, bot_code, and bot_name` followed by `no channels enabled` / `channels=[]`, and every `/bitrix24/*` request returned the dashboard SPA HTML instead of a handler response
