### PR TITLE
fix(teams): scope team tasks to the delegation origin, not the delivery channel

### DIFF
--- a/internal/tools/context_keys.go
+++ b/internal/tools/context_keys.go
@@ -660,6 +660,27 @@ func WorkspaceChatIDFromCtx(ctx context.Context) string {
 	return ""
 }
 
+// OriginChannelFromCtx returns the channel a run ultimately originated from.
+// A delegated run is delivered on the internal "delegate" channel while the
+// real origin is preserved separately (see buildAgentLinkRunRequest), so team
+// scoping and notification routing must follow the origin — addressing them to
+// the delivery channel makes the outbound dispatcher drop them. Identity for
+// non-delegated runs, where the workspace channel is unset.
+func OriginChannelFromCtx(ctx context.Context) string {
+	if c := WorkspaceChannelFromCtx(ctx); c != "" {
+		return c
+	}
+	return ToolChannelFromCtx(ctx)
+}
+
+// OriginChatIDFromCtx is the chat counterpart of OriginChannelFromCtx.
+func OriginChatIDFromCtx(ctx context.Context) string {
+	if c := WorkspaceChatIDFromCtx(ctx); c != "" {
+		return c
+	}
+	return ToolChatIDFromCtx(ctx)
+}
+
 // --- Pending team task dispatch (post-turn processing) ---
 
 const ctxPendingDispatch toolContextKey = "tool_pending_team_dispatch"

--- a/internal/tools/team_event_helpers.go
+++ b/internal/tools/team_event_helpers.go
@@ -118,8 +118,8 @@ func WithProgress(percent int, step string) TaskEventOption {
 func WithContextInfo(ctx context.Context) TaskEventOption {
 	return func(p *protocol.TeamTaskEventPayload) {
 		p.UserID = store.UserIDFromContext(ctx)
-		p.Channel = ToolChannelFromCtx(ctx)
-		p.ChatID = ToolChatIDFromCtx(ctx)
+		p.Channel = OriginChannelFromCtx(ctx)
+		p.ChatID = OriginChatIDFromCtx(ctx)
 		p.PeerKind = ToolPeerKindFromCtx(ctx)
 		p.LocalKey = ToolLocalKeyFromCtx(ctx)
 	}

--- a/internal/tools/team_task_origin_channel_test.go
+++ b/internal/tools/team_task_origin_channel_test.go
@@ -1,0 +1,93 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// A lead reached through `delegate` runs on the internal "delegate" delivery
+// channel, while the real origin is preserved separately. A task must record
+// the origin: notifications addressed to the delivery channel have no
+// registered handler and are dropped by the outbound dispatcher, so the caller
+// never hears about completions, failures or blocker escalations.
+func TestCreateRecordsDelegationOriginNotDeliveryChannel(t *testing.T) {
+	mb, tool, _, _, ctx := newTestTeamSetup()
+
+	// Shape the context the way a delegated run is built (buildAgentLinkRunRequest):
+	// delivery channel is "delegate", origin preserved as the workspace channel/chat.
+	ctx = WithToolChannel(ctx, "delegate")
+	ctx = WithToolChatID(ctx, "system")
+	ctx = WithWorkspaceChannel(ctx, "telegram")
+	ctx = WithWorkspaceChatID(ctx, "313683273")
+
+	ptd := NewPendingTeamDispatch()
+	ptd.MarkListed()
+	ctx = WithPendingTeamDispatch(ctx, ptd)
+
+	result := tool.Execute(ctx, map[string]any{
+		"action":      "create",
+		"subject":     "Origin routing",
+		"description": "Task created by a delegated lead",
+		"assignee":    "member-agent",
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.ForLLM)
+	}
+	if !strings.Contains(result.ForLLM, "Task created") {
+		t.Fatalf("expected 'Task created', got: %s", result.ForLLM)
+	}
+
+	mb.taskStore.mu.Lock()
+	var task *store.TeamTaskData
+	for _, v := range mb.taskStore.tasks {
+		task = v
+	}
+	mb.taskStore.mu.Unlock()
+	if task == nil {
+		t.Fatal("no task was created")
+	}
+	if task.Channel != "telegram" {
+		t.Errorf("task.Channel = %q, want %q — notifications on the delivery channel are dropped", task.Channel, "telegram")
+	}
+	if task.ChatID != "313683273" {
+		t.Errorf("task.ChatID = %q, want %q", task.ChatID, "313683273")
+	}
+}
+
+// Without a delegation origin the resolution is the identity: a task keeps the
+// channel and chat of the run that created it.
+func TestCreateKeepsOwnChannelWithoutDelegationOrigin(t *testing.T) {
+	mb, tool, _, _, ctx := newTestTeamSetup()
+
+	ptd := NewPendingTeamDispatch()
+	ptd.MarkListed()
+	ctx = WithPendingTeamDispatch(ctx, ptd)
+
+	result := tool.Execute(ctx, map[string]any{
+		"action":      "create",
+		"subject":     "Direct routing",
+		"description": "Task created by a lead talking to the user directly",
+		"assignee":    "member-agent",
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.ForLLM)
+	}
+
+	mb.taskStore.mu.Lock()
+	var task *store.TeamTaskData
+	for _, v := range mb.taskStore.tasks {
+		task = v
+	}
+	mb.taskStore.mu.Unlock()
+	if task == nil {
+		t.Fatal("no task was created")
+	}
+	if task.Channel != ChannelDashboard {
+		t.Errorf("task.Channel = %q, want %q", task.Channel, ChannelDashboard)
+	}
+	if task.ChatID != testTeamID.String() {
+		t.Errorf("task.ChatID = %q, want %q", task.ChatID, testTeamID.String())
+	}
+}

--- a/internal/tools/team_task_origin_channel_test.go
+++ b/internal/tools/team_task_origin_channel_test.go
@@ -1,10 +1,12 @@
 package tools
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
 )
 
 // A lead reached through `delegate` runs on the internal "delegate" delivery
@@ -89,5 +91,114 @@ func TestCreateKeepsOwnChannelWithoutDelegationOrigin(t *testing.T) {
 	}
 	if task.ChatID != testTeamID.String() {
 		t.Errorf("task.ChatID = %q, want %q", task.ChatID, testTeamID.String())
+	}
+}
+
+// delegatedCtx shapes a context the way buildAgentLinkRunRequest does: the run is
+// delivered on the internal "delegate" channel while the caller's origin is
+// preserved as the workspace channel and chat.
+func delegatedCtx(ctx context.Context, originChannel, originChat string) context.Context {
+	ctx = WithToolChannel(ctx, "delegate")
+	ctx = WithToolChatID(ctx, "system")
+	ctx = WithWorkspaceChannel(ctx, originChannel)
+	ctx = WithWorkspaceChatID(ctx, originChat)
+	ptd := NewPendingTeamDispatch()
+	ptd.MarkListed()
+	return WithPendingTeamDispatch(ctx, ptd)
+}
+
+func createTaskIn(t *testing.T, tool *TeamTasksTool, ctx context.Context, subject string) string {
+	t.Helper()
+	res := tool.Execute(ctx, map[string]any{
+		"action":      "create",
+		"subject":     subject,
+		"description": "work",
+		"assignee":    "member-agent",
+	})
+	if res.IsError {
+		t.Fatalf("create %q: %s", subject, res.ForLLM)
+	}
+	id := res.ForLLM
+	start := strings.Index(id, "id=")
+	if start < 0 {
+		t.Fatalf("no task id in %q", res.ForLLM)
+	}
+	id = id[start+3:]
+	if end := strings.IndexAny(id, ","); end >= 0 {
+		id = id[:end]
+	}
+	return id
+}
+
+func completionEvent(t *testing.T, mb *mockBackend, taskID string) protocol.TeamTaskEventPayload {
+	t.Helper()
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	for _, ev := range mb.events {
+		p, ok := ev.Payload.(protocol.TeamTaskEventPayload)
+		if ok && ev.Name == protocol.EventTeamTaskCompleted && p.TaskID == taskID {
+			return p
+		}
+	}
+	t.Fatalf("no completion event for task %s", taskID)
+	return protocol.TeamTaskEventPayload{}
+}
+
+// The notification a delegated lead emits on completion must be addressed to the
+// caller's origin. Addressed to the internal "delegate" delivery channel it is
+// dropped by the outbound dispatcher and the user never learns the work finished.
+func TestDelegatedLeadCompletionNotifiesOrigin(t *testing.T) {
+	mb, tool, _, _, base := newTestTeamSetup()
+	ctx := delegatedCtx(base, "telegram", "313683273")
+
+	taskID := createTaskIn(t, tool, ctx, "Deliverable")
+	res := tool.Execute(ctx, map[string]any{
+		"action":  "complete",
+		"task_id": taskID,
+		"result":  "done",
+	})
+	if res.IsError {
+		t.Fatalf("complete: %s", res.ForLLM)
+	}
+
+	ev := completionEvent(t, mb, taskID)
+	if ev.Channel != "telegram" || ev.ChatID != "313683273" {
+		t.Errorf("completion event addressed to %s/%s, want telegram/313683273 — "+
+			"the delivery channel has no registered handler and the notification is dropped",
+			ev.Channel, ev.ChatID)
+	}
+}
+
+// Origins must not bleed into each other: completing a task raised from one chat
+// must not produce a notification addressed to an unrelated origin sharing the
+// same board.
+func TestCompletionNotificationStaysWithinItsOwnOrigin(t *testing.T) {
+	mb, tool, _, _, base := newTestTeamSetup()
+	ctxA := delegatedCtx(base, "telegram", "chat-A")
+	ctxB := delegatedCtx(base, "discord", "chat-B")
+
+	taskA := createTaskIn(t, tool, ctxA, "Task A")
+	createTaskIn(t, tool, ctxB, "Task B")
+
+	res := tool.Execute(ctxA, map[string]any{"action": "complete", "task_id": taskA, "result": "done"})
+	if res.IsError {
+		t.Fatalf("complete: %s", res.ForLLM)
+	}
+
+	if ev := completionEvent(t, mb, taskA); ev.Channel != "telegram" || ev.ChatID != "chat-A" {
+		t.Errorf("task A announced to %s/%s, want telegram/chat-A", ev.Channel, ev.ChatID)
+	}
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	for _, ev := range mb.events {
+		p, ok := ev.Payload.(protocol.TeamTaskEventPayload)
+		if !ok || ev.Name != protocol.EventTeamTaskCompleted {
+			continue
+		}
+		if p.Channel == "discord" || p.ChatID == "chat-B" {
+			t.Errorf("completing task A produced a notification addressed to the unrelated origin %s/%s",
+				p.Channel, p.ChatID)
+		}
 	}
 }

--- a/internal/tools/team_tasks_create.go
+++ b/internal/tools/team_tasks_create.go
@@ -23,7 +23,7 @@ func (t *TeamTasksTool) executeCreate(ctx context.Context, args map[string]any) 
 
 	// Determine if caller is a lead or a member.
 	isLead := agentID == team.LeadAgentID
-	channel := ToolChannelFromCtx(ctx)
+	channel := OriginChannelFromCtx(ctx)
 	if channel == ChannelTeammate || channel == ChannelSystem {
 		isLead = true // system/teammate channels act on behalf of the lead
 	}
@@ -139,7 +139,7 @@ func (t *TeamTasksTool) executeCreate(ctx context.Context, args map[string]any) 
 	memberCfgForDispatch := ParseMemberRequestConfig(team.Settings)
 	skipAutoDispatch := !isLead && taskType == "request" && !memberCfgForDispatch.AutoDispatch
 
-	chatID := ToolChatIDFromCtx(ctx)
+	chatID := OriginChatIDFromCtx(ctx)
 
 	// Compute team workspace via layered pipeline: tenant → team → user/chat.
 	shared := IsSharedWorkspace(team.Settings)
@@ -226,7 +226,7 @@ func (t *TeamTasksTool) executeCreate(ctx context.Context, args map[string]any) 
 		// this same UserID. Migrating to ActorIDFromContext would hide group
 		// members' shared work from each other.
 		UserID:           store.UserIDFromContext(ctx),
-		Channel:          ToolChannelFromCtx(ctx),
+		Channel:          OriginChannelFromCtx(ctx),
 		TaskType:         taskType,
 		CreatedByAgentID: &agentID,
 		ChatID:           chatID,

--- a/internal/tools/team_tasks_followup.go
+++ b/internal/tools/team_tasks_followup.go
@@ -39,10 +39,10 @@ func (t *TeamTasksTool) executeAskUser(ctx context.Context, args map[string]any)
 	// Resolve channel: prefer task's channel, fallback to context channel.
 	channel := task.Channel
 	chatID := task.ChatID
-	ctxChannel := ToolChannelFromCtx(ctx)
+	ctxChannel := OriginChannelFromCtx(ctx)
 	if channel == "" || channel == ChannelTeammate || channel == ChannelSystem || channel == ChannelDashboard {
 		channel = ctxChannel
-		chatID = ToolChatIDFromCtx(ctx)
+		chatID = OriginChatIDFromCtx(ctx)
 	}
 	if channel == "" || channel == ChannelTeammate || channel == ChannelSystem || channel == ChannelDashboard {
 		return ErrorResult("cannot set follow-up: no valid channel found (task has no origin channel and context channel is internal)")

--- a/internal/tools/team_tasks_mutations.go
+++ b/internal/tools/team_tasks_mutations.go
@@ -211,7 +211,7 @@ func (t *TeamTasksTool) executeAttach(ctx context.Context, args map[string]any) 
 		return ErrorResult("task does not belong to your team")
 	}
 
-	chatID := ToolChatIDFromCtx(ctx)
+	chatID := OriginChatIDFromCtx(ctx)
 	if err := t.manager.Store().AttachFileToTask(ctx, &store.TeamTaskAttachmentData{
 		TaskID:           taskID,
 		TeamID:           team.ID,

--- a/internal/tools/team_tasks_read.go
+++ b/internal/tools/team_tasks_read.go
@@ -197,11 +197,11 @@ func (t *TeamTasksTool) executeList(ctx context.Context, args map[string]any) *R
 
 	// Teammate/system channels see all tasks; end users only see their own.
 	filterUserID := ""
-	channel := ToolChannelFromCtx(ctx)
+	channel := OriginChannelFromCtx(ctx)
 	if channel != ChannelTeammate && channel != ChannelSystem {
 		filterUserID = store.UserIDFromContext(ctx)
 	}
-	chatID := ToolChatIDFromCtx(ctx)
+	chatID := OriginChatIDFromCtx(ctx)
 	// Shared workspace: show all tasks across chats.
 	listChatID := chatID
 	if IsSharedWorkspace(team.Settings) {
@@ -375,13 +375,13 @@ func (t *TeamTasksTool) executeSearch(ctx context.Context, args map[string]any) 
 
 	// Teammate/system channels see all tasks; end users only see their own.
 	filterUserID := ""
-	channel := ToolChannelFromCtx(ctx)
+	channel := OriginChannelFromCtx(ctx)
 	if channel != ChannelTeammate && channel != ChannelSystem {
 		filterUserID = store.UserIDFromContext(ctx)
 	}
 
 	// Acquire team create lock so search also satisfies the list-before-create gate.
-	chatID := ToolChatIDFromCtx(ctx)
+	chatID := OriginChatIDFromCtx(ctx)
 	if ptd := PendingTeamDispatchFromCtx(ctx); ptd != nil && !ptd.HasListed() {
 		lock := getTeamCreateLock(team.ID.String(), chatID)
 		lock.Lock()

--- a/internal/tools/team_tool_dispatch.go
+++ b/internal/tools/team_tool_dispatch.go
@@ -123,11 +123,11 @@ func (m *TeamToolManager) dispatchTaskToAgent(ctx context.Context, task *store.T
 	// Falls back to ctx values for initial dispatch (task just created, fields match ctx).
 	originChannel := task.Channel
 	if originChannel == "" {
-		originChannel = ToolChannelFromCtx(ctx)
+		originChannel = OriginChannelFromCtx(ctx)
 	}
 	originChatID := task.ChatID
 	if originChatID == "" {
-		originChatID = ToolChatIDFromCtx(ctx)
+		originChatID = OriginChatIDFromCtx(ctx)
 	}
 	// Resolve lead agent key for completion announce routing.
 	fromAgent := ToolAgentKeyFromCtx(ctx)

--- a/internal/tools/team_tool_helpers.go
+++ b/internal/tools/team_tool_helpers.go
@@ -195,10 +195,10 @@ func (m *TeamToolManager) createEscalationTask(ctx context.Context, team *store.
 		Description:      description,
 		Status:           store.TeamTaskStatusPending,
 		UserID:           store.UserIDFromContext(ctx),
-		Channel:          ToolChannelFromCtx(ctx),
+		Channel:          OriginChannelFromCtx(ctx),
 		TaskType:         "escalation",
 		CreatedByAgentID: &agentID,
-		ChatID:           ToolChatIDFromCtx(ctx),
+		ChatID:           OriginChatIDFromCtx(ctx),
 	}
 	if err := m.teamStore.CreateTask(ctx, task); err != nil {
 		return ErrorResult("failed to create escalation task: " + err.Error())

--- a/internal/tools/team_tool_validation.go
+++ b/internal/tools/team_tool_validation.go
@@ -174,8 +174,8 @@ func (m *TeamToolManager) notifyLeaderCycleError(ctx context.Context, teamID uui
 	content := fmt.Sprintf("[System] %s\nPlease recreate these tasks with corrected dependencies.\nUse team_tasks(action=\"list\") to view current task board.", cycleDesc)
 
 	// Resolve routing: use context channel/chatID if available, fallback to dashboard.
-	channel := ToolChannelFromCtx(ctx)
-	chatID := ToolChatIDFromCtx(ctx)
+	channel := OriginChannelFromCtx(ctx)
+	chatID := OriginChatIDFromCtx(ctx)
 	if channel == "" || channel == ChannelSystem || channel == ChannelTeammate {
 		channel = "dashboard"
 		chatID = teamID.String()


### PR DESCRIPTION
Fixes #1529. Sibling of #1527 / #1528 — same underlying assumption, no code overlap. The two are independent and can land in either order.

### Problem

`buildAgentLinkRunRequest` is explicit that a delegated run is delivered on an internal channel while its real origin is kept aside:

```go
// preserves the origin's authorization-bearing identity while keeping
// delegation on its internal delivery channel.
Channel:          "delegate",
WorkspaceChannel: req.Channel,
WorkspaceChatID:  req.ChatID,
```

The team tools never consulted that origin, so a task created by a lead reached through `delegate` was stamped with the delivery channel. Nothing is registered for `"delegate"`, so `internal/channels/dispatch.go` dropped every notification about that task — completion, failure, blocker escalation, `ask_user`:

```
16:11:39  INFO teammate announce: batch processed  session=delegate:019f4566:brain:e7ee9913-...
16:11:39  WARN unknown channel for outbound message channel=delegate
```

The delegatee's *first* answer still arrived, because it travels back as the delegation result rather than through a channel. Everything the lead said afterwards was lost — one session produced 16 such drops, including an escalation the user needed:

> Reviewer is blocked: tetris.html does not exist, the coder's generation failed. Restarted generation (running), re-pointed the review at it.

### Change

Add `OriginChannelFromCtx` / `OriginChatIDFromCtx` beside the existing workspace-scope helpers, and use them where team scoping and notification routing are decided: task records, list/search scoping, dispatch fallbacks, event payloads, escalation tasks, `ask_user`, leader notifications. Both resolve to the identity when no delegation origin is present, so non-delegated flows are untouched.

Create and read had to move together — the create lock key and the `list` chat filter must agree, or a lead would stop seeing its own board.

**Deliberately not changed:** the channel used in authorization decisions — `checkTeamAccess`, `requireLead`, and the approve/reject lead bypass. Those ask "how did this call arrive", not "where should the answer go"; widening them is a separate question and a separate risk.

### Test

Two subtests around `executeCreate`: one shapes the context the way `buildAgentLinkRunRequest` does (delivery channel `"delegate"`, origin preserved separately) and asserts the task records the origin; the other asserts a non-delegated lead still records its own channel and chat. The first fails on `dev`:

```
task.Channel = "delegate", want "telegram" — notifications on the delivery channel are dropped
task.ChatID = "system", want "313683273"
```

`go test ./internal/tools/ ./cmd/... ./internal/gateway/... ./internal/http/... ./internal/agent/...` is green.

### Verified in a live deployment

Built with this change (on top of #1528, so the tasks actually dispatch) and deployed to Kubernetes. Same delegated-lead flow:

```
16:39:49  v3.run.completed agent=brain
16:39:49  team_tasks.dispatch: sent task to agent agent_key=coder
16:41:03  v3.run.completed agent=coder
16:41:03  team_tasks.dispatch: sent task to agent agent_key=reviewer
16:41:04  run_id=teammate-announce-brain-1  session_key=agent:019f4566-...:http-313683273-5fa7002d
```

That last line is the point: the completion announce is now delivered into the **caller's** session instead of a delegation session that closed minutes earlier. Drops on `channel=delegate` went from 16 in the previous session to 2, and both remaining ones come from tasks created *before* the change — their bad channel is already persisted, so the fix is forward-looking only. Existing stuck tasks keep routing nowhere until they are recreated; worth a note in release notes, or a migration if you would rather backfill from `TaskMetaOriginSession`.
