### PR TITLE
fix(bitrix24): label quoted-media reply note from downloaded MIME

### DIFF
--- a/internal/channels/bitrix24/reply_context.go
+++ b/internal/channels/bitrix24/reply_context.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels/media"
 )
 
 // quotedTextMaxRunes caps how much of a quoted text message we inline into the
@@ -55,26 +56,59 @@ func (c *Channel) resolveReplyContext(ctx context.Context, evt *Event) (string, 
 		return fmt.Sprintf("[Đang trả lời một tin nhắn của %s]\n", author), nil
 	}
 
-	note := quotedMediaNote(files, author)
 	// Re-inject through the SAME pipeline as inbound files: oversized files are
 	// skipped (note-only fallback) and the rest flow into the media tags /
 	// read_* tools exactly like a directly-attached upload. DRY — no new size
-	// or MIME logic here.
+	// or MIME logic here. Download BEFORE building the note so the note's kind
+	// label can use the authoritative downloaded MIME (im.dialog.messages.get
+	// often returns a blank type/name for voice notes).
 	extra := c.downloadEventFiles(ctx, c.BotID(), files)
+	note := quotedMediaNote(files, extra, author)
 	return note, extra
 }
 
 // quotedMediaNote builds the "[Đang trả lời một <loại> ...]" prefix for a
 // media-only quoted message. Single file → name + kind; multiple → a count.
-func quotedMediaNote(files []EventFile, author string) string {
-	if len(files) == 1 {
-		f := files[0]
-		if f.Name != "" {
-			return fmt.Sprintf("[Đang trả lời một %s \"%s\" của %s]\n", quotedKindVN(f.Type), f.Name, author)
-		}
-		return fmt.Sprintf("[Đang trả lời một %s của %s]\n", quotedKindVN(f.Type), author)
+// Prefers the downloaded file's MIME for the kind label + its filename, since
+// im.dialog.messages.get metadata (type/name) is frequently blank for voice
+// notes; falls back to the Bitrix file type from the message payload.
+func quotedMediaNote(files []EventFile, downloaded []bus.MediaFile, author string) string {
+	if len(files) > 1 {
+		return fmt.Sprintf("[Đang trả lời %d tệp đính kèm của %s]\n", len(files), author)
 	}
-	return fmt.Sprintf("[Đang trả lời %d tệp đính kèm của %s]\n", len(files), author)
+	kind := "tệp"
+	name := ""
+	if len(files) == 1 {
+		name = files[0].Name
+		if files[0].Type != "" {
+			kind = quotedKindVN(files[0].Type)
+		}
+	}
+	if len(downloaded) >= 1 {
+		kind = mediaKindVN(downloaded[0].MimeType) // authoritative
+		if name == "" {
+			name = downloaded[0].Filename
+		}
+	}
+	if name != "" {
+		return fmt.Sprintf("[Đang trả lời một %s \"%s\" của %s]\n", kind, name, author)
+	}
+	return fmt.Sprintf("[Đang trả lời một %s của %s]\n", kind, author)
+}
+
+// mediaKindVN maps a MIME type to a Vietnamese noun for the reply note, reusing
+// classifyMediaType so the label matches the <media:*> tag the agent receives.
+func mediaKindVN(mime string) string {
+	switch classifyMediaType(mime) {
+	case media.TypeImage:
+		return "hình ảnh"
+	case media.TypeVideo:
+		return "video"
+	case media.TypeAudio:
+		return "tin nhắn thoại"
+	default:
+		return "tệp"
+	}
 }
 
 // quotedAuthorName resolves a Bitrix user id to a display name for the reply

--- a/internal/channels/bitrix24/reply_context_test.go
+++ b/internal/channels/bitrix24/reply_context_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
 )
 
 func TestSanitizeQuotedText(t *testing.T) {
@@ -72,17 +74,50 @@ func TestQuotedKindVN(t *testing.T) {
 }
 
 func TestQuotedMediaNote(t *testing.T) {
-	single := quotedMediaNote([]EventFile{{Name: "voice.ogg", Type: "audio"}}, "Tình")
+	single := quotedMediaNote([]EventFile{{Name: "voice.ogg", Type: "audio"}}, nil, "Tình")
 	if want := "[Đang trả lời một tin nhắn thoại \"voice.ogg\" của Tình]\n"; single != want {
 		t.Errorf("single = %q; want %q", single, want)
 	}
-	noName := quotedMediaNote([]EventFile{{Type: "image"}}, "Tình")
+	noName := quotedMediaNote([]EventFile{{Type: "image"}}, nil, "Tình")
 	if want := "[Đang trả lời một hình ảnh của Tình]\n"; noName != want {
 		t.Errorf("noName = %q; want %q", noName, want)
 	}
-	multi := quotedMediaNote([]EventFile{{Name: "a"}, {Name: "b"}}, "Tình")
+	multi := quotedMediaNote([]EventFile{{Name: "a"}, {Name: "b"}}, nil, "Tình")
 	if want := "[Đang trả lời 2 tệp đính kèm của Tình]\n"; multi != want {
 		t.Errorf("multi = %q; want %q", multi, want)
+	}
+}
+
+// Regression: im.dialog.messages.get returns blank type/name for voice notes,
+// so the note must derive the kind (and filename) from the downloaded MIME
+// instead of falling back to the generic "tệp".
+func TestQuotedMediaNote_PrefersDownloadedMIME(t *testing.T) {
+	files := []EventFile{{ID: "32728"}} // blank Type + Name (as messages.get returned)
+	downloaded := []bus.MediaFile{{MimeType: "audio/x-m4a", Filename: "voice.m4a"}}
+	got := quotedMediaNote(files, downloaded, "Đình Chinh")
+	if want := "[Đang trả lời một tin nhắn thoại \"voice.m4a\" của Đình Chinh]\n"; got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+
+	// Blank downloaded filename → kind still upgraded, no filename shown.
+	got2 := quotedMediaNote([]EventFile{{ID: "1"}}, []bus.MediaFile{{MimeType: "image/png"}}, "Tình")
+	if want := "[Đang trả lời một hình ảnh của Tình]\n"; got2 != want {
+		t.Errorf("got2 %q; want %q", got2, want)
+	}
+}
+
+func TestMediaKindVN(t *testing.T) {
+	cases := map[string]string{
+		"audio/x-m4a":     "tin nhắn thoại",
+		"image/png":       "hình ảnh",
+		"video/mp4":       "video",
+		"application/pdf": "tệp",
+		"":                "tệp",
+	}
+	for mime, want := range cases {
+		if got := mediaKindVN(mime); got != want {
+			t.Errorf("mediaKindVN(%q) = %q; want %q", mime, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up to #1443. For a media-only quoted message, `im.dialog.messages.get` frequently returns a blank type/name (observed live for a voice note), so the reply note fell back to the generic **"một tệp"** even though the file was correctly downloaded and tagged `<media:audio>`.

## Fix

Build the note *after* downloading and derive the kind label from the downloaded file's MIME (reusing `classifyMediaType`), so it reads **"một tin nhắn thoại" / "một hình ảnh" / "một video"** — matching the `<media:*>` tag the agent receives. Falls back to the Bitrix file type, then `tệp`, when no download is available (e.g. oversized). Also adopts the downloaded filename when `messages.get` omitted it.

## Tests

MIME-preference path + `mediaKindVN`. Compile (PG + sqliteonly) + `go vet` + `go test ./internal/channels/bitrix24/...` all green.

## Surface parity

Gateway-only; API contract / Web UI / CLI N/A.
