### PR TITLE
fix(providers): omit temperature for Claude 5

### DIFF
--- a/internal/providers/adapter_anthropic_test.go
+++ b/internal/providers/adapter_anthropic_test.go
@@ -150,10 +150,16 @@ func TestAnthropicAdapterToRequest_Thinking(t *testing.T) {
 	}
 }
 
-func TestAnthropicAdapterToRequest_SkipsTemperatureForClaude46(t *testing.T) {
+func TestAnthropicAdapterToRequest_SkipsTemperatureForClaude46AndNewer(t *testing.T) {
 	adapter, _ := NewAnthropicAdapter(ProviderConfig{APIKey: "sk-test"})
 
-	for _, model := range []string{"claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-7-20260501"} {
+	for _, model := range []string{
+		"claude-opus-4-6",
+		"claude-sonnet-4-6",
+		"claude-opus-4-7-20260501",
+		"claude-opus-5",
+		"claude-sonnet-5",
+	} {
 		t.Run(model, func(t *testing.T) {
 			req := ChatRequest{
 				Model:    model,
@@ -371,4 +377,3 @@ func TestAnthropicAdapterToRequest_NativeToolIgnored(t *testing.T) {
 		t.Errorf("expected tool name 'web_search', got %v", tool["name"])
 	}
 }
-

--- a/internal/providers/anthropic_request.go
+++ b/internal/providers/anthropic_request.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 )
 
@@ -242,23 +243,31 @@ func (p *AnthropicProvider) buildRequestBody(model string, req ChatRequest, stre
 }
 
 // anthropicSkipsTemperature reports whether the Messages API rejects sampling
-// parameters for this model. Claude Opus/Sonnet 4.6+ and Opus 4.7+ return HTTP
-// 400 when temperature (and top_p/top_k) are included; omit them entirely.
+// parameters for this model. Claude Opus/Sonnet 4.6+ return HTTP 400 when
+// temperature (and top_p/top_k) are included; omit them entirely.
 func anthropicSkipsTemperature(model string) bool {
 	m := strings.ToLower(model)
-	for _, family := range []string{"claude-opus-4-", "claude-sonnet-4-"} {
+	for _, family := range []string{"claude-opus-", "claude-sonnet-"} {
 		after, ok := strings.CutPrefix(m, family)
 		if !ok {
 			continue
 		}
-		minor := 0
-		for _, c := range after {
-			if c < '0' || c > '9' {
-				break
-			}
-			minor = minor*10 + int(c-'0')
+
+		majorPart, afterMajor, hasMinor := strings.Cut(after, "-")
+		major, err := strconv.Atoi(majorPart)
+		if err != nil {
+			continue
 		}
-		if minor >= 6 {
+		if major > 4 {
+			return true
+		}
+		if major < 4 || !hasMinor {
+			continue
+		}
+
+		minorPart, _, _ := strings.Cut(afterMajor, "-")
+		minor, err := strconv.Atoi(minorPart)
+		if err == nil && minor >= 6 {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Handle Claude 5 model IDs as newer Anthropic models that reject sampling parameters. The version parser keeps the existing Claude 4.6+ behavior and preserves `temperature` for Claude 4.5.

Fixes #1474

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch

`dev`

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [ ] Tests pass: `go test -race ./...`
- [x] Web UI builds: `cd ui/web && pnpm build` (if UI changes) — N/A, no UI changes
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat) — N/A, no SQL changes
- [x] New user-facing strings added to all 3 locales (en/vi/zh) — N/A, no new strings
- [x] Migration version bumped in `internal/upgrade/version.go` (if new migration) — N/A, no migration

## Test Plan

- `go test ./internal/providers -run '^TestAnthropicAdapterToRequest_SkipsTemperatureForClaude46AndNewer$' -count=1`
- `go test ./internal/providers -count=1`
- `go build ./...`
- `go build -tags sqliteonly ./...`
- `go vet ./...`
- `git diff --check`

The broad race suite progressed through the repository but did not finish within the local worker window, so it is left unchecked above.
