### PR TITLE
feat(webhooks): accept inbound media on POST /v1/webhooks/llm (sync mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ All notable changes to GoClaw are documented here. For full documentation, see [
 
 ### Added
 
+- **Inbound media on `POST /v1/webhooks/llm`** — an optional `media[{url, filename}]` array,
+  **sync mode only**. The gateway downloads each URL server-side and hands the agent local
+  files plus the `<media:image>` tags the vision path needs, so a webhook caller can send an
+  image the way Telegram and the WebSocket client already can. Guards: SSRF validation with
+  per-redirect-hop dial checks, a 25 MB size cap, a 50 MP image-header cap, an eight-entry MIME
+  allowlist cross-checked against the file's actual bytes, a 10-item count cap, and a process-wide
+  byte budget. Any failed item fails the whole request, the status is picked by a fixed severity
+  order rather than array position, and the failure detail exposed to callers is a closed enum so
+  the endpoint cannot be used as an internal-network oracle. `mode=async` with `media` returns
+  400. Audit rows store media URLs with the query string stripped.
+
 - **Behavior UX sidecar delivery overrides** — Adds sidecar-generated Quick
   Acknowledgement and Intermediate Replies with provider/model, timeout, token,
   and char caps. Effective config resolves Channel > Agent > Workspace, with

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -332,6 +332,91 @@ Things that are not guessable from the shape:
 Media the agent produces is **not** returned: the sync response carries `output` text only. The
 asymmetry is deliberate for now, not an oversight.
 
+### Integrating a middleware (Zalo OA, Messenger, CRM)
+
+The common shape: a platform webhook hits your middleware, your middleware calls goclaw. The
+mistake that costs the most time is putting the image URL **inside `input`**:
+
+```json
+// WRONG — the URL is just text. Nothing is downloaded, no media tag is built,
+// and the model receives a string that looks like a link.
+{
+  "input": "Customer sent an image: https://cdn.example.com/abc.jpg\nAnswer based on it."
+}
+```
+
+```json
+// RIGHT — the URL goes in media[]. The gateway downloads it before the agent
+// runs and prepends a <media:image> tag to the message.
+{
+  "input": "Answer based on the image and the customer's question.",
+  "media": [
+    {"url": "https://cdn.example.com/abc.jpg", "filename": "abc.jpg"}
+  ]
+}
+```
+
+A URL left in `input` is not guaranteed to fail: the agent *may* choose to call `read_image`
+with it. That path is non-deterministic (it depends on the model deciding to call the tool),
+skips the size cap and the MIME allowlist, and does not persist the file to the workspace.
+`media[]` is the deterministic path.
+
+#### Requirements for the URL you send
+
+| Requirement | Why |
+|---|---|
+| Public HTTP(S), resolving to a public IP | The SSRF policy re-checks the resolved IP at every redirect hop's dial |
+| **No authentication needed** | The gateway issues a plain GET and sets no headers. A URL requiring `Authorization`, a cookie, or a signed header will fail — proxy it instead |
+| Response `Content-Type` in the allowlist | The header decides the type, not the file extension |
+| Reachable at POST time | The download happens before the agent starts, which is what makes short-lived signed CDN links usable |
+| Within 25 MB, and 50 MP for images | Hard caps |
+
+#### Pass the platform URL directly, or proxy it first?
+
+Both work. Choose by URL lifetime and auth:
+
+- **Direct** — fine when the platform serves a public, unauthenticated URL. Fewest moving parts.
+  The risk is expiry: platform CDN links are often short-lived, so a delayed retry, a replayed
+  `Idempotency-Key`, or an operator re-running a request from the audit log will hit a dead URL.
+- **Proxy through your own storage** (S3, R2, a Cloudflare Worker) — recommended when the
+  platform URL is short-lived or requires a token. A stable URL also keeps the redacted URL in
+  the audit row meaningful weeks later, which is when you actually need it.
+
+Proxying is **required** when the platform URL needs an auth header, since the gateway sends
+none.
+
+#### Errors your middleware should handle
+
+| Status | Meaning | Retry? |
+|---|---|---|
+| 400 | URL blocked by SSRF policy, download failed, or `media` sent with `mode=async` | No — fix the request |
+| 413 | File over 25 MB, or image over 50 MP | No — resize before sending |
+| 415 | MIME type not allowed, or content does not match the declared type | No |
+| 503 | Media download capacity exhausted (`Retry-After: 5`) or lane at capacity | Yes, with backoff |
+| 504 | The download plus the agent run exceeded `gateway.webhook_sync_timeout_sec` | Yes |
+
+Any one failed attachment fails the whole request, and the status reflects the most severe
+failure across all items, not the first one in the array. Failure messages are deliberately
+generic — do not parse them.
+
+#### Worked example
+
+```bash
+curl -X POST https://<host>/v1/webhooks/llm \
+  -H "Authorization: Bearer wh_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Answer based on the image and the customer question.",
+    "user_id": "zalo:1234567890",
+    "session_key": "zalo:1234567890",
+    "media": [{"url": "https://cdn.example.com/abc.jpg", "filename": "abc.jpg"}]
+  }'
+```
+
+Send a stable `user_id`: media is persisted under
+`<workspace>/<agent_key>/<user_id>/.uploads/`, and callers that omit it all share one
+directory. `session_key` keeps a multi-turn conversation together.
+
 ### Sync Response — 200 OK
 
 ```json

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -229,18 +229,20 @@ Triggers an agent with an input prompt. Available in all editions.
   "model": "claude-opus-4-5",
   "mode": "sync",
   "callback_url": "",
+  "media": [],
   "metadata": {}
 }
 ```
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `input` | string or array | yes | Plain string, or `[{role, content}]` array |
+| `input` | string or array | yes* | Plain string, or `[{role, content}]` array. *Optional when `media` is non-empty |
 | `session_key` | string | no | Stable key for multi-turn conversation continuity |
 | `user_id` | string | no | External user identifier for scoping |
 | `model` | string | no | Per-request model override |
 | `mode` | string | no | `"sync"` (default) or `"async"` |
 | `callback_url` | string | required if async | HTTPS URL for delivery. Validated against SSRF policy |
+| `media` | array | no | Attachments fetched server-side. Max 10 items, 25 MB each. **Sync mode only.** See [Media Attachments](#media-attachments) |
 | `metadata` | object | no | Echoed to callback payload (max 8 KB) |
 
 **Input formats:**
@@ -255,6 +257,80 @@ Triggers an agent with an input prompt. Available in all editions.
   {"role": "user", "content": "List 3 key metrics"}
 ]
 ```
+
+### Media Attachments
+
+Pass remote URLs in `media` and the gateway downloads each one before the agent runs, then hands
+the agent local files the same way the Telegram and WebSocket paths do. Attachments are fetched by
+URL rather than uploaded because `POST /v1/media/upload` requires a user or admin role, which a
+webhook caller holding a `wh_` bearer or an HMAC key does not have.
+
+```json
+{
+  "input": "What is wrong in this screenshot?",
+  "media": [
+    {"url": "https://cdn.example.com/shot.png", "filename": "shot.png"}
+  ]
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `url` | string | yes | Public HTTP(S). Validated against the SSRF policy; redirects are followed and every hop re-validated |
+| `filename` | string | no | Original name. Used for the stored file name and for the `<media:document>` tag |
+
+Things that are not guessable from the shape:
+
+- **Allowed MIME types** — the same list as `media_url` on `/message`: `image/jpeg`, `image/png`,
+  `image/gif`, `image/webp`, `video/mp4`, `audio/mpeg`, `audio/ogg`, `application/pdf`. The
+  response `Content-Type` decides, not the URL extension, so an extension-less CDN link works. The
+  declared type is also cross-checked against the file's actual leading bytes, and an
+  `image/*` file that does not decode is rejected. Source of truth:
+  `webhooks.AllowedMediaMIMETypes` in `internal/webhooks/inbound_media.go`.
+- **`media` is sync-only.** `mode=async` with a non-empty `media` returns **400** and enqueues
+  nothing. This is the first thing an integrator trips over. The async payload is frozen before
+  the mode dispatch, so a downloaded file has no way to reach the worker — an accepted request
+  would silently run with no image at all.
+- **Any failed item fails the whole request.** There is no partial success and no per-item note in
+  the answer. Either every attachment arrives or the request errors.
+- **Failure detail is deliberately coarse.** The body carries a generic message per status code
+  and never reveals whether a host resolved, what it resolved to, or why a connection failed —
+  otherwise this endpoint would be an internal-network and port-scanning oracle. Do not write
+  client logic that parses it.
+- **Private and loopback URLs are refused**, including via redirect and DNS rebinding: the
+  resolved destination IP is checked at every hop's dial. A self-hosted object store on a private
+  network will not work.
+- **Image dimensions are capped at 50 megapixels**, checked from the file header before any
+  decode. A small file declaring huge dimensions is rejected with 413. An `image/*` file whose
+  header does not decode at all is rejected with 415 — which includes **animated WebP**, since the
+  decoder in use handles still WebP only. Send an animated image as a still frame or as
+  `video/mp4`.
+- **The URL only has to be reachable at POST time.** The download happens before the agent starts,
+  so a short-lived signed Zalo or Messenger CDN URL works — that is the point of the design.
+- **Latency.** The download runs before the agent starts and shares one deadline with it, so a
+  sync call never exceeds `gateway.webhook_sync_timeout_sec` in total. A slow download eats into
+  the agent's share of that budget and can end in a 504 — size the timeout for both halves.
+- **Concurrency.** Each in-flight attachment reserves the full 25 MB against a 512 MB process-wide
+  budget, regardless of its actual size, so roughly **20 attachments can be downloading at once
+  across the whole gateway**. Past that, further media requests get 503 with `Retry-After: 5`
+  until one finishes. This bound is separate from — and reached sooner than — the webhook lane's
+  concurrency limit, because the download happens before a lane slot is taken.
+- **The URL's query string is stripped everywhere it is retained or forwarded.** A presigned
+  URL's signature is a bearer credential, so it is removed from the audit row
+  (`request_payload`, readable via `GET /v1/webhooks/{id}/calls/{callId}` for 30 days), from the
+  `<media:image url="...">` tag the agent sees — which is sent to the LLM provider and kept in
+  session history — and from every log line. Only the scheme, host, and path survive. The gateway
+  uses the full URL to fetch, and nothing else.
+- **`user_id` and workspace isolation.** Media is persisted under
+  `<workspace>/<agent_key>/<user_id>/.uploads/`. **A caller that omits `user_id` lands in
+  `<workspace>/<agent_key>/.uploads/`** — no empty segment is created, and every such caller shares
+  that one directory. Send a stable opaque id. The segment keeps only `[A-Za-z0-9_-]` and maps
+  everything else to `_`, so `a.b@x.com` and `a_b_x_com` collide.
+- **Not supported on the admin test endpoint.** `POST /v1/webhooks/{id}/test` and the web UI test
+  dialog stay text-only.
+
+Media the agent produces is **not** returned: the sync response carries `output` text only. The
+asymmetry is deliberate for now, not an oversight.
 
 ### Sync Response — 200 OK
 
@@ -345,13 +421,19 @@ The agent runs asynchronously. Results are delivered via outbound callback (see 
 
 | Status | Code | When |
 |--------|------|------|
-| 400 | `invalid_request` | Missing `input`, bad `mode`, missing `callback_url` for async |
+| 400 | `invalid_request` | Missing `input` and `media`, bad `mode`, missing `callback_url` for async, `media` sent with `mode=async`, or a `media` URL blocked by the SSRF policy |
 | 401 | — | Auth failure (bearer invalid, HMAC mismatch, revoked, HMAC replay) |
 | 403 | `unauthorized` | `localhost_only` violation, IP allowlist denial, kind mismatch, tenant mismatch |
 | 404 | `not_found` | Agent not found |
+| 413 | `invalid_request` | A media file exceeds 25 MB, or an image exceeds 50 megapixels |
+| 415 | `invalid_request` | Media MIME type not in the allowlist, or the content does not match the declared type |
 | 429 | — | Rate limit exceeded; `Retry-After: 60` header set |
-| 503 | — | Webhook processing lane at capacity |
+| 503 | — | Webhook processing lane at capacity, or media download capacity temporarily exhausted (retryable) |
 | 504 | — | LLM timeout (sync mode only) |
+
+When several attachments fail, the status is chosen by a fixed severity order —
+SSRF, then MIME denied, then too large, then download failed, then capacity — so it never depends
+on which array position happened to fail.
 
 ---
 
@@ -404,6 +486,7 @@ Sends a message to a user on a connected channel. **Standard edition only** — 
 | 400 | `invalid_request` | Missing `chat_id`, `content`, SSRF-blocked `media_url` |
 | 403 | `unauthorized` | Channel belongs to different tenant |
 | 404 | `not_found` | Channel instance not found |
+| 413 | `invalid_request` | `media_url` exceeds the 25 MB size limit |
 | 415 | `invalid_request` | MIME type denied for media |
 | 429 | — | Rate limit exceeded |
 | 501 | `invalid_request` | Channel does not support media and `fallback_to_text=false` |
@@ -609,11 +692,17 @@ Both tiers must pass. If either rejects the request, `429 Too Many Requests` is 
 | Feature | Standard | Lite |
 |---------|----------|------|
 | `/v1/webhooks/llm` | Available | Available (localhost_only forced) |
+| `media[]` on `/v1/webhooks/llm` | Available | Available |
 | `/v1/webhooks/message` | Available | Disabled |
 | `localhost_only=false` | Configurable | Always true; cannot be unset |
 | `kind="message"` webhook creation | Allowed | Rejected (403) |
 
 On Lite, all webhooks are automatically created with `localhost_only=true` regardless of the request field. Attempting to unset `localhost_only` via PATCH returns `403`.
+
+`media[]` is not edition-gated: it adds no channel dependency. Note that `localhost_only`
+restricts who may **call** the webhook, not where the media may be hosted — a Lite caller on
+localhost can still reference a public CDN URL, and a private-network media host is refused on
+both editions.
 
 ---
 
@@ -622,6 +711,7 @@ On Lite, all webhooks are automatically created with `localhost_only=true` regar
 ### SSRF Protection
 
 - `media_url` in message webhooks: validated against SSRF policy + HEAD-probed before fetch.
+- `media[].url` in LLM webhooks: validated before the fetch, and the resolved destination IP is re-checked at every redirect hop's dial, so a redirect into a private range or a DNS rebind is refused mid-fetch. Only the failure category reaches the caller — never a host, IP, port, or error string.
 - `callback_url` in async LLM webhooks: validated at enqueue time and re-validated at delivery time (prevents DNS rebinding attacks).
 - Log event: `security.webhook.ssrf_blocked` / `security.webhook.callback_ssrf_blocked`.
 
@@ -764,9 +854,16 @@ SHA-256 hex digest of the raw request body bytes. Used by the idempotency subsys
   "model": "optional-override",
   "mode": "sync",
   "callback_url": "",
+  "media": [{"url": "https://cdn.example.com/shot.png", "filename": "shot.png"}],
   "metadata": null
 }
 ```
+
+`media[].url` is stored with its **query string and userinfo stripped**. A presigned URL's
+signature is a bearer credential and this column is readable via
+`GET /v1/webhooks/{id}/calls/{callId}` for the full 30-day retention window. The same redaction
+is applied to the media tag the agent sees and to every log line. `body_hash` is computed over
+the raw body, so idempotency still sees the original request.
 
 **`POST /v1/webhooks/message`** — meta contains delivery context:
 

--- a/internal/http/webhooks_llm.go
+++ b/internal/http/webhooks_llm.go
@@ -13,11 +13,13 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/nextlevelbuilder/goclaw/internal/agent"
+	media "github.com/nextlevelbuilder/goclaw/internal/channels/media"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 	"github.com/nextlevelbuilder/goclaw/internal/scheduler"
 	"github.com/nextlevelbuilder/goclaw/internal/security"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/webhooks"
 	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
 )
 
@@ -40,8 +42,13 @@ const (
 // Input accepts either a plain string or a message array [{role,content}...].
 type webhookLLMReq struct {
 	// Input is the user prompt. Either a plain string or message array.
-	// Required.
+	// Required unless Media is non-empty.
 	Input json.RawMessage `json:"input"`
+
+	// Media is an optional list of remote attachments the gateway fetches
+	// server-side and hands to the agent as local files. Max 10 items, 25 MB
+	// each. Sync mode only - see the async guard in handle().
+	Media []webhooks.InboundMediaItem `json:"media,omitempty"`
 
 	// SessionKey is an optional stable conversation anchor for multi-turn conversations.
 	// If omitted, a per-call ephemeral key is generated.
@@ -188,8 +195,10 @@ func (h *WebhookLLMHandler) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate input field is present.
-	if len(req.Input) == 0 || string(req.Input) == "null" {
+	// input is optional when media is present: an image with no caption is a
+	// legitimate request. A request carrying neither is still rejected.
+	hasInput := len(req.Input) > 0 && string(req.Input) != "null"
+	if !hasInput && len(req.Media) == 0 {
 		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
 			i18n.T(locale, i18n.MsgRequired, "input"))
 		return
@@ -211,14 +220,31 @@ func (h *WebhookLLMHandler) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse and build user message + optional extra system prompt from input.
-	userMessage, extraSystemPrompt, err := buildInput(req.Input)
-	if err != nil {
+	// Async + media is refused, not deferred. requestPayload is frozen below,
+	// before the mode dispatch, and handleAsync stores that byte slice
+	// verbatim - so server-computed local paths have no way to reach the
+	// worker. An accepted request would run the agent with no media and no
+	// media tag, then answer confidently about an image nobody sent, with
+	// status "done" and nothing in last_error. Rejecting here means nothing is
+	// downloaded and no row is enqueued for a call that could never succeed.
+	if len(req.Media) > 0 && mode == "async" {
 		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
-			i18n.T(locale, i18n.MsgInvalidRequest, err.Error()))
+			i18n.T(locale, i18n.MsgInvalidRequest, "media is not supported in async mode"))
 		return
 	}
-	if userMessage == "" {
+
+	// Parse and build user message + optional extra system prompt from input.
+	var userMessage, extraSystemPrompt string
+	if hasInput {
+		var err error
+		userMessage, extraSystemPrompt, err = buildInput(req.Input)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
+				i18n.T(locale, i18n.MsgInvalidRequest, err.Error()))
+			return
+		}
+	}
+	if userMessage == "" && len(req.Media) == 0 {
 		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
 			i18n.T(locale, i18n.MsgRequired, "input"))
 		return
@@ -258,16 +284,101 @@ func (h *WebhookLLMHandler) handle(w http.ResponseWriter, r *http.Request) {
 	if reqBytes == nil {
 		reqBytes, _ = json.Marshal(req)
 	}
-	requestPayload, _ := buildAuditPayload(reqBytes, req)
+	// meta is surfaced verbatim by GET /v1/webhooks/{id}/calls/{callId} and kept
+	// for the 30-day retention window. The whole point of media[] is short-lived
+	// signed CDN URLs, and that signature is a bearer credential - store the URL
+	// with its query stripped, never raw. This stays cheap only because media is
+	// carried by URL; a future base64 option must drop the field here entirely.
+	requestPayload, _ := buildAuditPayload(reqBytes, redactedAuditReq(req))
 	idempotencyKey := optionalIdempotencyKey(r)
+
+	// ONE deadline covers the download and the agent run, so a sync request
+	// never outlives gateway.webhook_sync_timeout_sec no matter how the time is
+	// split. Without it the fetch would run on the bare request context, bounded
+	// only by the fetcher's 5-minute-per-item client timeout — ten items in
+	// sequence is nearly an hour of request-goroutine occupancy that no
+	// operator setting could shorten.
+	deadline := time.Now().Add(h.effectiveSyncTimeout())
+
+	// Fetch media BEFORE a lane slot is taken. The webhook lane's concurrency
+	// budget is small (4 by default) and a slow download must not hold a slot.
+	// Disk is bounded by the fetcher's own byte budget rather than by the rate
+	// limiter, whose allow() returns true whenever rpm <= 0.
+	var fetched webhooks.InboundMediaResult
+	if len(req.Media) > 0 {
+		fetchCtx, cancelFetch := context.WithDeadline(ctx, deadline)
+		fetched = webhooks.FetchInboundMedia(fetchCtx, req.Media)
+		cancelFetch()
+		if len(fetched.Failures) > 0 {
+			// All-or-nothing: FetchInboundMedia already removed its own temps.
+			writeMediaFailure(w, locale, webhooks.WorstFailure(fetched.Failures))
+			return
+		}
+	}
 
 	// Dispatch based on mode.
 	switch mode {
 	case "async":
 		h.handleAsync(w, r, ctx, locale, webhook, ag, agentID, req, callID, deliveryID, now, requestPayload, idempotencyKey, userMessage, extraSystemPrompt)
 	default: // "sync"
-		h.handleSync(w, r, ctx, locale, webhook, ag, agentID, req, callID, deliveryID, now, requestPayload, idempotencyKey, userMessage, extraSystemPrompt)
+		h.handleSync(w, r, ctx, locale, webhook, ag, agentID, req, callID, deliveryID, now, requestPayload, idempotencyKey, userMessage, extraSystemPrompt, fetched, deadline)
 	}
+}
+
+// effectiveSyncTimeout is the configured budget for one sync call
+// (gateway.webhook_sync_timeout_sec), falling back to the package default.
+func (h *WebhookLLMHandler) effectiveSyncTimeout() time.Duration {
+	if h.syncTimeout > 0 {
+		return h.syncTimeout
+	}
+	return webhookLLMTimeout
+}
+
+// writeMediaFailure maps a media failure to a status code deterministically.
+//
+// The code comes from WorstFailure, which applies a fixed severity order across
+// every failed item, so the status never depends on which array slot happened
+// to fail. The i18n message is the ONLY thing the caller sees: no hostname, no
+// IP, no port, no error string. The detail is already in slog.
+func writeMediaFailure(w http.ResponseWriter, locale string, f webhooks.InboundMediaFailure) {
+	switch f.Code {
+	case webhooks.FailSSRF:
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgWebhookMediaSSRFBlocked))
+	case webhooks.FailTooLarge:
+		writeError(w, http.StatusRequestEntityTooLarge, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgWebhookMediaTooLarge))
+	case webhooks.FailMIMEDenied:
+		writeError(w, http.StatusUnsupportedMediaType, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgWebhookMediaMIMEDenied))
+	case webhooks.FailBudgetExhausted:
+		// Transient and server-side: the caller should retry, not rewrite the
+		// request. Ranked lowest by WorstFailure so a genuinely bad item is
+		// never reported as retryable.
+		w.Header().Set("Retry-After", "5")
+		writeError(w, http.StatusServiceUnavailable, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgWebhookMediaBudgetExhausted))
+	default:
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgWebhookMediaDownloadFailed))
+	}
+}
+
+// redactedAuditReq returns a copy of req whose media URLs have query string and
+// userinfo stripped, for persistence into the audit row.
+func redactedAuditReq(req webhookLLMReq) webhookLLMReq {
+	if len(req.Media) == 0 {
+		return req
+	}
+	safe := make([]webhooks.InboundMediaItem, len(req.Media))
+	for i, item := range req.Media {
+		safe[i] = webhooks.InboundMediaItem{
+			URL:      security.RedactURL(item.URL),
+			Filename: item.Filename,
+		}
+	}
+	req.Media = safe
+	return req
 }
 
 // handleSync invokes the agent within a 30s timeout and returns the response directly.
@@ -285,6 +396,8 @@ func (h *WebhookLLMHandler) handleSync(
 	requestPayload []byte,
 	idempotencyKey *string,
 	userMessage, extraSystemPrompt string,
+	fetched webhooks.InboundMediaResult,
+	deadline time.Time,
 ) {
 	runID := uuid.NewString()
 	sessionKey := resolveWebhookSessionKey(req.SessionKey, agentID, webhook.ID, runID)
@@ -304,12 +417,36 @@ func (h *WebhookLLMHandler) handleSync(
 	}
 	callReserved, handled := reserveIdempotentCall(w, r, h.callStore, callRecord)
 	if handled {
+		// The run never starts, so nothing downstream will own these files.
+		webhooks.CleanupInboundMedia(fetched.Files)
 		return
+	}
+
+	// Media tags are load-bearing, not cosmetic. enrichImageIDs rewrites an
+	// EXISTING <media:image> tag via replaceFirstMediaTag; it never inserts one.
+	// When the agent has a dedicated read_image provider (file-ref vision mode)
+	// the images are not attached to the main LLM at all, so the tag is the only
+	// thing telling the model an image exists. No tag means a silent no-op: no
+	// error, no log, wrong answer - and only on that configuration, so it works
+	// on a dev box and fails at a customer.
+	//
+	// No skip annotations: all-or-nothing means the run only starts once every
+	// item succeeded, so fetched.Failures is empty here by construction.
+	message := userMessage
+	if len(fetched.Infos) > 0 {
+		if tags := media.BuildMediaTags(fetched.Infos); tags != "" {
+			if message != "" {
+				message = tags + "\n\n" + message
+			} else {
+				message = tags
+			}
+		}
 	}
 
 	rr := agent.RunRequest{
 		SessionKey:        sessionKey,
-		Message:           userMessage,
+		Message:           message,
+		Media:             fetched.Files,
 		Channel:           "webhook",
 		ChatID:            webhook.ID.String(),
 		RunID:             runID,
@@ -337,20 +474,29 @@ func (h *WebhookLLMHandler) handleSync(
 	}
 	outCh := make(chan runOutcome, 1)
 
-	// Determine the effective timeout (30s in production; overridable in tests).
-	timeout := webhookLLMTimeout
-	if h.syncTimeout > 0 {
-		timeout = h.syncTimeout
-	}
+	// deadline was set in handle() before the media fetch, so whatever the
+	// download consumed is already subtracted from the run's share.
 
 	// Acquire a webhook-lane slot; if full, return 503.
-	laneCtx, laneCancel := context.WithTimeout(ctx, timeout)
+	laneCtx, laneCancel := context.WithDeadline(ctx, deadline)
 	defer laneCancel()
 
 	submitErr := h.lane.Submit(laneCtx, func() {
-		// Each sync run gets its own hard timeout, isolated from request context
-		// so the HTTP response write path does not race with run cancellation.
-		runCtx, runCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+		// Cleanup belongs to the RUN, not to the handler. Submit runs fn in a
+		// detached goroutine and returns immediately; handleSync then selects on
+		// outCh or laneCtx.Done(), and laneCtx derives from the REQUEST context
+		// while the run below uses context.WithoutCancel. A deferred cleanup in
+		// the handler would therefore delete these files on client disconnect or
+		// lane timeout while ag.Run is still executing - persistMedia would fail
+		// its copy, log a warning, drop the ref, and the agent would spend
+		// minutes answering about a <media:image> tag with no image behind it.
+		defer webhooks.CleanupInboundMedia(fetched.Files)
+
+		// Each sync run gets its own hard deadline, isolated from the request
+		// context so the HTTP response write path does not race with run
+		// cancellation. Same instant as laneCtx, so download plus run share one
+		// budget rather than each getting a full one.
+		runCtx, runCancel := context.WithDeadline(context.WithoutCancel(ctx), deadline)
 		defer runCancel()
 
 		result, err := ag.Run(runCtx, rr)
@@ -358,6 +504,8 @@ func (h *WebhookLLMHandler) handleSync(
 	})
 
 	if submitErr != nil {
+		// The closure never ran, so its deferred cleanup never will either.
+		webhooks.CleanupInboundMedia(fetched.Files)
 		completedAt := time.Now()
 		errMsg := submitErr.Error()
 		callRecord.Status = "failed"

--- a/internal/http/webhooks_llm_media_test.go
+++ b/internal/http/webhooks_llm_media_test.go
@@ -1,0 +1,644 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/agent"
+	"github.com/nextlevelbuilder/goclaw/internal/scheduler"
+	"github.com/nextlevelbuilder/goclaw/internal/security"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// ---- helpers ----
+//
+// Media tests point at an httptest.Server on 127.0.0.1, which the SSRF policy
+// blocks. The bypass is a process-global atomic.Bool, so these tests must not
+// call t.Parallel() — under -race a parallel test flipping it reports a data
+// race that reads like a bug in the feature. Set and reset it per test, never
+// at TestMain level, so the one test that asserts loopback IS refused stays
+// honest.
+func allowLoopbackMedia(t *testing.T) {
+	t.Helper()
+	security.SetAllowLoopbackForTest(true)
+	t.Cleanup(func() { security.SetAllowLoopbackForTest(false) })
+}
+
+// isolateTempDir points os.CreateTemp at this test's own directory.
+//
+// Both this package and internal/webhooks glob os.TempDir() for goclaw_webhook_*
+// to prove a failed request left nothing behind, and `go test ./...` runs
+// packages in parallel — without isolation each would see the other's files and
+// the before/after deltas would flake. TMPDIR covers unix, TMP/TEMP cover
+// Windows, so the isolation holds however the suite is run.
+func isolateTempDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	t.Setenv("TMP", dir)
+	t.Setenv("TEMP", dir)
+}
+
+func mediaTestPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{R: 9, G: 9, B: 9, A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// servePNG starts a server returning a valid 1x1 PNG.
+func servePNG(t *testing.T) *httptest.Server {
+	t.Helper()
+	body := mediaTestPNG(t)
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(body)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// serveOversize starts a server streaming past the 25 MB cap.
+func serveOversize(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		io.CopyN(w, zeroSource{}, 25*1024*1024+1024)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// serveBadMIME starts a server returning a type outside the allowlist.
+func serveBadMIME(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte("<html>no</html>"))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func countMediaTemps(t *testing.T) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "goclaw_webhook_*"))
+	if err != nil {
+		t.Fatalf("glob temp: %v", err)
+	}
+	return len(matches)
+}
+
+type zeroSource struct{}
+
+func (zeroSource) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// mediaTestEnv wires a handler whose stub agent records the RunRequest it saw.
+type mediaTestEnv struct {
+	h         *WebhookLLMHandler
+	wh        *store.WebhookData
+	callStore *llmCallStore
+	// seen is the RunRequest the agent was invoked with, nil if never invoked.
+	seen *agent.RunRequest
+}
+
+func newMediaTestEnv(t *testing.T, lane *scheduler.Lane) *mediaTestEnv {
+	t.Helper()
+	agentUUID := uuid.New()
+	env := &mediaTestEnv{
+		callStore: &llmCallStore{},
+		wh: &store.WebhookData{
+			ID:       uuid.New(),
+			TenantID: uuid.New(),
+			AgentID:  &agentUUID,
+			Kind:     "llm",
+		},
+	}
+	ag := &stubLLMAgent{
+		id:      agentUUID.String(),
+		agentID: agentUUID,
+		runFn: func(_ context.Context, req agent.RunRequest) (*agent.RunResult, error) {
+			cp := req
+			env.seen = &cp
+			return &agent.RunResult{Content: "ok", RunID: "run-media"}, nil
+		},
+	}
+	env.h = newTestLLMHandler(env.callStore, &msgWebhookStore{}, lane)
+	env.h.agentRouter = stubRouterFor(agentUUID, ag)
+	return env
+}
+
+func (e *mediaTestEnv) post(t *testing.T, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	r := injectWebhook(buildLLMReq(t, body), e.wh)
+	w := httptest.NewRecorder()
+	e.h.handle(w, r)
+	return w
+}
+
+func mediaItem(url string, filename string) map[string]any {
+	item := map[string]any{"url": url}
+	if filename != "" {
+		item["filename"] = filename
+	}
+	return item
+}
+
+// ---- the core test ----
+
+// TestWebhookLLM_MediaURL_PopulatesRunRequest asserts BOTH halves of the
+// contract. A test that checked only len(Media) > 0 would pass while file-ref
+// vision mode is silently broken: with a dedicated read_image provider the
+// images are never attached to the main LLM, so the <media:image> tag is the
+// only signal the model gets, and enrichImageIDs rewrites an existing tag
+// rather than inserting a missing one.
+func TestWebhookLLM_MediaURL_PopulatesRunRequest(t *testing.T) {
+	allowLoopbackMedia(t)
+	srv := servePNG(t)
+	env := newMediaTestEnv(t, nil)
+
+	w := env.post(t, map[string]any{
+		"input": "What is in this screenshot?",
+		"media": []map[string]any{mediaItem(srv.URL+"/shot.png", "shot.png")},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if env.seen == nil {
+		t.Fatal("agent was never invoked")
+	}
+	if len(env.seen.Media) != 1 {
+		t.Fatalf("RunRequest.Media = %d, want 1", len(env.seen.Media))
+	}
+	if env.seen.Media[0].MimeType != "image/png" {
+		t.Errorf("MimeType = %q, want image/png", env.seen.Media[0].MimeType)
+	}
+	if !strings.Contains(env.seen.Message, "<media:image") {
+		t.Fatalf("Message has no <media:image tag; file-ref vision mode would silently ignore the image.\nMessage = %q", env.seen.Message)
+	}
+	if !strings.Contains(env.seen.Message, "What is in this screenshot?") {
+		t.Errorf("caller text lost from Message = %q", env.seen.Message)
+	}
+}
+
+func TestWebhookLLM_MediaOnly_NoInput(t *testing.T) {
+	allowLoopbackMedia(t)
+	srv := servePNG(t)
+	env := newMediaTestEnv(t, nil)
+
+	// An image with no caption is a legitimate request.
+	w := env.post(t, map[string]any{
+		"media": []map[string]any{mediaItem(srv.URL+"/shot.png", "shot.png")},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if env.seen == nil {
+		t.Fatal("agent was never invoked")
+	}
+	if !strings.Contains(env.seen.Message, "<media:image") {
+		t.Errorf("Message = %q, want a media tag", env.seen.Message)
+	}
+}
+
+func TestWebhookLLM_NoInputNoMedia_Returns400(t *testing.T) {
+	env := newMediaTestEnv(t, nil)
+
+	// Relaxing the input guard must not let a genuinely empty request through.
+	for _, body := range []map[string]any{
+		{},
+		{"media": []map[string]any{}},
+		{"input": ""},
+	} {
+		w := env.post(t, body)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("body %+v: expected 400, got %d: %s", body, w.Code, w.Body.String())
+		}
+	}
+	if env.seen != nil {
+		t.Error("agent invoked for an empty request")
+	}
+}
+
+// ---- failure mapping ----
+
+func TestWebhookLLM_MediaTooLarge_Returns413(t *testing.T) {
+	allowLoopbackMedia(t)
+	srv := serveOversize(t)
+	env := newMediaTestEnv(t, nil)
+
+	w := env.post(t, map[string]any{
+		"input": "hi",
+		"media": []map[string]any{mediaItem(srv.URL+"/big.png", "big.png")},
+	})
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+	if env.seen != nil {
+		t.Error("agent invoked despite a failed media item")
+	}
+}
+
+func TestWebhookLLM_MediaMimeDenied_Returns415(t *testing.T) {
+	allowLoopbackMedia(t)
+	srv := serveBadMIME(t)
+	env := newMediaTestEnv(t, nil)
+
+	w := env.post(t, map[string]any{
+		"input": "hi",
+		"media": []map[string]any{mediaItem(srv.URL+"/page.html", "page.html")},
+	})
+
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("expected 415, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestWebhookLLM_MediaSSRF_Returns400(t *testing.T) {
+	// No loopback bypass: this asserts a private-range URL is refused.
+	srv := servePNG(t)
+	env := newMediaTestEnv(t, nil)
+
+	w := env.post(t, map[string]any{
+		"input": "hi",
+		"media": []map[string]any{mediaItem(srv.URL+"/shot.png", "shot.png")},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if env.seen != nil {
+		t.Error("agent invoked for an SSRF-blocked URL")
+	}
+}
+
+func TestWebhookLLM_MediaAnyFailure_FailsRequest(t *testing.T) {
+	isolateTempDir(t)
+	allowLoopbackMedia(t)
+	before := countMediaTemps(t)
+
+	good := servePNG(t)
+	missing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer missing.Close()
+
+	env := newMediaTestEnv(t, nil)
+	w := env.post(t, map[string]any{
+		"input": "hi",
+		"media": []map[string]any{
+			mediaItem(good.URL+"/a.png", "a.png"),
+			mediaItem(missing.URL+"/b.png", "b.png"),
+		},
+	})
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected an error status, got 200: %s", w.Body.String())
+	}
+	if env.seen != nil {
+		t.Error("agent invoked despite one item failing — all-or-nothing violated")
+	}
+	if after := countMediaTemps(t); after != before {
+		t.Errorf("temp files leaked: before=%d after=%d", before, after)
+	}
+}
+
+// TestWebhookLLM_StatusIndependentOfArrayOrder pins the deterministic mapping:
+// the status comes from the highest-severity failure across all items, not from
+// whichever slot failed first.
+func TestWebhookLLM_StatusIndependentOfArrayOrder(t *testing.T) {
+	allowLoopbackMedia(t)
+	oversize := serveOversize(t)
+	badMIME := serveBadMIME(t)
+
+	orders := [][]map[string]any{
+		{mediaItem(oversize.URL+"/big.png", "big.png"), mediaItem(badMIME.URL+"/p.html", "p.html")},
+		{mediaItem(badMIME.URL+"/p.html", "p.html"), mediaItem(oversize.URL+"/big.png", "big.png")},
+	}
+	for i, media := range orders {
+		env := newMediaTestEnv(t, nil)
+		w := env.post(t, map[string]any{"input": "hi", "media": media})
+		// mime_denied outranks too_large, so both orders must yield 415.
+		if w.Code != http.StatusUnsupportedMediaType {
+			t.Errorf("order %d: expected 415, got %d: %s", i, w.Code, w.Body.String())
+		}
+	}
+}
+
+// TestWebhookLLM_FailureBodyLeaksNothing pins the closed-enum contract at the
+// HTTP boundary: a caller must not be able to use this endpoint to learn
+// whether an internal host exists, what it resolved to, or why a connection
+// failed.
+func TestWebhookLLM_FailureBodyLeaksNothing(t *testing.T) {
+	env := newMediaTestEnv(t, nil)
+
+	const metadataHost = "169.254.169.254"
+	w := env.post(t, map[string]any{
+		"input": "hi",
+		"media": []map[string]any{mediaItem("http://"+metadataHost+"/latest/meta-data/", "x.png")},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, leak := range []string{metadataHost, "169.254", "ssrf:", "meta-data", "dial", "connection refused"} {
+		if strings.Contains(body, leak) {
+			t.Errorf("response body leaks %q: %s", leak, body)
+		}
+	}
+}
+
+// ---- cleanup ownership ----
+
+// TestWebhookLLM_CleanupSurvivesClientDisconnect is the test that catches a
+// handler-level defer.
+//
+// lane.Submit runs its closure in a DETACHED goroutine. handleSync then selects
+// on outCh or laneCtx.Done(), and laneCtx derives from the request context
+// while the run itself uses context.WithoutCancel. A deferred cleanup in the
+// handler therefore fires on client disconnect while ag.Run is still executing,
+// and the agent spends the rest of its run answering about a <media:image> tag
+// with no file behind it. With cleanup inside the closure, the file outlives
+// the handler.
+func TestWebhookLLM_CleanupSurvivesClientDisconnect(t *testing.T) {
+	allowLoopbackMedia(t)
+	srv := servePNG(t)
+
+	agentUUID := uuid.New()
+	wh := &store.WebhookData{
+		ID:       uuid.New(),
+		TenantID: uuid.New(),
+		AgentID:  &agentUUID,
+		Kind:     "llm",
+	}
+
+	entered := make(chan string, 1) // media path, sent as the run starts
+	proceed := make(chan struct{})  // closed once the handler has returned
+	existed := make(chan bool, 1)   // whether the file survived
+	ag := &stubLLMAgent{
+		id:      agentUUID.String(),
+		agentID: agentUUID,
+		runFn: func(_ context.Context, req agent.RunRequest) (*agent.RunResult, error) {
+			if len(req.Media) != 1 {
+				entered <- ""
+				return &agent.RunResult{Content: "ok"}, nil
+			}
+			entered <- req.Media[0].Path
+			<-proceed
+			_, err := os.Stat(req.Media[0].Path)
+			existed <- err == nil
+			return &agent.RunResult{Content: "ok"}, nil
+		},
+	}
+
+	h := newTestLLMHandler(&llmCallStore{}, &msgWebhookStore{}, nil)
+	h.agentRouter = stubRouterFor(agentUUID, ag)
+	h.syncTimeout = 30 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r := injectWebhook(buildLLMReq(t, map[string]any{
+		"input": "hi",
+		"media": []map[string]any{mediaItem(srv.URL+"/shot.png", "shot.png")},
+	}), wh).WithContext(ctx)
+	// injectWebhook built its context off the original request, so re-inject
+	// onto the cancellable one.
+	r = injectWebhook(r, wh)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.handle(httptest.NewRecorder(), r)
+	}()
+
+	path := <-entered
+	if path == "" {
+		t.Fatal("run started with no media attached")
+	}
+
+	// Client goes away mid-run.
+	cancel()
+	<-done
+
+	// The handler is gone; the run is not. The file must still be there.
+	close(proceed)
+	if !<-existed {
+		t.Fatalf("media file %s was deleted while the agent run was still executing", path)
+	}
+}
+
+// TestWebhookLLM_CleanupOnLaneSaturated covers the branch where the closure
+// never runs, so its deferred cleanup never runs either.
+func TestWebhookLLM_CleanupOnLaneSaturated(t *testing.T) {
+	isolateTempDir(t)
+	allowLoopbackMedia(t)
+	before := countMediaTemps(t)
+	srv := servePNG(t)
+
+	// Occupy the lane's only slot with a job that never finishes within the
+	// test, so Submit blocks until laneCtx's deadline fires and returns an
+	// error. lane.Stop() would be racy here: Submit selects over both the
+	// shutdown channel and an available token, and Go picks a ready case at
+	// random.
+	lane := scheduler.NewLane("saturated", 1)
+	blocked := make(chan struct{})
+	defer close(blocked)
+	if err := lane.Submit(context.Background(), func() { <-blocked }); err != nil {
+		t.Fatalf("occupying the lane: %v", err)
+	}
+
+	env := newMediaTestEnv(t, lane)
+	env.h.syncTimeout = 50 * time.Millisecond
+
+	w := env.post(t, map[string]any{
+		"input": "hi",
+		"media": []map[string]any{mediaItem(srv.URL+"/shot.png", "shot.png")},
+	})
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	if after := countMediaTemps(t); after != before {
+		t.Errorf("temp files leaked on the lane-saturated path: before=%d after=%d", before, after)
+	}
+}
+
+// TestWebhookLLM_CleanupOnIdempotencyReplay covers the third and last cleanup
+// path. reserveIdempotentCall can return handled=true and write the response
+// itself, so handleSync returns before lane.Submit — the closure that normally
+// owns the temp files never runs.
+func TestWebhookLLM_CleanupOnIdempotencyReplay(t *testing.T) {
+	isolateTempDir(t)
+	allowLoopbackMedia(t)
+	before := countMediaTemps(t)
+	srv := servePNG(t)
+
+	env := newMediaTestEnv(t, nil)
+	env.callStore.createErr = errors.New("idempotency reserve failed")
+
+	r := injectWebhook(buildLLMReq(t, map[string]any{
+		"input": "hi",
+		"media": []map[string]any{mediaItem(srv.URL+"/shot.png", "shot.png")},
+	}), env.wh)
+	r.Header.Set("Idempotency-Key", "replayed-key")
+
+	w := httptest.NewRecorder()
+	env.h.handle(w, r)
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected the reserve failure to short-circuit, got 200: %s", w.Body.String())
+	}
+	if env.seen != nil {
+		t.Error("agent invoked despite the early return")
+	}
+	if after := countMediaTemps(t); after != before {
+		t.Errorf("temp files stranded by the idempotency early return: before=%d after=%d", before, after)
+	}
+}
+
+// TestWebhookLLM_MediaTagCarriesNoSignature is the end-to-end half of the
+// redaction contract: what the agent actually receives must not contain the
+// caller's presigned signature, because RunRequest.Message goes to the LLM
+// provider and into session history.
+func TestWebhookLLM_MediaTagCarriesNoSignature(t *testing.T) {
+	allowLoopbackMedia(t)
+	srv := servePNG(t)
+	env := newMediaTestEnv(t, nil)
+
+	w := env.post(t, map[string]any{
+		"input": "what is this",
+		"media": []map[string]any{mediaItem(srv.URL+"/shot.png?X-Amz-Signature=deadbeefcafe", "shot.png")},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if env.seen == nil {
+		t.Fatal("agent was never invoked")
+	}
+	if strings.Contains(env.seen.Message, "deadbeefcafe") {
+		t.Errorf("prompt carries the URL signature: %q", env.seen.Message)
+	}
+}
+
+// ---- regressions ----
+
+func TestWebhookLLM_NoMediaField_Unchanged(t *testing.T) {
+	env := newMediaTestEnv(t, nil)
+
+	w := env.post(t, map[string]any{"input": "plain text only"})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if env.seen == nil {
+		t.Fatal("agent was never invoked")
+	}
+	if len(env.seen.Media) != 0 {
+		t.Errorf("RunRequest.Media = %d, want 0", len(env.seen.Media))
+	}
+	if env.seen.Message != "plain text only" {
+		t.Errorf("Message = %q, want the caller text verbatim with no tag prefix", env.seen.Message)
+	}
+}
+
+// TestWebhookLLM_AsyncWithMedia_Returns400 — the second assertion is the one
+// that matters. An enqueued row that can never succeed is exactly the failure
+// mode this guard exists to prevent.
+func TestWebhookLLM_AsyncWithMedia_Returns400(t *testing.T) {
+	isolateTempDir(t)
+	allowLoopbackMedia(t)
+	srv := servePNG(t)
+	before := countMediaTemps(t)
+	env := newMediaTestEnv(t, nil)
+
+	w := env.post(t, map[string]any{
+		"input":        "hi",
+		"mode":         "async",
+		"callback_url": "https://example.com/cb",
+		"media":        []map[string]any{mediaItem(srv.URL+"/shot.png", "shot.png")},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(env.callStore.created) != 0 {
+		t.Errorf("enqueued %d rows for a call that could never succeed", len(env.callStore.created))
+	}
+	if after := countMediaTemps(t); after != before {
+		t.Errorf("media was downloaded for a rejected async request: before=%d after=%d", before, after)
+	}
+}
+
+func TestWebhookLLM_AsyncWithoutMedia_StillEnqueues(t *testing.T) {
+	env := newMediaTestEnv(t, nil)
+
+	w := env.post(t, map[string]any{
+		"input":        "hi",
+		"mode":         "async",
+		"callback_url": "https://example.com/cb",
+	})
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(env.callStore.created) != 1 {
+		t.Errorf("created %d rows, want 1", len(env.callStore.created))
+	}
+}
+
+// TestWebhookLLM_AuditPayloadRedactsMediaURL pins that a presigned URL's
+// signature never lands in an audit row. request_payload is surfaced verbatim
+// by GET /v1/webhooks/{id}/calls/{callId} and retained for 30 days, and a
+// presigned URL is a bearer credential.
+func TestWebhookLLM_AuditPayloadRedactsMediaURL(t *testing.T) {
+	allowLoopbackMedia(t)
+	srv := servePNG(t)
+	env := newMediaTestEnv(t, nil)
+
+	const secret = "X-Amz-Signature=deadbeefcafe"
+	w := env.post(t, map[string]any{
+		"input": "hi",
+		"media": []map[string]any{mediaItem(srv.URL+"/shot.png?"+secret, "shot.png")},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(env.callStore.created) != 1 {
+		t.Fatalf("created %d audit rows, want 1", len(env.callStore.created))
+	}
+	payload := string(env.callStore.created[0].RequestPayload)
+	if strings.Contains(payload, "deadbeefcafe") {
+		t.Errorf("audit payload retains the URL signature: %s", payload)
+	}
+	if !strings.Contains(payload, "shot.png") {
+		t.Errorf("audit payload lost the URL path entirely: %s", payload)
+	}
+}

--- a/internal/http/webhooks_media_fetch.go
+++ b/internal/http/webhooks_media_fetch.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/nextlevelbuilder/goclaw/internal/security"
+	"github.com/nextlevelbuilder/goclaw/internal/webhooks"
 )
 
 const (
@@ -18,19 +19,6 @@ const (
 	// webhookMediaProbeTimeout is the deadline for the HEAD probe request.
 	webhookMediaProbeTimeout = 15 * time.Second
 )
-
-// allowedMediaMIMETypes is the set of Content-Type values accepted for media attachments.
-// Must be lowercase prefix-matched against the probed value.
-var allowedMediaMIMETypes = map[string]bool{
-	"image/jpeg":       true,
-	"image/png":        true,
-	"image/gif":        true,
-	"image/webp":       true,
-	"video/mp4":        true,
-	"audio/mpeg":       true,
-	"audio/ogg":        true,
-	"application/pdf":  true,
-}
 
 // mediaProbeResult is returned by probeMediaURL on success.
 type mediaProbeResult struct {
@@ -110,7 +98,7 @@ func probeMediaURL(rawURL string) (*mediaProbeResult, error) {
 	// Step 5: Validate Content-Type against allowlist.
 	rawCT := resp.Header.Get("Content-Type")
 	mimeType := parseMIMEType(rawCT)
-	if !allowedMediaMIMETypes[mimeType] {
+	if !webhooks.AllowedMediaMIMETypes[mimeType] {
 		return nil, &mediaValidateError{
 			code:    "mime_denied",
 			message: fmt.Sprintf("media MIME type %q is not allowed", mimeType),

--- a/internal/i18n/catalog_en.go
+++ b/internal/i18n/catalog_en.go
@@ -286,6 +286,8 @@ func init() {
 		MsgWebhookMediaSSRFBlocked:            "media URL blocked by SSRF policy",
 		MsgWebhookMediaTooLarge:               "media file exceeds size limit",
 		MsgWebhookMediaMIMEDenied:             "media MIME type is not allowed",
+		MsgWebhookMediaDownloadFailed:         "media could not be downloaded",
+		MsgWebhookMediaBudgetExhausted:        "media download capacity is temporarily exhausted, retry shortly",
 		MsgWebhookCallbackURLInvalid:          "callback URL is invalid or blocked",
 		MsgWebhookLLMTimeout:                  "LLM processing timed out",
 		MsgWebhookLaneSaturated:               "webhook processing lane is at capacity",

--- a/internal/i18n/catalog_ko.go
+++ b/internal/i18n/catalog_ko.go
@@ -183,5 +183,14 @@ func init() {
 		MsgTenantUserNotFound:  "테넌트 사용자를 찾을 수 없습니다",
 		MsgTenantMismatch:      "테넌트 사용자가 이 테넌트에 속하지 않습니다",
 		MsgTenantScopeRequired: "이 작업에는 테넌트 범위가 필요합니다",
+
+		// Webhook inbound media. ko is a partial catalog and falls back to
+		// English for keys it omits; these four are the ones POST
+		// /v1/webhooks/llm can return for a media attachment.
+		MsgWebhookMediaSSRFBlocked:     "미디어 URL이 SSRF 정책에 의해 차단되었습니다",
+		MsgWebhookMediaTooLarge:        "미디어 파일이 크기 제한을 초과했습니다",
+		MsgWebhookMediaMIMEDenied:      "허용되지 않는 미디어 MIME 유형입니다",
+		MsgWebhookMediaDownloadFailed:  "미디어를 다운로드하지 못했습니다",
+		MsgWebhookMediaBudgetExhausted: "미디어 다운로드 용량이 일시적으로 소진되었습니다. 잠시 후 다시 시도하세요",
 	})
 }

--- a/internal/i18n/catalog_ru.go
+++ b/internal/i18n/catalog_ru.go
@@ -285,6 +285,8 @@ func init() {
 		MsgWebhookMediaSSRFBlocked:            "URL медиа заблокирован политикой SSRF",
 		MsgWebhookMediaTooLarge:               "медиафайл превышает ограничение по размеру",
 		MsgWebhookMediaMIMEDenied:             "MIME-тип медиа не разрешён",
+		MsgWebhookMediaDownloadFailed:         "не удалось загрузить медиафайл",
+		MsgWebhookMediaBudgetExhausted:        "ёмкость загрузки медиа временно исчерпана, повторите попытку позже",
 		MsgWebhookCallbackURLInvalid:          "URL обратного вызова недействителен или заблокирован",
 		MsgWebhookLLMTimeout:                  "истекло время обработки LLM",
 		MsgWebhookLaneSaturated:               "линия обработки вебхуков заполнена",

--- a/internal/i18n/catalog_vi.go
+++ b/internal/i18n/catalog_vi.go
@@ -276,6 +276,8 @@ func init() {
 		MsgWebhookMediaSSRFBlocked:            "URL media bị chặn bởi chính sách SSRF",
 		MsgWebhookMediaTooLarge:               "tệp media vượt quá giới hạn kích thước",
 		MsgWebhookMediaMIMEDenied:             "loại MIME của media không được phép",
+		MsgWebhookMediaDownloadFailed:         "không tải được tệp media",
+		MsgWebhookMediaBudgetExhausted:        "dung lượng tải media tạm thời đã hết, vui lòng thử lại sau",
 		MsgWebhookCallbackURLInvalid:          "URL callback không hợp lệ hoặc bị chặn",
 		MsgWebhookLLMTimeout:                  "LLM xử lý hết thời gian chờ",
 		MsgWebhookLaneSaturated:               "làn xử lý webhook đã đầy",

--- a/internal/i18n/catalog_zh.go
+++ b/internal/i18n/catalog_zh.go
@@ -276,6 +276,8 @@ func init() {
 		MsgWebhookMediaSSRFBlocked:            "媒体 URL 被 SSRF 策略拦截",
 		MsgWebhookMediaTooLarge:               "媒体文件超出大小限制",
 		MsgWebhookMediaMIMEDenied:             "媒体 MIME 类型不被允许",
+		MsgWebhookMediaDownloadFailed:         "媒体文件下载失败",
+		MsgWebhookMediaBudgetExhausted:        "媒体下载容量暂时耗尽，请稍后重试",
 		MsgWebhookCallbackURLInvalid:          "回调 URL 无效或被拦截",
 		MsgWebhookLLMTimeout:                  "LLM 处理超时",
 		MsgWebhookLaneSaturated:               "Webhook 处理通道已满",

--- a/internal/i18n/keys.go
+++ b/internal/i18n/keys.go
@@ -322,6 +322,8 @@ const (
 	MsgWebhookMediaSSRFBlocked            = "webhook.media_ssrf_blocked"             // "media URL blocked by SSRF policy"
 	MsgWebhookMediaTooLarge               = "webhook.media_too_large"                // "media file exceeds size limit"
 	MsgWebhookMediaMIMEDenied             = "webhook.media_mime_denied"              // "media MIME type is not allowed"
+	MsgWebhookMediaDownloadFailed         = "webhook.media_download_failed"          // "media could not be downloaded"
+	MsgWebhookMediaBudgetExhausted        = "webhook.media_budget_exhausted"         // "media download capacity temporarily exhausted"
 	MsgWebhookCallbackURLInvalid          = "webhook.callback_url_invalid"           // "callback URL is invalid or blocked"
 	MsgWebhookLLMTimeout                  = "webhook.llm_timeout"                    // "LLM processing timed out"
 	MsgWebhookLaneSaturated               = "webhook.lane_saturated"                 // "webhook processing lane is at capacity"

--- a/internal/security/ssrf.go
+++ b/internal/security/ssrf.go
@@ -250,6 +250,14 @@ func isBlocked(ip net.IP) bool {
 	return false
 }
 
+// ErrBlockedDial is returned by the safe dialer when the resolved destination
+// IP of a connection falls in a blocked range. net.OpError and url.Error both
+// wrap it on the way back to an http.Client caller and both implement Unwrap,
+// so callers classify the failure with errors.Is rather than matching on error
+// text. Text matching is brittle in the unsafe direction: a reworded message
+// would silently downgrade a real SSRF block to a generic network failure.
+var ErrBlockedDial = errors.New("ssrf: dial IP is in a blocked range")
+
 // IsBlocked reports whether ip falls within any blocked CIDR (loopback,
 // link-local including cloud-metadata 169.254.169.254, RFC 1918 private,
 // multicast, and unspecified 0.0.0.0/:: ranges).
@@ -258,6 +266,15 @@ func isBlocked(ip net.IP) bool {
 // duplicating the CIDR list across packages.
 func IsBlocked(ip net.IP) bool {
 	return isBlocked(ip)
+}
+
+// RedactURL exposes redactURL to other packages so a caller URL can be logged
+// or persisted without its query string — a presigned URL's signature is a
+// bearer credential and must not be written to an audit row. Exported as a
+// wrapper for the same reason IsBlocked is: keep the redaction rule in one
+// place rather than reimplemented per caller.
+func RedactURL(rawURL string) string {
+	return redactURL(rawURL)
 }
 
 // redactURL strips query string and userinfo for safe logging.

--- a/internal/security/ssrf_redirect.go
+++ b/internal/security/ssrf_redirect.go
@@ -26,7 +26,7 @@ func safeDialControl(_, address string, _ syscall.RawConn) error {
 	}
 	if !allowLoopbackForTest.Load() && isBlocked(ip) {
 		slog.Warn("security.ssrf_block", "reason", "blocked_dial_ip", "ip", ip.String())
-		return fmt.Errorf("ssrf: dial IP %s is in a blocked range", ip)
+		return fmt.Errorf("%w: %s", ErrBlockedDial, ip)
 	}
 	return nil
 }

--- a/internal/webhooks/inbound_media.go
+++ b/internal/webhooks/inbound_media.go
@@ -1,0 +1,538 @@
+package webhooks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	_ "image/gif"  // register GIF decoder for the dimension gate
+	_ "image/jpeg" // register JPEG decoder for the dimension gate
+	_ "image/png"  // register PNG decoder for the dimension gate
+
+	_ "golang.org/x/image/webp" // register WebP decoder for the dimension gate
+
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
+	media "github.com/nextlevelbuilder/goclaw/internal/channels/media"
+	mediastore "github.com/nextlevelbuilder/goclaw/internal/media"
+	"github.com/nextlevelbuilder/goclaw/internal/security"
+)
+
+const (
+	// MaxInboundMediaItems caps fan-out of HTTP fetches per request. Mirrors
+	// bitrix24's maxInboundFiles.
+	MaxInboundMediaItems = 10
+
+	// inboundMediaMaxBytes matches the outbound /message cap so both directions
+	// of the webhook API agree on one number.
+	inboundMediaMaxBytes = 25 * 1024 * 1024
+
+	// inboundDownloadTimeout bounds one fetch, covering all redirect hops.
+	inboundDownloadTimeout = 5 * time.Minute
+
+	// maxInboundRedirects caps redirect hops. Each hop's resolved IP is
+	// re-validated at dial time by the safe client.
+	maxInboundRedirects = 5
+
+	// inboundMediaSniffLen is how many leading bytes are buffered for
+	// http.DetectContentType, which never looks past 512.
+	inboundMediaSniffLen = 512
+
+	// inboundMediaMaxPixels rejects a declared image whose header dimensions
+	// would blow up on decode. The agent's SanitizeImage calls imaging.Open —
+	// a full decode to RGBA at 4 bytes per pixel — before it checks any size,
+	// so a header claiming 30000x30000 costs 3.6 GB per file. At this cap the
+	// worst case is ~200 MB per image, and inboundMediaByteBudget bounds how
+	// many requests can be in flight holding files at once.
+	inboundMediaMaxPixels = 50_000_000
+
+	// inboundMediaByteBudget bounds total on-disk bytes held by in-flight
+	// webhook media across the whole process.
+	//
+	// The per-webhook rate limiter does NOT bound this: allow() returns true
+	// immediately when rpm <= 0 (webhooks_ratelimit.go), and WebhookData
+	// .RateLimitPerMin has no non-zero default. Unbounded, the worst case is
+	// the tenant tier's 600 rpm x 10 items x 25 MB = 150 GB. 512 MB admits
+	// two concurrent worst-case requests; past that, callers get 503.
+	inboundMediaByteBudget = 512 * 1024 * 1024
+
+	// requestLevelFailureIndex marks a failure that belongs to the request as a
+	// whole rather than to one item — currently only the item-count cap.
+	requestLevelFailureIndex = -1
+)
+
+// AllowedMediaMIMETypes is the single source of truth for which Content-Type
+// values the webhook API accepts, inbound and outbound. internal/http reads it
+// directly; do not add a second copy there.
+var AllowedMediaMIMETypes = map[string]bool{
+	"image/jpeg":      true,
+	"image/png":       true,
+	"image/gif":       true,
+	"image/webp":      true,
+	"video/mp4":       true,
+	"audio/mpeg":      true,
+	"audio/ogg":       true,
+	"application/pdf": true,
+}
+
+// InboundMediaItem is one caller-supplied attachment on POST /v1/webhooks/llm.
+//
+// There is deliberately no Caption field: MediaInfo has nowhere to put one and
+// BuildMediaTags has no branch that would emit it, so a caption would be
+// accepted, plumbed, and never read. Callers already have `input`.
+type InboundMediaItem struct {
+	URL      string `json:"url"`
+	Filename string `json:"filename,omitempty"`
+}
+
+// InboundMediaFailureCode is a CLOSED enum. It is the only failure detail that
+// may cross the API boundary or enter an LLM prompt.
+type InboundMediaFailureCode string
+
+const (
+	FailSSRF            InboundMediaFailureCode = "ssrf"
+	FailTooLarge        InboundMediaFailureCode = "too_large"
+	FailMIMEDenied      InboundMediaFailureCode = "mime_denied"
+	FailDownloadFailed  InboundMediaFailureCode = "download_failed"
+	FailBudgetExhausted InboundMediaFailureCode = "budget_exhausted"
+)
+
+// InboundMediaFailure records one item that could not be fetched.
+//
+// There is deliberately NO free-text reason field. SSRF errors embed the
+// hostname and the resolved internal IP, and url.Error embeds the full caller
+// URL plus "connection refused" vs "i/o timeout". Any of that reaching a prompt
+// or a response body turns this endpoint into an internal-network and
+// port-scanning oracle. Detail goes to slog only.
+//
+// Index is the caller's array position, or requestLevelFailureIndex (-1) when
+// the failure is about the request rather than one item.
+type InboundMediaFailure struct {
+	Index int
+	Code  InboundMediaFailureCode
+}
+
+// InboundMediaResult carries everything the callers need.
+//
+// Files and Infos are always both empty or both populated with matching order.
+// They are nil whenever Failures is non-empty — see FetchInboundMedia.
+type InboundMediaResult struct {
+	Files    []bus.MediaFile   // -> agent.RunRequest.Media
+	Infos    []media.MediaInfo // -> media.BuildMediaTags
+	Failures []InboundMediaFailure
+}
+
+// failureSeverity ranks codes so the HTTP status a caller sees never depends on
+// which array slot happened to fail first. Higher wins.
+//
+// budget_exhausted ranks lowest on purpose: it is the one transient,
+// server-side, retryable code. If any item is also genuinely bad, the request
+// is bad on retry too and must not be reported as a 503.
+var failureSeverity = map[InboundMediaFailureCode]int{
+	FailSSRF:            4,
+	FailMIMEDenied:      3,
+	FailTooLarge:        2,
+	FailDownloadFailed:  1,
+	FailBudgetExhausted: 0,
+}
+
+// WorstFailure returns the failure ranking highest in the fixed severity order
+// ssrf > mime_denied > too_large > download_failed > budget_exhausted. Returns
+// the zero value for an empty slice.
+func WorstFailure(fs []InboundMediaFailure) InboundMediaFailure {
+	var worst InboundMediaFailure
+	best := -1
+	for _, f := range fs {
+		if rank, ok := failureSeverity[f.Code]; ok && rank > best {
+			best, worst = rank, f
+		}
+	}
+	return worst
+}
+
+// byteBudget bounds total on-disk bytes held by in-flight inbound media.
+//
+// A fetch reserves the worst case before downloading, then commits the actual
+// bytes written and hands the difference back. The committed amount stays held,
+// keyed by temp path, until CleanupInboundMedia removes that file — which is
+// what makes this a disk bound rather than a download-concurrency bound: files
+// live from fetch time until the agent run finishes, which can be minutes.
+type byteBudget struct {
+	mu        sync.Mutex
+	remaining int64
+	held      map[string]int64
+}
+
+var inboundBudget = &byteBudget{
+	remaining: inboundMediaByteBudget,
+	held:      make(map[string]int64),
+}
+
+// reserve takes n bytes, reporting false when the budget cannot cover it.
+func (b *byteBudget) reserve(n int64) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.remaining < n {
+		return false
+	}
+	b.remaining -= n
+	return true
+}
+
+// commit converts a reservation into an amount held against path, returning the
+// unused remainder to the pool.
+func (b *byteBudget) commit(path string, reserved, actual int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.remaining += reserved - actual
+	b.held[path] += actual
+}
+
+// left reports the unreserved bytes, for diagnostics only.
+func (b *byteBudget) left() int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.remaining
+}
+
+// release hands back an uncommitted reservation.
+func (b *byteBudget) release(n int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.remaining += n
+}
+
+// releasePath hands back whatever is held against path. Safe on a path that was
+// never committed or was already released, which is what makes
+// CleanupInboundMedia idempotent.
+func (b *byteBudget) releasePath(path string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if n, ok := b.held[path]; ok {
+		b.remaining += n
+		delete(b.held, path)
+	}
+}
+
+// FetchInboundMedia downloads every item to its own temp file.
+//
+// ALL-OR-NOTHING: on any failure it removes whatever it already wrote and
+// returns Files == nil with the full Failures list. Partial success was
+// dropped because this is a machine-to-machine API — the chat-channel
+// precedent it was modelled on annotates the message for a human to read, and
+// there is no human here.
+//
+// Every item is attempted even after one fails. Bailing on the first failure
+// would make the caller's HTTP status depend on array order.
+func FetchInboundMedia(ctx context.Context, items []InboundMediaItem) InboundMediaResult {
+	var res InboundMediaResult
+	if len(items) == 0 {
+		return res
+	}
+	if len(items) > MaxInboundMediaItems {
+		// Reject rather than truncate: silent truncation reads as "we handled
+		// everything" when we did not, and all-or-nothing makes rejecting the
+		// consistent choice anyway.
+		slog.Warn("webhook.media.too_many_items",
+			"count", len(items), "cap", MaxInboundMediaItems)
+		res.Failures = append(res.Failures, InboundMediaFailure{
+			Index: requestLevelFailureIndex,
+			Code:  FailDownloadFailed,
+		})
+		return res
+	}
+
+	// One client shared across items. NOT security.NewSafeClient: that one sets
+	// CheckRedirect to http.ErrUseLastResponse, so a presigned or CDN URL that
+	// 3xx-redirects yields a 0-byte body with no error at all. This client
+	// follows redirects and re-validates the resolved destination IP at every
+	// hop's dial, which also closes DNS rebinding.
+	hc := security.NewRedirectFollowingSafeClient(inboundDownloadTimeout, maxInboundRedirects)
+
+	for i, item := range items {
+		file, info, code := fetchOneInboundMedia(ctx, hc, item)
+		if code != "" {
+			res.Failures = append(res.Failures, InboundMediaFailure{Index: i, Code: code})
+			continue
+		}
+		res.Files = append(res.Files, file)
+		res.Infos = append(res.Infos, info)
+	}
+
+	if len(res.Failures) > 0 {
+		CleanupInboundMedia(res.Files)
+		res.Files = nil
+		res.Infos = nil
+	}
+	return res
+}
+
+// fetchOneInboundMedia downloads a single item. It returns an empty code on
+// success; on failure it leaves nothing on disk and holds no budget.
+func fetchOneInboundMedia(ctx context.Context, hc *http.Client, item InboundMediaItem) (bus.MediaFile, media.MediaInfo, InboundMediaFailureCode) {
+	if strings.TrimSpace(item.URL) == "" {
+		slog.Warn("webhook.media.empty_url")
+		return bus.MediaFile{}, media.MediaInfo{}, FailDownloadFailed
+	}
+	safeURL := security.RedactURL(item.URL)
+
+	// Cheap pre-flight. The per-hop dial check inside hc is the real guard;
+	// this catches the obvious cases without opening a connection.
+	if _, _, err := security.Validate(item.URL); err != nil {
+		slog.Warn("security.webhook.ssrf_blocked", "url", safeURL, "error", err)
+		return bus.MediaFile{}, media.MediaInfo{}, FailSSRF
+	}
+
+	if !inboundBudget.reserve(inboundMediaMaxBytes) {
+		slog.Warn("webhook.media.budget_exhausted",
+			"url", safeURL,
+			"budget", int64(inboundMediaByteBudget),
+			"remaining", inboundBudget.left(),
+			"want", int64(inboundMediaMaxBytes))
+		return bus.MediaFile{}, media.MediaInfo{}, FailBudgetExhausted
+	}
+	committed := false
+	var tmpPath string
+	defer func() {
+		if !committed {
+			inboundBudget.release(inboundMediaMaxBytes)
+			if tmpPath != "" {
+				os.Remove(tmpPath)
+			}
+		}
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, item.URL, nil)
+	if err != nil {
+		slog.Warn("webhook.media.request_build_failed", "url", safeURL, "error", err)
+		return bus.MediaFile{}, media.MediaInfo{}, FailDownloadFailed
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		// A destination blocked at dial time surfaces here, from the initial
+		// request or from any redirect hop.
+		if errors.Is(err, security.ErrBlockedDial) {
+			slog.Warn("security.webhook.ssrf_blocked", "url", safeURL, "error", stripURLEnvelope(err))
+			return bus.MediaFile{}, media.MediaInfo{}, FailSSRF
+		}
+		slog.Warn("webhook.media.download_failed", "url", safeURL, "error", stripURLEnvelope(err))
+		return bus.MediaFile{}, media.MediaInfo{}, FailDownloadFailed
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("webhook.media.download_failed", "url", safeURL, "status", resp.StatusCode)
+		return bus.MediaFile{}, media.MediaInfo{}, FailDownloadFailed
+	}
+
+	mimeType := resolveInboundMime(resp.Header.Get("Content-Type"), item.Filename)
+
+	// Buffer the leading bytes so the declared type can be cross-checked before
+	// anything is written. The declared Content-Type is attacker-controlled and
+	// persistMedia trusts MimeType verbatim to decide routing.
+	head := make([]byte, inboundMediaSniffLen)
+	n, err := io.ReadFull(resp.Body, head)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		slog.Warn("webhook.media.download_failed", "url", safeURL, "error", stripURLEnvelope(err))
+		return bus.MediaFile{}, media.MediaInfo{}, FailDownloadFailed
+	}
+	head = head[:n]
+
+	sniffed := parseMIMEValue(http.DetectContentType(head))
+	if !sniffCompatible(mimeType, sniffed) {
+		slog.Warn("webhook.media.mime_sniff_mismatch",
+			"url", safeURL, "declared", mimeType, "sniffed", sniffed)
+		return bus.MediaFile{}, media.MediaInfo{}, FailMIMEDenied
+	}
+
+	if !AllowedMediaMIMETypes[mimeType] {
+		slog.Warn("webhook.media.mime_denied", "url", safeURL, "mime", mimeType)
+		return bus.MediaFile{}, media.MediaInfo{}, FailMIMEDenied
+	}
+
+	ext := mediastore.ExtFromMime(mimeType)
+	if ext == "" {
+		ext = filepath.Ext(item.Filename)
+	}
+	tmp, err := os.CreateTemp("", "goclaw_webhook_*"+ext)
+	if err != nil {
+		slog.Warn("webhook.media.temp_create_failed", "url", safeURL, "error", err)
+		return bus.MediaFile{}, media.MediaInfo{}, FailDownloadFailed
+	}
+	tmpPath = tmp.Name()
+
+	// +1 is how "hit the cap and more was available" is detected.
+	body := io.MultiReader(bytes.NewReader(head), resp.Body)
+	written, err := io.Copy(tmp, io.LimitReader(body, inboundMediaMaxBytes+1))
+	tmp.Close()
+	if err != nil {
+		slog.Warn("webhook.media.write_failed", "url", safeURL, "error", stripURLEnvelope(err))
+		return bus.MediaFile{}, media.MediaInfo{}, FailDownloadFailed
+	}
+	if written > inboundMediaMaxBytes {
+		slog.Warn("webhook.media.too_large", "url", safeURL, "max", int64(inboundMediaMaxBytes))
+		return bus.MediaFile{}, media.MediaInfo{}, FailTooLarge
+	}
+
+	if strings.HasPrefix(mimeType, "image/") {
+		if code := checkImageDimensions(tmpPath, mimeType, safeURL); code != "" {
+			return bus.MediaFile{}, media.MediaInfo{}, code
+		}
+	}
+
+	inboundBudget.commit(tmpPath, inboundMediaMaxBytes, written)
+	committed = true
+
+	slog.Info("webhook.media.downloaded",
+		"url", safeURL, "bytes", written, "mime", mimeType)
+
+	return bus.MediaFile{
+			Path:     tmpPath,
+			MimeType: mimeType,
+			Filename: item.Filename,
+		}, media.MediaInfo{
+			Type:     media.MediaKindFromMime(mimeType),
+			FilePath: tmpPath,
+			// Redacted, not raw. BuildMediaTags renders this into
+			// <media:image url="..."> which is prepended to the agent message,
+			// so it is sent to the LLM provider and persisted in session
+			// history. A presigned URL's signature is a bearer credential; the
+			// path is the only part the model can use, and read_image works
+			// from the local file, not from this URL.
+			SourceURL:   security.RedactURL(item.URL),
+			ContentType: mimeType,
+			FileName:    item.Filename,
+			FileSize:    written,
+		}, ""
+}
+
+// checkImageDimensions reads only the image header. It rejects a file that does
+// not decode as an image at all, and one whose pixel count would make the
+// agent's full decode a memory bomb.
+//
+// It runs after the file is written rather than off the 512-byte sniff buffer
+// because a JPEG's SOF marker can sit past a large EXIF block. DecodeConfig
+// still reads only the header — it never allocates the pixel buffer, which is
+// the allocation this gate exists to prevent.
+//
+// Rejecting a non-decodable image here is what keeps a bogus file off the agent
+// path: SanitizeImage fails OPEN, logging "sanitize image failed, using
+// original" and proceeding with the original bytes under the attacker's
+// declared MIME. That fall-through is fine for authenticated channels and is
+// not fine for a webhook caller, so the boundary refuses the file instead.
+func checkImageDimensions(path, mimeType, safeURL string) InboundMediaFailureCode {
+	f, err := os.Open(path)
+	if err != nil {
+		slog.Warn("webhook.media.image_open_failed", "url", safeURL, "error", err)
+		return FailDownloadFailed
+	}
+	defer f.Close()
+
+	cfg, _, err := image.DecodeConfig(f)
+	if err != nil {
+		slog.Warn("webhook.media.image_undecodable", "url", safeURL, "mime", mimeType, "error", err)
+		return FailMIMEDenied
+	}
+	if int64(cfg.Width)*int64(cfg.Height) > inboundMediaMaxPixels {
+		slog.Warn("webhook.media.image_too_many_pixels",
+			"url", safeURL, "width", cfg.Width, "height", cfg.Height, "max_pixels", int64(inboundMediaMaxPixels))
+		return FailTooLarge
+	}
+	return ""
+}
+
+// CleanupInboundMedia removes temp files produced by FetchInboundMedia and
+// returns their bytes to the budget. Safe on a nil slice and safe to call
+// twice.
+func CleanupInboundMedia(files []bus.MediaFile) {
+	for _, f := range files {
+		if f.Path == "" {
+			continue
+		}
+		if err := os.Remove(f.Path); err != nil && !os.IsNotExist(err) {
+			slog.Warn("webhook.media.cleanup_failed", "path", f.Path, "error", err)
+		}
+		inboundBudget.releasePath(f.Path)
+	}
+}
+
+// resolveInboundMime prefers the response Content-Type over a filename guess.
+// Without this, an extension-less CDN URL lands as application/octet-stream,
+// gets typed as a document, and is silently skipped by vision.
+func resolveInboundMime(respContentType, filename string) string {
+	if ct := parseMIMEValue(respContentType); ct != "" && ct != "application/octet-stream" {
+		return ct
+	}
+	if filename != "" {
+		if detected := media.DetectMIMEType(filename); detected != "" {
+			return detected
+		}
+	}
+	return "application/octet-stream"
+}
+
+// parseMIMEValue strips parameters and lowercases a Content-Type value.
+func parseMIMEValue(ct string) string {
+	if ct == "" {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(strings.SplitN(ct, ";", 2)[0]))
+}
+
+// sniffCompatible reports whether the sniffed content family can plausibly be
+// the declared type.
+//
+// The comparison is on family, not exact string, because servers legitimately
+// serve a JPEG as image/pjpeg and Go sniffs to its own canonical names. An
+// empty or octet-stream sniff means the sniffer had no opinion, which is not
+// evidence of a lie — for images the DecodeConfig gate settles it instead.
+func sniffCompatible(declared, sniffed string) bool {
+	if sniffed == "" || sniffed == "application/octet-stream" {
+		return true
+	}
+	if declared == sniffed {
+		return true
+	}
+	// Go reports every Ogg container as application/ogg, including audio ones.
+	if declared == "audio/ogg" && sniffed == "application/ogg" {
+		return true
+	}
+	// Inside application/*, a family match proves nothing: ZIP, gzip and wasm
+	// all sniff as application/something, and an exact match was already ruled
+	// out above. Only application/pdf is allowlisted in that family, so a ZIP
+	// declared as a PDF would otherwise sail through the cross-check.
+	if mimeFamily(declared) == "application" {
+		return false
+	}
+	return mimeFamily(declared) == mimeFamily(sniffed)
+}
+
+func mimeFamily(mimeType string) string {
+	if i := strings.IndexByte(mimeType, '/'); i > 0 {
+		return mimeType[:i]
+	}
+	return mimeType
+}
+
+// stripURLEnvelope removes the *url.Error wrapper before an error is logged.
+//
+// url.Error.Error() renders as `%s %q: %s` with the full request URL in the
+// middle - query string included. On a presigned URL that text IS the
+// credential, so logging the error verbatim would undo the redaction applied to
+// the adjacent url field. The wrapped error keeps the useful part (timeout,
+// refused, blocked dial) without the URL.
+func stripURLEnvelope(err error) error {
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		return ue.Err
+	}
+	return err
+}

--- a/internal/webhooks/inbound_media_test.go
+++ b/internal/webhooks/inbound_media_test.go
@@ -1,0 +1,667 @@
+package webhooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	media "github.com/nextlevelbuilder/goclaw/internal/channels/media"
+	"github.com/nextlevelbuilder/goclaw/internal/security"
+)
+
+// ---- helpers ----
+//
+// Tests that point at an httptest.Server hit 127.0.0.1, which the SSRF policy
+// blocks. allowLoopback flips the process-global bypass for the duration of one
+// test. That global is why none of these tests may call t.Parallel(): under
+// -race a parallel test flipping it reports a data race that reads like a bug
+// in the feature.
+func allowLoopback(t *testing.T) {
+	t.Helper()
+	security.SetAllowLoopbackForTest(true)
+	t.Cleanup(func() { security.SetAllowLoopbackForTest(false) })
+}
+
+// isolateTempDir points os.CreateTemp at this test's own directory.
+//
+// Both this package and internal/http glob os.TempDir() for goclaw_webhook_*
+// to prove a failed request left nothing behind, and `go test ./...` runs
+// packages in parallel — without isolation each would see the other's files and
+// the before/after deltas would flake. TMPDIR covers unix, TMP/TEMP cover
+// Windows, so the isolation holds however the suite is run.
+func isolateTempDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	t.Setenv("TMP", dir)
+	t.Setenv("TEMP", dir)
+}
+
+// tinyPNG returns a valid 1x1 PNG.
+func tinyPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{R: 1, G: 2, B: 3, A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// tinyJPEG returns a valid 1x1 JPEG.
+func tinyJPEG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, nil); err != nil {
+		t.Fatalf("encode jpeg: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// bombPNG returns a structurally valid PNG whose IHDR *declares* w x h while
+// carrying the pixel data of a 1x1 image. DecodeConfig reads only the header,
+// so this is exactly the shape of a decompression bomb: a few hundred bytes on
+// the wire that would allocate w*h*4 bytes if fully decoded.
+func bombPNG(t *testing.T, w, h uint32) []byte {
+	t.Helper()
+	b := tinyPNG(t)
+	// Layout: 8-byte signature | 4-byte length | "IHDR" (12:16) | 13-byte data
+	// (16:29) | 4-byte CRC (29:33). Width and height are the first 8 data bytes.
+	binary.BigEndian.PutUint32(b[16:20], w)
+	binary.BigEndian.PutUint32(b[20:24], h)
+	// CRC covers chunk type + data.
+	binary.BigEndian.PutUint32(b[29:33], crc32.ChecksumIEEE(b[12:29]))
+	return b
+}
+
+// countTempFiles reports how many fetcher temp files are on disk, so a test can
+// prove that a failed request left nothing behind.
+func countTempFiles(t *testing.T) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "goclaw_webhook_*"))
+	if err != nil {
+		t.Fatalf("glob temp: %v", err)
+	}
+	return len(matches)
+}
+
+// serve starts a test server returning body under contentType.
+func serve(t *testing.T, contentType string, body []byte) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.Write(body)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// ---- fetch tests ----
+
+func TestFetchInboundMedia_HappyPath(t *testing.T) {
+	allowLoopback(t)
+	body := tinyJPEG(t)
+	srv := serve(t, "image/jpeg", body)
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/photo.jpg", Filename: "photo.jpg"},
+	})
+	defer CleanupInboundMedia(res.Files)
+
+	if len(res.Failures) != 0 {
+		t.Fatalf("unexpected failures: %+v", res.Failures)
+	}
+	if len(res.Files) != 1 || len(res.Infos) != 1 {
+		t.Fatalf("Files=%d Infos=%d, want 1 each", len(res.Files), len(res.Infos))
+	}
+	f := res.Files[0]
+	if f.MimeType != "image/jpeg" {
+		t.Errorf("MimeType = %q, want image/jpeg", f.MimeType)
+	}
+	if f.Filename != "photo.jpg" {
+		t.Errorf("Filename = %q, want photo.jpg", f.Filename)
+	}
+	st, err := os.Stat(f.Path)
+	if err != nil {
+		t.Fatalf("temp file not on disk: %v", err)
+	}
+	if st.Size() != int64(len(body)) {
+		t.Errorf("size = %d, want %d", st.Size(), len(body))
+	}
+	info := res.Infos[0]
+	if info.Type != "image" {
+		t.Errorf("Info.Type = %q, want image", info.Type)
+	}
+	// SourceURL is what makes BuildMediaTags emit <media:image url="...">.
+	if info.SourceURL == "" {
+		t.Error("Info.SourceURL empty; the media tag would lose the URL")
+	}
+}
+
+func TestFetchInboundMedia_FollowsRedirect(t *testing.T) {
+	allowLoopback(t)
+	body := tinyJPEG(t)
+	dest := serve(t, "image/jpeg", body)
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dest.URL+"/real.jpg", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: origin.URL + "/signed", Filename: "real.jpg"},
+	})
+	defer CleanupInboundMedia(res.Files)
+
+	if len(res.Failures) != 0 {
+		t.Fatalf("unexpected failures: %+v", res.Failures)
+	}
+	if len(res.Files) != 1 {
+		t.Fatalf("Files = %d, want 1", len(res.Files))
+	}
+	// Assert on SIZE, not just on the absence of an error. security.NewSafeClient
+	// refuses redirects via http.ErrUseLastResponse, which produces a
+	// successful-looking response with an EMPTY body — no error, a 0-byte temp
+	// file, and an agent that silently sees nothing. Only a size assertion
+	// catches that regression.
+	st, err := os.Stat(res.Files[0].Path)
+	if err != nil {
+		t.Fatalf("stat temp: %v", err)
+	}
+	if st.Size() == 0 {
+		t.Fatal("downloaded 0 bytes through a redirect — wrong HTTP client")
+	}
+	if st.Size() != int64(len(body)) {
+		t.Errorf("size = %d, want %d", st.Size(), len(body))
+	}
+}
+
+func TestFetchInboundMedia_MimeFromResponseHeader(t *testing.T) {
+	allowLoopback(t)
+	srv := serve(t, "image/png", tinyPNG(t))
+
+	// No extension anywhere in the URL or the filename: without the
+	// response-header rule this lands as octet-stream, is typed as a document,
+	// and vision skips it.
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/download?id=1"},
+	})
+	defer CleanupInboundMedia(res.Files)
+
+	if len(res.Failures) != 0 {
+		t.Fatalf("unexpected failures: %+v", res.Failures)
+	}
+	if got := res.Files[0].MimeType; got != "image/png" {
+		t.Errorf("MimeType = %q, want image/png", got)
+	}
+	if got := res.Files[0].Path; !strings.HasSuffix(got, ".png") {
+		t.Errorf("temp path = %q, want a .png suffix", got)
+	}
+}
+
+func TestFetchInboundMedia_TooLarge(t *testing.T) {
+	isolateTempDir(t)
+	allowLoopback(t)
+	before := countTempFiles(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		io.CopyN(w, zeroReader{}, inboundMediaMaxBytes+1024)
+	}))
+	defer srv.Close()
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/big.jpg", Filename: "big.jpg"},
+	})
+
+	if len(res.Files) != 0 {
+		t.Fatalf("Files = %d, want 0", len(res.Files))
+	}
+	if len(res.Failures) != 1 || res.Failures[0].Code != FailTooLarge {
+		t.Fatalf("failures = %+v, want one too_large", res.Failures)
+	}
+	if after := countTempFiles(t); after != before {
+		t.Errorf("temp files leaked: before=%d after=%d", before, after)
+	}
+}
+
+func TestFetchInboundMedia_MimeDenied(t *testing.T) {
+	allowLoopback(t)
+	srv := serve(t, "text/html", []byte("<html><body>nope</body></html>"))
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/page.html", Filename: "page.html"},
+	})
+
+	if len(res.Failures) != 1 || res.Failures[0].Code != FailMIMEDenied {
+		t.Fatalf("failures = %+v, want one mime_denied", res.Failures)
+	}
+}
+
+func TestFetchInboundMedia_SSRFBlocked(t *testing.T) {
+	// Deliberately NO loopback bypass: this test asserts that a loopback URL is
+	// refused. Setting and resetting the flag per test (never at TestMain level)
+	// is what keeps this test honest.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+	}))
+	defer srv.Close()
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/x.png"},
+	})
+
+	if len(res.Files) != 0 {
+		t.Fatalf("Files = %d, want 0", len(res.Files))
+	}
+	if len(res.Failures) != 1 || res.Failures[0].Code != FailSSRF {
+		t.Fatalf("failures = %+v, want one ssrf", res.Failures)
+	}
+}
+
+func TestFetchInboundMedia_AnyFailureFailsAll(t *testing.T) {
+	isolateTempDir(t)
+	allowLoopback(t)
+	before := countTempFiles(t)
+
+	ok := serve(t, "image/png", tinyPNG(t))
+	missing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer missing.Close()
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: ok.URL + "/a.png", Filename: "a.png"},
+		{URL: missing.URL + "/b.png", Filename: "b.png"},
+		{URL: ok.URL + "/c.png", Filename: "c.png"},
+	})
+
+	if res.Files != nil || res.Infos != nil {
+		t.Fatalf("all-or-nothing violated: Files=%v Infos=%v", res.Files, res.Infos)
+	}
+	if len(res.Failures) != 1 {
+		t.Fatalf("failures = %+v, want exactly one", res.Failures)
+	}
+	if res.Failures[0].Index != 1 || res.Failures[0].Code != FailDownloadFailed {
+		t.Errorf("failure = %+v, want {Index:1 Code:download_failed}", res.Failures[0])
+	}
+	if after := countTempFiles(t); after != before {
+		t.Errorf("temp files leaked from the two successful items: before=%d after=%d", before, after)
+	}
+}
+
+func TestFetchInboundMedia_CountCap(t *testing.T) {
+	allowLoopback(t)
+	srv := serve(t, "image/png", tinyPNG(t))
+
+	items := make([]InboundMediaItem, MaxInboundMediaItems+2)
+	for i := range items {
+		items[i] = InboundMediaItem{URL: srv.URL + "/x.png", Filename: "x.png"}
+	}
+	res := FetchInboundMedia(context.Background(), items)
+
+	// Rejected outright, never truncated: silent truncation reads as "we handled
+	// everything" when we did not.
+	if len(res.Files) != 0 {
+		t.Fatalf("Files = %d, want 0 — the request must be rejected, not truncated", len(res.Files))
+	}
+	if len(res.Failures) != 1 || res.Failures[0].Code != FailDownloadFailed {
+		t.Fatalf("failures = %+v, want one download_failed", res.Failures)
+	}
+	if res.Failures[0].Index != requestLevelFailureIndex {
+		t.Errorf("Index = %d, want %d (request-level)", res.Failures[0].Index, requestLevelFailureIndex)
+	}
+}
+
+func TestFetchInboundMedia_SniffMismatchRejected(t *testing.T) {
+	allowLoopback(t)
+	// A ZIP served as image/png. The declared type is attacker-controlled and
+	// persistMedia trusts MimeType verbatim to pick a routing path.
+	zip := append([]byte("PK\x03\x04"), bytes.Repeat([]byte{0}, 64)...)
+	srv := serve(t, "image/png", zip)
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/evil.png", Filename: "evil.png"},
+	})
+
+	if len(res.Failures) != 1 || res.Failures[0].Code != FailMIMEDenied {
+		t.Fatalf("failures = %+v, want one mime_denied", res.Failures)
+	}
+}
+
+func TestFetchInboundMedia_RejectsDecompressionBomb(t *testing.T) {
+	isolateTempDir(t)
+	allowLoopback(t)
+	before := countTempFiles(t)
+
+	// A few hundred bytes on the wire declaring 30000x30000 — 3.6 GB of RGBA if
+	// the agent's imaging.Open ever reached it.
+	srv := serve(t, "image/png", bombPNG(t, 30000, 30000))
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/bomb.png", Filename: "bomb.png"},
+	})
+
+	if len(res.Files) != 0 {
+		t.Fatalf("Files = %d, want 0", len(res.Files))
+	}
+	if len(res.Failures) != 1 || res.Failures[0].Code != FailTooLarge {
+		t.Fatalf("failures = %+v, want one too_large", res.Failures)
+	}
+	if after := countTempFiles(t); after != before {
+		t.Errorf("temp files leaked: before=%d after=%d", before, after)
+	}
+}
+
+func TestFetchInboundMedia_RejectsUndecodableImage(t *testing.T) {
+	allowLoopback(t)
+	// Bytes that sniff as octet-stream — the sniffer has no opinion, so the
+	// family cross-check passes. The header gate is what refuses the file, which
+	// matters because SanitizeImage fails OPEN: it logs and proceeds with the
+	// original bytes under the caller's declared MIME.
+	srv := serve(t, "image/png", bytes.Repeat([]byte{0x7f}, 256))
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/not-really.png", Filename: "not-really.png"},
+	})
+
+	if len(res.Failures) != 1 || res.Failures[0].Code != FailMIMEDenied {
+		t.Fatalf("failures = %+v, want one mime_denied", res.Failures)
+	}
+}
+
+func TestFetchInboundMedia_LargeImageWithinPixelCapAccepted(t *testing.T) {
+	allowLoopback(t)
+	// 6000x4000 = 24 MP: an ordinary camera photo. The bomb gate must not
+	// reject it.
+	srv := serve(t, "image/png", bombPNG(t, 6000, 4000))
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/photo.png", Filename: "photo.png"},
+	})
+	defer CleanupInboundMedia(res.Files)
+
+	if len(res.Failures) != 0 {
+		t.Fatalf("unexpected failures on a 24 MP image: %+v", res.Failures)
+	}
+}
+
+// TestFetchInboundMedia_SourceURLIsRedacted pins that the signature never
+// reaches the media tag. BuildMediaTags renders SourceURL into
+// <media:image url="..."> which is prepended to the agent message, so a raw
+// value would be sent to the LLM provider and persisted in session history —
+// the same credential the audit row deliberately strips.
+func TestFetchInboundMedia_SourceURLIsRedacted(t *testing.T) {
+	allowLoopback(t)
+	srv := serve(t, "image/png", tinyPNG(t))
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/shot.png?X-Amz-Signature=deadbeefcafe", Filename: "shot.png"},
+	})
+	defer CleanupInboundMedia(res.Files)
+
+	if len(res.Infos) != 1 {
+		t.Fatalf("Infos = %d, want 1: %+v", len(res.Infos), res.Failures)
+	}
+	got := res.Infos[0].SourceURL
+	if strings.Contains(got, "deadbeefcafe") || strings.Contains(got, "?") {
+		t.Errorf("SourceURL retains the signature: %q", got)
+	}
+	if !strings.HasSuffix(got, "/shot.png") {
+		t.Errorf("SourceURL = %q, want the path preserved", got)
+	}
+
+	tags := media.BuildMediaTags(res.Infos)
+	if strings.Contains(tags, "deadbeefcafe") {
+		t.Errorf("media tag carries the signature into the prompt: %q", tags)
+	}
+}
+
+func TestFetchInboundMedia_EmptyURL(t *testing.T) {
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{{URL: "   "}})
+
+	// Reported as a download failure rather than an SSRF block: nothing was
+	// resolved, so calling it an SSRF block would mislead the caller.
+	if len(res.Failures) != 1 || res.Failures[0].Code != FailDownloadFailed {
+		t.Fatalf("failures = %+v, want one download_failed", res.Failures)
+	}
+}
+
+// TestBlockedDialIsIdentifiableByErrorsIs proves the sentinel survives the
+// net.OpError and url.Error wrappers, which is what lets the fetcher report a
+// redirect into a private range as ssrf instead of a generic failure. The old
+// substring match on "ssrf:" would break silently if the message were reworded;
+// this breaks loudly.
+func TestBlockedDialIsIdentifiableByErrorsIs(t *testing.T) {
+	// No loopback bypass — it disables every blocked range, including this one.
+	hc := security.NewRedirectFollowingSafeClient(5*time.Second, maxInboundRedirects)
+	_, err := hc.Get("http://169.254.169.254/latest/meta-data/")
+	if err == nil {
+		t.Fatal("expected the link-local dial to be refused")
+	}
+	if !errors.Is(err, security.ErrBlockedDial) {
+		t.Fatalf("errors.Is(err, security.ErrBlockedDial) = false for %v", err)
+	}
+	// And the stripped form must not carry the request URL.
+	if stripped := stripURLEnvelope(err); strings.Contains(stripped.Error(), "meta-data") {
+		t.Errorf("stripURLEnvelope left the URL in place: %v", stripped)
+	}
+}
+
+func TestFetchInboundMedia_NoItems(t *testing.T) {
+	res := FetchInboundMedia(context.Background(), nil)
+	if len(res.Files) != 0 || len(res.Failures) != 0 {
+		t.Fatalf("empty input produced %+v", res)
+	}
+}
+
+// ---- cleanup ----
+
+func TestCleanupInboundMedia_Idempotent(t *testing.T) {
+	allowLoopback(t)
+	srv := serve(t, "image/png", tinyPNG(t))
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/a.png", Filename: "a.png"},
+	})
+	if len(res.Files) != 1 {
+		t.Fatalf("Files = %d, want 1", len(res.Files))
+	}
+	path := res.Files[0].Path
+
+	CleanupInboundMedia(res.Files)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file still present after cleanup: %v", err)
+	}
+	CleanupInboundMedia(res.Files) // must not panic
+	CleanupInboundMedia(nil)       // must not panic
+}
+
+// ---- severity ordering ----
+
+func TestWorstFailure_SeverityOrder(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []InboundMediaFailure
+		want InboundMediaFailureCode
+	}{
+		{"ssrf beats mime_denied", []InboundMediaFailure{
+			{Index: 0, Code: FailMIMEDenied}, {Index: 1, Code: FailSSRF}}, FailSSRF},
+		{"mime_denied beats too_large", []InboundMediaFailure{
+			{Index: 0, Code: FailTooLarge}, {Index: 1, Code: FailMIMEDenied}}, FailMIMEDenied},
+		{"too_large beats download_failed", []InboundMediaFailure{
+			{Index: 0, Code: FailDownloadFailed}, {Index: 1, Code: FailTooLarge}}, FailTooLarge},
+		{"download_failed beats budget_exhausted", []InboundMediaFailure{
+			{Index: 0, Code: FailBudgetExhausted}, {Index: 1, Code: FailDownloadFailed}}, FailDownloadFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			forward := WorstFailure(tc.in)
+			reversed := WorstFailure([]InboundMediaFailure{tc.in[1], tc.in[0]})
+			if forward.Code != tc.want || reversed.Code != tc.want {
+				t.Fatalf("forward=%q reversed=%q, want %q", forward.Code, reversed.Code, tc.want)
+			}
+		})
+	}
+
+	if got := WorstFailure(nil); got.Code != "" {
+		t.Errorf("WorstFailure(nil).Code = %q, want empty", got.Code)
+	}
+}
+
+// TestInboundMediaFailure_HasNoFreeText pins the closed-enum contract.
+//
+// Someone will eventually want to add a Reason string "just for debugging".
+// SSRF errors embed the hostname and the resolved internal IP, and url.Error
+// embeds the caller's full URL plus "connection refused" vs "i/o timeout" — any
+// of which turns this endpoint into a port-scanning oracle once it reaches a
+// prompt or a response body. The detail belongs in slog, which callers cannot
+// read.
+func TestInboundMediaFailure_HasNoFreeText(t *testing.T) {
+	typ := reflect.TypeOf(InboundMediaFailure{})
+	if typ.NumField() != 2 {
+		t.Fatalf("InboundMediaFailure has %d fields, want exactly 2 (Index, Code)", typ.NumField())
+	}
+	want := map[string]reflect.Type{
+		"Index": reflect.TypeOf(0),
+		"Code":  reflect.TypeOf(InboundMediaFailureCode("")),
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		exp, ok := want[f.Name]
+		if !ok {
+			t.Fatalf("unexpected field %q: failure detail must stay a closed enum", f.Name)
+		}
+		if f.Type != exp {
+			t.Errorf("field %q has type %v, want %v", f.Name, f.Type, exp)
+		}
+	}
+}
+
+// ---- byte budget ----
+
+func TestByteBudget_ReserveCommitRelease(t *testing.T) {
+	b := &byteBudget{remaining: 100, held: make(map[string]int64)}
+
+	if !b.reserve(60) {
+		t.Fatal("first reserve of 60/100 should succeed")
+	}
+	if b.reserve(60) {
+		t.Fatal("second reserve of 60 with 40 left should fail")
+	}
+
+	// Commit less than reserved: the remainder goes back to the pool.
+	b.commit("/tmp/a", 60, 10)
+	if b.remaining != 90 {
+		t.Fatalf("remaining = %d, want 90 (100 - 10 held)", b.remaining)
+	}
+
+	// Releasing the path frees exactly what was held, and is safe twice — this
+	// is what makes CleanupInboundMedia idempotent.
+	b.releasePath("/tmp/a")
+	if b.remaining != 100 {
+		t.Fatalf("remaining = %d, want 100", b.remaining)
+	}
+	b.releasePath("/tmp/a")
+	b.releasePath("/tmp/never-seen")
+	if b.remaining != 100 {
+		t.Fatalf("remaining = %d after redundant releases, want 100", b.remaining)
+	}
+
+	// An uncommitted reservation is handed back whole.
+	b.reserve(40)
+	b.release(40)
+	if b.remaining != 100 {
+		t.Fatalf("remaining = %d, want 100", b.remaining)
+	}
+}
+
+func TestFetchInboundMedia_BudgetExhausted(t *testing.T) {
+	allowLoopback(t)
+	srv := serve(t, "image/png", tinyPNG(t))
+
+	// Drain the shared budget, then restore it so later tests are unaffected.
+	if !inboundBudget.reserve(inboundMediaByteBudget) {
+		t.Fatal("budget was not full at test start")
+	}
+	defer inboundBudget.release(inboundMediaByteBudget)
+
+	res := FetchInboundMedia(context.Background(), []InboundMediaItem{
+		{URL: srv.URL + "/a.png", Filename: "a.png"},
+	})
+
+	if len(res.Files) != 0 {
+		t.Fatalf("Files = %d, want 0", len(res.Files))
+	}
+	if len(res.Failures) != 1 || res.Failures[0].Code != FailBudgetExhausted {
+		t.Fatalf("failures = %+v, want one budget_exhausted", res.Failures)
+	}
+}
+
+// ---- mime helpers ----
+
+func TestResolveInboundMime(t *testing.T) {
+	cases := []struct {
+		respCT, filename, want string
+	}{
+		{"image/png", "x.png", "image/png"},
+		{"image/PNG; charset=binary", "x.bin", "image/png"},
+		{"", "x.png", "image/png"},
+		{"application/octet-stream", "x.jpg", "image/jpeg"},
+		{"", "", "application/octet-stream"},
+	}
+	for _, tc := range cases {
+		if got := resolveInboundMime(tc.respCT, tc.filename); got != tc.want {
+			t.Errorf("resolveInboundMime(%q, %q) = %q, want %q", tc.respCT, tc.filename, got, tc.want)
+		}
+	}
+}
+
+func TestSniffCompatible(t *testing.T) {
+	cases := []struct {
+		declared, sniffed string
+		want              bool
+	}{
+		{"image/png", "image/png", true},
+		{"image/jpeg", "image/png", true},                // same family; the header gate settles images
+		{"image/png", "application/zip", false},          // the case this exists for
+		{"application/pdf", "application/zip", false},    // family match proves nothing inside application/*
+		{"application/pdf", "application/x-gzip", false}, //
+		{"image/png", "application/octet-stream", true},  // sniffer has no opinion
+		{"audio/ogg", "application/ogg", true},           // Go names every Ogg container application/ogg
+		{"application/pdf", "application/pdf", true},     //
+		{"video/mp4", "text/html; charset=utf-8", false}, // never
+	}
+	for _, tc := range cases {
+		if got := sniffCompatible(tc.declared, parseMIMEValue(tc.sniffed)); got != tc.want {
+			t.Errorf("sniffCompatible(%q, %q) = %v, want %v", tc.declared, tc.sniffed, got, tc.want)
+		}
+	}
+}
+
+// zeroReader is an endless source of zero bytes for the size-cap test.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}


### PR DESCRIPTION
`POST /v1/webhooks/llm` accepts text only today, so a webhook caller cannot send an image the way Telegram or the WebSocket client can. This adds an optional `media[{url, filename}]` array, **sync mode only**: the gateway downloads each URL to a temp file and hands local paths to `agent.RunRequest.Media`, where every other channel already converges.

Motivating case: a middleware sits between a platform callback (Zalo OA, Messenger) and the gateway, so the native channel is never in the path, and the platform's image URL has nowhere to go.

## Why the agent side needs no change

`RunRequest.Media []bus.MediaFile` already exists and everything downstream is channel-agnostic — `enrichInputMedia` branches only on `len(req.Media) > 0`. The gap was entirely at the request boundary.

## Design decisions

**`media[]` by URL, not by path.** Every existing request boundary (WS `chat.go`, MCP `chat_runner.go`) passes local paths because the caller pre-uploads via `POST /v1/media/upload` — which sits behind `requireAuth` needing a user/admin role, while a webhook caller holds only a `wh_` bearer or an HMAC key. `chat.go` also passes `item.Path` straight into `persistMedia` unvalidated, which is safe only because that caller is an authenticated user. A caller-supplied path on a webhook would be an arbitrary local file read.

**`NewRedirectFollowingSafeClient`, not `NewSafeClient`.** The latter sets `CheckRedirect` to `http.ErrUseLastResponse`, so a presigned or CDN URL silently yields a 0-byte body with **no error**. The redirect-following client re-validates the resolved destination IP at every hop's dial, which also closes DNS rebinding. The test for this asserts on **file size**, not just `err == nil` — with the wrong client the failure is silent.

**Sync only; `mode=async` + `media[]` returns 400.** Not deferred work, a deliberate rejection: `buildAuditPayload` freezes `requestPayload` *before* the mode dispatch and `handleAsync` stores it verbatim, so server-computed local paths have no way to reach the worker. An accepted request would run with no media and no tag, then answer confidently about an image nobody sent, with `status: "done"` and nothing in `last_error`.

**Media tags are load-bearing, not cosmetic.** `enrichImageIDs` uses `replaceFirstMediaTag` — it rewrites an *existing* `<media:image>` tag and never inserts one. When an agent has a dedicated `read_image` provider (file-ref vision mode), images are not attached to the main LLM at all, so the tag is the model's only signal. No tag means a silent no-op: no error, no log, wrong answer — and only on that configuration, so it works on a dev box and fails at a customer.

**Failure detail is a closed enum.** SSRF errors embed the hostname and the resolved internal IP; `url.Error` embeds the caller's full URL plus "connection refused" vs "i/o timeout". Any of that reaching the response body or the prompt turns this endpoint into an internal-network and port-scanning oracle. Detail goes to `slog` only, and a reflection test pins that the failure struct has no free-text field.

## Guards

- SSRF validation up front, plus per-redirect-hop dial re-validation.
- 10-item count cap — rejected, not truncated. Silent truncation reads as "we handled everything" when we did not.
- Content sniff cross-check against the declared `Content-Type`. That header is attacker-controlled and `persistMedia` trusts it verbatim to decide routing.
- 25 MB per file, matching the outbound `/message` cap so both directions of the API agree on one number.
- A 50 MP image gate read from the header via `image.DecodeConfig` before any full decode. `SanitizeImage` calls `imaging.Open` before checking dimensions, so ten 25 MB items each declaring 30000x30000 would decode to ~3.6 GB of RGBA. The gate also rejects an `image/*` file that does not decode at all, because `SanitizeImage` fails **open** — it logs and proceeds with the original bytes under the caller's declared MIME, which is fine for authenticated channels and not fine here.
- A 512 MB process-wide byte budget. The per-webhook rate limiter bounds none of this: `allow()` returns true whenever `rpm <= 0` and `RateLimitPerMin` has no non-zero default, leaving a 600 rpm x 10 items x 25 MB worst case.

## Semantics

**All-or-nothing.** Any failed item fails the whole request and the agent is never invoked. Partial success was dropped deliberately — the chat-channel precedent it would copy annotates the message for a human to read, and there is no human on a machine-to-machine API.

**Deterministic status.** Every item is attempted even after one fails, and the status comes from a fixed severity order (`ssrf > mime_denied > too_large > download_failed > budget_exhausted`) rather than from array position.

**Cleanup is owned by the run.** `lane.Submit` runs its closure in a detached goroutine and returns immediately; the handler then selects on the request-derived context while the run uses `context.WithoutCancel`. A `defer` in the handler would delete the files on client disconnect while `ag.Run` was still executing — `persistMedia` fails its copy, logs a warning, drops the ref, and the agent burns minutes answering about a tag with no image behind it. Cleanup therefore lives inside the closure, with the two paths that never reach it (a `Submit` error, the idempotency early return) cleaning up themselves. Each has a test.

**One deadline covers download and run**, so a sync call cannot outlive `gateway.webhook_sync_timeout_sec`.

**URL query strings are stripped** wherever the value is retained or forwarded — the audit row (`request_payload` is readable via the admin calls endpoint for 30 days), the `<media:image url="...">` tag (which reaches the LLM provider and persisted session history), and every log line. A presigned URL's signature is a bearer credential.

## Supporting changes

- `security.RedactURL` and `security.ErrBlockedDial` exported. The sentinel lets callers classify a blocked dial with `errors.Is` rather than matching error text — text matching is brittle in the unsafe direction, since a reworded message would silently downgrade a real SSRF block to a generic failure.
- The media MIME allowlist moves to `internal/webhooks` as one source of truth; the private copy in `internal/http` is deleted and `probeMediaURL` points at the exported map.
- One new i18n key across all five catalogs. `catalog_ko.go` also gains the three existing `MsgWebhookMedia*` keys it was missing.
- `docs/webhooks.md`: the `media[]` contract, a middleware integration guide, and the **413** row the `/v1/webhooks/message` error table has always been missing (the code has returned it since `webhooks_message.go`).

## Testing

42 new tests — 25 in `internal/webhooks`, 17 in `internal/http` — all green under `-race`. `go build ./...`, `go build -tags sqliteonly ./...`, and `go vet ./...` clean on this base.

Tests that pin the non-obvious behaviour rather than just executing code: the redirect test asserts file size; the core wiring test asserts **both** `RunRequest.Media` and `<media:image` in the message, since asserting only the former passes while file-ref vision mode is silently broken; the disconnect test asserts from inside the agent stub that the file still exists after the handler has returned; and one test proves `security.ErrBlockedDial` survives the `net.OpError` → `url.Error` wrapping, which is what makes `errors.Is` viable there.

Surface parity: `ui/web` N/A — the admin test endpoint (`POST /v1/webhooks/{id}/test`) and its UI dialog stay text-only in this change, stated in `docs/webhooks.md`. No schema change, so no migration on either PG or SQLite. The only public-contract additions are the two exported `internal/security` symbols and the optional `media` request field.

## Out of scope

Outbound media in the sync response (`webhookLLMSyncResp` drops `RunResult.Media`), `media[]` on the admin test endpoint, and async support. Async is documented as rejected rather than deferred, with the reasoning kept so the same design is not rebuilt.

## Known limitation

A caller that omits `user_id` lands in `<workspace>/<agent_key>/.uploads/`, shared with every other such caller. Documented, not changed — it is pre-existing behaviour of the upload path, not introduced here.
