### PR TITLE
fix(providers): iterate tool-call accumulators by map, not index

### DIFF
--- a/internal/providers/openai_chat.go
+++ b/internal/providers/openai_chat.go
@@ -195,9 +195,15 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, req ChatRequest, onChun
 		return result, fmt.Errorf("%s: stream read error: %w", p.name, err)
 	}
 
-	// Parse accumulated tool call arguments
-	for i := 0; i < len(accumulators); i++ {
-		acc := accumulators[i]
+	// Parse accumulated tool call arguments.
+	// Iterate the map directly (not 0..len(accumulators)-1): providers are not
+	// guaranteed to emit contiguous zero-based tc.Index values in delta.ToolCalls,
+	// so indexing by position can miss populated slots and hit a nil accumulator,
+	// causing a nil-pointer panic (observed with the point-p1/9router provider).
+	for _, acc := range accumulators {
+		if acc == nil {
+			continue
+		}
 		args := make(map[string]any)
 		if err := json.Unmarshal([]byte(acc.rawArgs), &args); err != nil && acc.rawArgs != "" {
 			slog.Warn("openai_stream: failed to parse tool call arguments",


### PR DESCRIPTION
## Problem
`OpenAIProvider.ChatStream` parses the accumulated tool-call arguments with a positional loop:

```go
for i := 0; i < len(accumulators); i++ {
    acc := accumulators[i]
    ...
}
```

This assumes every OpenAI-compatible provider emits contiguous, zero-based `tc.Index` values in streamed `delta.tool_calls`. That assumption doesn't hold for all providers — I hit it against a self-hosted OpenAI-compatible gateway that emits non-contiguous/non-zero-based indices. When that happens, `accumulators[i]` misses a populated map key and returns a nil `*toolCallAccumulator`, and the very next line dereferences `acc.rawArgs` on that nil pointer:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x91af07]
goroutine ... [running]:
github.com/nextlevelbuilder/goclaw/internal/providers.(*OpenAIProvider).ChatStream(...)
	/src/internal/providers/openai_chat.go:202 +0x16e7
...
created by .../internal/gateway/methods.(*ChatMethods).dispatchChatSends
```

The panic kills the in-flight chat-run goroutine. It's recovered at a higher level (the gateway logs `tracing: safety-net finalizing orphan trace`), so the process stays up, but the user's in-progress message goes unanswered with no visible error.

## Fix
Range over the `accumulators` map directly instead of indexing by position, and skip nil entries defensively:

```go
for _, acc := range accumulators {
    if acc == nil {
        continue
    }
    ...
}
```

## Verification
- Built a full backend image from this branch (`CGO_ENABLED=0 go build -tags embedui`, same as `make build-full`) — compiles clean.
- Deployed it live against the agent/provider combo that was reliably panicking (multi-tool-call turns: `use_skill` → `read_file` → `exec` x3).
- Before the fix: 2 panics logged within ~10 minutes of runtime, each on the first multi-tool-call turn for that agent.
- After the fix: the same agent/provider ran multiple consecutive multi-tool-call turns end to end, each completing with `v3.run.completed`, zero panics, zero safety-net orphan-trace log lines, restart count stayed at 0.