### PR TITLE
fix(teams): recover task locks for all active teams, not only v2

### DIFF
--- a/internal/store/pg/teams_tasks_followup.go
+++ b/internal/store/pg/teams_tasks_followup.go
@@ -52,7 +52,7 @@ func (s *PGTeamStore) ListAllFollowupDueTasks(ctx context.Context) ([]store.Team
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT `+taskSelectCols+`
 		 `+taskJoinClause+`
-		 `+v2ActiveTeamJoin+`
+		 `+activeTeamJoin+`
 		 WHERE t.followup_at IS NOT NULL
 		   AND t.followup_at <= $1
 		   AND t.status = $2

--- a/internal/store/pg/teams_tasks_progress.go
+++ b/internal/store/pg/teams_tasks_progress.go
@@ -71,15 +71,14 @@ func (s *PGTeamStore) RenewTaskLock(ctx context.Context, taskID, teamID uuid.UUI
 }
 
 // ============================================================
-// Stale recovery (batch — all v2 active teams in one query)
+// Stale recovery (batch — all active teams in one query)
 // ============================================================
 
-// v2ActiveTeamJoin is the JOIN clause that filters to v2 active teams.
-const v2ActiveTeamJoin = `JOIN agent_teams tm ON tm.id = t.team_id
-		 AND tm.status = 'active'
-		 AND COALESCE((tm.settings->>'version')::int, 0) >= 2`
+// activeTeamJoin is the JOIN clause that filters to active teams.
+const activeTeamJoin = `JOIN agent_teams tm ON tm.id = t.team_id
+		 AND tm.status = 'active'`
 
-// RecoverAllStaleTasks resets in_progress tasks with expired locks across all v2 active teams.
+// RecoverAllStaleTasks resets in_progress tasks with expired locks across all active teams.
 func (s *PGTeamStore) RecoverAllStaleTasks(ctx context.Context) ([]store.RecoveredTaskInfo, error) {
 	now := time.Now()
 	rows, err := s.db.QueryContext(ctx,
@@ -89,7 +88,6 @@ func (s *PGTeamStore) RecoverAllStaleTasks(ctx context.Context) ([]store.Recover
 		     followup_channel = NULL, followup_chat_id = NULL, updated_at = $2
 		 FROM agent_teams tm
 		 WHERE t.team_id = tm.id AND tm.status = 'active'
-		   AND COALESCE((tm.settings->>'version')::int, 0) >= 2
 		   AND t.status = $3
 		   AND t.lock_expires_at IS NOT NULL AND t.lock_expires_at < $2
 		 RETURNING t.id, t.team_id, t.tenant_id, t.task_number, t.subject, COALESCE(t.channel, ''), COALESCE(t.chat_id, '')`,
@@ -102,7 +100,7 @@ func (s *PGTeamStore) RecoverAllStaleTasks(ctx context.Context) ([]store.Recover
 	return scanRecoveredTaskInfoRows(rows)
 }
 
-// ForceRecoverAllTasks resets ALL in_progress tasks across v2 active teams (startup).
+// ForceRecoverAllTasks resets ALL in_progress tasks across active teams (startup).
 func (s *PGTeamStore) ForceRecoverAllTasks(ctx context.Context) ([]store.RecoveredTaskInfo, error) {
 	now := time.Now()
 	rows, err := s.db.QueryContext(ctx,
@@ -112,7 +110,6 @@ func (s *PGTeamStore) ForceRecoverAllTasks(ctx context.Context) ([]store.Recover
 		     followup_channel = NULL, followup_chat_id = NULL, updated_at = $2
 		 FROM agent_teams tm
 		 WHERE t.team_id = tm.id AND tm.status = 'active'
-		   AND COALESCE((tm.settings->>'version')::int, 0) >= 2
 		   AND t.status = $3
 		 RETURNING t.id, t.team_id, t.tenant_id, t.task_number, t.subject, COALESCE(t.channel, ''), COALESCE(t.chat_id, '')`,
 		store.TeamTaskStatusPending, now, store.TeamTaskStatusInProgress,
@@ -148,7 +145,7 @@ func (s *PGTeamStore) ListRecoverableTasks(ctx context.Context, teamID uuid.UUID
 	return scanTaskRowsJoined(rows)
 }
 
-// MarkAllStaleTasks marks pending tasks older than olderThan as stale across all v2 active teams.
+// MarkAllStaleTasks marks pending tasks older than olderThan as stale across all active teams.
 func (s *PGTeamStore) MarkAllStaleTasks(ctx context.Context, olderThan time.Time) ([]store.RecoveredTaskInfo, error) {
 	now := time.Now()
 	rows, err := s.db.QueryContext(ctx,
@@ -156,7 +153,6 @@ func (s *PGTeamStore) MarkAllStaleTasks(ctx context.Context, olderThan time.Time
 		 SET status = $1, updated_at = $2
 		 FROM agent_teams tm
 		 WHERE t.team_id = tm.id AND tm.status = 'active'
-		   AND COALESCE((tm.settings->>'version')::int, 0) >= 2
 		   AND t.status = $3 AND t.updated_at < $4
 		 RETURNING t.id, t.team_id, t.tenant_id, t.task_number, t.subject, COALESCE(t.channel, ''), COALESCE(t.chat_id, '')`,
 		store.TeamTaskStatusStale, now, store.TeamTaskStatusPending, olderThan,
@@ -168,7 +164,7 @@ func (s *PGTeamStore) MarkAllStaleTasks(ctx context.Context, olderThan time.Time
 	return scanRecoveredTaskInfoRows(rows)
 }
 
-// MarkInReviewStaleTasks marks in_review tasks older than olderThan as stale across all v2 active teams.
+// MarkInReviewStaleTasks marks in_review tasks older than olderThan as stale across all active teams.
 func (s *PGTeamStore) MarkInReviewStaleTasks(ctx context.Context, olderThan time.Time) ([]store.RecoveredTaskInfo, error) {
 	now := time.Now()
 	rows, err := s.db.QueryContext(ctx,
@@ -176,7 +172,6 @@ func (s *PGTeamStore) MarkInReviewStaleTasks(ctx context.Context, olderThan time
 		 SET status = $1, updated_at = $2
 		 FROM agent_teams tm
 		 WHERE t.team_id = tm.id AND tm.status = 'active'
-		   AND COALESCE((tm.settings->>'version')::int, 0) >= 2
 		   AND t.status = $3 AND t.updated_at < $4
 		 RETURNING t.id, t.team_id, t.tenant_id, t.task_number, t.subject, COALESCE(t.channel, ''), COALESCE(t.chat_id, '')`,
 		store.TeamTaskStatusStale, now, store.TeamTaskStatusInReview, olderThan,
@@ -197,7 +192,6 @@ func (s *PGTeamStore) FixOrphanedBlockedTasks(ctx context.Context) ([]store.Reco
 		 SET blocked_by = '{}', status = $1, updated_at = $2
 		 FROM agent_teams tm
 		 WHERE t.team_id = tm.id AND tm.status = 'active'
-		   AND COALESCE((tm.settings->>'version')::int, 0) >= 2
 		   AND t.status = 'blocked'
 		   AND array_length(t.blocked_by, 1) > 0
 		   AND NOT EXISTS (

--- a/internal/store/sqlitestore/teams_tasks_activity.go
+++ b/internal/store/sqlitestore/teams_tasks_activity.go
@@ -352,11 +352,10 @@ func (s *SQLiteTeamStore) RenewTaskLock(ctx context.Context, taskID, teamID uuid
 // Stale recovery
 // ============================================================
 
-// v2ActiveTeamJoin is the JOIN that filters to v2 active teams.
+// activeTeamJoin is the JOIN that filters to active teams.
 // SQLite uses json_extract instead of PG's ->> operator.
-const v2ActiveTeamJoin = `JOIN agent_teams tm ON tm.id = t.team_id
-		 AND tm.status = 'active'
-		 AND COALESCE(CAST(json_extract(tm.settings, '$.version') AS INTEGER), 0) >= 2`
+const activeTeamJoin = `JOIN agent_teams tm ON tm.id = t.team_id
+		 AND tm.status = 'active'`
 
 func (s *SQLiteTeamStore) RecoverAllStaleTasks(ctx context.Context) ([]store.RecoveredTaskInfo, error) {
 	now := time.Now()
@@ -368,7 +367,6 @@ func (s *SQLiteTeamStore) RecoverAllStaleTasks(ctx context.Context) ([]store.Rec
 		 WHERE status = ? AND lock_expires_at IS NOT NULL AND lock_expires_at < ?
 		   AND team_id IN (
 		     SELECT id FROM agent_teams WHERE status = 'active'
-		       AND COALESCE(CAST(json_extract(settings, '$.version') AS INTEGER), 0) >= 2
 		   )`,
 		store.TeamTaskStatusPending, now, store.TeamTaskStatusInProgress, now,
 	)
@@ -387,7 +385,6 @@ func (s *SQLiteTeamStore) ForceRecoverAllTasks(ctx context.Context) ([]store.Rec
 		 WHERE status = ?
 		   AND team_id IN (
 		     SELECT id FROM agent_teams WHERE status = 'active'
-		       AND COALESCE(CAST(json_extract(settings, '$.version') AS INTEGER), 0) >= 2
 		   )`,
 		store.TeamTaskStatusPending, now, store.TeamTaskStatusInProgress,
 	)
@@ -426,7 +423,6 @@ func (s *SQLiteTeamStore) MarkAllStaleTasks(ctx context.Context, olderThan time.
 		 WHERE status = ? AND updated_at < ?
 		   AND team_id IN (
 		     SELECT id FROM agent_teams WHERE status = 'active'
-		       AND COALESCE(CAST(json_extract(settings, '$.version') AS INTEGER), 0) >= 2
 		   )`,
 		store.TeamTaskStatusStale, now, store.TeamTaskStatusPending, olderThan,
 	)
@@ -443,7 +439,6 @@ func (s *SQLiteTeamStore) MarkInReviewStaleTasks(ctx context.Context, olderThan 
 		 WHERE status = ? AND updated_at < ?
 		   AND team_id IN (
 		     SELECT id FROM agent_teams WHERE status = 'active'
-		       AND COALESCE(CAST(json_extract(settings, '$.version') AS INTEGER), 0) >= 2
 		   )`,
 		store.TeamTaskStatusStale, now, store.TeamTaskStatusInReview, olderThan,
 	)
@@ -462,7 +457,6 @@ func (s *SQLiteTeamStore) FixOrphanedBlockedTasks(ctx context.Context) ([]store.
 		        COALESCE(t.channel, ''), COALESCE(t.chat_id, '')
 		 FROM team_tasks t
 		 JOIN agent_teams tm ON tm.id = t.team_id AND tm.status = 'active'
-		   AND COALESCE(CAST(json_extract(tm.settings, '$.version') AS INTEGER), 0) >= 2
 		 WHERE t.status = 'blocked'
 		   AND t.blocked_by IS NOT NULL AND t.blocked_by != '[]'
 		   AND NOT EXISTS (
@@ -501,7 +495,6 @@ func (s *SQLiteTeamStore) queryRecoveredTasks(ctx context.Context, status string
 		   AND t.updated_at >= ?
 		   AND t.team_id IN (
 		     SELECT id FROM agent_teams WHERE status = 'active'
-		       AND COALESCE(CAST(json_extract(settings, '$.version') AS INTEGER), 0) >= 2
 		   )
 		 ORDER BY t.updated_at DESC
 		 LIMIT 200`,
@@ -599,7 +592,7 @@ func (s *SQLiteTeamStore) ListAllFollowupDueTasks(ctx context.Context) ([]store.
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT `+taskSelectCols+`
 		 `+taskJoinClause+`
-		 `+v2ActiveTeamJoin+`
+		 `+activeTeamJoin+`
 		 WHERE t.followup_at IS NOT NULL
 		   AND t.followup_at <= ?
 		   AND t.status = ?


### PR DESCRIPTION
## Problem

Task **locking** (`AssignTask` / `ClaimTask`) applies to every active team — there is no version check when a lock is placed. But the **recovery / stale-marking / follow-up** queries in `TaskTicker` only ran for teams whose `settings.version >= 2`:

```sql
WHERE t.team_id = tm.id AND tm.status = 'active'
  AND COALESCE((tm.settings->>'version')::int, 0) >= 2   -- <-- the gate
```

Any team created before the `settings.version` flag existed (or otherwise lacking it) has `version = 0`. Such a team can still dispatch tasks and place locks, but its expired locks are **never reclaimed** — the periodic recovery, the startup `ForceRecoverAllTasks`, stale-marking and follow-ups all skip it.

### Observed impact

A pre-v2 team had a task dispatched to a member, the member stopped responding, the lock expired after `taskLockDuration` — and the task sat `in_progress` **indefinitely** (3.5 days, across a process restart). The leader could not re-dispatch: the ticker's own hint says use `team_tasks(action="retry")`, but recovery (when it eventually runs on a v2 team) leaves the task `pending`, and `retry` only accepts `stale`/`failed`/`completed`. On a version-0 team recovery never runs at all, so the task is stuck permanently.

## Fix

Align the maintenance scope with the locking scope: filter recovery, stale-marking and follow-ups to **active teams**, dropping the `settings.version >= 2` condition. Since locking already applies to all active teams, so must lock recovery.

- Postgres (`internal/store/pg/teams_tasks_progress.go`, `teams_tasks_followup.go`)
- SQLite (`internal/store/sqlitestore/teams_tasks_activity.go`)
- Renames the shared JOIN constant `v2ActiveTeamJoin` → `activeTeamJoin` and updates doc comments.

Net: 13 insertions, 26 deletions. No schema/migration change.

## Testing

- `go build` (pg default + `-tags sqlite`) — both backends compile.
- `go test ./internal/tasks/... ./internal/tools/...` and `go test -tags sqlite ./internal/store/sqlitestore/...` — pass.
- No existing test asserts the v1-exclusion behavior (the ticker test uses an in-memory mock backend), so none needed updating.

## Notes for reviewers

If the version gate was intentional to keep genuinely-legacy v1 teams out of ticker maintenance, an alternative is to stamp `settings.version = 2` at team creation plus a backfill migration — but that leaves the locking/recovery asymmetry in place for any team that slips through. Removing the gate fixes the asymmetry directly; follow-ups remain per-task opt-in (they require `followup_channel`/`followup_chat_id`), and stale-marking/recovery only ever touch teams that actually have tasks.