### PR TITLE
fix(teams): stream teammate runs so long generations keep the connection alive

### DIFF
--- a/cmd/gateway_consumer_handlers.go
+++ b/cmd/gateway_consumer_handlers.go
@@ -276,7 +276,17 @@ func handleTeammateMessage(
 		SenderID:        teammateSenderID, // real user who triggered the teammate dispatch (#915)
 		Role:            teammateRole,     // RBAC role for admin bypass during teammate turn (#915)
 		RunID:           fmt.Sprintf("teammate-%s-%s", msg.Metadata[tools.MetaFromAgent], msg.Metadata[tools.MetaToAgent]),
-		Stream:          false,
+		// Streamed for connection liveness, not for delivery. A teammate run is
+		// never registered with the channel manager, so HandleAgentEvent drops its
+		// chunks on the first line and nothing is delivered incrementally; the task
+		// result still comes from the final RunResult. What streaming buys is the
+		// response headers arriving immediately: a non-streamed request to a slow
+		// reasoning model holds a silent connection for the whole generation, and
+		// ResponseHeaderTimeout kills it — observed as
+		// `http2: timeout awaiting response headers` on a member asked to produce a
+		// large file, while the same model over the same provider was fine on a
+		// streamed channel run.
+		Stream:          true,
 		TeamTaskID:      msg.Metadata[tools.MetaTeamTaskID],
 		TeamWorkspace:   msg.Metadata[tools.MetaTeamWorkspace],
 		LeaderAgentID:   msg.Metadata[tools.MetaLeaderAgentID],

--- a/cmd/gateway_consumer_teammate_stream_test.go
+++ b/cmd/gateway_consumer_teammate_stream_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/agent"
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	"github.com/nextlevelbuilder/goclaw/internal/channels"
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/scheduler"
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
+)
+
+// A teammate run must ask the provider to stream. Without it a slow reasoning
+// model holds a silent connection for the whole generation and
+// ResponseHeaderTimeout kills the request before a single token is produced.
+//
+// The same test pins the other half of the contract: streaming here is for
+// connection liveness only. The run is deliberately never registered with the
+// channel manager, so HandleAgentEvent drops its chunks and nothing reaches a
+// user incrementally — the task result keeps coming from the final RunResult.
+func TestHandleTeammateMessageSchedulesStreamedRun(t *testing.T) {
+	var gotReq agent.RunRequest
+	ran := make(chan struct{})
+
+	sched := scheduler.NewScheduler(
+		scheduler.DefaultLanes(),
+		scheduler.QueueConfig{
+			Mode:          scheduler.QueueModeQueue,
+			Cap:           1,
+			Drop:          scheduler.DropOld,
+			MaxConcurrent: 1,
+		},
+		func(_ context.Context, req agent.RunRequest) (*agent.RunResult, error) {
+			gotReq = req
+			close(ran)
+			return &agent.RunResult{Content: "member deliverable"}, nil
+		},
+	)
+	defer sched.Stop()
+
+	channelMgr := channels.NewManager(nil)
+	deps := &ConsumerDeps{
+		Cfg:        &config.Config{},
+		Sched:      sched,
+		ChannelMgr: channelMgr,
+	}
+
+	msg := bus.InboundMessage{
+		Channel:  tools.ChannelSystem,
+		SenderID: "teammate:dashboard",
+		AgentID:  "coder",
+		Content:  "[Assigned task #1 (id: 00000000-0000-0000-0000-000000000001)]: build something",
+		Metadata: map[string]string{
+			tools.MetaOriginChannel: "telegram",
+			tools.MetaOriginChatID:  "12345",
+			tools.MetaFromAgent:     "brain",
+			tools.MetaToAgent:       "coder",
+		},
+	}
+
+	if !handleTeammateMessage(context.Background(), msg, deps) {
+		t.Fatal("handleTeammateMessage() = false, want true for a teammate: message on the system channel")
+	}
+
+	select {
+	case <-ran:
+	case <-time.After(5 * time.Second):
+		t.Fatal("teammate run was never scheduled")
+	}
+
+	if !gotReq.Stream {
+		t.Error("teammate run requested a non-streamed provider call: a slow model then holds a silent " +
+			"connection for the whole generation until ResponseHeaderTimeout kills it")
+	}
+
+	if delivered, last := channelMgr.InterimDeliverySnapshot(gotReq.RunID); delivered != 0 || last != "" {
+		t.Errorf("teammate run is registered for channel delivery (delivered=%d, last=%q); "+
+			"streamed chunks would reach a user incrementally", delivered, last)
+	}
+}


### PR DESCRIPTION
Fixes #1532.

### Problem

`handleTeammateMessage` pinned `Stream: false`, so every team member run — coder, reviewer, researcher — made a non-streamed provider call, with no setting to change it. On a slow reasoning model the connection then stays silent for the whole generation while the provider buffers the full response, and `ResponseHeaderTimeout` kills it:

```
iter 0 think: llm call: litellm: request failed:
  Post ".../v1/chat/completions": http2: timeout awaiting response headers
```

Measured on one task (a complete single-file HTML game, `openrouter/stealth/ox-alpha` behind a LiteLLM proxy):

```
before   one LLM span, ~15 min   status=error  tools=0   out_tok=0      (3 attempts, all identical)
after    completed               iterations=18 tools=22  out_tok=22432  duration=570s
```

The same model over the same provider was always fine on ordinary channel runs, which stream by default.

### Change

One line: `Stream: true`, plus a comment recording why — because "why is a background run streamed to nobody" is a fair question to ask of this code later.

Streaming on this path is for connection liveness, not delivery, and cannot leak a partial answer:

- `emitChunk` only publishes `ChatEventThinking` / `ChatEventChunk` run events; it never publishes an outbound message.
- `handleTeammateMessage` never registers the run with the channel manager, and `HandleAgentEvent` opens with `m.runs.Load(runID); if !ok { return }` — the chunks are dropped immediately.
- The task result is untouched: `ChatStream` returns the complete response once the stream ends, and `resolveTeamTaskOutcome` reads `outcome.Result`.

The only visible difference is that a dashboard subscriber can watch a member work.

### Alternatives considered

- **Raising `ResponseHeaderTimeout`** — treats the symptom, and the comment already in `internal/providers/defaults.go` explains why that value should not keep growing: it is the only thing bounding a silently dead connection.
- **Making it configurable** — a knob implies a reason to turn it off, and on this path there is none: nothing consumes the chunks either way. Happy to add one if you disagree.

### Test

No new unit test: the change is a field value on a scheduler request, and asserting it would only restate the assignment. What matters is behavioural and is covered by the before/after above on a live deployment. `go test ./cmd/... ./internal/channels/... ./internal/agent/...` is green.

### Note

The failure is easy to misattribute because it hides behind the per-agent `max_tokens` default of 8192: below that cap the same task fails earlier and differently, with `llm response truncated before content after compaction`. Only after the cap is raised enough for the answer to fit does the timeout surface. Worth keeping in mind when triaging similar reports.
