### PR TITLE
fix(providers): detect llama.cpp context size overflow in error classifier

### DIFF
--- a/internal/providers/error_classify.go
+++ b/internal/providers/error_classify.go
@@ -170,6 +170,9 @@ func isContextOverflow(lower string) bool {
 		"request_too_large",         // Generic
 		"input is too long",         // DashScope
 		"exceed_context_size",       // Ollama native /api/chat 400
+		// llama.cpp / OpenAI-compat local servers return:
+		//   "request (N tokens) exceeds the available context size (M tokens)"
+		"context size",              // llama.cpp native /v1/chat/completions 400
 		"请求输入过长",                    // Chinese generic
 	)
 }

--- a/internal/providers/error_classify_test.go
+++ b/internal/providers/error_classify_test.go
@@ -151,6 +151,14 @@ func TestClassifyTooManyTokens(t *testing.T) {
 	}
 }
 
+func TestClassifyContextOverflowLlamaCpp(t *testing.T) {
+	classifier := NewDefaultClassifier()
+	result := classifier.Classify(nil, 400, `{"error":{"code":400,"message":"request (218678 tokens) exceeds the available context size (204800 tokens), try increasing it","type":"exceed_context_size_error","n_prompt_tokens":218678,"n_ctx":204800}}`)
+	if result.Kind != "context_overflow" {
+		t.Errorf("expected context_overflow for llama.cpp message, got %s", result.Kind)
+	}
+}
+
 func TestClassifyNetworkTimeoutError(t *testing.T) {
 	classifier := NewDefaultClassifier()
 	timeoutErr := &net.DNSError{


### PR DESCRIPTION
## Summary

`isContextOverflow()` failed to recognize llama.cpp / OpenAI-compat local servers' `400` overflow error, so a Telegram session hitting llama-cpp's max context (204800 tokens) never auto-compacted. The overflow was misclassified as a generic HTTP error and emergency compaction never triggered.

Adds the `"context size"` pattern (matches `"request (N tokens) exceeds the available context size (M tokens)"`).

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch

`dev`

## Checklist

- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes) — N/A
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat) — N/A
- [x] New user-facing strings added to all 3 locales (en/vi/zh) — N/A
- [x] Migration version bumped in `internal/upgrade/version.go` (if new migration) — N/A

## Test Plan

Added `TestClassifyContextOverflowLlamaCpp` covering the real llama.cpp 400 message body. Existing context-overflow compaction pipeline tests (`TestThinkStage_ContextOverflow_*`) pass.

## Surface parity

- Gateway server: error classification fix in `internal/providers/error_classify.go` — no handler/RPC/store/migration changes.
- API contract: N/A — no wire/type changes.
- Web UI: N/A — no UI changes.
- CLI/runtime package: N/A — no CLI changes.