### PR TITLE
fix(vault): sanitize context window to prevent invalid UTF-8

### DIFF
--- a/internal/vault/links.go
+++ b/internal/vault/links.go
@@ -33,10 +33,14 @@ func ExtractWikilinks(content string) []WikilinkMatch {
 			continue
 		}
 
-		// Build context: ~25 chars before and after the link
+		// Build context: ~25 bytes before and after the link.
+		// Sanitize with ToValidUTF8 so the byte-offset window does not
+		// split a multi-byte rune (Vietnamese, CJK, emoji), which would
+		// produce invalid UTF-8 that PostgreSQL rejects with
+		// "invalid byte sequence for encoding UTF8" (SQLSTATE 22021).
 		start := max(m[0]-25, 0)
 		end := min(m[1]+25, len(content))
-		ctx := content[start:end]
+		ctx := strings.ToValidUTF8(content[start:end], "")
 
 		result = append(result, WikilinkMatch{
 			Target:  target,

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // ============================================================================
@@ -466,4 +468,31 @@ Use [[templates/new-feature.md]] when creating features.
 func hashRef(data []byte) string {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
+}
+
+// ============================================================================
+// Multi-byte UTF-8 Context Tests
+// ============================================================================
+
+// TestExtractWikilinks_MultibyteUTF8Context reproduces issue #1472:
+// the byte-offset context window (±25 bytes) can split multi-byte UTF-8
+// characters (Vietnamese, CJK, emoji), producing invalid UTF-8 that
+// PostgreSQL rejects with "invalid byte sequence for encoding UTF8"
+// (SQLSTATE 22021).
+//
+// "ế" (U+1EBF) is 3 bytes in UTF-8. Ten of them = 30 bytes; adding a
+// single ASCII byte shifts the window start to byte 7, which lands on
+// a continuation byte of the 3rd "ế" — an invalid UTF-8 start.
+func TestExtractWikilinks_MultibyteUTF8Context(t *testing.T) {
+	prefix := strings.Repeat("ế", 10) + "x" // 31 bytes
+	suffix := "x" + strings.Repeat("ệ", 10)  // 31 bytes
+	content := prefix + " [[target]] " + suffix
+
+	matches := ExtractWikilinks(content)
+	if len(matches) != 1 {
+		t.Fatalf("ExtractWikilinks returned %d matches, want 1", len(matches))
+	}
+	if !utf8.ValidString(matches[0].Context) {
+		t.Errorf("context contains invalid UTF-8: %q", matches[0].Context)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #1472

`ExtractWikilinks` builds a ±25-byte context window around each wikilink match using byte offsets from `regexp.FindAllStringSubmatchIndex`. When the note content contains multi-byte UTF-8 characters (Vietnamese, CJK, emoji), the byte-offset start/end can fall on a continuation byte, producing invalid UTF-8.

PostgreSQL rejects this with `ERROR: invalid byte sequence for encoding "UTF8" (SQLSTATE 22021)` during `sync_wikilinks`, which breaks vault enrichment for any note containing non-ASCII text.

## Fix

Wrap the byte-offset slice with `strings.ToValidUTF8`, which strips any leading/trailing partial runes:

```go
// Before
ctx := content[start:end]

// After
ctx := strings.ToValidUTF8(content[start:end], "")
```

This is a minimal one-line change that preserves the existing context semantics (±25 bytes of surrounding text) while ensuring the output is always valid UTF-8.

## Verification

- Reproduced the bug: content with Vietnamese diacritics (ế = U+1EBF, 3 bytes) caused `ExtractWikilinks` to return a context starting with continuation bytes (`\xba\xbf...\xe1\xbb`).
- Added `TestExtractWikilinks_MultibyteUTF8Context` asserting `utf8.ValidString(matches[0].Context)`.
- `go test ./internal/vault/ -v` — all 64 tests pass (1 pre-existing Windows SKIP for symlink test).

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Notes

- `strings.ToValidUTF8` is available since Go 1.21; this project uses Go 1.26.
- No behavioral change for ASCII-only content (already valid UTF-8 → no-op).
- The fix is at the extraction layer, so it protects all downstream consumers of `WikilinkMatch.Context`.
