### PR TITLE
fix(memory): enforce auto-inject budget and correct search schema

### DIFF
--- a/internal/memory/auto_injector_budget_test.go
+++ b/internal/memory/auto_injector_budget_test.go
@@ -1,0 +1,70 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/tokencount"
+)
+
+type budgetTestEpisodicStore struct {
+	store.EpisodicStore
+	results []store.EpisodicSearchResult
+}
+
+func (s *budgetTestEpisodicStore) Search(
+	context.Context,
+	string,
+	string,
+	string,
+	store.EpisodicSearchOptions,
+) ([]store.EpisodicSearchResult, error) {
+	return s.results, nil
+}
+
+func TestAutoInjectorRespectsMaxTokens(t *testing.T) {
+	results := make([]store.EpisodicSearchResult, 12)
+	for i := range results {
+		results[i] = store.EpisodicSearchResult{
+			L0Abstract: fmt.Sprintf("memory %02d: %s", i, "important project context repeated for token budget coverage"),
+			Score:      0.9,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		maxTokens int
+		wantLimit int
+	}{
+		{name: "explicit budget", maxTokens: 100, wantLimit: 100},
+		{name: "default budget", maxTokens: 0, wantLimit: 200},
+	}
+
+	counter := tokencount.NewFallbackCounter()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			injector := NewAutoInjector(&budgetTestEpisodicStore{results: results}, nil)
+			got, err := injector.Inject(context.Background(), InjectParams{
+				AgentID:     "agent-id",
+				UserID:      "user-id",
+				UserMessage: "What did we decide about the project?",
+				MaxEntries:  len(results),
+				MaxTokens:   tt.maxTokens,
+			})
+			if err != nil {
+				t.Fatalf("Inject() error = %v", err)
+			}
+			if got.Injected == 0 {
+				t.Fatal("Inject() injected no memories within a usable budget")
+			}
+			if got.Injected >= len(results) {
+				t.Fatalf("Inject() injected %d memories; want budget to truncate %d available memories", got.Injected, len(results))
+			}
+			if tokens := counter.Count("", got.Section); tokens > tt.wantLimit {
+				t.Fatalf("Inject() section uses %d tokens; want <= %d\n%s", tokens, tt.wantLimit, got.Section)
+			}
+		})
+	}
+}

--- a/internal/memory/auto_injector_impl.go
+++ b/internal/memory/auto_injector_impl.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/tokencount"
 )
+
+const defaultAutoInjectMaxTokens = 200
 
 // pgAutoInjector implements AutoInjector backed by EpisodicStore + FTS search.
 type pgAutoInjector struct {
@@ -35,6 +38,10 @@ func (a *pgAutoInjector) Inject(ctx context.Context, params InjectParams) (*Inje
 	maxEntries := params.MaxEntries
 	if maxEntries <= 0 {
 		maxEntries = 5
+	}
+	maxTokens := params.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultAutoInjectMaxTokens
 	}
 	threshold := params.Threshold
 	if threshold <= 0 {
@@ -64,8 +71,13 @@ func (a *pgAutoInjector) Inject(ctx context.Context, params InjectParams) (*Inje
 	}
 
 	// Build prompt section from L0 abstracts
+	const sectionHeader = "## Memory Context\n\nRelevant memories from past sessions (use memory_search for details):\n"
+	counter := tokencount.NewFallbackCounter()
+	if counter.Count("", sectionHeader) > maxTokens {
+		return &InjectResult{MatchCount: len(results)}, nil
+	}
 	var sb strings.Builder
-	sb.WriteString("## Memory Context\n\nRelevant memories from past sessions (use memory_search for details):\n")
+	sb.WriteString(sectionHeader)
 
 	injected := 0
 	var topScore float64
@@ -76,9 +88,11 @@ func (a *pgAutoInjector) Inject(ctx context.Context, params InjectParams) (*Inje
 		if r.L0Abstract == "" {
 			continue
 		}
-		sb.WriteString("- ")
-		sb.WriteString(r.L0Abstract)
-		sb.WriteString("\n")
+		line := "- " + r.L0Abstract + "\n"
+		if counter.Count("", sb.String()+line) > maxTokens {
+			break
+		}
+		sb.WriteString(line)
 		injected++
 		if r.Score > topScore {
 			topScore = r.Score

--- a/internal/tools/memory.go
+++ b/internal/tools/memory.go
@@ -49,7 +49,7 @@ func (t *MemorySearchTool) SetHasKG(has bool) {
 func (t *MemorySearchTool) Name() string { return "memory_search" }
 
 func (t *MemorySearchTool) Description() string {
-	return "Mandatory recall step: search memory documents and episodic memory before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. For recency/date questions such as today, yesterday, last 24h, this week, \"hom nay\", \"hom qua\", or \"24h gan nhat\": do NOT put date words or guessed topics into query. Use query=\"*\" with createdAfter/createdBefore for calendar windows, or query=\"*\" with timeRange for relative windows; then run a second semantic search only if the user asks for a narrower topic. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user. IMPORTANT: Always query in the SAME language as the stored memory content. If the user speaks Vietnamese, search in Vietnamese. If memory was written in English, search in English. Matching the language dramatically improves search accuracy. If no relevant results found or confidence is low, tell the user you checked but found nothing — do not fabricate or guess memories."
+	return "Mandatory recall step: search memory documents and episodic memory before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. Episodic results are L0 previews; use memory_expand with the episodic ID for full content. For recency/date questions such as today, yesterday, last 24h, this week, \"hom nay\", \"hom qua\", or \"24h gan nhat\": do NOT put date words or guessed topics into query. Use query=\"*\" with createdAfter/createdBefore for calendar windows, or query=\"*\" with timeRange for relative windows; then run a second semantic search only if the user asks for a narrower topic. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user. IMPORTANT: Always query in the SAME language as the stored memory content. If the user speaks Vietnamese, search in Vietnamese. If memory was written in English, search in English. Matching the language dramatically improves search accuracy. If no relevant results found or confidence is low, tell the user you checked but found nothing — do not fabricate or guess memories."
 }
 
 func (t *MemorySearchTool) Parameters() map[string]any {
@@ -67,11 +67,6 @@ func (t *MemorySearchTool) Parameters() map[string]any {
 			"minScore": map[string]any{
 				"type":        "number",
 				"description": "Minimum relevance score threshold (0-1)",
-			},
-			"depth": map[string]any{
-				"type":        "string",
-				"description": "Result depth: l0 (abstracts only), l1 (overview), l2 (full content). Default: l1. Only affects episodic memories.",
-				"enum":        []string{"l0", "l1", "l2"},
 			},
 			"timeRange": map[string]any{
 				"type":        "string",

--- a/internal/tools/memory_search_topics_test.go
+++ b/internal/tools/memory_search_topics_test.go
@@ -70,6 +70,20 @@ func TestMemorySearchDescriptionGuidesRecencyFilters(t *testing.T) {
 	}
 }
 
+func TestMemorySearchSchemaDoesNotAdvertiseUnsupportedDepth(t *testing.T) {
+	tool := NewMemorySearchTool()
+	props, ok := tool.Parameters()["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("memory_search parameters missing properties")
+	}
+	if _, exists := props["depth"]; exists {
+		t.Fatal("memory_search advertises depth, but Execute does not implement it")
+	}
+	if !strings.Contains(tool.Description(), "memory_expand") {
+		t.Fatal("memory_search description must direct callers to memory_expand for full episodic content")
+	}
+}
+
 func (f *memorySearchFakeEpisodicStore) Search(_ context.Context, query string, _ string, _ string, opts store.EpisodicSearchOptions) ([]store.EpisodicSearchResult, error) {
 	f.query = query
 	f.opts = opts


### PR DESCRIPTION
## Summary

- enforce `InjectParams.MaxTokens` across the complete auto-injected memory section
- apply the documented 200-token default when callers leave `MaxTokens` unset
- remove the unsupported `memory_search.depth` schema parameter
- direct callers to `memory_expand` when they need full episodic content

## Root cause

`pgAutoInjector.Inject` limited only the number of L0 entries. It never read
`MaxTokens`, so long abstracts could exceed the documented prompt budget.

`memory_search` advertised `depth` values (`l0`, `l1`, and `l2`), but its
execution path never consumed that argument. Episodic search already returns L0
previews and exposes `memory_expand` as the explicit full-content operation.

## Behavior after this change

- auto-injection counts the header and every selected L0 entry with the existing
  conservative fallback token counter
- entries stop being added before the configured/default budget would be exceeded
- older callers that still send `depth` remain tolerated because tool execution
  ignores unknown arguments; the unsupported option is simply no longer advertised

## Validation

- `go test ./internal/memory ./internal/tools ./internal/agent`
- `go build ./...`
- `go build -tags sqliteonly ./...`
- `go vet ./...`
- `go test -race -tags integration ./tests/integration/`

The full `go test ./...` run reached one unrelated environment-specific failure:
`TestProvidersHandlerCreateAllows1536EmbeddingDimensions` resolved
`generativelanguage.googleapis.com` to reserved address `198.18.28.90`, so the
provider URL guard returned HTTP 400 instead of the test's expected 201. The
memory, tools, and agent packages passed.

## Surface parity

- Gateway/runtime: auto-inject budget is now enforced.
- Tool contract: unsupported `depth` schema removed; `memory_expand` guidance added.
- PostgreSQL/SQLite: N/A because no store behavior or schema changes.
- Web UI: N/A because the tool schema is consumed by the agent runtime, not a UI form.
- CLI/runtime package: N/A because no CLI command or response shape changes.
