### PR TITLE
fix(providers): skip temperature for base gpt-5 and gpt-5-chat models

### DIFF
--- a/internal/providers/openai_request.go
+++ b/internal/providers/openai_request.go
@@ -265,8 +265,14 @@ func (p *OpenAIProvider) buildRequestBody(model string, req ChatRequest, stream 
 		// Certain model families don't support custom temperature (locked to default).
 		// This is a model-level constraint, not provider-specific — applies to both OpenAI and Azure.
 		// Note: gpt-5.X flagship models (gpt-5.1, gpt-5.4, gpt-5.5) DO support temperature;
-		// only the mini/nano reasoning variants reject it.
-		skipTemp := strings.HasPrefix(capabilityModel, "gpt-5-mini") || strings.HasPrefix(capabilityModel, "gpt-5-nano") || strings.HasPrefix(capabilityModel, "o1") || strings.HasPrefix(capabilityModel, "o3") || strings.HasPrefix(capabilityModel, "o4")
+		// the locked ones are the base gpt-5, gpt-5-chat, and the mini/nano reasoning variants.
+		skipTemp := capabilityModel == "gpt-5" ||
+			strings.HasPrefix(capabilityModel, "gpt-5-chat") ||
+			strings.HasPrefix(capabilityModel, "gpt-5-mini") ||
+			strings.HasPrefix(capabilityModel, "gpt-5-nano") ||
+			strings.HasPrefix(capabilityModel, "o1") ||
+			strings.HasPrefix(capabilityModel, "o3") ||
+			strings.HasPrefix(capabilityModel, "o4")
 		// Kimi Coding rejects any temperature override — `invalid temperature: only
 		// 1 is allowed for this model`. Skip sending so the upstream applies its
 		// own default (1). Matches the model-locked behavior of o1/o3/o4.

--- a/internal/providers/openai_test.go
+++ b/internal/providers/openai_test.go
@@ -59,6 +59,9 @@ func TestBuildRequestBody_TemperatureSkippedForReasoningModels(t *testing.T) {
 	// These model families don't support custom temperature (locked to default).
 	// This is a model-level constraint, not provider-specific.
 	models := []string{
+		"gpt-5",
+		"gpt-5-chat",
+		"gpt-5-chat-latest",
 		"gpt-5-mini",
 		"gpt-5-mini-2025-01",
 		"gpt-5-nano",
@@ -68,6 +71,8 @@ func TestBuildRequestBody_TemperatureSkippedForReasoningModels(t *testing.T) {
 		"o3",
 		"o3-mini",
 		"o4-mini",
+		"openai/gpt-5",
+		"openai/gpt-5-chat-latest",
 		"openai/gpt-5-mini",
 		"openai/o3-mini",
 	}
@@ -96,7 +101,6 @@ func TestBuildRequestBody_TemperatureKeptForNonReasoningModels(t *testing.T) {
 		"gpt-4",
 		"gpt-4o",
 		"gpt-4-turbo",
-		"gpt-5",
 		"gpt-5.1",
 		"gpt-5.4",
 		"openai/gpt-5.4",


### PR DESCRIPTION

## What

`skipTemp` in `buildRequestBody` only covered `gpt-5-mini` / `gpt-5-nano` and the o-series, so base **`gpt-5`** and **`gpt-5-chat`** fell through and received the default `temperature: 0.7`, which OpenAI-compatible gateways reject:

HTTP 400: Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.

Because the inbound error is suppressed on channel integrations, the agent goes silently dead with no user-visible error.

## Change

Extend the locked-temperature gate in `internal/providers/openai_request.go`:

- exact match `gpt-5`
- prefix match `gpt-5-chat` (covers `gpt-5-chat-latest`)

The gpt-5.X flagship variants (`gpt-5.1`, `gpt-5.4`, `gpt-5.5`) keep their temperature — only the base `gpt-5` and `gpt-5-chat` aliases are locked to the default, per the maintainer triage note on the issue.

## Tests

- Moved `gpt-5` from the kept list to the skipped list in `TestBuildRequestBody_TemperatureKeptForNonReasoningModels` (test expectation updated per triage).
- Added regression cases: `gpt-5`, `gpt-5-chat`, `gpt-5-chat-latest`, `openai/gpt-5`, `openai/gpt-5-chat-latest` in `TestBuildRequestBody_TemperatureSkippedForReasoningModels`.
- Verified bug-first: new cases fail against `dev` without the fix, pass with it.
- Full package: `go test ./internal/providers/` green, `go build ./...` and `go vet ./internal/providers/` clean.

Fixes #1460

