### PR TITLE
test(teams): fix the data races in the teammate streaming test

### DIFF
--- a/cmd/gateway_consumer_teammate_stream_test.go
+++ b/cmd/gateway_consumer_teammate_stream_test.go
@@ -22,8 +22,11 @@ import (
 // channel manager, so HandleAgentEvent drops its chunks and nothing reaches a
 // user incrementally — the task result keeps coming from the final RunResult.
 func TestHandleTeammateMessageSchedulesStreamedRun(t *testing.T) {
-	var gotReq agent.RunRequest
-	ran := make(chan struct{})
+	// The scheduler runs its RunFunc on its own goroutine, and the announce loop
+	// schedules a second run after the teammate one, so a shared variable here is
+	// written concurrently with the assertions below. Hand the requests over a
+	// channel instead: no shared state, and a second run cannot clobber the first.
+	scheduled := make(chan agent.RunRequest, 4)
 
 	sched := scheduler.NewScheduler(
 		scheduler.DefaultLanes(),
@@ -34,8 +37,10 @@ func TestHandleTeammateMessageSchedulesStreamedRun(t *testing.T) {
 			MaxConcurrent: 1,
 		},
 		func(_ context.Context, req agent.RunRequest) (*agent.RunResult, error) {
-			gotReq = req
-			close(ran)
+			select {
+			case scheduled <- req:
+			default:
+			}
 			return &agent.RunResult{Content: "member deliverable"}, nil
 		},
 	)
@@ -47,6 +52,14 @@ func TestHandleTeammateMessageSchedulesStreamedRun(t *testing.T) {
 		Sched:      sched,
 		ChannelMgr: channelMgr,
 	}
+	// handleTeammateMessage hands the announce loop to a background goroutine that
+	// keeps calling Schedule after this function returns. Drain it before the
+	// deferred Stop above runs, mirroring the shutdown order the gateway itself
+	// uses (gateway_consumer.go waits on BgWg; sched.Stop is an outer defer in
+	// gateway.go). Without this the teardown races the announce loop inside the
+	// lane's WaitGroup — Submit's Add against Stop's Wait — and -race fails the
+	// test intermittently.
+	defer deps.BgWg.Wait()
 
 	msg := bus.InboundMessage{
 		Channel:  tools.ChannelSystem,
@@ -65,8 +78,9 @@ func TestHandleTeammateMessageSchedulesStreamedRun(t *testing.T) {
 		t.Fatal("handleTeammateMessage() = false, want true for a teammate: message on the system channel")
 	}
 
+	var gotReq agent.RunRequest
 	select {
-	case <-ran:
+	case gotReq = <-scheduled:
 	case <-time.After(5 * time.Second):
 		t.Fatal("teammate run was never scheduled")
 	}


### PR DESCRIPTION
`TestHandleTeammateMessageSchedulesStreamedRun` fails CI intermittently under `-race`. It arrived with #1533, so this is mine to clean up.

Both races are in the test, not in what it exercises. Nothing in production changes.

### Observed

CI runs `go test -race`, and the `go` job goes red on and off across branches — `dev` failed on 7 September at 17:31 and passed at 03:31 the next morning, #1554 failed on 6 September, and both of my open PRs (#1530, #1537) are red on it now. The report is always the same test:

```
--- FAIL: TestHandleTeammateMessageSchedulesStreamedRun
    testing.go:1712: race detected during execution of test
```

### The two races

**1. A shared variable across goroutines.** The test kept `gotReq` and had the scheduler's `RunFunc` assign it. That function runs on a scheduler goroutine, and the announce loop schedules a second run right after the teammate one, so the write could land while the assertions were reading. The second run also called `close(ran)` on an already-closed channel.

Requests now arrive over a buffered channel and the test takes the first one. No shared state, and a later run cannot clobber the first or close anything twice.

**2. Teardown racing the background goroutine.** `defer sched.Stop()` ran while `handleTeammateMessage`'s background goroutine was still calling `Schedule`, so `Lane.Submit`'s `wg.Add` raced `Lane.Stop`'s `wg.Wait`.

The gateway does not do this: `gateway_consumer.go` drains `deps.BgWg` on the way out, and `sched.Stop()` is an outer defer in `gateway.go`, so background work is finished before the lanes stop. The test skipped the drain. It now does `defer deps.BgWg.Wait()`, which both removes the race and makes the teardown match the shutdown order the test is meant to stand for.

### Verification

Before the fix, `go test -race -count=60 -cpu=1,4 -run TestHandleTeammateMessageSchedulesStreamedRun ./cmd/` fails within a few iterations. After it, clean over `-count=200 -cpu=1,2,4`, and the whole `cmd` package is clean under `-race`.

The two assertions the test exists for — `Stream: true` on the scheduled run, and the run staying unregistered with the channel manager — are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
