### PR TITLE
fix(packages): make .runtime group-writable for goclaw self-update

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,12 +10,17 @@ RUNTIME_DIR="/app/data/.runtime"
 mkdir -p "$RUNTIME_DIR/pip" "$RUNTIME_DIR/npm-global/lib" "$RUNTIME_DIR/pip-cache" "$RUNTIME_DIR/bin" || true
 
 # Fix .runtime ownership for split root/goclaw access.
-# .runtime itself must be root-owned so pkg-helper (root) can write apk-packages.
+# .runtime stays root-owned so pkg-helper (root) can write apk-packages, but the
+# group (goclaw) needs write access too: the gateway runs as goclaw and must be
+# able to create the github-package self-update scratch dir (.runtime/tmp) and
+# rewrite the manifest (.runtime/github-packages.json[.tmp], updates-cache.json).
+# 0750 (no group write) makes those updates fail with "permission denied"; 0770
+# keeps root ownership while letting the goclaw group write.
 # Subdirs pip/, npm-global/, pip-cache/ must be goclaw-owned for runtime installs.
 # This also handles upgrades from older images where .runtime was fully goclaw-owned.
 if [ "$(id -u)" = "0" ] && [ -d "$RUNTIME_DIR" ]; then
   chown root:goclaw "$RUNTIME_DIR" 2>/dev/null || true
-  chmod 0750 "$RUNTIME_DIR" 2>/dev/null || true
+  chmod 0770 "$RUNTIME_DIR" 2>/dev/null || true
   chown -R goclaw:goclaw "$RUNTIME_DIR/pip" "$RUNTIME_DIR/npm-global" "$RUNTIME_DIR/pip-cache" "$RUNTIME_DIR/bin" 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## Problem
Updating a github binary package from the **Runtime & Packages** UI (e.g. `goclaw` v0.6.2 → v0.8.0) fails with:
```
create scratch dir: /app/data/.runtime/tmp/goclaw-v0.8.0-<nanos>: mkdir /app/data/.runtime/tmp: permission denied
```
and, once the scratch dir is worked around, the manifest write fails:
```
binary swapped but manifest save failed: open /app/data/.runtime/github-packages.json.tmp: permission denied
```
(leaving `manifestDesynced=true`).

## Root cause
`docker-entrypoint.sh` sets `/app/data/.runtime` to `root:goclaw` mode **0750** (comment: so the root `pkg-helper` can write `apk-packages`). But the gateway runs as **goclaw**, and the github-package self-update flow (in-process, as goclaw) must write **inside** `.runtime`:
- scratch dir `.runtime/tmp/<pkg>-<tag>-<nanos>` (`GitHubUpdateExecutor.createScratchDir`, candidates all resolve under `.runtime`)
- manifest `.runtime/github-packages.json[.tmp]` and `updates-cache.json`

With **0750** the group has no write bit → both writes fail.

## Fix
Change the mode to **0770**: root keeps ownership (apk-packages still root-written by pkg-helper) while the `goclaw` group gains write, so the scratch dir + manifest writes succeed. One-line change in `docker-entrypoint.sh` + explanatory comment.

## Verified
On an affected running container: `chmod g+w /app/data/.runtime` (equivalent to 0770) → package update completes cleanly (`{"fromVersion":"v0.6.2","ok":true,"toVersion":"v0.8.0"}`), manifest in sync, no pending updates. No regression: root still owns `.runtime` and writes `apk-packages`.

Surface parity: gateway/runtime only (entrypoint). Web UI / API / CLI N/A — this is a filesystem-permission fix in container startup.