### PR TITLE
fix(onboarding): keep the chosen agent identity when the prompt is edited

### DIFF
--- a/ui/desktop/frontend/src/components/onboarding/AgentStep.tsx
+++ b/ui/desktop/frontend/src/components/onboarding/AgentStep.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getApiClient } from '../../lib/api'
+import { slugify, isValidSlug } from '../../lib/slug'
 import { agentService } from '../../services/agent-service'
 
 import { SummoningModal } from './SummoningModal'
@@ -28,6 +29,13 @@ export function AgentStep({ provider, model, onBack, onComplete }: AgentStepProp
   const { t } = useTranslation(['desktop', 'agents', 'common'])
   const [selectedPresetIdx, setSelectedPresetIdx] = useState<number>(0)
   const [description, setDescription] = useState('')
+  // Identity is editable state, only *prefilled* from the selected preset. It must
+  // survive description edits — deselecting a preset never rewrites the name/key.
+  const [displayName, setDisplayName] = useState('')
+  const [agentKey, setAgentKey] = useState('')
+  const [displayNameEdited, setDisplayNameEdited] = useState(false)
+  const [agentKeyEdited, setAgentKeyEdited] = useState(false)
+  const [emoji, setEmoji] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [createdAgent, setCreatedAgent] = useState<{ id: string; name: string } | null>(null)
@@ -39,62 +47,87 @@ export function AgentStep({ provider, model, onBack, onComplete }: AgentStepProp
     return t(`${preset.ns}:presets.${preset.key}.prompt`)
   }
 
-  // Init description from first preset
+  // Label format: "🦊 Fox Spirit" — the display name drops the emoji prefix
+  function getPresetName(idx: number): string {
+    const preset = PRESET_KEYS[idx]
+    if (!preset) return ''
+    const label = t(`${preset.ns}:presets.${preset.key}.label`) as string
+    return label.replace(/^\S+\s+/, '').trim() || label.trim()
+  }
+
+  // Init key + emoji from the first preset; name and prompt are filled by the
+  // locale-sync effects below.
   useEffect(() => {
-    if (!description) setDescription(getPresetPrompt(0))
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    setAgentKey(PRESET_KEYS[0].agentKey)
+    setEmoji(PRESET_KEYS[0].emoji)
   }, [])
 
-  const displayName = useMemo(() => {
-    const preset = PRESET_KEYS[selectedPresetIdx]
-    if (preset) {
-      const label = t(`${preset.ns}:presets.${preset.key}.label`) as string
-      // Label format: "🦊 Fox Spirit" — strip emoji prefix
-      return label.replace(/^\S+\s*/, '')
-    }
-    return 'Fox Spirit'
-  }, [selectedPresetIdx, t])
+  const presetPrompt = selectedPresetIdx >= 0 ? getPresetPrompt(selectedPresetIdx) : undefined
+  const presetName = selectedPresetIdx >= 0 ? getPresetName(selectedPresetIdx) : undefined
 
-  // Agent key: stable English slug, never translated
-  const agentKey = useMemo(() => {
-    const preset = PRESET_KEYS[selectedPresetIdx]
-    return preset?.agentKey ?? 'little-fox'
-  }, [selectedPresetIdx])
-  const selectedEmoji = PRESET_KEYS[selectedPresetIdx]?.emoji ?? '🦊'
-
-  // Sync description when preset changes
+  // Language-aware re-sync: while a preset is active and the field is untouched,
+  // follow the translated preset text. Deps are plain strings, so this only fires
+  // when the translation actually changes (locale switch), not on every render.
   useEffect(() => {
-    if (selectedPresetIdx >= 0) {
-      setDescription(getPresetPrompt(selectedPresetIdx))
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedPresetIdx])
+    if (presetPrompt === undefined) return
+    setDescription(presetPrompt)
+  }, [presetPrompt])
+
+  useEffect(() => {
+    if (presetName === undefined || displayNameEdited) return
+    setDisplayName(presetName)
+  }, [presetName, displayNameEdited])
+
+  const trimmedName = displayName.trim()
+  const keyValid = isValidSlug(agentKey)
+  const canSubmit = !!trimmedName && keyValid && !!description.trim()
+
+  const handleSelectPreset = (idx: number) => {
+    const preset = PRESET_KEYS[idx]
+    if (!preset) return
+    setSelectedPresetIdx(idx)
+    setDescription(getPresetPrompt(idx))
+    setDisplayName(getPresetName(idx))
+    setDisplayNameEdited(false)
+    setEmoji(preset.emoji)
+    setAgentKey(preset.agentKey)
+    setAgentKeyEdited(false)
+  }
 
   const handleDescriptionChange = (value: string) => {
     setDescription(value)
-    if (selectedPresetIdx >= 0) {
-      const presetPrompt = getPresetPrompt(selectedPresetIdx)
-      if (value !== presetPrompt) setSelectedPresetIdx(-1)
-    }
+    // Editing the prompt only clears the preset highlight — identity stays as typed.
+    if (selectedPresetIdx >= 0 && value !== presetPrompt) setSelectedPresetIdx(-1)
+  }
+
+  const handleDisplayNameChange = (value: string) => {
+    setDisplayNameEdited(true)
+    setDisplayName(value)
+    if (!agentKeyEdited) setAgentKey(slugify(value))
+  }
+
+  const handleAgentKeyChange = (value: string) => {
+    setAgentKeyEdited(true)
+    setAgentKey(value)
   }
 
   const handleSubmit = async () => {
-    if (!description.trim()) return
+    if (!canSubmit) return
     setLoading(true)
     setError('')
     try {
       const result = await getApiClient().post<{ id: string }>('/v1/agents', {
         agent_key: agentKey,
-        display_name: displayName.trim() || undefined,
+        display_name: trimmedName,
         provider: provider.name,
         model: model || '',
         agent_type: 'predefined',
         is_default: true,
         // Promoted fields at top level — agent_description triggers summoning on backend
         agent_description: description.trim() || null,
-        emoji: selectedEmoji || null,
+        emoji: emoji.trim() || null,
       })
-      setCreatedAgent({ id: result.id, name: displayName.trim() || agentKey })
+      setCreatedAgent({ id: result.id, name: trimmedName || agentKey })
     } catch (err) {
       setError(err instanceof Error ? err.message : t('common:failedToCreateAgent'))
     } finally {
@@ -140,6 +173,50 @@ export function AgentStep({ provider, model, onBack, onComplete }: AgentStepProp
         )}
       </div>
 
+      {/* Agent identity — editable name + key, prefilled from the preset */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <label htmlFor="onboard-agent-name" className="block text-sm font-medium text-text-secondary">
+            {t('agents:create.displayName')}
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="onboard-agent-emoji"
+              value={emoji}
+              onChange={(e) => setEmoji(e.target.value)}
+              maxLength={2}
+              placeholder="🤖"
+              title={t('agents:create.emojiHint')}
+              className="w-14 shrink-0 text-center w-full bg-surface-tertiary border border-border rounded-lg px-3 py-2.5 text-base md:text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+            />
+            <input
+              id="onboard-agent-name"
+              value={displayName}
+              onChange={(e) => handleDisplayNameChange(e.target.value)}
+              placeholder={t('agents:create.displayNamePlaceholder')}
+              className="w-full bg-surface-tertiary border border-border rounded-lg px-3 py-2.5 text-base md:text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="onboard-agent-key" className="block text-sm font-medium text-text-secondary">
+            {t('agents:create.agentKey')}
+          </label>
+          <input
+            id="onboard-agent-key"
+            value={agentKey}
+            onChange={(e) => handleAgentKeyChange(e.target.value)}
+            onBlur={(e) => setAgentKey(slugify(e.target.value))}
+            placeholder={t('agents:create.agentKeyPlaceholder')}
+            className="w-full bg-surface-tertiary border border-border rounded-lg px-3 py-2.5 text-base md:text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+          />
+          <p className={agentKey && !keyValid ? 'text-xs text-error' : 'text-xs text-text-muted'}>
+            {t('agents:create.agentKeyHint')}
+          </p>
+        </div>
+      </div>
+
       {/* Preset personality buttons */}
       <div className="space-y-2">
         <label className="block text-sm font-medium text-text-secondary">{t('agents:detail.personality')}</label>
@@ -148,7 +225,7 @@ export function AgentStep({ provider, model, onBack, onComplete }: AgentStepProp
             <button
               key={preset.key}
               type="button"
-              onClick={() => setSelectedPresetIdx(idx)}
+              onClick={() => handleSelectPreset(idx)}
               className={[
                 'cursor-pointer rounded-full border px-3 py-1 text-xs transition-colors',
                 selectedPresetIdx === idx
@@ -185,7 +262,7 @@ export function AgentStep({ provider, model, onBack, onComplete }: AgentStepProp
         </button>
         <button
           onClick={handleSubmit}
-          disabled={loading || !description.trim()}
+          disabled={loading || !canSubmit}
           className="px-6 py-2.5 bg-accent text-white rounded-lg font-medium hover:bg-accent-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2"
         >
           {loading && <div className="w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin" />}

--- a/ui/web/src/pages/agents/agent-presets.ts
+++ b/ui/web/src/pages/agents/agent-presets.ts
@@ -1,48 +1,42 @@
 import { useTranslation } from "react-i18next";
 
 export interface AgentPreset {
+  /** Chip label as translated, may carry a leading emoji (e.g. "🦊 Fox Spirit"). */
   label: string;
+  /** Translated display name with the leading emoji stripped. */
+  name: string;
   prompt: string;
   emoji: string;
+  /** Stable English slug used as agent_key — never translated. */
+  agentKey: string;
+}
+
+/** Labels are stored as "<emoji> <name>"; the emoji lives in its own field. */
+function stripLeadingEmoji(label: string): string {
+  return label.replace(/^\S+\s+/, "").trim() || label.trim();
 }
 
 export function useAgentPresets(): AgentPreset[] {
   const { t } = useTranslation("agents");
+
+  const build = (key: string, emoji: string, agentKey: string): AgentPreset => {
+    const label = t(`presets.${key}.label`);
+    return {
+      label,
+      name: stripLeadingEmoji(label),
+      prompt: t(`presets.${key}.prompt`),
+      emoji,
+      agentKey,
+    };
+  };
+
   return [
-    {
-      label: t("presets.foxSpirit.label"),
-      prompt: t("presets.foxSpirit.prompt"),
-      emoji: "🦊",
-    },
-    {
-      label: t("presets.coder.label"),
-      prompt: t("presets.coder.prompt"),
-      emoji: "💻",
-    },
-    {
-      label: t("presets.support.label"),
-      prompt: t("presets.support.prompt"),
-      emoji: "🎧",
-    },
-    {
-      label: t("presets.writer.label"),
-      prompt: t("presets.writer.prompt"),
-      emoji: "✍️",
-    },
-    {
-      label: t("presets.translator.label"),
-      prompt: t("presets.translator.prompt"),
-      emoji: "🌐",
-    },
-    {
-      label: t("presets.artisan.label"),
-      prompt: t("presets.artisan.prompt"),
-      emoji: "🎨",
-    },
-    {
-      label: t("presets.astrologer.label"),
-      prompt: t("presets.astrologer.prompt"),
-      emoji: "🔮",
-    },
+    build("foxSpirit", "🦊", "little-fox"),
+    build("coder", "💻", "dev"),
+    build("support", "🎧", "support"),
+    build("writer", "✍️", "quill"),
+    build("translator", "🌐", "translator"),
+    build("artisan", "🎨", "artisan"),
+    build("astrologer", "🔮", "mimi"),
   ];
 }

--- a/ui/web/src/pages/setup/step-agent.tsx
+++ b/ui/web/src/pages/setup/step-agent.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -12,7 +13,7 @@ import { useAgents } from "@/pages/agents/hooks/use-agents";
 import { SummoningModal } from "@/pages/agents/summoning-modal";
 import { useAgentPresets } from "@/pages/agents/agent-presets";
 import { useWsEvent } from "@/hooks/use-ws-event";
-import { slugify } from "@/lib/slug";
+import { slugify, isValidSlug } from "@/lib/slug";
 import { toast } from "@/stores/use-toast-store";
 import type { ProviderData } from "@/types/provider";
 import type { AgentData } from "@/types/agent";
@@ -27,6 +28,7 @@ interface StepAgentProps {
 
 export function StepAgent({ provider, model, onComplete, onBack, existingAgent }: StepAgentProps) {
   const { t } = useTranslation("setup");
+  const { t: tAgents } = useTranslation("agents");
   const { createAgent, updateAgent, deleteAgent, resummonAgent, cancelSummonAgent } = useAgents();
   const agentPresets = useAgentPresets();
 
@@ -39,6 +41,19 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
   );
   const [selectedPresetIdx, setSelectedPresetIdx] = useState<number | null>(
     existingAgent ? null : 0,
+  );
+  // Identity is editable state, only *prefilled* from the selected preset. It must
+  // survive description edits — deselecting a preset never rewrites the name/key.
+  const [displayName, setDisplayName] = useState(
+    existingAgent?.display_name ?? defaultPreset?.name ?? "",
+  );
+  const [agentKey, setAgentKey] = useState(
+    existingAgent?.agent_key ?? defaultPreset?.agentKey ?? "",
+  );
+  const [displayNameEdited, setDisplayNameEdited] = useState(false);
+  const [agentKeyEdited, setAgentKeyEdited] = useState(false);
+  const [emoji, setEmoji] = useState(
+    existingAgent?.emoji ?? defaultPreset?.emoji ?? "",
   );
   const [selfEvolve, setSelfEvolve] = useState(
     Boolean(existingAgent?.self_evolve),
@@ -57,26 +72,25 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
   const [createdAgent, setCreatedAgent] = useState<{ id: string; name: string } | null>(null);
   const [agentResult, setAgentResult] = useState<AgentData | null>(null);
 
-  // Derive agent key and display name from selected preset or description
-  const displayName = useMemo(() => {
-    if (existingAgent) return existingAgent.display_name ?? "";
-    if (selectedPresetIdx !== null && agentPresets[selectedPresetIdx]) {
-      return agentPresets[selectedPresetIdx].label;
-    }
-    return "Fox Spirit";
-  }, [existingAgent, selectedPresetIdx, agentPresets]);
+  const activePreset = selectedPresetIdx !== null ? agentPresets[selectedPresetIdx] : undefined;
+  const presetPrompt = activePreset?.prompt;
+  const presetName = activePreset?.name;
 
-  const agentKey = useMemo(() => {
-    const slug = slugify(displayName);
-    return slug || "fox-spirit";
-  }, [displayName]);
+  // Deps are plain strings, so this only fires when the translated preset text
+  // actually changes (locale switch) — not on every render.
+  useEffect(() => {
+    if (presetPrompt === undefined) return;
+    setDescription(presetPrompt);
+  }, [presetPrompt]);
 
-  const selectedEmoji = useMemo(() => {
-    if (selectedPresetIdx !== null && agentPresets[selectedPresetIdx]) {
-      return agentPresets[selectedPresetIdx].emoji;
-    }
-    return "🦊";
-  }, [selectedPresetIdx, agentPresets]);
+  useEffect(() => {
+    if (presetName === undefined || displayNameEdited || isEditing) return;
+    setDisplayName(presetName);
+  }, [presetName, displayNameEdited, isEditing]);
+
+  const trimmedName = displayName.trim();
+  const keyValid = isValidSlug(agentKey);
+  const canSubmit = !!trimmedName && (isEditing || keyValid) && !!description.trim();
 
   const providerLabel = useMemo(() => {
     if (!provider) return "—";
@@ -95,13 +109,6 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
   );
   useWsEvent("agent.summoning", handleSummoningEvent);
 
-  // Sync description when preset changes on initial load
-  useEffect(() => {
-    if (selectedPresetIdx !== null && agentPresets[selectedPresetIdx]) {
-      setDescription(agentPresets[selectedPresetIdx].prompt);
-    }
-  }, [selectedPresetIdx, agentPresets]);
-
   const handleContinue = () => {
     if (agentResult) onComplete(agentResult);
   };
@@ -111,19 +118,35 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
     if (!preset) return;
     setSelectedPresetIdx(idx);
     setDescription(preset.prompt);
+    setDisplayName(preset.name);
+    setDisplayNameEdited(false);
+    setEmoji(preset.emoji);
+    if (!isEditing) {
+      setAgentKey(preset.agentKey);
+      setAgentKeyEdited(false);
+    }
   };
 
   const handleDescriptionChange = (value: string) => {
     setDescription(value);
-    // If user edits text, deselect preset (unless it still matches)
-    if (selectedPresetIdx !== null) {
-      const presetPrompt = agentPresets[selectedPresetIdx]?.prompt;
-      if (value !== presetPrompt) setSelectedPresetIdx(null);
-    }
+    // Editing the prompt only clears the preset highlight — identity stays as typed.
+    if (selectedPresetIdx !== null && value !== presetPrompt) setSelectedPresetIdx(null);
+  };
+
+  const handleDisplayNameChange = (value: string) => {
+    setDisplayNameEdited(true);
+    setDisplayName(value);
+    if (!agentKeyEdited && !isEditing) setAgentKey(slugify(value));
+  };
+
+  const handleAgentKeyChange = (value: string) => {
+    setAgentKeyEdited(true);
+    setAgentKey(value);
   };
 
   const handleSubmit = async () => {
     if (!provider) { setError(t("agent.errors.noProvider")); return; }
+    if (!canSubmit) return;
 
     setLoading(true);
     setError("");
@@ -132,20 +155,20 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
     try {
       if (isEditing) {
         const patch: Partial<AgentData> = {
-          display_name: displayName.trim() || undefined,
+          display_name: trimmedName,
           provider: provider.name,
           model: model || "",
           // Promoted fields at top level
           agent_description: description.trim() || null,
           self_evolve: selfEvolve,
-          emoji: selectedEmoji || null,
+          emoji: emoji.trim() || null,
         };
         await updateAgent(existingAgent!.id, patch);
         onComplete({ ...existingAgent!, ...patch } as AgentData);
       } else {
         const data: Partial<AgentData> = {
           agent_key: agentKey,
-          display_name: displayName.trim() || undefined,
+          display_name: trimmedName,
           provider: provider.name,
           model: model || "",
           agent_type: "predefined",
@@ -153,7 +176,7 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
           // Promoted fields at top level
           agent_description: description.trim() || null,
           self_evolve: selfEvolve,
-          emoji: selectedEmoji || null,
+          emoji: emoji.trim() || null,
           grant_gateway_operator_access: gatewayOperatorAccess || undefined,
         };
 
@@ -169,7 +192,7 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
         }
         setAgentResult(result);
         setSummoningOutcome("pending");
-        setCreatedAgent({ id: result.id, name: displayName.trim() || agentKey });
+        setCreatedAgent({ id: result.id, name: trimmedName || agentKey });
         setSummoningOpen(true);
       }
     } catch (err) {
@@ -178,7 +201,6 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
       setLoading(false);
     }
   };
-
   const handleSummoningComplete = () => {};
 
   const handleModalClose = async () => {
@@ -219,6 +241,49 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
                   <Badge variant="outline">{model}</Badge>
                 </div>
               )}
+            </div>
+
+            {/* Agent identity — editable name + key, prefilled from the preset */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="setup-display-name">{tAgents("create.displayName")}</Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="setup-emoji"
+                    value={emoji}
+                    onChange={(e) => setEmoji(e.target.value)}
+                    placeholder="🤖"
+                    className="w-14 shrink-0 text-center text-base md:text-lg"
+                    maxLength={2}
+                    title={tAgents("create.emojiHint")}
+                  />
+                  <Input
+                    id="setup-display-name"
+                    value={displayName}
+                    onChange={(e) => handleDisplayNameChange(e.target.value)}
+                    placeholder={tAgents("create.displayNamePlaceholder")}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="setup-agent-key">{tAgents("create.agentKey")}</Label>
+                <Input
+                  id="setup-agent-key"
+                  value={agentKey}
+                  onChange={(e) => handleAgentKeyChange(e.target.value)}
+                  onBlur={(e) => setAgentKey(slugify(e.target.value))}
+                  placeholder={tAgents("create.agentKeyPlaceholder")}
+                  disabled={isEditing}
+                />
+                <p
+                  className={`text-xs ${
+                    !isEditing && agentKey && !keyValid ? "text-destructive" : "text-muted-foreground"
+                  }`}
+                >
+                  {tAgents("create.agentKeyHint")}
+                </p>
+              </div>
             </div>
 
             {/* Prompt / description with preset selection */}
@@ -297,7 +362,7 @@ export function StepAgent({ provider, model, onComplete, onBack, existingAgent }
               )}
               <Button
                 onClick={handleSubmit}
-                disabled={loading || !description.trim()}
+                disabled={loading || !canSubmit}
               >
                 {loading
                   ? isEditing ? t("agent.updating", "Updating...") : t("agent.creating")


### PR DESCRIPTION
## Problem

Onboarding step 3 (Create your agent) never lets you name the agent. The display name, agent key and emoji are derived from the currently selected personality preset — and editing the prompt clears that selection.

`ui/web/src/pages/setup/step-agent.tsx`:

```ts
const displayName = useMemo(() => {
  if (selectedPresetIdx !== null && agentPresets[selectedPresetIdx]) {
    return agentPresets[selectedPresetIdx].label;
  }
  return "Fox Spirit";           // ← hardcoded fallback
}, [...]);

const agentKey = useMemo(() => slugify(displayName) || "fox-spirit", [displayName]);
```

```ts
// handleDescriptionChange
if (value !== presetPrompt) setSelectedPresetIdx(null);   // ← clears the preset
```

Reported flow, on a freshly created tenant:

| # | Action | Result |
|---|---|---|
| 1 | Pick the **Writer** preset | `selectedPresetIdx = 3` |
| 2 | Clear the description, type a new one | text ≠ preset prompt → `selectedPresetIdx = null` |
| 3 | Press Create | agent created as **Fox Spirit** / `fox-spirit` / 🦊 |

`ui/desktop/frontend/src/components/onboarding/AgentStep.tsx` has the same shape and the same fallback (`'Fox Spirit'` / `'little-fox'`).

Two smaller defects on the web side, both from deriving identity out of a translated label:

- The label carries its emoji (`"✍️ Writer"`), and unlike desktop the web step does not strip it, so `display_name` is stored with a leading emoji next to the separate `emoji` field.
- `agent_key` is `slugify()` of the translated label, so the same preset yields `writer` in English and `bien-tap` in Vietnamese.

## Fix

Identity becomes editable state that a preset only *prefills*, rather than a value derived from the preset.

- Add display name, emoji and agent key inputs to both onboarding steps. The key is derived from the name until it is edited by hand, and `slugify()` normalizes it on blur.
- Editing the prompt only clears the preset highlight — the name, key and emoji stay as they are.
- Submit is blocked on an empty name or an invalid slug (`isValidSlug`), instead of silently substituting a fallback. The key field is read-only when returning to the step to edit an already-created agent, since `agent_key` is immutable.
- Picking a preset is treated as an explicit identity action: it resets name, emoji and key together.
- `useAgentPresets()` gains `name` (label with the emoji prefix stripped) and a stable English `agentKey`, matching the `PRESET_KEYS` table the desktop step already had. The slug no longer depends on the UI locale.
- While a preset is active and its field is untouched, the name and prompt still follow a locale switch — the setup page has a language selector, and the previous `useMemo`-on-`t` behavior would otherwise be lost.

No new i18n keys: the inputs reuse `agents:create.{displayName,displayNamePlaceholder,agentKey,agentKeyPlaceholder,agentKeyHint,emojiHint}`, already present in en/vi/zh on both surfaces.

## Tests

No automated coverage added — the change is confined to two onboarding components, neither of which has an existing test file on either surface, and the repo has no component-level render harness for them.

Manual check of the reported flow: pick Writer → rewrite the description → the name stays `Writer` / `quill`; typing a custom name updates the slug until the slug is edited directly; clearing the name disables Create.

## Verification

- `ui/web`: `tsc -b`, `vite build`, `eslint` on the changed files — all clean
- `ui/web`: `vitest run` — 55 files / 355 tests pass
- `ui/desktop/frontend`: `tsc -b` — clean apart from the four pre-existing `wailsjs/*` module errors (bindings are generated by Wails at build time)
- `ui/desktop/frontend`: `vitest run` — 28/30 pass; the two failures are in `components/agents/__tests__/voice-picker.test.tsx` and reproduce with this branch's changes stashed
- Go gates (`go build ./...`, `-tags sqliteonly`, `go vet`, `go test -race ./...`) were **not run** — no Go toolchain on the machine used. The diff touches no Go file; leaving these to CI.

## Surface parity

- Gateway server: N/A — no handler, store, migration or runtime change
- API contract: N/A — `POST /v1/agents` already accepts `agent_key`, `display_name` and `emoji`; the payload shape is unchanged
- Web UI: covered — `ui/web/src/pages/setup/step-agent.tsx`, `ui/web/src/pages/agents/agent-presets.ts`
- Desktop UI: covered — `ui/desktop/frontend/src/components/onboarding/AgentStep.tsx`
- CLI/runtime package: N/A — the `onboard` wizard does not create agents through this flow
