### PR TITLE
fix(skills): preserve custom skills during bundled seeding

### DIFF
--- a/cmd/gateway_setup.go
+++ b/cmd/gateway_setup.go
@@ -562,15 +562,14 @@ func setupSkillsSystem(
 					seeded, skipped, seededSkills, err := seeder.Seed(context.Background())
 					if err != nil {
 						slog.Warn("system skills seed failed", "error", err)
-					} else {
-						if seeded > 0 {
-							slog.Info("system skills seeded", "seeded", seeded, "skipped", skipped)
-						}
-						// Check dependencies asynchronously — does not block startup.
-						// Emits WS events per-skill so UI updates in realtime.
-						if len(seededSkills) > 0 {
-							seeder.CheckDepsAsync(seededSkills, msgBus)
-						}
+					}
+					if seeded > 0 {
+						slog.Info("system skills seeded", "seeded", seeded, "skipped", skipped)
+					}
+					// Check dependencies for successful partial results even when another
+					// bundled skill needs manual recovery.
+					if len(seededSkills) > 0 {
+						seeder.CheckDepsAsync(seededSkills, msgBus)
 					}
 				}
 			}

--- a/internal/skills/seeder.go
+++ b/internal/skills/seeder.go
@@ -3,6 +3,8 @@ package skills
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -55,6 +57,7 @@ func (s *Seeder) Seed(ctx context.Context) (seeded int, skipped int, skills []se
 	if err != nil {
 		return 0, 0, nil, fmt.Errorf("read bundled dir: %w", err)
 	}
+	var seedErrs []error
 
 	for _, e := range entries {
 		if !e.IsDir() {
@@ -119,6 +122,20 @@ func (s *Seeder) Seed(ctx context.Context) (seeded int, skipped int, skills []se
 
 		id, changed, actualDir, upsertErr := s.store.UpsertSystemSkill(ctx, p)
 		if upsertErr != nil {
+			if errors.Is(upsertErr, store.ErrMisclassifiedCustomSkill) {
+				if err := s.restoreCustomSkillMetadata(ctx, id, p); err != nil {
+					slog.Warn("seeder: failed to restore custom skill metadata", "slug", slug, "error", err)
+					seedErrs = append(seedErrs, fmt.Errorf("restore custom skill %q: %w", slug, err))
+				}
+				slog.Warn("seeder: skip bundled skill with custom slug", "slug", slug)
+				skipped++
+				continue
+			}
+			if errors.Is(upsertErr, store.ErrSystemSkillSlugConflict) {
+				slog.Warn("seeder: skip bundled skill with custom slug", "slug", slug)
+				skipped++
+				continue
+			}
 			slog.Error("seeder: failed to upsert skill", "slug", slug, "error", upsertErr)
 			continue
 		}
@@ -153,7 +170,123 @@ func (s *Seeder) Seed(ctx context.Context) (seeded int, skipped int, skills []se
 	if seeded > 0 {
 		s.store.BumpVersion()
 	}
-	return seeded, skipped, skills, nil
+	return seeded, skipped, skills, errors.Join(seedErrs...)
+}
+
+// restoreCustomSkillMetadata repairs a row that the older slug-only seeder
+// converted from custom to system. The store calls this only for rows marked
+// by the repair migration. Ambiguous history is left private and archived for
+// manual recovery instead of guessing which version was custom.
+func (s *Seeder) restoreCustomSkillMetadata(ctx context.Context, id uuid.UUID, p store.SkillCreateParams) error {
+	if id == uuid.Nil {
+		return errors.New("custom skill ID is missing")
+	}
+	if p.Version <= 1 {
+		return fmt.Errorf("invalid bundled version %d", p.Version)
+	}
+
+	if p.FileHash == nil || len(*p.FileHash) < 12 {
+		return errors.New("bundled skill hash is missing or invalid")
+	}
+	quarantineDir := filepath.Join(
+		filepath.Dir(p.FilePath),
+		".goclaw-bundled-"+filepath.Base(p.FilePath)+"-"+(*p.FileHash)[:12],
+	)
+	overwrittenDir := p.FilePath
+	alreadyQuarantined := false
+	if _, err := os.Stat(overwrittenDir); errors.Is(err, os.ErrNotExist) {
+		overwrittenDir = quarantineDir
+		alreadyQuarantined = true
+	} else if err != nil {
+		return fmt.Errorf("inspect overwritten bundled version: %w", err)
+	}
+
+	overwrittenFile := filepath.Join(overwrittenDir, "SKILL.md")
+	overwrittenContent, err := os.ReadFile(overwrittenFile)
+	if err != nil {
+		return fmt.Errorf("read overwritten bundled skill: %w", err)
+	}
+	overwrittenHash := fmt.Sprintf("%x", sha256.Sum256(overwrittenContent))
+	if overwrittenHash != *p.FileHash {
+		return errors.New("next managed version does not match the current bundled skill")
+	}
+
+	customVersion := p.Version - 1
+	customDir := filepath.Join(filepath.Dir(p.FilePath), fmt.Sprintf("%d", customVersion))
+	skillFile := filepath.Join(customDir, "SKILL.md")
+	content, err := os.ReadFile(skillFile)
+	if err != nil {
+		return fmt.Errorf("read previous custom skill: %w", err)
+	}
+	meta := parseMetadata(skillFile)
+	if meta == nil || meta.Name == "" {
+		return errors.New("previous custom skill has no name")
+	}
+
+	frontmatter := map[string]string{}
+	if fm := extractFrontmatter(string(content)); fm != "" {
+		frontmatter = parseSimpleYAML(fm)
+	}
+	if looksLikeBundledVersion(meta, frontmatter, p) {
+		return errors.New("previous managed version still looks bundled; custom version is ambiguous")
+	}
+	frontmatterJSON, err := json.Marshal(frontmatter)
+	if err != nil {
+		return fmt.Errorf("marshal custom skill frontmatter: %w", err)
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256(content))
+
+	if !alreadyQuarantined {
+		if err := os.Rename(p.FilePath, quarantineDir); err != nil {
+			return fmt.Errorf("quarantine overwritten bundled version: %w", err)
+		}
+	}
+
+	if err := s.store.UpdateSkill(
+		store.WithTenantID(ctx, store.MasterTenantID),
+		id,
+		map[string]any{
+			"name":        meta.Name,
+			"description": meta.Description,
+			"frontmatter": frontmatterJSON,
+			"visibility":  "private",
+			"status":      "archived",
+			"version":     customVersion,
+			"file_path":   customDir,
+			"file_size":   int64(len(content)),
+			"file_hash":   hash,
+		},
+	); err != nil {
+		if !alreadyQuarantined {
+			if rollbackErr := os.Rename(quarantineDir, p.FilePath); rollbackErr != nil {
+				return errors.Join(
+					fmt.Errorf("update custom skill metadata: %w", err),
+					fmt.Errorf("restore bundled version after failed update: %w", rollbackErr),
+				)
+			}
+		}
+		return fmt.Errorf("update custom skill metadata: %w", err)
+	}
+	return nil
+}
+
+func looksLikeBundledVersion(meta *Metadata, frontmatter map[string]string, p store.SkillCreateParams) bool {
+	// Auto-recovery requires an explicit custom version marker. Without it,
+	// historical bundled content cannot be distinguished reliably from a user
+	// skill that reused the same name or description.
+	if strings.TrimSpace(frontmatter["version"]) == "" {
+		return true
+	}
+	description := ""
+	if p.Description != nil {
+		description = *p.Description
+	}
+	if strings.TrimSpace(meta.Name) == strings.TrimSpace(p.Name) &&
+		strings.TrimSpace(meta.Description) == strings.TrimSpace(description) {
+		return true
+	}
+	bundledLicense := strings.TrimSpace(p.Frontmatter["license"])
+	return bundledLicense != "" && strings.TrimSpace(frontmatter["license"]) == bundledLicense
 }
 
 // CheckDepsAsync checks dependencies for seeded skills in a background goroutine.

--- a/internal/skills/seeder_test.go
+++ b/internal/skills/seeder_test.go
@@ -1,0 +1,250 @@
+package skills
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+type customSlugConflictStore struct {
+	customID    uuid.UUID
+	nextVersion int
+	conflictErr error
+	updatedID   uuid.UUID
+	updatedCtx  context.Context
+	updates     map[string]any
+	updateErr   error
+}
+
+func (s *customSlugConflictStore) UpsertSystemSkill(context.Context, store.SkillCreateParams) (uuid.UUID, bool, string, error) {
+	return s.customID, false, "", s.conflictErr
+}
+
+func (s *customSlugConflictStore) GetNextVersion(context.Context, string) int { return s.nextVersion }
+func (s *customSlugConflictStore) BumpVersion()                               {}
+
+func (s *customSlugConflictStore) UpdateSkill(ctx context.Context, id uuid.UUID, updates map[string]any) error {
+	s.updatedID = id
+	s.updatedCtx = ctx
+	s.updates = updates
+	return s.updateErr
+}
+
+func (s *customSlugConflictStore) StoreMissingDeps(context.Context, uuid.UUID, []string) error {
+	return nil
+}
+
+func TestSeeder_RestoresCustomMetadataWhenBundledSlugConflicts(t *testing.T) {
+	bundledDir := filepath.Join(t.TempDir(), "bundled")
+	managedDir := filepath.Join(t.TempDir(), "managed")
+	slug := "lark-pm"
+	bundledContent := "---\nname: lark-pm\ndescription: Bundled workflow\nlicense: Proprietary. Part of GoClaw bundled skills.\n---\n"
+	customContent := "---\nname: Lark PM\ndescription: Custom Lark workflow\nversion: 1.0.0\n---\n\n# Custom Lark PM\n"
+
+	for path, content := range map[string]string{
+		filepath.Join(bundledDir, slug, "SKILL.md"):      bundledContent,
+		filepath.Join(managedDir, slug, "4", "SKILL.md"): customContent,
+		filepath.Join(managedDir, slug, "5", "SKILL.md"): bundledContent,
+	} {
+		writeSeederSkillFile(t, path, content)
+	}
+
+	customID := uuid.New()
+	skillStore := &customSlugConflictStore{customID: customID, nextVersion: 5, conflictErr: store.ErrMisclassifiedCustomSkill}
+	seeder := NewSeeder(bundledDir, managedDir, skillStore)
+	seeded, skipped, _, err := seeder.Seed(context.Background())
+	if err != nil {
+		t.Fatalf("Seed error: %v", err)
+	}
+	if seeded != 0 || skipped != 1 {
+		t.Fatalf("Seed = (%d seeded, %d skipped), want (0, 1)", seeded, skipped)
+	}
+	if skillStore.updatedID != customID {
+		t.Fatalf("updated ID = %s, want %s", skillStore.updatedID, customID)
+	}
+	if tenantID := store.TenantIDFromContext(skillStore.updatedCtx); tenantID != store.MasterTenantID {
+		t.Fatalf("update tenant = %s, want master tenant %s", tenantID, store.MasterTenantID)
+	}
+	if got := skillStore.updates["name"]; got != "Lark PM" {
+		t.Fatalf("restored name = %q, want custom name", got)
+	}
+	if got := skillStore.updates["description"]; got != "Custom Lark workflow" {
+		t.Fatalf("restored description = %q, want custom description", got)
+	}
+	if got := skillStore.updates["file_path"]; got != filepath.Join(managedDir, slug, "4") {
+		t.Fatalf("restored file path = %q, want custom version directory", got)
+	}
+	if got := skillStore.updates["visibility"]; got != "private" {
+		t.Fatalf("restored visibility = %q, want private", got)
+	}
+	if got := skillStore.updates["status"]; got != "archived" {
+		t.Fatalf("restored status = %q, want archived", got)
+	}
+	if got := skillStore.updates["version"]; got != 4 {
+		t.Fatalf("restored version = %v, want 4", got)
+	}
+
+	var frontmatter map[string]string
+	if err := json.Unmarshal(skillStore.updates["frontmatter"].([]byte), &frontmatter); err != nil {
+		t.Fatalf("unmarshal restored frontmatter: %v", err)
+	}
+	if frontmatter["name"] != "Lark PM" || frontmatter["description"] != "Custom Lark workflow" {
+		t.Fatalf("restored frontmatter = %#v", frontmatter)
+	}
+	if _, err := os.Stat(filepath.Join(managedDir, slug, "5")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("overwritten numeric directory still exists: %v", err)
+	}
+	quarantineDir := filepath.Join(managedDir, slug, ".goclaw-bundled-5-"+hashSeederContent(bundledContent)[:12])
+	if _, err := os.Stat(filepath.Join(quarantineDir, "SKILL.md")); err != nil {
+		t.Fatalf("quarantined bundled skill missing: %v", err)
+	}
+	loader := NewLoader("", "", "")
+	if version, dir := loader.findLatestVersion(managedDir, slug); version != 4 || dir != filepath.Join(managedDir, slug, "4") {
+		t.Fatalf("latest managed version = (%d, %q), want restored custom version 4", version, dir)
+	}
+}
+
+func TestSeeder_ReportsAmbiguousCustomRecovery(t *testing.T) {
+	bundledDir := filepath.Join(t.TempDir(), "bundled")
+	managedDir := filepath.Join(t.TempDir(), "managed")
+	slug := "lark-pm"
+	bundledContent := "---\nname: lark-pm\ndescription: Bundled workflow\nlicense: Proprietary. Part of GoClaw bundled skills.\n---\n"
+	priorBundledContent := bundledContent + "\n# Previous bundled body\n"
+	writeSeederSkillFile(t, filepath.Join(bundledDir, slug, "SKILL.md"), bundledContent)
+	writeSeederSkillFile(t, filepath.Join(managedDir, slug, "4", "SKILL.md"), priorBundledContent)
+	writeSeederSkillFile(t, filepath.Join(managedDir, slug, "5", "SKILL.md"), bundledContent)
+
+	skillStore := &customSlugConflictStore{customID: uuid.New(), nextVersion: 5, conflictErr: store.ErrMisclassifiedCustomSkill}
+	seeder := NewSeeder(bundledDir, managedDir, skillStore)
+	_, skipped, _, err := seeder.Seed(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "custom version is ambiguous") {
+		t.Fatalf("Seed error = %v, want ambiguous recovery error", err)
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", skipped)
+	}
+	if skillStore.updatedID != uuid.Nil {
+		t.Fatalf("ambiguous recovery updated skill %s", skillStore.updatedID)
+	}
+	if _, err := os.Stat(filepath.Join(managedDir, slug, "5", "SKILL.md")); err != nil {
+		t.Fatalf("ambiguous bundled version was moved: %v", err)
+	}
+}
+
+func TestSeeder_SkipsLegitimateCustomSlugConflictWithoutRecovery(t *testing.T) {
+	bundledDir := filepath.Join(t.TempDir(), "bundled")
+	managedDir := filepath.Join(t.TempDir(), "managed")
+	slug := "lark-pm"
+	writeSeederSkillFile(t, filepath.Join(bundledDir, slug, "SKILL.md"), "---\nname: lark-pm\ndescription: Bundled workflow\n---\n")
+
+	skillStore := &customSlugConflictStore{customID: uuid.New(), nextVersion: 2, conflictErr: store.ErrSystemSkillSlugConflict}
+	seeder := NewSeeder(bundledDir, managedDir, skillStore)
+	_, skipped, _, err := seeder.Seed(context.Background())
+	if err != nil {
+		t.Fatalf("Seed error: %v", err)
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", skipped)
+	}
+	if skillStore.updatedID != uuid.Nil {
+		t.Fatalf("legitimate custom collision updated skill %s", skillStore.updatedID)
+	}
+}
+
+func TestSeeder_ReportsMissingMarkedRecoveryFiles(t *testing.T) {
+	bundledDir := filepath.Join(t.TempDir(), "bundled")
+	managedDir := filepath.Join(t.TempDir(), "managed")
+	slug := "lark-pm"
+	writeSeederSkillFile(t, filepath.Join(bundledDir, slug, "SKILL.md"), "---\nname: lark-pm\ndescription: Bundled workflow\n---\n")
+
+	skillStore := &customSlugConflictStore{
+		customID:    uuid.New(),
+		nextVersion: 5,
+		conflictErr: store.ErrMisclassifiedCustomSkill,
+	}
+	seeder := NewSeeder(bundledDir, managedDir, skillStore)
+	_, skipped, _, err := seeder.Seed(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "read overwritten bundled skill") {
+		t.Fatalf("Seed error = %v, want missing recovery file error", err)
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", skipped)
+	}
+}
+
+func TestSeeder_ContinuesRecoveryFromQuarantinedBundledVersion(t *testing.T) {
+	bundledDir := filepath.Join(t.TempDir(), "bundled")
+	managedDir := filepath.Join(t.TempDir(), "managed")
+	slug := "lark-pm"
+	bundledContent := "---\nname: lark-pm\ndescription: Bundled workflow\n---\n"
+	writeSeederSkillFile(t, filepath.Join(bundledDir, slug, "SKILL.md"), bundledContent)
+	writeSeederSkillFile(t, filepath.Join(managedDir, slug, "4", "SKILL.md"), "---\nname: Lark PM\ndescription: Custom workflow\nversion: 1.0.0\n---\n")
+	quarantineDir := filepath.Join(managedDir, slug, ".goclaw-bundled-5-"+hashSeederContent(bundledContent)[:12])
+	writeSeederSkillFile(t, filepath.Join(quarantineDir, "SKILL.md"), bundledContent)
+
+	skillStore := &customSlugConflictStore{
+		customID:    uuid.New(),
+		nextVersion: 5,
+		conflictErr: store.ErrMisclassifiedCustomSkill,
+	}
+	seeder := NewSeeder(bundledDir, managedDir, skillStore)
+	_, _, _, err := seeder.Seed(context.Background())
+	if err != nil {
+		t.Fatalf("Seed error: %v", err)
+	}
+	if skillStore.updatedID == uuid.Nil {
+		t.Fatal("quarantined recovery did not update custom metadata")
+	}
+	if _, err := os.Stat(filepath.Join(quarantineDir, "SKILL.md")); err != nil {
+		t.Fatalf("quarantine missing after recovery: %v", err)
+	}
+}
+
+func TestSeeder_PropagatesCustomRecoveryUpdateFailure(t *testing.T) {
+	bundledDir := filepath.Join(t.TempDir(), "bundled")
+	managedDir := filepath.Join(t.TempDir(), "managed")
+	slug := "lark-pm"
+	bundledContent := "---\nname: lark-pm\ndescription: Bundled workflow\n---\n"
+	writeSeederSkillFile(t, filepath.Join(bundledDir, slug, "SKILL.md"), bundledContent)
+	writeSeederSkillFile(t, filepath.Join(managedDir, slug, "4", "SKILL.md"), "---\nname: Lark PM\ndescription: Custom workflow\nversion: 1.0.0\n---\n")
+	writeSeederSkillFile(t, filepath.Join(managedDir, slug, "5", "SKILL.md"), bundledContent)
+
+	skillStore := &customSlugConflictStore{
+		customID:    uuid.New(),
+		nextVersion: 5,
+		conflictErr: store.ErrMisclassifiedCustomSkill,
+		updateErr:   errors.New("database unavailable"),
+	}
+	seeder := NewSeeder(bundledDir, managedDir, skillStore)
+	_, _, _, err := seeder.Seed(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "database unavailable") {
+		t.Fatalf("Seed error = %v, want update failure", err)
+	}
+	if _, err := os.Stat(filepath.Join(managedDir, slug, "5", "SKILL.md")); err != nil {
+		t.Fatalf("bundled version moved despite failed update: %v", err)
+	}
+}
+
+func writeSeederSkillFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("create skill directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+}
+
+func hashSeederContent(content string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(content)))
+}

--- a/internal/store/pg/skills_admin.go
+++ b/internal/store/pg/skills_admin.go
@@ -2,6 +2,8 @@ package pg
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -14,12 +16,15 @@ import (
 // When hash is unchanged, returns the existing file_path from DB so the caller
 // uses the correct directory for dep scanning (not a non-existent next-version dir).
 func (s *PGSkillStore) UpsertSystemSkill(ctx context.Context, p store.SkillCreateParams) (uuid.UUID, bool, string, error) {
-	// Check if skill already exists
+	// System skills always live in the master tenant. Do not match a custom
+	// skill from another tenant just because it happens to share a slug.
 	var existingID uuid.UUID
 	var existingHash *string
 	var existingFilePath string
 	err := s.db.QueryRowContext(ctx,
-		"SELECT id, file_hash, file_path FROM skills WHERE slug = $1", p.Slug,
+		`SELECT id, file_hash, file_path FROM skills
+		 WHERE slug = $1 AND tenant_id = $2 AND is_system = true`,
+		p.Slug, store.MasterTenantID,
 	).Scan(&existingID, &existingHash, &existingFilePath)
 
 	if err == nil {
@@ -50,6 +55,28 @@ func (s *PGSkillStore) UpsertSystemSkill(ctx context.Context, p store.SkillCreat
 		}
 		s.BumpVersion()
 		return existingID, true, p.FilePath, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return uuid.Nil, false, "", fmt.Errorf("find system skill: %w", err)
+	}
+
+	// The master tenant has a unique slug index. Preserve a custom skill that
+	// already owns the bundled slug instead of replacing it.
+	var customID uuid.UUID
+	var recoveryMarker string
+	err = s.db.QueryRowContext(ctx,
+		`SELECT id, COALESCE(frontmatter->>'_goclaw_recovery', '') FROM skills
+		 WHERE slug = $1 AND tenant_id = $2 AND is_system = false`,
+		p.Slug, store.MasterTenantID,
+	).Scan(&customID, &recoveryMarker)
+	if err == nil {
+		if recoveryMarker == store.SkillRecoveryBundledSlugCollision {
+			return customID, false, "", store.ErrMisclassifiedCustomSkill
+		}
+		return customID, false, "", store.ErrSystemSkillSlugConflict
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return uuid.Nil, false, "", fmt.Errorf("find custom skill conflict: %w", err)
 	}
 
 	// New skill — insert

--- a/internal/store/skill_store.go
+++ b/internal/store/skill_store.go
@@ -2,9 +2,20 @@ package store
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 )
+
+const SkillRecoveryBundledSlugCollision = "bundled_slug_collision"
+
+// ErrSystemSkillSlugConflict prevents a bundled skill from replacing or
+// shadowing an existing custom skill with the same slug.
+var ErrSystemSkillSlugConflict = errors.New("system skill slug conflicts with custom skill")
+
+// ErrMisclassifiedCustomSkill marks a custom row repaired by the schema
+// migration that still needs its metadata restored from managed files.
+var ErrMisclassifiedCustomSkill = errors.New("custom skill requires bundled collision recovery")
 
 // SkillInfo describes a discovered skill.
 type SkillInfo struct {

--- a/internal/store/sqlitestore/schema.go
+++ b/internal/store/sqlitestore/schema.go
@@ -16,7 +16,7 @@ var schemaSQL string
 
 // SchemaVersion is the current SQLite schema version.
 // Bump this when adding new migration steps below.
-const SchemaVersion = 57
+const SchemaVersion = 58
 
 // migrations maps version → SQL to apply when upgrading FROM that version.
 // schema.sql always represents the LATEST full schema (for fresh DBs).
@@ -30,6 +30,25 @@ const SchemaVersion = 57
 //
 // Then bump SchemaVersion to 2.
 var migrations = map[int]string{
+	// Version 57 → 58: restore custom skills previously converted by the bundled skill seeder.
+	57: `UPDATE skills
+SET is_system = 0,
+    visibility = 'private',
+    status = 'archived',
+    frontmatter = json_set(
+        CASE WHEN json_valid(frontmatter) THEN frontmatter ELSE '{}' END,
+        '$._goclaw_recovery',
+        'bundled_slug_collision'
+    ),
+    version = CASE WHEN version > 1 THEN version - 1 ELSE 1 END,
+    file_path = CASE
+        WHEN file_path LIKE '%/' || version THEN
+            substr(file_path, 1, length(file_path) - length(CAST(version AS TEXT))) ||
+            CAST(CASE WHEN version > 1 THEN version - 1 ELSE 1 END AS TEXT)
+        ELSE file_path
+    END,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE is_system = 1 AND owner_id <> 'system';`,
 	// Version 49 → 50: per-cron-job LLM provider/model override (mirrors agent_heartbeats).
 	49: `ALTER TABLE cron_jobs ADD COLUMN provider_id TEXT REFERENCES llm_providers(id) ON DELETE SET NULL;
 ALTER TABLE cron_jobs ADD COLUMN model VARCHAR(200);`,

--- a/internal/store/sqlitestore/skills_content.go
+++ b/internal/store/sqlitestore/skills_content.go
@@ -4,6 +4,8 @@ package sqlitestore
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -245,7 +247,9 @@ func (s *SQLiteSkillStore) UpsertSystemSkill(ctx context.Context, p store.SkillC
 	var existingHash *string
 	var existingFilePath string
 	err := s.db.QueryRowContext(ctx,
-		"SELECT id, file_hash, file_path FROM skills WHERE slug = ?", p.Slug,
+		`SELECT id, file_hash, file_path FROM skills
+		 WHERE slug = ? AND tenant_id = ? AND is_system = 1`,
+		p.Slug, store.MasterTenantID,
 	).Scan(&existingID, &existingHash, &existingFilePath)
 
 	if err == nil {
@@ -273,6 +277,31 @@ func (s *SQLiteSkillStore) UpsertSystemSkill(ctx context.Context, p store.SkillC
 		}
 		s.BumpVersion()
 		return existingID, true, p.FilePath, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return uuid.Nil, false, "", fmt.Errorf("find system skill: %w", err)
+	}
+
+	// The master tenant has a unique slug index. Preserve a custom skill that
+	// already owns the bundled slug instead of replacing it.
+	var customID uuid.UUID
+	var recoveryMarker string
+	err = s.db.QueryRowContext(ctx,
+		`SELECT id, CASE WHEN json_valid(frontmatter)
+		     THEN COALESCE(json_extract(frontmatter, '$._goclaw_recovery'), '')
+		     ELSE '' END
+		 FROM skills
+		 WHERE slug = ? AND tenant_id = ? AND is_system = 0`,
+		p.Slug, store.MasterTenantID,
+	).Scan(&customID, &recoveryMarker)
+	if err == nil {
+		if recoveryMarker == store.SkillRecoveryBundledSlugCollision {
+			return customID, false, "", store.ErrMisclassifiedCustomSkill
+		}
+		return customID, false, "", store.ErrSystemSkillSlugConflict
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return uuid.Nil, false, "", fmt.Errorf("find custom skill conflict: %w", err)
 	}
 
 	id := store.GenNewID()

--- a/internal/store/sqlitestore/skills_test.go
+++ b/internal/store/sqlitestore/skills_test.go
@@ -5,6 +5,7 @@ package sqlitestore
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -67,6 +68,163 @@ func TestSQLiteSkillStore_CreateSkillManaged_PersistsArchivedDependencyState(t *
 	}
 	if !reflect.DeepEqual(info.MissingDeps, missing) {
 		t.Fatalf("MissingDeps = %v, want %v", info.MissingDeps, missing)
+	}
+}
+
+func TestSQLiteSkillStore_UpsertSystemSkill_DoesNotReclassifyCustomSkill(t *testing.T) {
+	ctx, skillStore := newTestSQLiteSkillStore(t)
+	customID, err := skillStore.CreateSkillManaged(ctx, store.SkillCreateParams{
+		Name:       "Lark PM",
+		Slug:       "lark-pm",
+		OwnerID:    "user-1",
+		Visibility: "private",
+		FilePath:   filepath.Join(t.TempDir(), "lark-pm", "1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSkillManaged error: %v", err)
+	}
+
+	returnedID, changed, _, err := skillStore.UpsertSystemSkill(ctx, store.SkillCreateParams{
+		Name:     "Bundled Lark PM",
+		Slug:     "lark-pm",
+		Status:   "active",
+		Version:  2,
+		FilePath: filepath.Join(t.TempDir(), "lark-pm", "2"),
+	})
+	if !errors.Is(err, store.ErrSystemSkillSlugConflict) {
+		t.Fatalf("UpsertSystemSkill error = %v, want ErrSystemSkillSlugConflict", err)
+	}
+	if changed {
+		t.Fatal("UpsertSystemSkill changed custom skill")
+	}
+	if returnedID != customID {
+		t.Fatalf("UpsertSystemSkill ID = %s, want custom skill ID %s", returnedID, customID)
+	}
+
+	custom, ok := skillStore.GetSkillByID(ctx, customID)
+	if !ok {
+		t.Fatal("GetSkillByID returned !ok")
+	}
+	if custom.IsSystem {
+		t.Fatal("custom skill was reclassified as a system skill")
+	}
+	if custom.Version != 1 {
+		t.Fatalf("custom version = %d, want 1", custom.Version)
+	}
+	if custom.Visibility != "private" {
+		t.Fatalf("custom visibility = %q, want private", custom.Visibility)
+	}
+}
+
+func TestSQLiteSkillStore_UpsertSystemSkill_DoesNotReclassifyOtherTenantCustomSkill(t *testing.T) {
+	_, skillStore, db := newTestSQLiteSkillStoreWithDB(t)
+	tenantID, _ := seedSQLiteTenantAgent(t, db)
+	customCtx := store.WithTenantID(context.Background(), tenantID)
+	customID, err := skillStore.CreateSkillManaged(customCtx, store.SkillCreateParams{
+		Name:       "Lark Playbook",
+		Slug:       "lark-playbook",
+		OwnerID:    "user-1",
+		Visibility: "private",
+		FilePath:   filepath.Join(t.TempDir(), "tenant-lark-playbook", "1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSkillManaged error: %v", err)
+	}
+
+	_, changed, _, err := skillStore.UpsertSystemSkill(context.Background(), store.SkillCreateParams{
+		Name:     "Bundled Lark Playbook",
+		Slug:     "lark-playbook",
+		Status:   "active",
+		Version:  1,
+		FilePath: filepath.Join(t.TempDir(), "bundled-lark-playbook", "1"),
+	})
+	if err != nil {
+		t.Fatalf("UpsertSystemSkill error: %v", err)
+	}
+	if !changed {
+		t.Fatal("UpsertSystemSkill did not add the master system skill")
+	}
+
+	custom, ok := skillStore.GetSkillByID(customCtx, customID)
+	if !ok || custom.IsSystem {
+		t.Fatalf("custom skill = %+v, found = %t; want unchanged custom skill", custom, ok)
+	}
+	var systemCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM skills WHERE slug = ? AND is_system = 1", "lark-playbook").Scan(&systemCount); err != nil {
+		t.Fatalf("count system skills: %v", err)
+	}
+	if systemCount != 1 {
+		t.Fatalf("system skill count = %d, want 1", systemCount)
+	}
+}
+
+func TestEnsureSchema_RestoresMisclassifiedCustomSkills(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "skills.db"))
+	if err != nil {
+		t.Fatalf("OpenDB error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema initial error: %v", err)
+	}
+
+	if _, err := db.Exec(
+		`INSERT INTO skills (id, name, slug, owner_id, tenant_id, visibility, version, status, is_system, file_path)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		uuid.New().String(), "Lark PM", "lark-pm", "user-1", store.MasterTenantID.String(), "public", 5, "active", true, filepath.Join(t.TempDir(), "lark-pm", "5"),
+	); err != nil {
+		t.Fatalf("insert misclassified skill: %v", err)
+	}
+	if _, err := db.Exec("UPDATE schema_version SET version = 57"); err != nil {
+		t.Fatalf("set prior schema version: %v", err)
+	}
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema migration error: %v", err)
+	}
+
+	var isSystem bool
+	var visibility string
+	var version int
+	var status string
+	var recoveryMarker string
+	var filePath string
+	if err := db.QueryRow(`SELECT is_system, visibility, version, status,
+		COALESCE(json_extract(frontmatter, '$._goclaw_recovery'), ''), file_path
+		FROM skills WHERE slug = ?`, "lark-pm").Scan(&isSystem, &visibility, &version, &status, &recoveryMarker, &filePath); err != nil {
+		t.Fatalf("query repaired skill: %v", err)
+	}
+	if isSystem {
+		t.Fatal("misclassified custom skill remained a system skill")
+	}
+	if version != 4 {
+		t.Fatalf("repaired skill version = %d, want 4", version)
+	}
+	if visibility != "private" {
+		t.Fatalf("repaired skill visibility = %q, want private", visibility)
+	}
+	if status != "archived" {
+		t.Fatalf("repaired skill status = %q, want archived", status)
+	}
+	if recoveryMarker != store.SkillRecoveryBundledSlugCollision {
+		t.Fatalf("recovery marker = %q, want bundled_slug_collision", recoveryMarker)
+	}
+	if filePath != filepath.Join(filepath.Dir(filePath), "4") {
+		t.Fatalf("repaired skill path = %q, want version 4 directory", filePath)
+	}
+
+	skillStore := NewSQLiteSkillStore(db, t.TempDir())
+	repairedID, changed, _, err := skillStore.UpsertSystemSkill(context.Background(), store.SkillCreateParams{
+		Name:     "Bundled Lark PM",
+		Slug:     "lark-pm",
+		Status:   "active",
+		Version:  5,
+		FilePath: filepath.Join(filepath.Dir(filePath), "5"),
+	})
+	if !errors.Is(err, store.ErrMisclassifiedCustomSkill) {
+		t.Fatalf("UpsertSystemSkill error = %v, want ErrMisclassifiedCustomSkill", err)
+	}
+	if changed || repairedID == uuid.Nil {
+		t.Fatalf("UpsertSystemSkill = (%s, %t), want repaired custom ID and unchanged row", repairedID, changed)
 	}
 }
 

--- a/internal/upgrade/version.go
+++ b/internal/upgrade/version.go
@@ -2,4 +2,4 @@ package upgrade
 
 // RequiredSchemaVersion is the schema migration version this binary requires.
 // Bump this whenever adding a new SQL migration file.
-const RequiredSchemaVersion uint = 94
+const RequiredSchemaVersion uint = 95

--- a/migrations/000095_restore_misclassified_custom_skills.down.sql
+++ b/migrations/000095_restore_misclassified_custom_skills.down.sql
@@ -1,0 +1,3 @@
+-- This data repair is intentionally irreversible: the original system/custom
+-- classification cannot be inferred safely after restoration.
+SELECT 1;

--- a/migrations/000095_restore_misclassified_custom_skills.up.sql
+++ b/migrations/000095_restore_misclassified_custom_skills.up.sql
@@ -1,0 +1,22 @@
+-- Restore custom skills previously converted to system skills by an unscoped
+-- bundled-skill seed lookup. The faulty seed wrote bundled content into the
+-- next managed version; startup validates the preceding version before using
+-- it as recovery data. Genuine bundled skills always use owner_id='system'.
+-- Visibility and lifecycle state cannot
+-- be recovered from the overwritten row, so default to the non-public,
+-- non-active state until the owner explicitly reviews the repaired skill.
+UPDATE skills
+SET is_system = false,
+    visibility = 'private',
+    status = 'archived',
+    frontmatter = COALESCE(frontmatter, '{}'::jsonb) ||
+        '{"_goclaw_recovery":"bundled_slug_collision"}'::jsonb,
+    version = GREATEST(version - 1, 1),
+    file_path = regexp_replace(
+        file_path,
+        '/[0-9]+$',
+        '/' || GREATEST(version - 1, 1)::text
+    ),
+    updated_at = NOW()
+WHERE is_system = true
+  AND owner_id <> 'system';

--- a/tests/integration/v3_skills_store_test.go
+++ b/tests/integration/v3_skills_store_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -109,6 +110,41 @@ func TestStoreSkill_CreateAndGet(t *testing.T) {
 	}
 	if ownerID2 != "test-owner" {
 		t.Errorf("OwnerIDBySlug = %q, want %q", ownerID2, "test-owner")
+	}
+}
+
+func TestStoreSkill_UpsertSystemSkillPreservesCustomCollision(t *testing.T) {
+	s := newSkillStore(t)
+	ctx := store.WithTenantID(context.Background(), store.MasterTenantID)
+	slug := "system-collision-" + uuid.NewString()[:8]
+	customID := seedSkill(t, s, ctx, slug, "Custom Skill")
+	bundledHash := "bundled-hash"
+
+	returnedID, changed, _, err := s.UpsertSystemSkill(ctx, store.SkillCreateParams{
+		Name:       "Bundled Skill",
+		Slug:       slug,
+		Status:     "active",
+		Version:    2,
+		FilePath:   "/tmp/skills/" + slug + "/2",
+		FileHash:   &bundledHash,
+		Visibility: "public",
+	})
+	if !errors.Is(err, store.ErrSystemSkillSlugConflict) {
+		t.Fatalf("UpsertSystemSkill error = %v, want ErrSystemSkillSlugConflict", err)
+	}
+	if changed {
+		t.Fatal("UpsertSystemSkill changed the custom skill")
+	}
+	if returnedID != customID {
+		t.Fatalf("UpsertSystemSkill ID = %s, want custom ID %s", returnedID, customID)
+	}
+
+	got, ok := s.GetSkillByID(ctx, customID)
+	if !ok {
+		t.Fatal("custom skill disappeared after system collision")
+	}
+	if got.IsSystem || got.Name != "Custom Skill" || got.Version != 1 || got.Visibility != "private" {
+		t.Fatalf("custom skill changed after system collision: %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- scope bundled skill upserts to master-tenant system rows so matching custom skills are preserved
- repair previously misclassified custom skills conservatively through PostgreSQL and SQLite migrations
- quarantine overwritten bundled versions and report ambiguous or incomplete recovery instead of silently guessing

## Test plan

- [x] `go test ./... -count=1`
- [x] focused race tests for seeder recovery and SQLite migration
- [x] PostgreSQL integration test for custom/system slug collision
- [x] `go build ./...`
- [x] `go build -tags sqliteonly ./...`
- [x] `go vet ./...`
- [x] `git diff --check`