### PR TITLE
fix(bitrix24): preserve whisper visibility on intermediate replies

### DIFF
--- a/internal/channels/routing_metadata.go
+++ b/internal/channels/routing_metadata.go
@@ -16,6 +16,13 @@ var routingMetaKeys = []string{
 	"pancake_mode",           // pancake inbox vs comment routing
 	"post_id",                // pancake: post id for template vars
 	"display_name",           // pancake: commenter display name for template vars
+	// bitrix24 whisper/public visibility. MUST survive into intermediate
+	// replies (quick-ack, progress, reasoning bubbles, block replies) so a
+	// whisper-mode turn doesn't leak its FIRST (intermediate) message to the
+	// external connector while only the final answer is whispered. Literal
+	// string mirrors bitrix24.MetaKeyVisibility (kept as a string here to
+	// avoid a channels→bitrix24 import cycle). Non-bitrix channels ignore it.
+	"bitrix_visibility",
 }
 
 var finalReplyMetaKeys = append([]string{

--- a/internal/channels/routing_metadata_test.go
+++ b/internal/channels/routing_metadata_test.go
@@ -62,3 +62,20 @@ func TestCopyRoutingMeta_PreservesPancakePrivateReplyKeys(t *testing.T) {
 		}
 	}
 }
+
+// TestCopyRoutingMeta_PreservesBitrixVisibility guards the whisper-leak
+// regression: intermediate replies (quick-ack, progress, reasoning bubbles,
+// block replies) must carry bitrix_visibility so a whisper-mode turn does not
+// leak its FIRST (intermediate) message to the external connector while only
+// the final answer is whispered. copyRoutingMeta is the path used by every
+// intermediate publish site; CopyFinalRoutingMeta must keep it too.
+func TestCopyRoutingMeta_PreservesBitrixVisibility(t *testing.T) {
+	src := map[string]string{"bitrix_visibility": "whisper"}
+
+	if got := copyRoutingMeta(src); got["bitrix_visibility"] != "whisper" {
+		t.Fatalf("copyRoutingMeta()[%q] = %q, want %q", "bitrix_visibility", got["bitrix_visibility"], "whisper")
+	}
+	if got := CopyFinalRoutingMeta(src); got["bitrix_visibility"] != "whisper" {
+		t.Fatalf("CopyFinalRoutingMeta()[%q] = %q, want %q", "bitrix_visibility", got["bitrix_visibility"], "whisper")
+	}
+}


### PR DESCRIPTION
## Bug

Whisper-mode leak: with whisper mode enabled, the **first** message the bot sends back is **not** whispered (leaks to the external Open Channel connector); only from the **2nd** message onward does whisper take effect.

## Root cause

Each reply turn emits multiple messages in order:
1. **Intermediate** messages (sent first) — quick-ack, progress, reasoning bubbles, block replies
2. **Final** answer (sent last)

They take two different metadata-copy paths:

| Message | Copy path | `bitrix_visibility` | Result |
|---------|-----------|:---:|---------|
| Final | consumer re-adds the key explicitly | ✅ | correct whisper (v1 `imbot.message.add` + `SKIP_CONNECTOR=Y`) |
| Intermediate | `copyRoutingMeta()` filtered by `routingMetaKeys` | ❌ missing | defaults to public → **leaks to connector** |

`routingMetaKeys` in `internal/channels/routing_metadata.go` omitted `bitrix_visibility`, so every intermediate publish site (block reply, quick-ack, progress, reasoning bubbles) dropped the whisper flag.

## Fix

Add `bitrix_visibility` to `routingMetaKeys` so all intermediate replies inherit the inbound visibility. Uses a literal string (mirrors `bitrix24.MetaKeyVisibility`) to avoid a `channels → bitrix24` import cycle; non-bitrix channels ignore the key.

## Files
- `internal/channels/routing_metadata.go` — add key
- `internal/channels/routing_metadata_test.go` — regression test `TestCopyRoutingMeta_PreservesBitrixVisibility`

## Verify
- `go build ./...` + `go build -tags sqliteonly ./...` — pass
- `go vet ./internal/channels/...` — clean
- `go test ./internal/channels/...` (incl. `bitrix24`) — all pass