### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Single binary. Production-tested. Agents that orchestrate for you.
 - **Agent Teams & Orchestration** — Shared task boards, inter-agent delegation (sync/async), 3 orchestration modes (auto/explicit/manual)
 - **Self-Evolution** — Metrics → suggestions → auto-adapt with guardrails. Agents refine their own communication style
 - **Multi-Tenant PostgreSQL** — Per-user workspaces, per-user context files, encrypted API keys (AES-256-GCM), RBAC, isolated sessions
-- **20+ LLM Providers** — Anthropic (native HTTP+SSE with prompt caching), OpenAI, OpenRouter, Groq, DeepSeek, Gemini, Mistral, xAI, MiniMax, DashScope, Claude CLI, Codex, ACP, and any OpenAI-compatible endpoint
+- **20+ LLM Providers** — Anthropic (native HTTP+SSE with prompt caching), OpenAI, OpenRouter, OrcaRouter, Groq, DeepSeek, Gemini, Mistral, xAI, MiniMax, DashScope, Claude CLI, Codex, ACP, and any OpenAI-compatible endpoint
 - **7 Messaging Channels** — Telegram, Discord, Slack, Zalo OA, Zalo Personal, Feishu/Lark, WhatsApp
 - **Production Security** — 5-layer permission system, rate limiting, prompt injection detection, SSRF protection, AES-256-GCM encryption
 - **Single Binary** — ~25 MB static Go binary, no Node.js runtime, <1s startup, runs on a $5 VPS

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -99,10 +99,12 @@ func runDoctor() {
 		checkProvider("Anthropic (env)", cfg.Providers.Anthropic.APIKey)
 		checkProvider("OpenAI (env)", cfg.Providers.OpenAI.APIKey)
 		checkProvider("OpenRouter (env)", cfg.Providers.OpenRouter.APIKey)
+		checkProvider("OrcaRouter (env)", cfg.Providers.OrcaRouter.APIKey)
 	} else {
 		checkProvider("Anthropic", cfg.Providers.Anthropic.APIKey)
 		checkProvider("OpenAI", cfg.Providers.OpenAI.APIKey)
 		checkProvider("OpenRouter", cfg.Providers.OpenRouter.APIKey)
+		checkProvider("OrcaRouter", cfg.Providers.OrcaRouter.APIKey)
 		checkProvider("Gemini", cfg.Providers.Gemini.APIKey)
 		checkProvider("Groq", cfg.Providers.Groq.APIKey)
 		checkProvider("DeepSeek", cfg.Providers.DeepSeek.APIKey)

--- a/cmd/gateway_providers.go
+++ b/cmd/gateway_providers.go
@@ -61,6 +61,17 @@ func registerProviders(registry *providers.Registry, cfg *config.Config, modelRe
 		slog.Info("registered provider", "name", "openrouter")
 	}
 
+	if cfg.Providers.OrcaRouter.APIKey != "" {
+		base := cfg.Providers.OrcaRouter.APIBase
+		if base == "" {
+			base = store.OrcaRouterDefaultAPIBase
+		}
+		prov := providers.NewOpenAIProvider("orcarouter", cfg.Providers.OrcaRouter.APIKey, base, store.OrcaRouterDefaultModel)
+		prov.WithProviderType(store.ProviderOrcaRouter)
+		registry.Register(prov)
+		slog.Info("registered provider", "name", "orcarouter")
+	}
+
 	if cfg.Providers.Groq.APIKey != "" {
 		registry.Register(providers.NewOpenAIProvider("groq", cfg.Providers.Groq.APIKey, "https://api.groq.com/openai/v1", "llama-3.3-70b-versatile"))
 		slog.Info("registered provider", "name", "groq")
@@ -449,6 +460,14 @@ func registerProvidersFromDB(registry *providers.Registry, provStore store.Provi
 			registry.RegisterForTenant(p.TenantID, prov)
 		case store.ProviderAIMLAPI:
 			prov := providers.NewAIMLAPIProvider(p.Name, p.APIKey, p.APIBase)
+			prov.WithProviderType(p.ProviderType)
+			registry.RegisterForTenant(p.TenantID, prov)
+		case store.ProviderOrcaRouter:
+			base := p.APIBase
+			if base == "" {
+				base = store.OrcaRouterDefaultAPIBase
+			}
+			prov := providers.NewOpenAIProvider(p.Name, p.APIKey, base, store.OrcaRouterDefaultModel)
 			prov.WithProviderType(p.ProviderType)
 			registry.RegisterForTenant(p.TenantID, prov)
 		default:

--- a/cmd/onboard_managed.go
+++ b/cmd/onboard_managed.go
@@ -30,6 +30,7 @@ func testPostgresConnection(dsn string) error {
 var defaultPlaceholderProviders = []store.LLMProviderData{
 	{Name: "aimlapi", DisplayName: "AI/ML API", ProviderType: store.ProviderAIMLAPI, APIBase: providers.AIMLAPIDefaultAPIBase, Enabled: false},
 	{Name: "openrouter", DisplayName: "OpenRouter", ProviderType: store.ProviderOpenRouter, APIBase: "https://openrouter.ai/api/v1", Enabled: false},
+	{Name: "orcarouter", DisplayName: "OrcaRouter", ProviderType: store.ProviderOrcaRouter, APIBase: "https://api.orcarouter.ai/v1", Enabled: false},
 	{Name: "synthetic", DisplayName: "Synthetic", ProviderType: store.ProviderOpenAICompat, APIBase: "https://api.synthetic.new/openai/v1", Enabled: false},
 	{Name: "alicloud-api", DisplayName: "AliCloud API", ProviderType: store.ProviderDashScope, APIBase: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", Enabled: false},
 	{Name: "alicloud-sub", DisplayName: "AliCloud Sub", ProviderType: store.ProviderBailian, APIBase: "https://coding-intl.dashscope.aliyuncs.com/v1", Enabled: false},

--- a/cmd/providers_cmd.go
+++ b/cmd/providers_cmd.go
@@ -125,6 +125,7 @@ func runProvidersAdd() {
 		{"OpenAI", "openai"},
 		{"Atlas Cloud", "atlascloud"},
 		{"OpenRouter", "openrouter"},
+		{"OrcaRouter", "orcarouter"},
 		{"DashScope (Alibaba)", "dashscope"},
 		{"OpenAI-compatible", "openai_compat"},
 	}
@@ -315,6 +316,8 @@ func defaultBaseURL(providerType string) string {
 		return "https://api.atlascloud.ai/v1"
 	case "openrouter":
 		return "https://openrouter.ai/api/v1"
+	case "orcarouter":
+		return "https://api.orcarouter.ai/v1"
 	case "dashscope":
 		return "https://dashscope.aliyuncs.com/compatible-mode/v1"
 	default:

--- a/cmd/setup_provider.go
+++ b/cmd/setup_provider.go
@@ -49,6 +49,7 @@ func addProvider() {
 		{"OpenAI", "openai"},
 		{"Atlas Cloud", "atlascloud"},
 		{"OpenRouter", "openrouter"},
+		{"OrcaRouter", "orcarouter"},
 		{"DashScope (Alibaba)", "dashscope"},
 		{"OpenAI-compatible", "openai_compat"},
 	}

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -257,6 +257,7 @@ type ProvidersConfig struct {
 	OpenAI         ProviderConfig  `json:"openai"`
 	AtlasCloud     ProviderConfig  `json:"atlascloud"` // Atlas Cloud (OpenAI-compatible endpoint)
 	OpenRouter     ProviderConfig  `json:"openrouter"`
+	OrcaRouter     ProviderConfig  `json:"orcarouter"` // OrcaRouter (OpenAI-compatible gateway)
 	Groq           ProviderConfig  `json:"groq"`
 	Gemini         ProviderConfig  `json:"gemini"`
 	DeepSeek       ProviderConfig  `json:"deepseek"`
@@ -336,6 +337,8 @@ func (p *ProvidersConfig) APIBaseForType(providerType string) string {
 		return p.AtlasCloud.APIBase
 	case "openrouter":
 		return p.OpenRouter.APIBase
+	case "orcarouter":
+		return p.OrcaRouter.APIBase
 	case "groq":
 		return p.Groq.APIBase
 	case "deepseek":
@@ -383,6 +386,7 @@ func (c *Config) HasAnyProvider() bool {
 		p.OpenAI.APIKey != "" ||
 		p.AtlasCloud.APIKey != "" ||
 		p.OpenRouter.APIKey != "" ||
+		p.OrcaRouter.APIKey != "" ||
 		p.Groq.APIKey != "" ||
 		p.Gemini.APIKey != "" ||
 		p.DeepSeek.APIKey != "" ||

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -162,6 +162,7 @@ func (c *Config) applyEnvOverrides() {
 	envStr("GOCLAW_ATLASCLOUD_API_KEY", &c.Providers.AtlasCloud.APIKey)
 	envStr("GOCLAW_ATLASCLOUD_BASE_URL", &c.Providers.AtlasCloud.APIBase)
 	envStr("GOCLAW_OPENROUTER_API_KEY", &c.Providers.OpenRouter.APIKey)
+	envStr("GOCLAW_ORCAROUTER_API_KEY", &c.Providers.OrcaRouter.APIKey)
 	envStr("GOCLAW_GROQ_API_KEY", &c.Providers.Groq.APIKey)
 	envStr("GOCLAW_DEEPSEEK_API_KEY", &c.Providers.DeepSeek.APIKey)
 	envStr("GOCLAW_GEMINI_API_KEY", &c.Providers.Gemini.APIKey)

--- a/internal/config/config_secrets.go
+++ b/internal/config/config_secrets.go
@@ -25,6 +25,7 @@ func (c *Config) MaskedCopy() *Config {
 	maskNonEmpty(&cp.Providers.OpenAI.APIKey)
 	maskNonEmpty(&cp.Providers.AtlasCloud.APIKey)
 	maskNonEmpty(&cp.Providers.OpenRouter.APIKey)
+	maskNonEmpty(&cp.Providers.OrcaRouter.APIKey)
 	maskNonEmpty(&cp.Providers.Groq.APIKey)
 	maskNonEmpty(&cp.Providers.DeepSeek.APIKey)
 	maskNonEmpty(&cp.Providers.Gemini.APIKey)
@@ -75,6 +76,7 @@ func (c *Config) StripSecrets() {
 	c.Providers.OpenAI.APIKey = ""
 	c.Providers.AtlasCloud.APIKey = ""
 	c.Providers.OpenRouter.APIKey = ""
+	c.Providers.OrcaRouter.APIKey = ""
 	c.Providers.Groq.APIKey = ""
 	c.Providers.DeepSeek.APIKey = ""
 	c.Providers.Gemini.APIKey = ""
@@ -130,6 +132,7 @@ func (c *Config) StripMaskedSecrets() {
 	stripIfMasked(&c.Providers.OpenAI.APIKey)
 	stripIfMasked(&c.Providers.AtlasCloud.APIKey)
 	stripIfMasked(&c.Providers.OpenRouter.APIKey)
+	stripIfMasked(&c.Providers.OrcaRouter.APIKey)
 	stripIfMasked(&c.Providers.Groq.APIKey)
 	stripIfMasked(&c.Providers.DeepSeek.APIKey)
 	stripIfMasked(&c.Providers.Gemini.APIKey)

--- a/internal/http/providers.go
+++ b/internal/http/providers.go
@@ -357,6 +357,14 @@ func (h *ProvidersHandler) registerInMemory(p *store.LLMProviderData) providerRu
 		prov := providers.NewAIMLAPIProvider(p.Name, p.APIKey, apiBase)
 		prov.WithProviderType(p.ProviderType)
 		h.providerReg.RegisterForTenant(p.TenantID, prov)
+	case store.ProviderOrcaRouter:
+		base := apiBase
+		if base == "" {
+			base = store.OrcaRouterDefaultAPIBase
+		}
+		prov := providers.NewOpenAIProvider(p.Name, p.APIKey, base, store.OrcaRouterDefaultModel)
+		prov.WithProviderType(p.ProviderType)
+		h.providerReg.RegisterForTenant(p.TenantID, prov)
 	case store.ProviderOllamaCloud:
 		base := apiBase
 		if base == "" {

--- a/internal/providers/openai_config.go
+++ b/internal/providers/openai_config.go
@@ -205,14 +205,15 @@ func (p *OpenAIProvider) schemaProviderName() string {
 }
 
 // resolveModel returns the model ID to use for a request.
-// For OpenRouter, model IDs require a provider prefix (e.g. "anthropic/claude-sonnet-4-5-20250929").
+// For OpenRouter and OrcaRouter, model IDs require a provider prefix
+// (e.g. "anthropic/claude-sonnet-4-5-20250929" / "openai/gpt-4o-mini").
 // If the caller passes an unprefixed model, fall back to the provider's default.
 // After alias resolution, checks the registry for forward-compat specs.
 func (p *OpenAIProvider) resolveModel(model string) string {
 	if model == "" {
 		return p.defaultModel
 	}
-	if p.name == "openrouter" && !strings.Contains(model, "/") {
+	if (p.name == "openrouter" || p.name == "orcarouter") && !strings.Contains(model, "/") {
 		return p.defaultModel
 	}
 	// Trigger forward-compat resolution to cache specs for token counting.

--- a/internal/store/provider_store.go
+++ b/internal/store/provider_store.go
@@ -37,6 +37,11 @@ const (
 	ProviderVertex          = "vertex"          // Google Cloud Vertex AI (OAuth2 service account + ADC)
 	ProviderKimiCoding      = "kimi_coding"     // Moonshot Kimi Coding (OpenAI-compat, requires fixed User-Agent)
 	ProviderAtlasCloud      = "atlascloud"      // Atlas Cloud (OpenAI-compatible endpoint)
+	ProviderOrcaRouter      = "orcarouter"      // OrcaRouter (OpenAI-compatible gateway, provider-prefixed model IDs)
+
+	// OrcaRouter defaults.
+	OrcaRouterDefaultAPIBase = "https://api.orcarouter.ai/v1"
+	OrcaRouterDefaultModel   = "orcarouter/auto"
 
 	// MiniMax defaults.
 	MiniMaxDefaultAPIBase = "https://api.minimax.io/v1"
@@ -102,6 +107,7 @@ var ValidProviderTypes = map[string]bool{
 	ProviderVertex:          true,
 	ProviderKimiCoding:      true,
 	ProviderAtlasCloud:      true,
+	ProviderOrcaRouter:      true,
 }
 
 // VertexProviderSettings holds Vertex-specific config stored in llm_providers.settings JSONB.

--- a/ui/desktop/frontend/src/constants/providers.ts
+++ b/ui/desktop/frontend/src/constants/providers.ts
@@ -12,6 +12,7 @@ export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: 'gemini_native', label: 'Google Gemini', apiBase: 'https://generativelanguage.googleapis.com/v1beta/openai', needsKey: true },
   { value: 'vertex', label: 'Google Vertex AI', apiBase: '', needsKey: false },
   { value: 'openrouter', label: 'OpenRouter', apiBase: 'https://openrouter.ai/api/v1', needsKey: true },
+  { value: 'orcarouter', label: 'OrcaRouter', apiBase: 'https://api.orcarouter.ai/v1', needsKey: true },
   { value: 'groq', label: 'Groq', apiBase: 'https://api.groq.com/openai/v1', needsKey: true },
   { value: 'deepseek', label: 'DeepSeek', apiBase: 'https://api.deepseek.com/v1', needsKey: true },
   { value: 'mistral', label: 'Mistral AI', apiBase: 'https://api.mistral.ai/v1', needsKey: true },

--- a/ui/web/src/constants/providers.ts
+++ b/ui/web/src/constants/providers.ts
@@ -19,6 +19,7 @@ export const PROVIDER_TYPES: ProviderTypeInfo[] = [
   { value: "gemini_native", label: "Google Gemini", apiBase: "https://generativelanguage.googleapis.com/v1beta/openai", placeholder: "" },
   { value: "vertex", label: "Google Vertex AI", apiBase: "", placeholder: "Auto-computed from project_id + region (settings)" },
   { value: "openrouter", label: "OpenRouter", apiBase: "https://openrouter.ai/api/v1", placeholder: "" },
+  { value: "orcarouter", label: "OrcaRouter", apiBase: "https://api.orcarouter.ai/v1", placeholder: "" },
   { value: "groq", label: "Groq", apiBase: "https://api.groq.com/openai/v1", placeholder: "" },
   { value: "deepseek", label: "DeepSeek", apiBase: "https://api.deepseek.com/v1", placeholder: "" },
   { value: "mistral", label: "Mistral AI", apiBase: "https://api.mistral.ai/v1", placeholder: "" },


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a first-class named provider in GoClaw's provider registry, mirroring the existing OpenRouter adapter.

For GoClaw users running multi-agent gateways with encrypted API keys and per-tenant provider rows, OrcaRouter previously had to be entered as an anonymous `openai_compat` custom base URL. This PR makes it a discoverable provider in the dashboard, CLI wizards, onboard seeding, and env-var config — the same surface OpenRouter already gets.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## What & why

GoClaw describes itself as a *"Multi-agent AI gateway built in Go. 20+ LLM providers"* with a unified provider-adapter system, and it already lists OpenRouter as a named provider alongside Anthropic, OpenAI, Gemini, and others. OrcaRouter fits that same slot: it is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This PR wires OrcaRouter through the exact paths OpenRouter already uses:

- `internal/store/provider_store.go` — new `orcarouter` provider type + default API base/model
- `internal/config/` — `providers.orcarouter` config block, `GOCLAW_ORCAROUTER_API_KEY` env override, secret masking, `HasAnyProvider`
- `cmd/gateway_providers.go` + `internal/http/providers.go` — runtime registration for env/config and DB-backed providers (verify + chat work without a restart)
- `cmd/providers_cmd.go`, `cmd/setup_provider.go`, `cmd/onboard_managed.go`, `cmd/doctor.go` — CLI/onboard/doctor surfaces
- `internal/providers/openai_config.go` — provider-prefixed model-ID resolution, same guard as OpenRouter
- `ui/web` + `ui/desktop` provider constants — dashboard picker entries
- `README.md` — provider list

## Test Plan

- `go build ./...` and `go build -tags sqliteonly ./...` pass
- `go vet ./...` passes
- `go test ./internal/store/ ./internal/config/ ./internal/providers/ ./cmd/` pass
- Live-tested the OrcaRouter endpoint (`https://api.orcarouter.ai/v1`) with a real API key: `GET /v1/models`, non-streaming and streaming `/v1/chat/completions` all return 200

> Note: `internal/http` has pre-existing Ollama-related test failures in this container (`DockerLocalhost` rewrites `localhost` → `host.docker.internal` because `/.dockerenv` exists); they fail identically on the unmodified baseline and are unrelated to this change.

---

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
