### PR TITLE
fix: handle input and database read errors in client and doctor commands

### DIFF
--- a/cmd/agent_chat_client.go
+++ b/cmd/agent_chat_client.go
@@ -76,6 +76,10 @@ func runClientMode(cfg *config.Config, addr, agentName, message, sessionKey stri
 		}
 		fmt.Printf("\n%s\n\n", resp)
 	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "Input error: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 // wsConnect sends the connect RPC and waits for auth response.

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -187,6 +187,10 @@ func checkDBChannels(db *sql.DB) {
 		label := fmt.Sprintf("%s/%s", channelType, name)
 		fmt.Printf("    %-24s %s\n", label+":", status)
 	}
+	if err := rows.Err(); err != nil {
+		fmt.Printf("    (could not read channels: %s)\n", err)
+		return
+	}
 	if !found {
 		fmt.Println("    (none configured in database)")
 	}
@@ -217,6 +221,10 @@ func checkDBProviders(db *sql.DB) {
 			status += " (no API key)"
 		}
 		fmt.Printf("    %-16s %s\n", displayName+":", status)
+	}
+	if err := rows.Err(); err != nil {
+		fmt.Printf("    (could not read providers: %s)\n", err)
+		return
 	}
 	if !found {
 		fmt.Println("    (none configured in database)")

--- a/cmd/gateway_subagent_announce_format.go
+++ b/cmd/gateway_subagent_announce_format.go
@@ -14,11 +14,14 @@ func buildMergedSubagentAnnounce(entries []subagentAnnounceEntry, roster tools.S
 
 	if len(entries) == 1 {
 		e := entries[0]
-		statusLabel := "completed successfully"
-		if e.Status == "failed" {
+		var statusLabel string
+		switch e.Status {
+		case "failed":
 			statusLabel = "failed"
-		} else if e.Status == "cancelled" {
+		case "cancelled":
 			statusLabel = "was cancelled"
+		default:
+			statusLabel = "completed successfully"
 		}
 		fmt.Fprintf(&sb, "[System Message] A subagent task %q just %s.\n\nResult:\n%s\n\nStats: runtime %s, iterations %d, tokens %d in / %d out\n",
 			e.Label, statusLabel, e.Content,


### PR DESCRIPTION
Added error handling for input reading in the agent chat client and for database row reading in the doctor commands, ensuring that errors are reported clearly to the user.

## Summary
<!-- 1-2 sentences: What does this PR do and why? -->

## Type
<!-- Check one -->
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
<!--
  ⚠️  IMPORTANT: Read before submitting!

  - Features/bugfixes → `dev` (default)
  - Hotfixes only → `main` (cherry-pick back to `dev` after merge)
  - DO NOT target `main` for regular development
-->

## Checklist
- [x] `go build ./...` passes
- [ ] `go build -tags sqliteonly ./...` passes (if Go changes)
- [ ] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [ ] No hardcoded secrets or credentials
- [ ] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
<!-- How was this tested? -->
