### PR TITLE
feat(bitrix24): recognize reply/quote context across all message types

### DIFF
--- a/internal/channels/bitrix24/events.go
+++ b/internal/channels/bitrix24/events.go
@@ -43,16 +43,16 @@ type Event struct {
 // reject spoofed webhooks — AppToken is the stable per-install secret,
 // MemberID is the stable portal id (stable across domain renames).
 type EventAuth struct {
-	Domain           string
-	AppToken         string
-	AccessToken      string
-	RefreshToken     string
-	MemberID         string
-	ExpiresIn        int
-	Scope            string
-	ServerEndpoint   string
-	ClientEndpoint   string
-	Status           string
+	Domain         string
+	AppToken       string
+	AccessToken    string
+	RefreshToken   string
+	MemberID       string
+	ExpiresIn      int
+	Scope          string
+	ServerEndpoint string
+	ClientEndpoint string
+	Status         string
 }
 
 // EventParams covers the `data[PARAMS]` section plus resolved bot/user ids.
@@ -69,8 +69,11 @@ type EventParams struct {
 	MessageOriginal string // raw BBCode (`[USER=<id>]…[/USER]`); group chat only, "" on DMs
 	MessageType     string // "private" | "chat"
 	SystemMessage   bool
-	ReplyToMID      string
-	Files           []EventFile
+	// ReplyMessage is the quoted/replied-to message Bitrix24 ships inline on
+	// ONIMBOTMESSAGEADD when the user replies to an earlier message. nil when
+	// the event is not a reply. See EventReplyMessage for field semantics.
+	ReplyMessage *EventReplyMessage
+	Files        []EventFile
 	// MentionedList is the structured map data[PARAMS][MENTIONED_LIST][<id>]=<id>
 	// Bitrix24 emits on group messages. Highest-authority mention source —
 	// no regex / Unicode edge cases. Absent (nil) on DMs.
@@ -135,6 +138,33 @@ type EventParams struct {
 	// imbot.message.add with SKIP_CONNECTOR=Y instead of the v2 path.
 	// Absent or any value other than "HiddenMessage" → false (public).
 	IsHiddenMessage bool
+}
+
+// EventReplyMessage captures the message a user replied to (quoted). Bitrix24
+// ships it inline on the reply event as `data[PARAMS][REPLY_MESSAGE][...]`:
+//   - ID       — MESSAGE_ID of the quoted message (fallback: PARAMS[REPLY_ID])
+//   - AuthorID — user id who authored the quoted message
+//   - Text     — full quoted body (BBCode); EMPTY when the quoted message is
+//     media-only (image/audio/file/video), in which case the attachment must
+//     be fetched separately via im.dialog.messages.get (see reply_context.go).
+type EventReplyMessage struct {
+	ID       string
+	AuthorID string
+	Text     string
+}
+
+// newReplyMessage builds an EventReplyMessage from the raw REPLY_MESSAGE fields.
+// replyID is the fallback id from the nested PARAMS[REPLY_ID] used when
+// REPLY_MESSAGE[ID] is absent. Returns nil when there is no reply signal at all
+// so callers can treat "not a reply" as the natural zero case.
+func newReplyMessage(id, authorID, text, replyID string) *EventReplyMessage {
+	if id == "" {
+		id = replyID
+	}
+	if id == "" {
+		return nil
+	}
+	return &EventReplyMessage{ID: id, AuthorID: authorID, Text: text}
 }
 
 // EventFile is one attachment element extracted from
@@ -234,7 +264,6 @@ func parseFormEvent(v url.Values) (*Event, error) {
 		Message:         formGet(v, "data", "PARAMS", "MESSAGE"),
 		MessageOriginal: formGet(v, "data", "PARAMS", "MESSAGE_ORIGINAL"),
 		MessageType:     formGet(v, "data", "PARAMS", "MESSAGE_TYPE"),
-		ReplyToMID:      formGet(v, "data", "PARAMS", "REPLY_TO_MESSAGE_ID"),
 		ChatEntityType:  formGet(v, "data", "PARAMS", "CHAT_ENTITY_TYPE"),
 		ChatEntityID:    formGet(v, "data", "PARAMS", "CHAT_ENTITY_ID"),
 		ChatTitle:       formGet(v, "data", "PARAMS", "CHAT_TITLE"),
@@ -259,6 +288,17 @@ func parseFormEvent(v url.Values) (*Event, error) {
 	if s := formGet(v, "data", "USER", "IS_CONNECTOR"); strings.EqualFold(s, "Y") {
 		p.FromIsConnector = true
 	}
+
+	// REPLY_MESSAGE: the quoted message when the user replied. Bitrix ships the
+	// full quoted text inline for text originals; media-only originals carry
+	// just ID+AUTHOR_ID (MESSAGE empty) and are resolved later. REPLY_ID lives
+	// in the nested inner PARAMS as a numeric fallback id.
+	p.ReplyMessage = newReplyMessage(
+		formGet(v, "data", "PARAMS", "REPLY_MESSAGE", "ID"),
+		formGet(v, "data", "PARAMS", "REPLY_MESSAGE", "AUTHOR_ID"),
+		formGet(v, "data", "PARAMS", "REPLY_MESSAGE", "MESSAGE"),
+		formGet(v, "data", "PARAMS", "PARAMS", "REPLY_ID"),
+	)
 
 	// MENTIONED_LIST: data[PARAMS][MENTIONED_LIST][<user_id>]=<user_id>.
 	// Iterate all form keys to discover the structured map; key format is
@@ -387,34 +427,42 @@ func parseJSONEvent(body io.ReadCloser) (*Event, error) {
 			Status           string `json:"status"`
 		} `json:"auth"`
 		Data struct {
-			Bot    map[string]map[string]any `json:"BOT"`
-			User   struct {
+			Bot  map[string]map[string]any `json:"BOT"`
+			User struct {
 				IsConnector string `json:"IS_CONNECTOR"`
 			} `json:"USER"`
 			Params struct {
-				MessageID       any              `json:"MESSAGE_ID"`
-				DialogID        any              `json:"DIALOG_ID"`
-				ChatID          any              `json:"CHAT_ID"`
-				FromUserID      any              `json:"FROM_USER_ID"`
-				ToUserID        any              `json:"TO_USER_ID"`
-				Message         string           `json:"MESSAGE"`
-				MessageOriginal string           `json:"MESSAGE_ORIGINAL"`
-				MentionedList   map[string]any   `json:"MENTIONED_LIST"`
-				MessageType     string           `json:"MESSAGE_TYPE"`
-				System          string           `json:"SYSTEM"`
-				ReplyToMID      any              `json:"REPLY_TO_MESSAGE_ID"`
-				ChatEntityType  string           `json:"CHAT_ENTITY_TYPE"`
-				ChatEntityID    string           `json:"CHAT_ENTITY_ID"`
-				ChatTitle       string           `json:"CHAT_TITLE"`
-				ChatType        string           `json:"CHAT_TYPE"`
-				ChatEntityData1 string           `json:"CHAT_ENTITY_DATA_1"`
-				ChatEntityData2 string           `json:"CHAT_ENTITY_DATA_2"`
-				ChatEntityData3 string           `json:"CHAT_ENTITY_DATA_3"`
+				MessageID       any            `json:"MESSAGE_ID"`
+				DialogID        any            `json:"DIALOG_ID"`
+				ChatID          any            `json:"CHAT_ID"`
+				FromUserID      any            `json:"FROM_USER_ID"`
+				ToUserID        any            `json:"TO_USER_ID"`
+				Message         string         `json:"MESSAGE"`
+				MessageOriginal string         `json:"MESSAGE_ORIGINAL"`
+				MentionedList   map[string]any `json:"MENTIONED_LIST"`
+				MessageType     string         `json:"MESSAGE_TYPE"`
+				System          string         `json:"SYSTEM"`
+				ChatEntityType  string         `json:"CHAT_ENTITY_TYPE"`
+				ChatEntityID    string         `json:"CHAT_ENTITY_ID"`
+				ChatTitle       string         `json:"CHAT_TITLE"`
+				ChatType        string         `json:"CHAT_TYPE"`
+				ChatEntityData1 string         `json:"CHAT_ENTITY_DATA_1"`
+				ChatEntityData2 string         `json:"CHAT_ENTITY_DATA_2"`
+				ChatEntityData3 string         `json:"CHAT_ENTITY_DATA_3"`
 				// Nested PARAMS holds UI component metadata. COMPONENT_ID=
 				// HiddenMessage marks a whisper / internal-only message.
+				// REPLY_ID is the numeric fallback id of the quoted message.
 				NestedParams struct {
 					ComponentID string `json:"COMPONENT_ID"`
+					ReplyID     any    `json:"REPLY_ID"`
 				} `json:"PARAMS"`
+				// REPLY_MESSAGE is the quoted message on reply events (see
+				// EventReplyMessage). MESSAGE is empty for media-only originals.
+				ReplyMessage struct {
+					ID       any    `json:"ID"`
+					AuthorID any    `json:"AUTHOR_ID"`
+					Message  string `json:"MESSAGE"`
+				} `json:"REPLY_MESSAGE"`
 				// FILES may arrive as an array OR a map keyed by file id — keep
 				// raw and normalize after Decode.
 				Files json.RawMessage `json:"FILES"`
@@ -469,7 +517,12 @@ func parseJSONEvent(body io.ReadCloser) (*Event, error) {
 	p.MessageOriginal = raw.Data.Params.MessageOriginal
 	p.MessageType = raw.Data.Params.MessageType
 	p.SystemMessage = raw.Data.Params.System == "Y"
-	p.ReplyToMID = asString(raw.Data.Params.ReplyToMID)
+	p.ReplyMessage = newReplyMessage(
+		asString(raw.Data.Params.ReplyMessage.ID),
+		asString(raw.Data.Params.ReplyMessage.AuthorID),
+		raw.Data.Params.ReplyMessage.Message,
+		asString(raw.Data.Params.NestedParams.ReplyID),
+	)
 	p.ChatEntityType = raw.Data.Params.ChatEntityType
 	p.ChatEntityID = raw.Data.Params.ChatEntityID
 	p.ChatTitle = raw.Data.Params.ChatTitle

--- a/internal/channels/bitrix24/events_reply_test.go
+++ b/internal/channels/bitrix24/events_reply_test.go
@@ -1,0 +1,105 @@
+package bitrix24
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func parseForm(t *testing.T, v interface{ Encode() string }) *Event {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/bitrix24/events", strings.NewReader(v.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	evt, err := ParseEvent(req)
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+	return evt
+}
+
+func TestParseEvent_Form_ReplyMessage_Text(t *testing.T) {
+	v := buildBitrixForm()
+	v.Set("data[PARAMS][REPLY_MESSAGE][ID]", "315900")
+	v.Set("data[PARAMS][REPLY_MESSAGE][AUTHOR_ID]", "62")
+	v.Set("data[PARAMS][REPLY_MESSAGE][MESSAGE]", "báo giá cho anh nhé")
+
+	rm := parseForm(t, v).Params.ReplyMessage
+	if rm == nil {
+		t.Fatal("ReplyMessage nil; want parsed")
+	}
+	if rm.ID != "315900" || rm.AuthorID != "62" || rm.Text != "báo giá cho anh nhé" {
+		t.Errorf("ReplyMessage = %+v", rm)
+	}
+}
+
+func TestParseEvent_Form_ReplyMessage_MediaEmptyText(t *testing.T) {
+	// Media-only original: ID + AUTHOR present, MESSAGE empty (no file id inline).
+	v := buildBitrixForm()
+	v.Set("data[PARAMS][REPLY_MESSAGE][ID]", "315968")
+	v.Set("data[PARAMS][REPLY_MESSAGE][AUTHOR_ID]", "62")
+	v.Set("data[PARAMS][REPLY_MESSAGE][MESSAGE]", "")
+
+	rm := parseForm(t, v).Params.ReplyMessage
+	if rm == nil || rm.ID != "315968" || rm.Text != "" {
+		t.Errorf("ReplyMessage = %+v; want ID 315968, empty text", rm)
+	}
+}
+
+func TestParseEvent_Form_ReplyID_Fallback(t *testing.T) {
+	// Only the nested PARAMS[REPLY_ID] present (no REPLY_MESSAGE[ID]).
+	v := buildBitrixForm()
+	v.Set("data[PARAMS][PARAMS][REPLY_ID]", "315901")
+
+	rm := parseForm(t, v).Params.ReplyMessage
+	if rm == nil || rm.ID != "315901" {
+		t.Errorf("ReplyMessage = %+v; want fallback ID 315901", rm)
+	}
+}
+
+func TestParseEvent_Form_NoReply_NilReplyMessage(t *testing.T) {
+	if rm := parseForm(t, buildBitrixForm()).Params.ReplyMessage; rm != nil {
+		t.Errorf("non-reply event should have nil ReplyMessage, got %+v", rm)
+	}
+}
+
+func TestParseEvent_JSON_ReplyMessage(t *testing.T) {
+	body := `{
+		"event": "ONIMBOTMESSAGEADD",
+		"data": {
+			"PARAMS": {
+				"MESSAGE_ID": "500",
+				"DIALOG_ID": "chat9",
+				"FROM_USER_ID": "7",
+				"MESSAGE": "còn hàng không",
+				"REPLY_MESSAGE": {"ID": 315900, "AUTHOR_ID": 62, "MESSAGE": "áo sơ mi trắng"}
+			}
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/bitrix24/events", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	evt, err := ParseEvent(req)
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+	rm := evt.Params.ReplyMessage
+	if rm == nil || rm.ID != "315900" || rm.AuthorID != "62" || rm.Text != "áo sơ mi trắng" {
+		t.Errorf("ReplyMessage = %+v", rm)
+	}
+}
+
+func TestParseEvent_JSON_ReplyID_Fallback(t *testing.T) {
+	body := `{
+		"event": "ONIMBOTMESSAGEADD",
+		"data": {"PARAMS": {"MESSAGE_ID": "500", "FROM_USER_ID": "7", "PARAMS": {"REPLY_ID": 315901}}}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/bitrix24/events", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	evt, err := ParseEvent(req)
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+	if rm := evt.Params.ReplyMessage; rm == nil || rm.ID != "315901" {
+		t.Errorf("ReplyMessage = %+v; want fallback ID 315901", rm)
+	}
+}

--- a/internal/channels/bitrix24/handle.go
+++ b/internal/channels/bitrix24/handle.go
@@ -321,9 +321,6 @@ func (c *Channel) handleMessage(ctx context.Context, evt *Event) {
 	if participantSenderID != "" {
 		meta[MetaKeyParticipantUserID] = participantSenderID
 	}
-	if evt.Params.ReplyToMID != "" {
-		meta["bitrix_reply_to_mid"] = evt.Params.ReplyToMID
-	}
 	if evt.Params.ChatID != "" {
 		meta["bitrix_chat_id"] = evt.Params.ChatID
 	}
@@ -417,10 +414,19 @@ func (c *Channel) handleMessage(ctx context.Context, evt *Event) {
 		}
 	}
 
+	// Reply/quote context: when the user replied to an earlier message, Bitrix
+	// ships the quoted text inline (REPLY_MESSAGE); a media-only original carries
+	// only an id, which we resolve via im.dialog.messages.get. resolveReplyContext
+	// returns a short note to prepend so the agent knows what's being answered,
+	// plus any quoted attachment re-injected through the SAME download pipeline as
+	// a direct upload (bounded by media_max_mb, best-effort). No-op when not a reply.
+	replyPrefix, replyMedia := c.resolveReplyContext(ctx, evt)
+
 	// Download any attachments via imbot.v2.File.download and forward them to
 	// the agent with their MIME type preserved. Best-effort: failures are logged
 	// inside downloadEventFiles and never block the text from reaching the agent.
 	mediaFiles := c.downloadEventFiles(ctx, c.BotID(), evt.Params.Files)
+	mediaFiles = append(mediaFiles, replyMedia...)
 	// Prepend <media:*> tags so the LLM sees the attachment alongside the body
 	// text. The agent loop's enrichInputMedia REPLACES tags it finds (it does
 	// NOT insert new ones), so without this step a Bitrix-borne PDF / audio
@@ -436,6 +442,11 @@ func (c *Channel) handleMessage(ctx context.Context, evt *Event) {
 				text = tags + "\n" + text
 			}
 		}
+	}
+	// Reply note goes at the very front so the agent reads "who/what is being
+	// answered" before the (possibly quoted) media tags and the user's own text.
+	if replyPrefix != "" {
+		text = replyPrefix + text
 	}
 	slog.Info("bitrix24 message: publish to bus",
 		"sender_id", senderID,

--- a/internal/channels/bitrix24/reply_context.go
+++ b/internal/channels/bitrix24/reply_context.go
@@ -1,0 +1,258 @@
+package bitrix24
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+)
+
+// quotedTextMaxRunes caps how much of a quoted text message we inline into the
+// agent prompt. Long quotes add little context but cost tokens; ~500 runes is
+// enough for the agent to recognise which message is being answered.
+const quotedTextMaxRunes = 500
+
+// resolveReplyContext turns a reply/quote event into (a) a short note to
+// prepend to the agent's input and (b) any quoted attachment re-injected as
+// media. It is the single entry point for the Hybrid design:
+//
+//   - Text original  → Bitrix ships REPLY_MESSAGE.MESSAGE inline; no API call.
+//   - Media original → REPLY_MESSAGE.MESSAGE is empty and carries no file id, so
+//     fetch the original via im.dialog.messages.get and re-inject the file(s)
+//     through the same download+size pipeline as a direct upload.
+//
+// Best-effort and non-blocking: any fetch/download failure degrades to a
+// note-only result so the user's message still reaches the agent. Returns
+// ("", nil) when the event is not a reply.
+func (c *Channel) resolveReplyContext(ctx context.Context, evt *Event) (string, []bus.MediaFile) {
+	rm := evt.Params.ReplyMessage
+	if rm == nil {
+		return "", nil
+	}
+	author := c.quotedAuthorName(ctx, rm.AuthorID)
+
+	// TEXT quote — the common case. Bitrix delivers the full quoted body inline,
+	// so no extra REST call is needed.
+	if q := sanitizeQuotedText(rm.Text); q != "" {
+		return fmt.Sprintf("[Đang trả lời tin của %s: \"%s\"]\n", author, q), nil
+	}
+
+	// MEDIA quote — MESSAGE empty. Recover the quoted attachment(s) so the agent
+	// can actually "see" the file being answered (STT for audio, vision for
+	// images, read_document for the rest).
+	files, err := c.fetchReplyMessageFiles(ctx, evt.Params.DialogID, rm.ID)
+	if err != nil || len(files) == 0 {
+		if err != nil {
+			slog.Debug("bitrix24 reply: could not resolve quoted media, note only",
+				"reply_id", rm.ID, "dialog_id", evt.Params.DialogID, "err", err)
+		}
+		return fmt.Sprintf("[Đang trả lời một tin nhắn của %s]\n", author), nil
+	}
+
+	note := quotedMediaNote(files, author)
+	// Re-inject through the SAME pipeline as inbound files: oversized files are
+	// skipped (note-only fallback) and the rest flow into the media tags /
+	// read_* tools exactly like a directly-attached upload. DRY — no new size
+	// or MIME logic here.
+	extra := c.downloadEventFiles(ctx, c.BotID(), files)
+	return note, extra
+}
+
+// quotedMediaNote builds the "[Đang trả lời một <loại> ...]" prefix for a
+// media-only quoted message. Single file → name + kind; multiple → a count.
+func quotedMediaNote(files []EventFile, author string) string {
+	if len(files) == 1 {
+		f := files[0]
+		if f.Name != "" {
+			return fmt.Sprintf("[Đang trả lời một %s \"%s\" của %s]\n", quotedKindVN(f.Type), f.Name, author)
+		}
+		return fmt.Sprintf("[Đang trả lời một %s của %s]\n", quotedKindVN(f.Type), author)
+	}
+	return fmt.Sprintf("[Đang trả lời %d tệp đính kèm của %s]\n", len(files), author)
+}
+
+// quotedAuthorName resolves a Bitrix user id to a display name for the reply
+// note, falling back to "người dùng <id>" (and a generic label for an empty id)
+// so the note is always human-readable.
+func (c *Channel) quotedAuthorName(ctx context.Context, authorID string) string {
+	authorID = strings.TrimSpace(authorID)
+	if authorID == "" {
+		return "người dùng"
+	}
+	if name, _ := c.resolveContactName(ctx, authorID); strings.TrimSpace(name) != "" {
+		return name
+	}
+	return "người dùng " + authorID
+}
+
+// quotedKindVN maps a Bitrix file type to a Vietnamese noun for the reply note.
+func quotedKindVN(fileType string) string {
+	switch strings.ToLower(strings.TrimSpace(fileType)) {
+	case "image":
+		return "hình ảnh"
+	case "audio":
+		return "tin nhắn thoại"
+	case "video":
+		return "video"
+	default:
+		return "tệp"
+	}
+}
+
+// bxResidualBBCodeRE strips the BBCode formatting / container tags Bitrix may
+// leave in a quoted body AFTER user mentions are rewritten to readable form.
+// It removes the tags only — inner text is kept.
+var bxResidualBBCodeRE = regexp.MustCompile(`(?is)\[/?(b|i|u|s|quote|code|color|size|font|table|tr|td|list|\*|img|url|context|disk|br|p)(=[^\]]*)?\]`)
+
+// sanitizeQuotedText normalises a quoted Bitrix message body for inlining into
+// the agent prompt: rewrite user mentions to "@Name (ID:..)", strip residual
+// BBCode noise, collapse whitespace, and truncate. Returns "" for an
+// empty/whitespace-only or media-only quote.
+func sanitizeQuotedText(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	text = bxConvertUserMentionsToReadable(text)
+	text = bxResidualBBCodeRE.ReplaceAllString(text, "")
+	text = strings.Join(strings.Fields(text), " ") // collapse newlines + runs of spaces
+	return truncateRunes(text, quotedTextMaxRunes)
+}
+
+// truncateRunes truncates on rune boundaries (Bitrix bodies are UTF-8 with
+// multibyte Vietnamese) and appends an ellipsis when it cuts.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}
+
+// fetchReplyMessageFiles fetches the attachment metadata of the quoted message
+// via im.dialog.messages.get (scope `im`, available to the bot token — unlike
+// imbot.v2.Chat.Message.get which is blocked for TYPE=bot bots). FIRST_ID is
+// the anchor for "newer than": msgID-1 so the quoted message itself is included.
+func (c *Channel) fetchReplyMessageFiles(ctx context.Context, dialogID, msgID string) ([]EventFile, error) {
+	client := c.Client()
+	if client == nil {
+		return nil, errors.New("bitrix24 reply: no REST client")
+	}
+	dialogID = strings.TrimSpace(dialogID)
+	msgID = strings.TrimSpace(msgID)
+	if dialogID == "" || msgID == "" {
+		return nil, errors.New("bitrix24 reply: dialog_id/msg_id empty")
+	}
+
+	// FIRST_ID returns messages with id strictly greater than it, so anchor at
+	// msgID-1 to include the quoted message. LIMIT 2 keeps the payload tiny.
+	firstID := msgID
+	if n, err := strconv.Atoi(msgID); err == nil && n > 0 {
+		firstID = strconv.Itoa(n - 1)
+	}
+
+	rr, err := client.Call(ctx, "im.dialog.messages.get", map[string]any{
+		"DIALOG_ID": dialogID,
+		"FIRST_ID":  firstID,
+		"LIMIT":     2,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return parseReplyFiles(rr.Result, msgID)
+}
+
+// parseReplyFiles extracts the EventFile metadata of the message whose id ==
+// msgID from an im.dialog.messages.get result. Defensive against Bitrix's PHP
+// JSON quirks: `messages` and `files` are decoded as raw first so an empty
+// collection encoded as `[]` (object→array) never breaks the whole decode.
+func parseReplyFiles(raw json.RawMessage, msgID string) ([]EventFile, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("bitrix24 reply: empty result")
+	}
+	var res struct {
+		Messages json.RawMessage `json:"messages"`
+		Files    json.RawMessage `json:"files"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("bitrix24 reply: decode result: %w", err)
+	}
+
+	// messages: [] of { id, params: { FILE_ID: [...] } }.
+	var msgs []struct {
+		ID     any             `json:"id"`
+		Params json.RawMessage `json:"params"`
+	}
+	_ = json.Unmarshal(res.Messages, &msgs) // tolerate `[]`/absent → no files
+
+	var fileIDs []string
+	for _, m := range msgs {
+		if asString(m.ID) != msgID {
+			continue
+		}
+		fileIDs = append(fileIDs, extractFileIDs(m.Params)...)
+	}
+	if len(fileIDs) == 0 {
+		return nil, nil
+	}
+
+	// files: map keyed by file id → { id, type, name, size }. Absent/`[]` → the
+	// ids still let downloadEventFiles fetch by id (name/type just unknown).
+	var filesMap map[string]struct {
+		ID   any    `json:"id"`
+		Type string `json:"type"`
+		Name string `json:"name"`
+		Size any    `json:"size"`
+	}
+	_ = json.Unmarshal(res.Files, &filesMap)
+
+	out := make([]EventFile, 0, len(fileIDs))
+	for _, fid := range fileIDs {
+		ef := EventFile{ID: fid}
+		if f, ok := filesMap[fid]; ok {
+			ef.Name = f.Name
+			ef.Type = f.Type
+			ef.Size = int64(asInt(f.Size))
+		}
+		out = append(out, ef)
+	}
+	return out, nil
+}
+
+// extractFileIDs pulls the FILE_ID list from a message's raw params. FILE_ID is
+// an array of ids in live payloads, but tolerate a scalar and an empty/`[]`
+// params object without erroring.
+func extractFileIDs(rawParams json.RawMessage) []string {
+	if len(rawParams) == 0 {
+		return nil
+	}
+	var p struct {
+		FileID json.RawMessage `json:"FILE_ID"`
+	}
+	if err := json.Unmarshal(rawParams, &p); err != nil || len(p.FileID) == 0 {
+		return nil
+	}
+	var arr []any
+	if err := json.Unmarshal(p.FileID, &arr); err == nil {
+		out := make([]string, 0, len(arr))
+		for _, v := range arr {
+			if s := asString(v); s != "" && s != "0" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	var one any
+	if err := json.Unmarshal(p.FileID, &one); err == nil {
+		if s := asString(one); s != "" && s != "0" {
+			return []string{s}
+		}
+	}
+	return nil
+}

--- a/internal/channels/bitrix24/reply_context_test.go
+++ b/internal/channels/bitrix24/reply_context_test.go
@@ -1,0 +1,273 @@
+package bitrix24
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestSanitizeQuotedText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   \n\t ", ""},
+		{"plain", "báo giá cho anh nhé", "báo giá cho anh nhé"},
+		{"user mention", "[USER=62]Đặng Văn Tình[/USER] xong chưa", "@Đặng Văn Tình (ID:62) xong chưa"},
+		{"strip formatting", "[b]quan trọng[/b] [i]lắm[/i]", "quan trọng lắm"},
+		{"strip quote+context", "[quote][CONTEXT=chat123]cũ[/quote] mới", "cũ mới"},
+		{"collapse whitespace", "dòng 1\n\n  dòng 2", "dòng 1 dòng 2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeQuotedText(tc.in); got != tc.want {
+				t.Errorf("sanitizeQuotedText(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeQuotedText_Truncates(t *testing.T) {
+	long := strings.Repeat("ă", quotedTextMaxRunes+50) // multibyte on purpose
+	got := sanitizeQuotedText(long)
+	gotRunes := []rune(got)
+	// quotedTextMaxRunes content runes + 1 ellipsis rune.
+	if len(gotRunes) != quotedTextMaxRunes+1 {
+		t.Fatalf("truncated len = %d runes; want %d", len(gotRunes), quotedTextMaxRunes+1)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated text should end with ellipsis, got %q", got[len(got)-6:])
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	if got := truncateRunes("abc", 5); got != "abc" {
+		t.Errorf("no truncation expected, got %q", got)
+	}
+	if got := truncateRunes("abcdef", 3); got != "abc…" {
+		t.Errorf("truncateRunes = %q; want %q", got, "abc…")
+	}
+}
+
+func TestQuotedKindVN(t *testing.T) {
+	cases := map[string]string{
+		"image": "hình ảnh",
+		"audio": "tin nhắn thoại",
+		"video": "video",
+		"file":  "tệp",
+		"":      "tệp",
+		"WEIRD": "tệp",
+	}
+	for in, want := range cases {
+		if got := quotedKindVN(in); got != want {
+			t.Errorf("quotedKindVN(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestQuotedMediaNote(t *testing.T) {
+	single := quotedMediaNote([]EventFile{{Name: "voice.ogg", Type: "audio"}}, "Tình")
+	if want := "[Đang trả lời một tin nhắn thoại \"voice.ogg\" của Tình]\n"; single != want {
+		t.Errorf("single = %q; want %q", single, want)
+	}
+	noName := quotedMediaNote([]EventFile{{Type: "image"}}, "Tình")
+	if want := "[Đang trả lời một hình ảnh của Tình]\n"; noName != want {
+		t.Errorf("noName = %q; want %q", noName, want)
+	}
+	multi := quotedMediaNote([]EventFile{{Name: "a"}, {Name: "b"}}, "Tình")
+	if want := "[Đang trả lời 2 tệp đính kèm của Tình]\n"; multi != want {
+		t.Errorf("multi = %q; want %q", multi, want)
+	}
+}
+
+func TestExtractFileIDs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"array", `{"FILE_ID":[32728,40]}`, []string{"32728", "40"}},
+		{"scalar", `{"FILE_ID":32728}`, []string{"32728"}},
+		{"string ids", `{"FILE_ID":["a","b"]}`, []string{"a", "b"}},
+		{"filters zero", `{"FILE_ID":[0,32728]}`, []string{"32728"}},
+		{"absent", `{"TEXT":"hi"}`, nil},
+		{"empty params array", `[]`, nil},
+		{"empty raw", ``, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractFileIDs(json.RawMessage(tc.in))
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("extractFileIDs(%s) = %v; want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseReplyFiles(t *testing.T) {
+	// Realistic im.dialog.messages.get result: numeric ids, files keyed by id.
+	result := `{
+		"messages": [
+			{"id": 315968, "author_id": 62, "params": {"FILE_ID": [32728]}, "text": ""},
+			{"id": 315969, "author_id": 62, "text": "câu hỏi"}
+		],
+		"files": {
+			"32728": {"id": 32728, "type": "audio", "name": "voice.ogg", "size": 6789}
+		}
+	}`
+	files, err := parseReplyFiles(json.RawMessage(result), "315968")
+	if err != nil {
+		t.Fatalf("parseReplyFiles: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("want 1 file, got %d: %+v", len(files), files)
+	}
+	if files[0].ID != "32728" || files[0].Name != "voice.ogg" || files[0].Type != "audio" || files[0].Size != 6789 {
+		t.Errorf("file mismatch: %+v", files[0])
+	}
+}
+
+func TestParseReplyFiles_NoMatchingMessage(t *testing.T) {
+	result := `{"messages":[{"id":999,"params":{"FILE_ID":[1]}}],"files":{"1":{"name":"x"}}}`
+	files, err := parseReplyFiles(json.RawMessage(result), "315968")
+	if err != nil {
+		t.Fatalf("parseReplyFiles: %v", err)
+	}
+	if files != nil {
+		t.Errorf("want nil (no message matched id), got %+v", files)
+	}
+}
+
+func TestParseReplyFiles_MissingFileMetadata_FallsBackToBareID(t *testing.T) {
+	// FILE_ID present on the message but no files map entry → still return the id
+	// so downloadEventFiles can fetch by id (imbot.v2.File.download needs only id).
+	result := `{"messages":[{"id":315968,"params":{"FILE_ID":[32728]}}],"files":[]}`
+	files, err := parseReplyFiles(json.RawMessage(result), "315968")
+	if err != nil {
+		t.Fatalf("parseReplyFiles: %v", err)
+	}
+	if len(files) != 1 || files[0].ID != "32728" || files[0].Name != "" {
+		t.Errorf("want bare-id file, got %+v", files)
+	}
+}
+
+func TestParseReplyFiles_EmptyResult(t *testing.T) {
+	if _, err := parseReplyFiles(json.RawMessage(``), "1"); err == nil {
+		t.Error("want error on empty result")
+	}
+}
+
+// replyMessagesHandler stubs im.dialog.messages.get, recording FIRST_ID and
+// returning the supplied result object.
+func replyMessagesHandler(t *testing.T, calls *atomic.Int32, gotFirstID *string, result any) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/rest/im.dialog.messages.get.json") {
+			t.Errorf("unexpected REST path: %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		calls.Add(1)
+		_ = r.ParseForm()
+		if gotFirstID != nil {
+			*gotFirstID = r.Form.Get("FIRST_ID")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": result})
+	}
+}
+
+func TestFetchReplyMessageFiles_HappyPath(t *testing.T) {
+	var calls atomic.Int32
+	var firstID string
+	result := map[string]any{
+		"messages": []map[string]any{
+			{"id": 315968, "params": map[string]any{"FILE_ID": []int{32728}}},
+		},
+		"files": map[string]any{
+			"32728": map[string]any{"id": 32728, "type": "audio", "name": "voice.ogg", "size": 6789},
+		},
+	}
+	srv := httptest.NewServer(replyMessagesHandler(t, &calls, &firstID, result))
+	defer srv.Close()
+	bc := newChannelWithBoundPortal(t, srv)
+
+	files, err := bc.fetchReplyMessageFiles(context.Background(), "chat1234", "315968")
+	if err != nil {
+		t.Fatalf("fetchReplyMessageFiles: %v", err)
+	}
+	// FIRST_ID must be msgID-1 so the quoted message itself is returned.
+	if firstID != "315967" {
+		t.Errorf("FIRST_ID = %q; want 315967", firstID)
+	}
+	if len(files) != 1 || files[0].Name != "voice.ogg" || files[0].Type != "audio" {
+		t.Fatalf("files mismatch: %+v", files)
+	}
+}
+
+func TestFetchReplyMessageFiles_NilClient(t *testing.T) {
+	bc := &Channel{}
+	if _, err := bc.fetchReplyMessageFiles(context.Background(), "chat1", "1"); err == nil {
+		t.Error("want error when no REST client bound")
+	}
+}
+
+func TestFetchReplyMessageFiles_EmptyArgs(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(replyMessagesHandler(t, &calls, nil, map[string]any{}))
+	defer srv.Close()
+	bc := newChannelWithBoundPortal(t, srv)
+
+	if _, err := bc.fetchReplyMessageFiles(context.Background(), "", "1"); err == nil {
+		t.Error("want error on empty dialog id")
+	}
+	if _, err := bc.fetchReplyMessageFiles(context.Background(), "chat1", ""); err == nil {
+		t.Error("want error on empty msg id")
+	}
+	if calls.Load() != 0 {
+		t.Errorf("should not call REST for empty args, calls=%d", calls.Load())
+	}
+}
+
+func TestResolveReplyContext_NotAReply(t *testing.T) {
+	bc := &Channel{}
+	evt := &Event{Params: EventParams{ReplyMessage: nil}}
+	prefix, media := bc.resolveReplyContext(context.Background(), evt)
+	if prefix != "" || media != nil {
+		t.Errorf("non-reply should be no-op, got prefix=%q media=%v", prefix, media)
+	}
+}
+
+func TestResolveReplyContext_TextBranch(t *testing.T) {
+	var calls atomic.Int32
+	// Author id 62 resolves via user.get to a display name for the note.
+	srv := httptest.NewServer(userGetHandler(t, &calls, map[string]userGetRaw{
+		"62": {ID: "62", Name: "Đặng", LastName: "Tình"},
+	}))
+	defer srv.Close()
+	bc := newChannelWithBoundPortal(t, srv)
+
+	evt := &Event{Params: EventParams{
+		DialogID:     "chat1234",
+		ReplyMessage: &EventReplyMessage{ID: "42", AuthorID: "62", Text: "[b]báo giá[/b] chưa em"},
+	}}
+	prefix, media := bc.resolveReplyContext(context.Background(), evt)
+	if media != nil {
+		t.Errorf("text branch should not fetch media, got %v", media)
+	}
+	if !strings.Contains(prefix, "báo giá chưa em") {
+		t.Errorf("prefix missing sanitized quote: %q", prefix)
+	}
+	if !strings.HasPrefix(prefix, "[Đang trả lời tin của ") {
+		t.Errorf("prefix format wrong: %q", prefix)
+	}
+	if !strings.Contains(prefix, "Đặng Tình") {
+		t.Errorf("prefix should carry resolved author name: %q", prefix)
+	}
+}


### PR DESCRIPTION
## Problem

When a user **replies to / quotes** an earlier message, the Bitrix24 channel showed the agent nothing about the quoted message. `events.go` parsed a `REPLY_TO_MESSAGE_ID` field that Bitrix never sends, so the reply signal was silently dropped and the agent answered without the context it was clearly meant to use.

Bitrix actually ships the quoted message inline on `ONIMBOTMESSAGEADD` as `data[PARAMS][REPLY_MESSAGE][ID|AUTHOR_ID|MESSAGE]` (plus `PARAMS[PARAMS][REPLY_ID]`). For a **text** original the full body is in `MESSAGE`; for a **media** original (image/audio/file/video) `MESSAGE` is empty and no file id is included.

## Approach (Hybrid)

- **Parse** `REPLY_MESSAGE` (form + JSON) into `EventParams.ReplyMessage`, with `PARAMS[REPLY_ID]` as a fallback id. Removes the dead `ReplyToMID` field + `bitrix_reply_to_mid` meta.
- **`reply_context.go` (new)** — `resolveReplyContext`:
  - **Text quote** → sanitize BBCode (reuse the existing user-mention rewriter) + truncate, prepend `[Đang trả lời tin của <author>: "..."]`. No API call.
  - **Media quote** → `im.dialog.messages.get` to recover the quoted attachment, then re-inject it through the **same download pipeline** as a direct upload (STT / vision / read_document), bounded by the existing `media_max_mb`. Always prepends a note; falls back to note-only on any fetch/download failure.
  - `im.dialog.messages.get` is used deliberately: `imbot.v2.Chat.Message.get` returns `BOT_TYPE_NOT_ALLOWED` for `TYPE=bot` bots, whereas `im.dialog.messages.get` (scope `im`) works with the bot token.
- **`handle.go`** — wire the note + extra media into message assembly.

Covers text, image, audio, file, video quotes. Non-reply events are a no-op; one extra REST call only when the quote is media.

## Safety / DRY

- Reuses `downloadEventFiles` (size cap, SSRF-safe client, temp-file streaming) — no new size/MIME logic.
- Best-effort: fetch/download failure never blocks the user's own message from reaching the agent.
- No recursion (does not resolve quote-of-quote). One `im.dialog.messages.get` call, only for media quotes.

## Tests

New unit tests: `REPLY_MESSAGE` parse (form + JSON, text / media / REPLY_ID fallback / non-reply), `sanitizeQuotedText` (+ truncation), `extractFileIDs` (array/scalar/empty/zero-filter), `parseReplyFiles` (match / no-match / missing-metadata / empty), `fetchReplyMessageFiles` (happy path asserts `FIRST_ID = msgID-1`, nil-client, empty-args), and `resolveReplyContext` (non-reply + text branch).

- `go build ./...` ✅ · `go build -tags sqliteonly ./...` ✅ · `go vet ./...` ✅ · `go test ./internal/channels/bitrix24/...` ✅

## Surface parity

Gateway-only. API contract / Web UI / CLI: N/A — inbound channel parsing + agent input assembly; no request/response struct, UI, or CLI surface changes.
