### PR TITLE
fix: handle SQLite provider settings updates

### DIFF
--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -818,6 +818,7 @@ func (h *ProvidersHandler) handleUpdateProvider(w http.ResponseWriter, r *http.R
 			return
 		}
 		candidate.Settings = rawSettings
+		updates["settings"] = rawSettings
 	}
 
 	// Re-validate URLs against the (possibly new) provider type.

--- a/internal/http/providers_test.go
+++ b/internal/http/providers_test.go
@@ -554,6 +554,42 @@ func TestProvidersHandlerUpdateAllowsClaudeCLIExecutablePath(t *testing.T) {
 	}
 }
 
+func TestProvidersHandlerUpdateMarshalsSettingsForStore(t *testing.T) {
+	token := setupProvidersAdminToken(t)
+	providerStore := newMockProviderStore()
+	provider := &store.LLMProviderData{
+		BaseModel:    store.BaseModel{ID: uuid.New()},
+		Name:         "openai",
+		ProviderType: store.ProviderOpenAICompat,
+		Enabled:      true,
+		Settings:     json.RawMessage(`{}`),
+	}
+	if err := providerStore.CreateProvider(context.Background(), provider); err != nil {
+		t.Fatalf("CreateProvider() error = %v", err)
+	}
+
+	handler := NewProvidersHandler(providerStore, newMockSecretsStore(), nil, "")
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	body := `{"settings":{"timeout_seconds":60}}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/providers/"+provider.ID.String(), bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d, body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	current, err := providerStore.GetProvider(context.Background(), provider.ID)
+	if err != nil {
+		t.Fatalf("GetProvider() error = %v", err)
+	}
+	if got, want := string(current.Settings), `{"timeout_seconds":60}`; got != want {
+		t.Fatalf("settings = %s, want %s", got, want)
+	}
+}
+
 func TestProvidersHandlerUpdateRejectsIncompatibleEmbeddingDimensions(t *testing.T) {
 	token := setupProvidersAdminToken(t)
 	providerStore := newMockProviderStore()

--- a/internal/store/sqlitestore/providers_settings_test.go
+++ b/internal/store/sqlitestore/providers_settings_test.go
@@ -1,0 +1,69 @@
+//go:build sqlite || sqliteonly
+
+package sqlitestore
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+func TestSQLiteProviderStoreReadsTextAndBlobSettings(t *testing.T) {
+	db := openTestDB(t)
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	initSqlx(db)
+
+	providerStore := NewSQLiteProviderStore(db, "")
+	ctx := store.WithTenantID(context.Background(), store.MasterTenantID)
+
+	tests := []struct {
+		name     string
+		settings json.RawMessage
+	}{
+		{name: "text-settings", settings: json.RawMessage(`{"source":"text"}`)},
+		{name: "blob-settings", settings: json.RawMessage(`{"source":"blob"}`)},
+	}
+	providerIDs := make([]uuid.UUID, len(tests))
+	for i := range tests {
+		provider := &store.LLMProviderData{
+			BaseModel:    store.BaseModel{ID: uuid.New()},
+			Name:         tests[i].name,
+			ProviderType: store.ProviderOpenAICompat,
+			Enabled:      true,
+			Settings:     tests[i].settings,
+		}
+		if err := providerStore.CreateProvider(ctx, provider); err != nil {
+			t.Fatalf("CreateProvider(%q): %v", provider.Name, err)
+		}
+		providerIDs[i] = provider.ID
+	}
+
+	textSettings := string(tests[0].settings)
+	if _, err := db.Exec(`UPDATE llm_providers SET settings = ? WHERE id = ?`, textSettings, providerIDs[0]); err != nil {
+		t.Fatalf("store settings as TEXT: %v", err)
+	}
+
+	for i, wantType := range []string{"text", "blob"} {
+		var gotType string
+		if err := db.QueryRow(`SELECT typeof(settings) FROM llm_providers WHERE id = ?`, providerIDs[i]).Scan(&gotType); err != nil {
+			t.Fatalf("read settings storage type: %v", err)
+		}
+		if gotType != wantType {
+			t.Fatalf("settings storage type = %q, want %q", gotType, wantType)
+		}
+
+		got, err := providerStore.GetProvider(ctx, providerIDs[i])
+		if err != nil {
+			t.Fatalf("GetProvider(%s): %v", wantType, err)
+		}
+		if string(got.Settings) != string(tests[i].settings) {
+			t.Fatalf("GetProvider(%s) settings = %s, want %s", wantType, got.Settings, tests[i].settings)
+		}
+	}
+}

--- a/internal/store/sqlitestore/scan_json.go
+++ b/internal/store/sqlitestore/scan_json.go
@@ -1,0 +1,23 @@
+//go:build sqlite || sqliteonly
+
+package sqlitestore
+
+import "fmt"
+
+// sqliteJSONValue accepts JSON stored by SQLite as either TEXT or BLOB.
+type sqliteJSONValue []byte
+
+// Scan implements sql.Scanner.
+func (j *sqliteJSONValue) Scan(src any) error {
+	switch value := src.(type) {
+	case nil:
+		*j = nil
+	case string:
+		*j = append((*j)[:0], value...)
+	case []byte:
+		*j = append((*j)[:0], value...)
+	default:
+		return fmt.Errorf("sqliteJSONValue: unsupported type %T", src)
+	}
+	return nil
+}

--- a/internal/store/sqlitestore/sqlx_scan_structs.go
+++ b/internal/store/sqlitestore/sqlx_scan_structs.go
@@ -20,7 +20,7 @@ type providerRow struct {
 	APIBase      string          `json:"api_base" db:"api_base"`
 	APIKey       string          `json:"api_key" db:"api_key"`
 	Enabled      bool            `json:"enabled" db:"enabled"`
-	Settings     json.RawMessage `json:"settings" db:"settings"`
+	Settings     sqliteJSONValue `json:"settings" db:"settings"`
 	CreatedAt    sqliteTime      `json:"created_at" db:"created_at"`
 	UpdatedAt    sqliteTime      `json:"updated_at" db:"updated_at"`
 	TenantID     uuid.UUID       `json:"tenant_id" db:"tenant_id"`
@@ -36,7 +36,7 @@ func (r *providerRow) toLLMProviderData() store.LLMProviderData {
 		APIBase:      r.APIBase,
 		APIKey:       r.APIKey,
 		Enabled:      r.Enabled,
-		Settings:     r.Settings,
+		Settings:     json.RawMessage(r.Settings),
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix SQLite provider settings updates by passing validated JSON bytes to the store and allowing provider rows to scan settings stored as either `TEXT` or `BLOB`. Existing affected rows recover without a migration.

Closes #978

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch

`dev`

## Checklist

- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [x] Web UI builds: not applicable — no UI changes
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized placeholders
- [x] User-facing translations: not applicable — no new strings
- [x] Migration version: not applicable — no migration

## Test Plan

- Added an HTTP regression test verifying provider settings reach the store as `json.RawMessage`.
- Added SQLite regression coverage for both `TEXT` and `BLOB` settings.
- Ran the full race test suite and the full `sqliteonly` test suite.

## Surface Parity

- API contract: unchanged.
- Web UI: no changes required; the backend recovers affected rows.
- CLI/runtime: unchanged.
