### PR TITLE
fix(slack): don't double-emit trailing text on odd number of ``` fences

### DIFF
--- a/internal/channels/slack/format.go
+++ b/internal/channels/slack/format.go
@@ -113,8 +113,17 @@ func extractCodeBlocks(text string) (blocks []string, result string) {
 		return nil, text
 	}
 
+	// An odd number of ``` fences makes Split return an even number of parts;
+	// the final segment then follows an unpaired opening fence and must stay
+	// literal (it is re-appended verbatim below), so exclude it from the
+	// paired-scan loop instead of misclassifying it as a closed code block.
+	scanEnd := len(parts)
+	if scanEnd%2 == 0 {
+		scanEnd--
+	}
 	var sb strings.Builder
-	for i, part := range parts {
+	for i := 0; i < scanEnd; i++ {
+		part := parts[i]
 		if i%2 == 1 {
 			blocks = append(blocks, part)
 			sb.WriteString(fmt.Sprintf("\x00CB%d\x00", len(blocks)-1))

--- a/internal/channels/slack/format_test.go
+++ b/internal/channels/slack/format_test.go
@@ -319,6 +319,14 @@ func TestExtractCodeBlocks(t *testing.T) {
 			expectedCount: 0,
 		},
 		{
+			// A closed block followed by an unpaired opening fence: 3 fences ->
+			// 4 parts. Only the middle part is a real code block; the trailing
+			// segment must stay literal, not be counted (and re-emitted) as one.
+			name:          "closed block then unpaired trailing fence",
+			input:         "a```b```c```d",
+			expectedCount: 1,
+		},
+		{
 			name:          "empty code block",
 			input:         "```\n\n```",
 			expectedCount: 1,


### PR DESCRIPTION
## Problem

`extractCodeBlocks` in `internal/channels/slack/format.go` splits the message on `` ``` `` and treats every **odd-indexed** part as a closed code block:

```go
parts := strings.Split(text, "```")
...
for i, part := range parts {
    if i%2 == 1 {
        blocks = append(blocks, part)
        sb.WriteString(fmt.Sprintf("\x00CB%d\x00", len(blocks)-1))
    } else {
        sb.WriteString(part)
    }
}
// If odd number of ```, the last unpaired one is literal
if len(parts)%2 == 0 {
    sb.WriteString("```")
    sb.WriteString(parts[len(parts)-1])
}
```

With an **odd number of fences** (≥3), `Split` returns an **even** number of parts, so the final segment lands on an odd index. That segment actually follows an *unpaired opening* fence and must stay literal — the trailing `len(parts)%2==0` block already re-appends it verbatim. But the loop also emits it as a `\x00CB\x00` placeholder (restored to `` ```seg``` `` in `markdownToSlackMrkdwn`), so the segment is written **twice**, and `blocks` gains a spurious entry.

`markdownToSlackMrkdwn` runs on the outbound send path (`send.go`) and streaming render (`stream.go`), and unclosed trailing fences are common in streamed LLM output — so the trigger is realistic.

## Reproduction

Input `` a```b```c```d `` (3 fences → 4 parts):

| | blocks | rendered result |
|---|---|---|
| before | `["b","d"]` (2) | `` a```b```c```d``````d `` — `d` duplicated |
| after | `["b"]` (1) | `` a```b```c```d `` — round-trips exactly |

Paired-fence input (`` a```b```c ``, 2 fences) is unchanged.

## Fix

Exclude the final unpaired part from the paired-scan loop (it's re-appended literally just below):

```go
scanEnd := len(parts)
if scanEnd%2 == 0 {
    scanEnd--
}
for i := 0; i < scanEnd; i++ {
    part := parts[i]
    ...
}
```

## Test

Added a `TestExtractCodeBlocks` case (`closed block then unpaired trailing fence`, input `` a```b```c```d ``, `expectedCount: 1`). It fails on the current code (`returned 2 blocks, want 1`) and passes after the fix. Full package green: `go test ./internal/channels/slack/` → ok.
