### PR TITLE
fix(migrations): remove superuser-required CREATE EXTENSION from migration

### DIFF
--- a/migrations/000001_init_schema.up.sql
+++ b/migrations/000001_init_schema.up.sql
@@ -1,8 +1,8 @@
 -- GoClaw Multi-Tenant Schema
--- Requires: pgcrypto, pgvector extensions
-
-CREATE EXTENSION IF NOT EXISTS "pgcrypto";
-CREATE EXTENSION IF NOT EXISTS "vector";
+-- PREREQUISITE: pgcrypto and pgvector extensions must be created by a superuser
+-- before running this migration. Example (as superuser):
+--   CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+--   CREATE EXTENSION IF NOT EXISTS "vector";
 
 -- UUID v7 function (matching backend-go)
 CREATE OR REPLACE FUNCTION uuid_generate_v7() RETURNS uuid AS $$


### PR DESCRIPTION
## Problem

goclaw's initial migration (000001_init_schema.up.sql) executes:
```sql
CREATE EXTENSION IF NOT EXISTS "pgcrypto";
CREATE EXTENSION IF NOT EXISTS "vector";
```

**Both extensions require superuser privileges.** When goclaw connects with a least-privilege database role (the recommended security posture), the migration fails midway and marks the schema as dirty (`schema_migrations.dirty = true`). This blocks every subsequent boot with no automated recovery — the only workaround is manual intervention to clean the schema.

## Root Cause

PostgreSQL does not allow non-superuser roles to create extensions (unless explicitly granted CREATE privilege on the extension via ALTER). This is a security boundary. Once a migration fails, the dirty flag prevents the app from starting again until the flag is manually cleared.

## Solution

**Move extension creation out of the application migration into a database provisioning prerequisite.** The extensions must be created by a database administrator before goclaw's first connection.

Changes:
- Removed `CREATE EXTENSION` statements from the migration
- Documented the two extensions as an explicit prerequisite in the migration header
- Provided example SQL for administrators to create the extensions

goclaw will now fail fast with a clear error if the extensions are missing at query time (PostgreSQL's standard "extension does not exist" error), rather than leaving a dirty schema state.

## Migration Path

**For existing deployments:**
1. Ensure pgcrypto and pgvector are already created (if goclaw is running, they likely are)
2. Manually clear the schema_migrations dirty flag if needed:
   ```sql
   UPDATE schema_migrations SET dirty = false WHERE version = 1;
   ```
3. Deploy this fix
4. goclaw will boot normally on the next startup

**For new deployments:**
1. Database administrator creates extensions (before goclaw connects)
2. goclaw starts and runs migration without privilege errors

## Testing

- [x] Migration runs without superuser privileges on a least-privilege goclaw role
- [x] Migration fails with clear error if extensions are missing (expected behavior)
- [x] Schema is not marked dirty when extensions are already created
- [x] Existing goclaw instances with extensions pre-created still work